### PR TITLE
fixup validation errors for kube 1.22 deprecations

### DIFF
--- a/k8s/cloud_deps/base/elastic/operator/elastic_operator.yaml
+++ b/k8s/cloud_deps/base/elastic/operator/elastic_operator.yaml
@@ -5,217 +5,210 @@ metadata:
   creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: APM version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
-    - elastic
+      - elastic
     kind: ApmServer
     listKind: ApmServerList
     plural: apmservers
     shortNames:
-    - apm
+      - apm
     singular: apmserver
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ApmServer represents an APM Server resource in a Kubernetes cluster.
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ApmServerSpec holds the specification of an APM Server.
-          properties:
-            config:
-              type: object
-            count:
-              description: Count of APM Server instances to deploy.
-              format: int32
-              type: integer
-            elasticsearchRef:
-              properties:
-                name:
-                  description: Name of the Kubernetes object.
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              type: object
-            http:
-              properties:
-                service:
-                  properties:
-                    metadata:
-                      type: object
-                    spec:
-                      description: Spec is the specification of the service.
-                      properties:
-                        clusterIP:
-                          type: string
-                        externalIPs:
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          type: string
-                        externalTrafficPolicy:
-                          type: string
-                        healthCheckNodePort:
-                          format: int32
-                          type: integer
-                        ipFamily:
-                          type: string
-                        loadBalancerIP:
-                          type: string
-                        loadBalancerSourceRanges:
-                          items:
-                            type: string
-                          type: array
-                        ports:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              nodePort:
-                                format: int32
-                                type: integer
-                              port:
-                                format: int32
-                                type: integer
-                              protocol:
-                                type: string
-                              targetPort:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                          type: array
-                        publishNotReadyAddresses:
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        sessionAffinity:
-                          type: string
-                        sessionAffinityConfig:
-                          properties:
-                            clientIP:
-                              properties:
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        type:
-                          type: string
-                      type: object
-                  type: object
-                tls:
-                  description: TLS defines options for configuring TLS for HTTP.
-                  properties:
-                    certificate:
-                      properties:
-                        secretName:
-                          description: SecretName is the name of the secret.
-                          type: string
-                      type: object
-                    selfSignedCertificate:
-                      properties:
-                        disabled:
-                          type: boolean
-                        subjectAltNames:
-                          items:
-                            properties:
-                              dns:
-                                description: DNS is the DNS name of the subject.
-                                type: string
-                              ip:
-                                description: IP is the IP address of the subject.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-              type: object
-            image:
-              description: Image is the APM Server Docker image to deploy.
-              type: string
-            podTemplate:
-              type: object
-            secureSettings:
-              items:
-                properties:
-                  entries:
-                    items:
-                      properties:
-                        key:
-                        path:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                    type: array
-                  secretName:
-                    description: SecretName is the name of the secret.
-                    type: string
-                required:
-                - secretName
-                type: object
-              type: array
-            version:
-              description: Version of the APM Server.
-              type: string
-          type: object
-        status:
-          description: ApmServerStatus defines the observed state of ApmServer
-          properties:
-            associationStatus:
-              type: string
-            availableNodes:
-              format: int32
-              type: integer
-            health:
-              type: string
-            secretTokenSecret:
-              type: string
-            service:
-              type: string
-          type: object
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1alpha1
-    served: false
-    storage: false
+    - name: v1
+      storage: true
+      served: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.health
+          name: health
+          type: string
+        - jsonPath: .status.availableNodes
+          description: Available nodes
+          name: nodes
+          type: integer
+        - jsonPath: .spec.version
+          description: APM version
+          name: version
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: ApmServer represents an APM Server resource in a Kubernetes cluster.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ApmServerSpec holds the specification of an APM Server.
+              properties:
+                config:
+                  type: object
+                count:
+                  description: Count of APM Server instances to deploy.
+                  format: int32
+                  type: integer
+                elasticsearchRef:
+                  properties:
+                    name:
+                      description: Name of the Kubernetes object.
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                http:
+                  properties:
+                    service:
+                      properties:
+                        metadata:
+                          type: object
+                        spec:
+                          description: Spec is the specification of the service.
+                          properties:
+                            clusterIP:
+                              type: string
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            ipFamily:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                            ports:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    type: string
+                                  targetPort:
+                                    type: integer
+                                required:
+                                  - port
+                                type: object
+                              type: array
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                    tls:
+                      description: TLS defines options for configuring TLS for HTTP.
+                      properties:
+                        certificate:
+                          properties:
+                            secretName:
+                              description: SecretName is the name of the secret.
+                              type: string
+                          type: object
+                        selfSignedCertificate:
+                          properties:
+                            disabled:
+                              type: boolean
+                            subjectAltNames:
+                              items:
+                                properties:
+                                  dns:
+                                    description: DNS is the DNS name of the subject.
+                                    type: string
+                                  ip:
+                                    description: IP is the IP address of the subject.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                image:
+                  description: Image is the APM Server Docker image to deploy.
+                  type: string
+                podTemplate:
+                  type: object
+                secureSettings:
+                  items:
+                    properties:
+                      entries:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            path:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        type: array
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                      - secretName
+                    type: object
+                  type: array
+                version:
+                  description: Version of the APM Server.
+                  type: string
+              type: object
+            status:
+              description: ApmServerStatus defines the observed state of ApmServer
+              properties:
+                associationStatus:
+                  type: string
+                availableNodes:
+                  format: int32
+                  type: integer
+                health:
+                  type: string
+                secretTokenSecret:
+                  type: string
+                service:
+                  type: string
+              type: object
 status:
   acceptedNames:
     kind: ""
@@ -229,381 +222,370 @@ metadata:
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Elasticsearch version
-    name: version
-    type: string
-  - JSONPath: .status.phase
-    name: phase
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
-    - elastic
+      - elastic
     kind: Elasticsearch
     listKind: ElasticsearchList
     plural: elasticsearches
     shortNames:
-    - es
+      - es
     singular: elasticsearch
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+  versions:
+    - name: v1
+      storage: true
+      served: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-        spec:
           properties:
-            http:
-              description: HTTP holds HTTP layer settings for Elasticsearch.
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
               properties:
-                service:
+                http:
+                  description: HTTP holds HTTP layer settings for Elasticsearch.
+                  properties:
+                    service:
+                      properties:
+                        metadata:
+                          type: object
+                        spec:
+                          description: Spec is the specification of the service.
+                          properties:
+                            clusterIP:
+                              type: string
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            ipFamily:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                            ports:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    type: string
+                                  targetPort:
+                                    type: integer
+                                required:
+                                  - port
+                                type: object
+                              type: array
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                    tls:
+                      description: TLS defines options for configuring TLS for HTTP.
+                      properties:
+                        certificate:
+                          properties:
+                            secretName:
+                              description: SecretName is the name of the secret.
+                              type: string
+                          type: object
+                        selfSignedCertificate:
+                          properties:
+                            disabled:
+                              type: boolean
+                            subjectAltNames:
+                              items:
+                                properties:
+                                  dns:
+                                    description: DNS is the DNS name of the subject.
+                                    type: string
+                                  ip:
+                                    description: IP is the IP address of the subject.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                image:
+                  description: Image is the Elasticsearch Docker image to deploy.
+                  type: string
+                nodeSets:
+                  items:
+                    properties:
+                      config:
+                        description: Config holds the Elasticsearch configuration.
+                        type: object
+                      count:
+                        description: Count of Elasticsearch nodes to deploy.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      name:
+                        maxLength: 23
+                        pattern: "[a-zA-Z0-9-]+"
+                        type: string
+                      podTemplate:
+                        type: object
+                      volumeClaimTemplates:
+                        items:
+                          properties:
+                            apiVersion:
+                              type: string
+                            kind:
+                              type: string
+                            metadata:
+                              type: object
+                            spec:
+                              properties:
+                                accessModes:
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  properties:
+                                    apiGroup:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                    - kind
+                                    - name
+                                  type: object
+                                resources:
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  type: string
+                                volumeMode:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              type: object
+                            status:
+                              properties:
+                                accessModes:
+                                  items:
+                                    type: string
+                                  type: array
+                                capacity:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                conditions:
+                                  items:
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                      - status
+                                      - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase of PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                      - count
+                      - name
+                    type: object
+                  minItems: 1
+                  type: array
+                podDisruptionBudget:
                   properties:
                     metadata:
                       type: object
                     spec:
-                      description: Spec is the specification of the service.
+                      description: Spec is the specification of the PDB.
                       properties:
-                        clusterIP:
-                          type: string
-                        externalIPs:
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          type: string
-                        externalTrafficPolicy:
-                          type: string
-                        healthCheckNodePort:
-                          format: int32
+                        maxUnavailable:
                           type: integer
-                        ipFamily:
-                          type: string
-                        loadBalancerIP:
-                          type: string
-                        loadBalancerSourceRanges:
-                          items:
-                            type: string
-                          type: array
-                        ports:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              nodePort:
-                                format: int32
-                                type: integer
-                              port:
-                                format: int32
-                                type: integer
-                              protocol:
-                                type: string
-                              targetPort:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                          type: array
-                        publishNotReadyAddresses:
-                          type: boolean
+                        minAvailable:
+                          type: integer
                         selector:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        sessionAffinity:
-                          type: string
-                        sessionAffinityConfig:
                           properties:
-                            clientIP:
-                              properties:
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        type:
-                          type: string
-                      type: object
-                  type: object
-                tls:
-                  description: TLS defines options for configuring TLS for HTTP.
-                  properties:
-                    certificate:
-                      properties:
-                        secretName:
-                          description: SecretName is the name of the secret.
-                          type: string
-                      type: object
-                    selfSignedCertificate:
-                      properties:
-                        disabled:
-                          type: boolean
-                        subjectAltNames:
-                          items:
-                            properties:
-                              dns:
-                                description: DNS is the DNS name of the subject.
-                                type: string
-                              ip:
-                                description: IP is the IP address of the subject.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-              type: object
-            image:
-              description: Image is the Elasticsearch Docker image to deploy.
-              type: string
-            nodeSets:
-              items:
-                properties:
-                  config:
-                    description: Config holds the Elasticsearch configuration.
-                    type: object
-                  count:
-                    description: Count of Elasticsearch nodes to deploy.
-                    format: int32
-                    minimum: 1
-                    type: integer
-                  name:
-                    maxLength: 23
-                    pattern: '[a-zA-Z0-9-]+'
-                    type: string
-                  podTemplate:
-                    type: object
-                  volumeClaimTemplates:
-                    items:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        metadata:
-                          type: object
-                        spec:
-                          properties:
-                            accessModes:
+                            matchExpressions:
                               items:
-                                type: string
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                  - key
+                                  - operator
+                                type: object
                               type: array
-                            dataSource:
-                              properties:
-                                apiGroup:
-                                  type: string
-                                kind:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - kind
-                              - name
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            selector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            storageClassName:
-                              type: string
-                            volumeMode:
-                              type: string
-                            volumeName:
-                              type: string
-                          type: object
-                        status:
-                          properties:
-                            accessModes:
-                              items:
-                                type: string
-                              type: array
-                            capacity:
+                            matchLabels:
                               additionalProperties:
                                 type: string
                               type: object
-                            conditions:
-                              items:
-                                properties:
-                                  lastProbeTime:
-                                    description: Last time we probed the condition.
-                                    format: date-time
-                                    type: string
-                                  lastTransitionTime:
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    type: string
-                                  reason:
-                                    type: string
-                                  status:
-                                    type: string
-                                  type:
-                                    type: string
-                                required:
-                                - status
-                                - type
-                                type: object
-                              type: array
-                            phase:
-                              description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: object
+                      type: object
+                  type: object
+                secureSettings:
+                  items:
+                    properties:
+                      entries:
+                        items:
+                          properties:
+                            key:
                               type: string
-                          type: object
-                      type: object
-                    type: array
-                required:
-                - count
-                - name
-                type: object
-              minItems: 1
-              type: array
-            podDisruptionBudget:
-              properties:
-                metadata:
-                  type: object
-                spec:
-                  description: Spec is the specification of the PDB.
-                  properties:
-                    maxUnavailable:
-                      anyOf:
-                      - type: string
-                      - type: integer
-                    minAvailable:
-                      anyOf:
-                      - type: string
-                      - type: integer
-                    selector:
-                      properties:
-                        matchExpressions:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              operator:
-                                type: string
-                              values:
-                                items:
-                                  type: string
-                                type: array
-                            required:
+                            path:
+                              type: string
+                          required:
                             - key
-                            - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
                           type: object
-                      type: object
-                  type: object
-              type: object
-            secureSettings:
-              items:
-                properties:
-                  entries:
-                    items:
-                      properties:
-                        key:
-                        path:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                    type: array
-                  secretName:
-                    description: SecretName is the name of the secret.
-                    type: string
-                required:
-                - secretName
-                type: object
-              type: array
-            updateStrategy:
-              properties:
-                changeBudget:
+                        type: array
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                      - secretName
+                    type: object
+                  type: array
+                updateStrategy:
                   properties:
-                    maxSurge:
-                      format: int32
-                      type: integer
-                    maxUnavailable:
-                      format: int32
-                      type: integer
+                    changeBudget:
+                      properties:
+                        maxSurge:
+                          format: int32
+                          type: integer
+                        maxUnavailable:
+                          format: int32
+                          type: integer
+                      type: object
                   type: object
+                version:
+                  description: Version of Elasticsearch.
+                  type: string
+              required:
+                - nodeSets
               type: object
-            version:
-              description: Version of Elasticsearch.
-              type: string
-          required:
-          - nodeSets
-          type: object
-        status:
-          description: ElasticsearchStatus defines the observed state of Elasticsearch
-          properties:
-            availableNodes:
-              format: int32
-              type: integer
-            health:
-              type: string
-            phase:
-              type: string
-          type: object
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1alpha1
-    served: false
-    storage: false
+            status:
+              description: ElasticsearchStatus defines the observed state of Elasticsearch
+              properties:
+                availableNodes:
+                  format: int32
+                  type: integer
+                health:
+                  type: string
+                phase:
+                  type: string
+              type: object
+      additionalPrinterColumns:
+        - jsonPath: .status.health
+          name: health
+          type: string
+        - jsonPath: .status.availableNodes
+          description: Available nodes
+          name: nodes
+          type: integer
+        - jsonPath: .spec.version
+          description: Elasticsearch version
+          name: version
+          type: string
+        - jsonPath: .status.phase
+          name: phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
 status:
   acceptedNames:
     kind: ""
@@ -617,218 +599,210 @@ metadata:
   creationTimestamp: null
   name: kibanas.kibana.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Kibana version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
-    - elastic
+      - elastic
     kind: Kibana
     listKind: KibanaList
     plural: kibanas
     shortNames:
-    - kb
+      - kb
     singular: kibana
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Kibana represents a Kibana resource in a Kubernetes cluster.
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: KibanaSpec holds the specification of a Kibana instance.
-          properties:
-            config:
-              type: object
-            count:
-              description: Count of Kibana instances to deploy.
-              format: int32
-              type: integer
-            elasticsearchRef:
-              properties:
-                name:
-                  description: Name of the Kubernetes object.
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              type: object
-            http:
-              description: HTTP holds the HTTP layer configuration for Kibana.
-              properties:
-                service:
-                  properties:
-                    metadata:
-                      type: object
-                    spec:
-                      description: Spec is the specification of the service.
-                      properties:
-                        clusterIP:
-                          type: string
-                        externalIPs:
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          type: string
-                        externalTrafficPolicy:
-                          type: string
-                        healthCheckNodePort:
-                          format: int32
-                          type: integer
-                        ipFamily:
-                          type: string
-                        loadBalancerIP:
-                          type: string
-                        loadBalancerSourceRanges:
-                          items:
-                            type: string
-                          type: array
-                        ports:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              nodePort:
-                                format: int32
-                                type: integer
-                              port:
-                                format: int32
-                                type: integer
-                              protocol:
-                                type: string
-                              targetPort:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                          type: array
-                        publishNotReadyAddresses:
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        sessionAffinity:
-                          type: string
-                        sessionAffinityConfig:
-                          properties:
-                            clientIP:
-                              properties:
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        type:
-                          type: string
-                      type: object
-                  type: object
-                tls:
-                  description: TLS defines options for configuring TLS for HTTP.
-                  properties:
-                    certificate:
-                      properties:
-                        secretName:
-                          description: SecretName is the name of the secret.
-                          type: string
-                      type: object
-                    selfSignedCertificate:
-                      properties:
-                        disabled:
-                          type: boolean
-                        subjectAltNames:
-                          items:
-                            properties:
-                              dns:
-                                description: DNS is the DNS name of the subject.
-                                type: string
-                              ip:
-                                description: IP is the IP address of the subject.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-              type: object
-            image:
-              description: Image is the Kibana Docker image to deploy.
-              type: string
-            podTemplate:
-              type: object
-            secureSettings:
-              items:
-                properties:
-                  entries:
-                    items:
-                      properties:
-                        key:
-                          description: Key is the key contained in the secret.
-                          type: string
-                        path:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                    type: array
-                  secretName:
-                    description: SecretName is the name of the secret.
-                    type: string
-                required:
-                - secretName
-                type: object
-              type: array
-            version:
-              description: Version of Kibana.
-              type: string
-          type: object
-        status:
-          description: KibanaStatus defines the observed state of Kibana
-          properties:
-            associationStatus:
-              description: AssociationStatus is the status of an association resource.
-              type: string
-            availableNodes:
-              format: int32
-              type: integer
-            health:
-              description: KibanaHealth expresses the status of the Kibana instances.
-              type: string
-          type: object
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1alpha1
-    served: false
-    storage: false
+    - name: v1
+      storage: true
+      served: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: Kibana represents a Kibana resource in a Kubernetes cluster.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KibanaSpec holds the specification of a Kibana instance.
+              properties:
+                config:
+                  type: object
+                count:
+                  description: Count of Kibana instances to deploy.
+                  format: int32
+                  type: integer
+                elasticsearchRef:
+                  properties:
+                    name:
+                      description: Name of the Kubernetes object.
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                http:
+                  description: HTTP holds the HTTP layer configuration for Kibana.
+                  properties:
+                    service:
+                      properties:
+                        metadata:
+                          type: object
+                        spec:
+                          description: Spec is the specification of the service.
+                          properties:
+                            clusterIP:
+                              type: string
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            ipFamily:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                            ports:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    type: string
+                                  targetPort:
+                                    type: integer
+                                required:
+                                  - port
+                                type: object
+                              type: array
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                    tls:
+                      description: TLS defines options for configuring TLS for HTTP.
+                      properties:
+                        certificate:
+                          properties:
+                            secretName:
+                              description: SecretName is the name of the secret.
+                              type: string
+                          type: object
+                        selfSignedCertificate:
+                          properties:
+                            disabled:
+                              type: boolean
+                            subjectAltNames:
+                              items:
+                                properties:
+                                  dns:
+                                    description: DNS is the DNS name of the subject.
+                                    type: string
+                                  ip:
+                                    description: IP is the IP address of the subject.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                image:
+                  description: Image is the Kibana Docker image to deploy.
+                  type: string
+                podTemplate:
+                  type: object
+                secureSettings:
+                  items:
+                    properties:
+                      entries:
+                        items:
+                          properties:
+                            key:
+                              description: Key is the key contained in the secret.
+                              type: string
+                            path:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        type: array
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                      - secretName
+                    type: object
+                  type: array
+                version:
+                  description: Version of Kibana.
+                  type: string
+              type: object
+            status:
+              description: KibanaStatus defines the observed state of Kibana
+              properties:
+                associationStatus:
+                  description: AssociationStatus is the status of an association resource.
+                  type: string
+                availableNodes:
+                  format: int32
+                  type: integer
+                health:
+                  description: KibanaHealth expresses the status of the Kibana instances.
+                  type: string
+              type: object
+      additionalPrinterColumns:
+        - jsonPath: .status.health
+          name: health
+          type: string
+        - jsonPath: .status.availableNodes
+          description: Available nodes
+          name: nodes
+          type: integer
+        - jsonPath: .spec.version
+          description: Kibana version
+          name: version
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
 status:
   acceptedNames:
     kind: ""
@@ -842,119 +816,119 @@ kind: ClusterRole
 metadata:
   name: elastic-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - endpoints
-  - events
-  - persistentvolumeclaims
-  - secrets
-  - services
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - elasticsearch.k8s.elastic.co
-  resources:
-  - elasticsearches
-  - elasticsearches/status
-  - elasticsearches/finalizers
-  - enterpriselicenses
-  - enterpriselicenses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - kibana.k8s.elastic.co
-  resources:
-  - kibanas
-  - kibanas/status
-  - kibanas/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apm.k8s.elastic.co
-  resources:
-  - apmservers
-  - apmservers/status
-  - apmservers/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - associations.k8s.elastic.co
-  resources:
-  - apmserverelasticsearchassociations
-  - apmserverelasticsearchassociations/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - endpoints
+      - events
+      - persistentvolumeclaims
+      - secrets
+      - services
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - elasticsearch.k8s.elastic.co
+    resources:
+      - elasticsearches
+      - elasticsearches/status
+      - elasticsearches/finalizers
+      - enterpriselicenses
+      - enterpriselicenses/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - kibana.k8s.elastic.co
+    resources:
+      - kibanas
+      - kibanas/status
+      - kibanas/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apm.k8s.elastic.co
+    resources:
+      - apmservers
+      - apmservers/status
+      - apmservers/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - associations.k8s.elastic.co
+    resources:
+      - apmserverelasticsearchassociations
+      - apmserverelasticsearchassociations/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -966,9 +940,9 @@ roleRef:
   kind: ClusterRole
   name: elastic-operator
 subjects:
-- kind: ServiceAccount
-  name: elastic-operator
-  namespace: elastic-system
+  - kind: ServiceAccount
+    name: elastic-operator
+    namespace: elastic-system
 
 ---
 apiVersion: v1
@@ -996,41 +970,41 @@ spec:
     spec:
       serviceAccountName: elastic-operator
       containers:
-      - image: docker.elastic.co/eck/eck-operator:1.0.1
-        name: manager
-        args: ["manager", "--operator-roles", "all", "--log-verbosity=0"]
-        env:
-        - name: OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: WEBHOOK_SECRET
-          value: elastic-webhook-server-cert
-        - name: WEBHOOK_PODS_LABEL
-          value: elastic-operator
-        - name: OPERATOR_IMAGE
-          value: docker.elastic.co/eck/eck-operator:1.0.1
-        resources:
-          limits:
-            cpu: 1
-            memory: 150Mi
-          requests:
-            cpu: 100m
-            memory: 50Mi
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
+        - image: docker.elastic.co/eck/eck-operator:1.0.1
+          name: manager
+          args: ["manager", "--operator-roles", "all", "--log-verbosity=0"]
+          env:
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WEBHOOK_SECRET
+              value: elastic-webhook-server-cert
+            - name: WEBHOOK_PODS_LABEL
+              value: elastic-operator
+            - name: OPERATOR_IMAGE
+              value: docker.elastic.co/eck/eck-operator:1.0.1
+          resources:
+            limits:
+              cpu: 1
+              memory: 150Mi
+            requests:
+              cpu: 100m
+              memory: 50Mi
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: elastic-webhook-server-cert
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: elastic-webhook-server-cert
 
 ---
 apiVersion: v1
@@ -1040,47 +1014,53 @@ metadata:
   namespace: elastic-system
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: elastic-webhook.k8s.elastic.co
 webhooks:
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
-  failurePolicy: Ignore
-  name: elastic-es-validation-v1.k8s.elastic.co
-  rules:
-  - apiGroups:
-    - elasticsearch.k8s.elastic.co
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - elasticsearches
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
-  failurePolicy: Ignore
-  name: elastic-es-validation-v1beta1.k8s.elastic.co
-  rules:
-  - apiGroups:
-    - elasticsearch.k8s.elastic.co
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - elasticsearches
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: elastic-webhook-server
+        namespace: elastic-system
+        path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
+    failurePolicy: Ignore
+    admissionReviewVersions:
+      - v1beta1
+    sideEffects: None
+    name: elastic-es-validation-v1.k8s.elastic.co
+    rules:
+      - apiGroups:
+          - elasticsearch.k8s.elastic.co
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - elasticsearches
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: elastic-webhook-server
+        namespace: elastic-system
+        path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
+    failurePolicy: Ignore
+    admissionReviewVersions:
+      - v1beta1
+    sideEffects: None
+    name: elastic-es-validation-v1beta1.k8s.elastic.co
+    rules:
+      - apiGroups:
+          - elasticsearch.k8s.elastic.co
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - elasticsearches
 ---
 apiVersion: v1
 kind: Service
@@ -1089,8 +1069,8 @@ metadata:
   namespace: elastic-system
 spec:
   ports:
-  - port: 443
-    targetPort: 9443
+    - port: 443
+      targetPort: 9443
   selector:
     control-plane: elastic-operator
 ---


### PR DESCRIPTION
Was just taking the self-hosted instructions for a spin and followed
this guide

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22

... very naively to get the validation errors to stop. My editor also
auto-formatted so the reader may want to use the `w=1` query param.

I ended up just dropping all the pre-v1 versions of the crd's to get
something working quickly. I understand there are probably a number of
reasons why this isn't usable as is, but I figured I'd at least put it
up in case anyone could use it for prior art.