### PR TITLE
New template for Live View Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/Live_view_request.md
+++ b/.github/ISSUE_TEMPLATE/Live_view_request.md
@@ -19,9 +19,9 @@ Output Widgets
 
 **Desired collaboration scheme**
 
-- Would you share this view with your team (yes/no)?
-- Would you want to persist this view in your team's git repo (yes/no)?
-- Would you want to persist this view in pixie-community's git repo (yes/no)?
+- Do you want to share this view with your team (yes/no)?
+- Do you want to persist this view in your team's git repo (yes/no)?
+- Do you want to persist this view in pixie-community's git repo (yes/no)?
 
 
 **Additional requirements**


### PR DESCRIPTION
Added template to request new live views. 

Note" that this does not include a separate request for scripts. The rationale was that it'd be good to get requests about the views end-users would want and not raw scripts. If pxl scripts would be the right way to go we can still use this template. 