### PR TITLE
Add MatchRegexRule UDF

### DIFF
--- a/src/carnot/funcs/builtins/regex_ops.cc
+++ b/src/carnot/funcs/builtins/regex_ops.cc
@@ -32,7 +32,7 @@ void RegisterRegexOpsOrDie(udf::Registry* registry) {
   // String contains.
   registry->RegisterOrDie<RegexMatchUDF>("regex_match");
   registry->RegisterOrDie<RegexReplaceUDF>("replace");
-  registry->RegisterOrDie<MatchRegexRule>("match_regex_rule");
+  registry->RegisterOrDie<MatchRegexRule>("_match_regex_rule");
   /*****************************************
    * Aggregate UDFs.
    *****************************************/

--- a/src/carnot/funcs/builtins/regex_ops.cc
+++ b/src/carnot/funcs/builtins/regex_ops.cc
@@ -32,6 +32,7 @@ void RegisterRegexOpsOrDie(udf::Registry* registry) {
   // String contains.
   registry->RegisterOrDie<RegexMatchUDF>("regex_match");
   registry->RegisterOrDie<RegexReplaceUDF>("replace");
+  registry->RegisterOrDie<MatchRegexRule>("match_regex_rule");
   /*****************************************
    * Aggregate UDFs.
    *****************************************/

--- a/src/carnot/funcs/builtins/regex_ops.h
+++ b/src/carnot/funcs/builtins/regex_ops.h
@@ -121,12 +121,12 @@ class MatchRegexRule : public udf::ScalarUDF {
    if (!parse_result) {
      return Status(statuspb::Code::INVALID_ARGUMENT, "unable to parse string as json");
    }
-   // populate self::regex_rules_map_
+   // Populate the parse regular expressions into self::regex_rules_map_.
    for (rapidjson::Value::ConstMemberIterator itr = regex_rules.MemberBegin(); 
         itr != regex_rules.MemberEnd(); ++itr) {
     RegexMatchUDF regex_match_udf; 
-    auto name = itr->name.GetString();
-    auto regex_pattern = itr->value.GetString();
+    std::string name = itr->name.GetString();
+    std::string regex_pattern = itr->value.GetString();
     PL_RETURN_IF_ERROR(regex_match_udf.Init(ctx, regex_pattern)); 
     regex_rules_map_.emplace(name, std::move(regex_match_udf));
    }
@@ -139,7 +139,7 @@ class MatchRegexRule : public udf::ScalarUDF {
         return rule_name;
       }
     }
-  return "";
+    return "";
   }
 
   static udf::ScalarUDFDocBuilder Doc() {
@@ -158,7 +158,7 @@ class MatchRegexRule : public udf::ScalarUDF {
   }
 
  private:
-  std::map<std::string, RegexMatchUDF> regex_rules_map_;
+  absl::flat_hash_map<std::string, RegexMatchUDF> regex_rules_map_;
 };
 
 void RegisterRegexOpsOrDie(udf::Registry* registry);

--- a/src/carnot/funcs/builtins/regex_ops.h
+++ b/src/carnot/funcs/builtins/regex_ops.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <regex>
 #include <string>
+#include <utility>
+#include <vector>
 #include "re2/re2.h"
 #include "src/carnot/udf/registry.h"
 #include "src/common/base/utils.h"

--- a/src/carnot/funcs/builtins/regex_ops.h
+++ b/src/carnot/funcs/builtins/regex_ops.h
@@ -19,11 +19,11 @@
 #pragma once
 
 #include <absl/strings/strip.h>
+#include <rapidjson/document.h>
 #include <algorithm>
 #include <memory>
-#include <string>
 #include <regex>
-#include <rapidjson/document.h>
+#include <string>
 #include "re2/re2.h"
 #include "src/carnot/udf/registry.h"
 #include "src/common/base/utils.h"
@@ -115,25 +115,25 @@ class RegexReplaceUDF : public udf::ScalarUDF {
 class MatchRegexRule : public udf::ScalarUDF {
  public:
   Status Init(FunctionContext* ctx, StringValue encodedRegexRules) {
-   // parse encodedRegexRules as json
-   rapidjson::Document regex_rules;
-   rapidjson::ParseResult parse_result = regex_rules.Parse(encodedRegexRules.data());
-   if (!parse_result) {
-     return Status(statuspb::Code::INVALID_ARGUMENT, "unable to parse string as json");
-   }
-   // Populate the parse regular expressions into self::regex_rules_map_.
-   for (rapidjson::Value::ConstMemberIterator itr = regex_rules.MemberBegin(); 
-        itr != regex_rules.MemberEnd(); ++itr) {
-    RegexMatchUDF regex_match_udf; 
-    std::string name = itr->name.GetString();
-    std::string regex_pattern = itr->value.GetString();
-    PL_RETURN_IF_ERROR(regex_match_udf.Init(ctx, regex_pattern)); 
-    regex_rules_map_.emplace(name, std::move(regex_match_udf));
-   }
-   return Status::OK();
+    // parse encodedRegexRules as json
+    rapidjson::Document regex_rules;
+    rapidjson::ParseResult parse_result = regex_rules.Parse(encodedRegexRules.data());
+    if (!parse_result) {
+      return Status(statuspb::Code::INVALID_ARGUMENT, "unable to parse string as json");
+    }
+    // Populate the parse regular expressions into self::regex_rules_map_.
+    for (rapidjson::Value::ConstMemberIterator itr = regex_rules.MemberBegin();
+         itr != regex_rules.MemberEnd(); ++itr) {
+      RegexMatchUDF regex_match_udf;
+      std::string name = itr->name.GetString();
+      std::string regex_pattern = itr->value.GetString();
+      PL_RETURN_IF_ERROR(regex_match_udf.Init(ctx, regex_pattern));
+      regex_rules_map_.emplace(name, std::move(regex_match_udf));
+    }
+    return Status::OK();
   }
-  
-  types::StringValue Exec(FunctionContext *ctx, StringValue value) {
+
+  types::StringValue Exec(FunctionContext* ctx, StringValue value) {
     for (auto& [rule_name, regex_match_udf] : regex_rules_map_) {
       if (regex_match_udf.Exec(ctx, value).val) {
         return rule_name;
@@ -143,18 +143,24 @@ class MatchRegexRule : public udf::ScalarUDF {
   }
 
   static udf::ScalarUDFDocBuilder Doc() {
-    return udf::ScalarUDFDocBuilder("Check for a match to a json of regex pattern rules in a string.")
+    return udf::ScalarUDFDocBuilder(
+               "Check for a match to a json of regex pattern rules in a string.")
         .Details(
-            "This function checks the input string (second arg) for a match with the regex pattern rules"
+            "This function checks the input string (second arg) for a match with the regex pattern "
+            "rules"
             "(first arg). "
             "The regex pattern must match the full string. For example, the pattern 'abc' doesn't "
             "match the string 'abcd' but the pattern 'abc*' does match that string. "
             "We support google RE2 syntax. More details on that syntax can be found "
             "[here](https://github.com/google/re2/wiki/Syntax). ")
-        .Example("df.is_match = px.regex_match('{\"rule1\": \".*my_regex_pattern.*\"}', df.resp_body)")
-        .Arg("arg1", "The encoded json map from the name of the rule to the regex pattern for the rule.")
+        .Example(
+            "df.is_match = px.regex_match('{\"rule1\": \".*my_regex_pattern.*\"}', df.resp_body)")
+        .Arg("arg1",
+             "The encoded json map from the name of the rule to the regex pattern for the rule.")
         .Arg("arg2", "The string column to match the pattern against.")
-        .Returns("string representing the name of the first rule that matched or an empty string if no match.");
+        .Returns(
+            "string representing the name of the first rule that matched or an empty string if no "
+            "match.");
   }
 
  private:

--- a/src/carnot/funcs/builtins/regex_ops.h
+++ b/src/carnot/funcs/builtins/regex_ops.h
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <regex>
+#include <rapidjson/document.h>
 #include "re2/re2.h"
 #include "src/carnot/udf/registry.h"
 #include "src/common/base/utils.h"
@@ -108,6 +110,48 @@ class RegexReplaceUDF : public udf::ScalarUDF {
 
  private:
   std::unique_ptr<re2::RE2> regex_;
+};
+
+class MatchRegexRule : public udf::ScalarUDF {
+ public:
+  Status Init(FunctionContext*, StringValue encodedRegexRules) {
+    rapidjson::ParseResult ok = regex_rules.Parse(encodedRegexRules.data());
+    // TODO(zasgar/michellenguyen, PP-419): Replace with null when available.
+    if (ok == nullptr) {
+      return Status(statuspb::Code::INVALID_ARGUMENT, "unable to convert to json");
+    }
+    return Status::OK();
+  }
+  types::StringValue Exec(FunctionContext*, StringValue value) {
+    RegexMatchUDF regex_match; 
+    for (rapidjson::Value::ConstMemberIterator itr = regex_rules.MemberBegin(); itr != regex_rules.MemberEnd(); ++itr) {
+        auto name = itr->name.GetString();
+        PL_UNUSED(regex_match.Init(nullptr, itr->value.GetString()));
+        auto is_match = regex_match.Exec(nullptr, value).val;
+        if (is_match) {
+            return name; 
+        }
+    }
+    return "";
+  }
+
+  static udf::ScalarUDFDocBuilder Doc() {
+    return udf::ScalarUDFDocBuilder("Check for a match to a json of regex pattern rules in a string.")
+        .Details(
+            "This function checks the input string (second arg) for a match with the regex pattern rules"
+            "(first arg). "
+            "The regex pattern must match the full string. For example, the pattern 'abc' doesn't "
+            "match the string 'abcd' but the pattern 'abc*' does match that string. "
+            "We support google RE2 syntax. More details on that syntax can be found "
+            "[here](https://github.com/google/re2/wiki/Syntax). ")
+        .Example("df.is_match = px.regex_match('{\"rule1\": \".*my_regex_pattern.*\"}', df.resp_body)")
+        .Arg("arg1", "The encoded json of regex patterns to match.")
+        .Arg("arg2", "The string column to match the pattern against.")
+        .Returns("string representing the name of the first rule that matched or an empty string if no match.");
+  }
+
+ private:
+  rapidjson::Document regex_rules;
 };
 
 void RegisterRegexOpsOrDie(udf::Registry* registry);

--- a/src/carnot/funcs/builtins/regex_ops.h
+++ b/src/carnot/funcs/builtins/regex_ops.h
@@ -128,7 +128,7 @@ class MatchRegexRule : public udf::ScalarUDF {
       std::string name = itr->name.GetString();
       std::string regex_pattern = itr->value.GetString();
       PL_RETURN_IF_ERROR(regex_match_udf.Init(ctx, regex_pattern));
-      regex_rules.push_back(make_pair(name, std::move(regex_match_udf)));
+      regex_rules.emplace_back(make_pair(name, std::move(regex_match_udf)));
       regex_rules_length++;
     }
     return Status::OK();

--- a/src/carnot/funcs/builtins/regex_ops_test.cc
+++ b/src/carnot/funcs/builtins/regex_ops_test.cc
@@ -23,8 +23,8 @@
 
 #include "src/carnot/funcs/builtins/regex_ops.h"
 #include "src/carnot/udf/test_utils.h"
-#include "src/common/base/test_utils.h"
 #include "src/common/base/base.h"
+#include "src/common/base/test_utils.h"
 
 namespace px {
 namespace carnot {
@@ -77,27 +77,18 @@ TEST(RegexOps, invalid_regex_replace) {
 }
 
 TEST(RegexOps, regex_match_rules) {
-  auto udf_tester =
-      udf::UDFTester<MatchRegexRule>();
+  auto udf_tester = udf::UDFTester<MatchRegexRule>();
   // Value matches regex rule.
-  udf_tester.Init(
-    "{\"onpointerenter_event\":\"(?i).*onpointerenter.*\"}"
-  ).ForInput(
-    "UPDATE courses SET name = '<a/+/OnpOinteRENtER+=+a=prompt,a()%0dx>v3dm0s ' WHERE id = 2"
-  ).Expect("onpointerenter_event");
+  udf_tester.Init("{\"onpointerenter_event\":\"(?i).*onpointerenter.*\"}")
+      .ForInput(
+          "UPDATE courses SET name = '<a/+/OnpOinteRENtER+=+a=prompt,a()%0dx>v3dm0s ' WHERE id = 2")
+      .Expect("onpointerenter_event");
   // Value does not match regex rule.
-  udf_tester.Init(
-    "{\"onpointerenter_event\":\"(?i).*onpointerenter.*\"}"
-  ).ForInput(
-    "UPDATE courses SET name = 'foo' WHERE id = 2"
-  ).Expect("");
+  udf_tester.Init("{\"onpointerenter_event\":\"(?i).*onpointerenter.*\"}")
+      .ForInput("UPDATE courses SET name = 'foo' WHERE id = 2")
+      .Expect("");
   // Regex rules is not a valid json.
-  EXPECT_NOT_OK(
-    MatchRegexRule().Init(
-      nullptr,
-      "(?i).*onpointerenter.*"
-    )
-  );
+  EXPECT_NOT_OK(MatchRegexRule().Init(nullptr, "(?i).*onpointerenter.*"));
 }
 
 }  // namespace builtins

--- a/src/carnot/funcs/builtins/regex_ops_test.cc
+++ b/src/carnot/funcs/builtins/regex_ops_test.cc
@@ -23,6 +23,7 @@
 
 #include "src/carnot/funcs/builtins/regex_ops.h"
 #include "src/carnot/udf/test_utils.h"
+#include "src/common/base/test_utils.h"
 #include "src/common/base/base.h"
 
 namespace px {
@@ -73,6 +74,30 @@ TEST(RegexOps, invalid_regex_replace) {
       .Expect(
           "Invalid regex in substitution string: Rewrite schema error: '\\' must be followed by "
           "a digit or '\\'.");
+}
+
+TEST(RegexOps, regex_match_rules) {
+  auto udf_tester =
+      udf::UDFTester<MatchRegexRule>();
+  // Value matches regex rule.
+  udf_tester.Init(
+    "{\"onpointerenter_event\":\"(?i).*onpointerenter.*\"}"
+  ).ForInput(
+    "UPDATE courses SET name = '<a/+/OnpOinteRENtER+=+a=prompt,a()%0dx>v3dm0s ' WHERE id = 2"
+  ).Expect("onpointerenter_event");
+  // Value does not match regex rule.
+  udf_tester.Init(
+    "{\"onpointerenter_event\":\"(?i).*onpointerenter.*\"}"
+  ).ForInput(
+    "UPDATE courses SET name = 'foo' WHERE id = 2"
+  ).Expect("");
+  // Regex rules is not a valid json.
+  EXPECT_NOT_OK(
+    MatchRegexRule().Init(
+      nullptr,
+      "(?i).*onpointerenter.*"
+    )
+  );
 }
 
 }  // namespace builtins


### PR DESCRIPTION
Add MatchRegexRule UDF for use in security PxL scripts. 
* Add a UDF, MatchRegexRule, that takes an encoded json of regular expression rules, and string. It returns the first rule that matches the string or empty string if no match.
* Add unit tests for MatchRegexRule.