### PR TITLE
Update install command so interactive commands work correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installing Pixie is easy. Visit [product page](https://withpixie.ai/) and follow
 
 1. Sign-up with your google account
 
-2. `curl -fsSL https://withpixie.ai/install.sh | bash`
+2. `bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"`
 
 3. `px deploy`
 


### PR DESCRIPTION
We ask user confirmation for install and fall back to manual auth if on a remote session. Both of these required an interactive shell session that does not work properly with | to bash.