### PR TITLE
Add mux stitcher implementation

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/BUILD.bazel
@@ -46,6 +46,12 @@ pl_cc_test(
 )
 
 pl_cc_test(
+    name = "stitcher_test",
+    srcs = ["stitcher_test.cc"],
+    deps = [":cc_library"],
+)
+
+pl_cc_test(
     name = "types_test",
     srcs = ["types_test.cc"],
     deps = [":cc_library"],

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
@@ -74,7 +74,7 @@ RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
             break;
         }
 
-        if (! req_consumed) {
+        if (!req_consumed) {
             records.push_back({req, {}});
 
             error_count++;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
@@ -78,6 +78,7 @@ RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
             break;
         }
     }
+    // TODO(ddelnano): Clean up stale requests once there is a mechanism to do so
     for (const auto& req_frame : *reqs) {
         if (!req_frame.consumed) {
             break;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
@@ -59,11 +59,11 @@ RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
                 continue;
             }
 
-            std::optional<Type> matching_resp_type = GetMatchingRespType(req_type);
+            StatusOr<Type> matching_resp_type = GetMatchingRespType(req_type);
             Type res_type = static_cast<Type>(res.type);
             if (
-                !matching_resp_type.has_value() ||
-                res_type != matching_resp_type.value() ||
+                !matching_resp_type.ok() ||
+                res_type != matching_resp_type.ValueOrDie() ||
                 res.tag != req.tag
             ) {
                 continue;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h"
+
+#include <string>
+#include <utility>
+#include <variant>
+#include <set>
+
+#include <absl/strings/str_replace.h>
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/interface.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/parse.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
+#include "src/stirling/utils/binary_decoder.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mux {
+
+RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
+                                                  std::deque<mux::Frame>* resps) {
+    std::vector<mux::Record> records;
+    int error_count = 0;
+
+    for (auto& req : *reqs) {
+        auto req_consumed = false;
+        for (auto& res : *resps) {
+            Type req_type = static_cast<Type>(req.type);
+            if (req_type == Type::kTlease) {
+
+                records.push_back({req, {}});
+                req_consumed = true;
+                break;
+            }
+            if (req.timestamp_ns > res.timestamp_ns) {
+
+                records.push_back({{}, res});
+                resps->pop_front();
+                error_count++;
+                continue;
+            }
+
+            std::optional<Type> matching_resp_type = GetMatchingRespType(req_type);
+            Type res_type = static_cast<Type>(res.type);
+            if (
+                !matching_resp_type.has_value() ||
+                res_type != matching_resp_type.value() ||
+                res.tag != req.tag
+            ) {
+                continue;
+            }
+
+            records.push_back({req, res});
+            resps->pop_front();
+            req_consumed = true;
+            break;
+        }
+
+        if (! req_consumed) {
+            records.push_back({req, {}});
+
+            error_count++;
+        }
+    }
+    reqs->erase(reqs->begin(), reqs->end());
+    resps->erase(resps->begin(), resps->end());
+
+    return {records, error_count};
+}
+
+}  // namespace mux
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
@@ -44,6 +44,8 @@ RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
         auto req_consumed = false;
         for (auto& res : *resps) {
             Type req_type = static_cast<Type>(req.type);
+
+            // Tlease messages do not have a response pair
             if (req_type == Type::kTlease) {
 
                 records.push_back({req, {}});

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.cc
@@ -55,6 +55,7 @@ RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
 
                 resps->pop_front();
                 error_count++;
+                VLOG(1) << absl::Substitute("Did not find a request matching the response. Tag = $0 Type = $1", uint32_t(res.tag), res.type);
                 continue;
             }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h
@@ -30,14 +30,14 @@ namespace stirling {
 namespace protocols {
 namespace mux {
 
-    RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
-                                                         std::deque<mux::Frame>* resps);
+RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
+                                                std::deque<mux::Frame>* resps);
 }  // namespace mux
 
 template <>
 inline RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
-                                                         std::deque<mux::Frame>* resps,
-                                                         NoState* /*state*/) {
+                                                       std::deque<mux::Frame>* resps,
+                                                       NoState* /*state*/) {
   return mux::StitchFrames(reqs, resps);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <deque>
+#include <vector>
+
+#include "src/common/base/base.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/interface.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mux {
+
+    RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
+                                                         std::deque<mux::Frame>* resps);
+}  // namespace mux
+
+template <>
+inline RecordsWithErrorCount<mux::Record> StitchFrames(std::deque<mux::Frame>* reqs,
+                                                         std::deque<mux::Frame>* resps,
+                                                         NoState* /*state*/) {
+  return mux::StitchFrames(reqs, resps);
+}
+
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher_test.cc
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h"
+
+#include <string>
+
+#include "src/common/testing/testing.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/parse.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::Field;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+using ::testing::StrEq;
+
+class StitchFramesTest : public ::testing::Test {
+};
+
+mux::Frame CreateMuxFrame(uint64_t ts_ns, mux::Type type, uint32_t tag) {
+    mux::Frame frame;
+    frame.timestamp_ns = ts_ns;
+    frame.type = static_cast<int8_t>(type);
+    frame.tag = tag;
+    return frame;
+}
+
+TEST_F(StitchFramesTest, VerifyTransmitReceivePairsAreMatched) {
+    std::deque<mux::Frame> reqs = {
+        // tinit check message
+        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+        CreateMuxFrame(2, mux::Type::kTinit, 1),
+        CreateMuxFrame(4, mux::Type::kTping, 1),
+        CreateMuxFrame(6, mux::Type::kTdispatch, 1),
+        CreateMuxFrame(8, mux::Type::kTdiscardedOld, 1),
+        CreateMuxFrame(10, mux::Type::kTdiscarded, 1),
+        CreateMuxFrame(12, mux::Type::kTreq, 1),
+        CreateMuxFrame(14, mux::Type::kTdrain, 1),
+    };
+    std::deque<mux::Frame> resps = {
+        // tinit check message response
+        CreateMuxFrame(1, mux::Type::kRerrOld, 1),
+        CreateMuxFrame(3, mux::Type::kRinit, 1),
+        CreateMuxFrame(5, mux::Type::kRping, 1),
+        CreateMuxFrame(7, mux::Type::kRdispatch, 1),
+        CreateMuxFrame(9, mux::Type::kRdiscarded, 1),
+        CreateMuxFrame(11, mux::Type::kRdiscarded, 1),
+        CreateMuxFrame(13, mux::Type::kRreq, 1),
+        CreateMuxFrame(15, mux::Type::kRdrain, 1),
+    };
+
+    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+    EXPECT_EQ(result.error_count, 0);
+    EXPECT_EQ(result.records.size(), 8);
+    EXPECT_THAT(reqs, IsEmpty());
+    EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(StitchFramesTest, VerifyTleaseIsHandled) {
+    std::deque<mux::Frame> reqs = {
+        // tinit check message
+        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+        CreateMuxFrame(2, mux::Type::kTlease, 1),
+        CreateMuxFrame(4, mux::Type::kTping, 1),
+    };
+    std::deque<mux::Frame> resps = {
+        // tinit check message response
+        CreateMuxFrame(1, mux::Type::kRerrOld, 1),
+        CreateMuxFrame(5, mux::Type::kRping, 1),
+    };
+
+    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+
+    EXPECT_EQ(result.error_count, 0);
+    EXPECT_EQ(result.records.size(), 3);
+    EXPECT_EQ(mux::Type(result.records[1].req.type), mux::Type::kTlease);
+    // There is no response for Tlease so the response frame should
+    // have an uninitialized type field
+    EXPECT_EQ(result.records[1].resp.type, 0);
+
+    EXPECT_THAT(reqs, IsEmpty());
+    EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(StitchFramesTest, UnmatchedResponsesAreHandled) {
+    std::deque<mux::Frame> reqs = {
+        // tinit check message
+        CreateMuxFrame(1, mux::Type::kRerrOld, 1),
+    };
+    std::deque<mux::Frame> resps = {
+        // tinit check message response
+        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+        CreateMuxFrame(2, mux::Type::kRerrOld, 1),
+    };
+
+    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+
+    EXPECT_EQ(result.error_count, 1);
+    EXPECT_EQ(result.records.size(), 2);
+    EXPECT_EQ(mux::Type(result.records[0].resp.type), mux::Type::kRerrOld);
+    // Verify that the request in the unmatched request has an
+    // uninitialized type field
+    EXPECT_EQ(result.records[0].req.type, 0);
+
+    EXPECT_THAT(reqs, IsEmpty());
+    EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(StitchFramesTest, UnmatchedRequestsAreHandled) {
+    std::deque<mux::Frame> reqs = {
+        // tinit check message
+        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+        CreateMuxFrame(1, mux::Type::kTdispatch, 1),
+        CreateMuxFrame(3, mux::Type::kTdrain, 1),
+    };
+    std::deque<mux::Frame> resps = {
+        // tinit check message response
+        CreateMuxFrame(2, mux::Type::kRdispatch, 1),
+        CreateMuxFrame(4, mux::Type::kRdrain, 1),
+    };
+
+    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+
+    EXPECT_EQ(result.error_count, 1);
+    EXPECT_EQ(result.records.size(), 3);
+    EXPECT_EQ(mux::Type(result.records[0].req.type), mux::Type::kRerrOld);
+    // Verify that the response in the unmatched request has an
+    // uninitialized type field
+    EXPECT_EQ(result.records[0].resp.type, 0);
+
+    EXPECT_THAT(reqs, IsEmpty());
+    EXPECT_THAT(resps, IsEmpty());
+}
+
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher_test.cc
@@ -34,122 +34,117 @@ using ::testing::IsEmpty;
 using ::testing::SizeIs;
 using ::testing::StrEq;
 
-class StitchFramesTest : public ::testing::Test {
-};
+class StitchFramesTest : public ::testing::Test {};
 
 mux::Frame CreateMuxFrame(uint64_t ts_ns, mux::Type type, uint24_t tag) {
-    mux::Frame frame;
-    frame.timestamp_ns = ts_ns;
-    frame.type = static_cast<int8_t>(type);
-    frame.tag = tag;
-    return frame;
+  mux::Frame frame;
+  frame.timestamp_ns = ts_ns;
+  frame.type = static_cast<int8_t>(type);
+  frame.tag = tag;
+  return frame;
 }
 
 TEST_F(StitchFramesTest, VerifyTransmitReceivePairsAreMatched) {
-    std::deque<mux::Frame> reqs = {
-        // tinit check message
-        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
-        CreateMuxFrame(2, mux::Type::kTinit, 1),
-        CreateMuxFrame(4, mux::Type::kTping, 1),
-        CreateMuxFrame(6, mux::Type::kTdispatch, 1),
-        CreateMuxFrame(8, mux::Type::kTdiscardedOld, 1),
-        CreateMuxFrame(10, mux::Type::kTdiscarded, 1),
-        CreateMuxFrame(12, mux::Type::kTreq, 1),
-        CreateMuxFrame(14, mux::Type::kTdrain, 1),
-    };
-    std::deque<mux::Frame> resps = {
-        // tinit check message response
-        CreateMuxFrame(1, mux::Type::kRerrOld, 1),
-        CreateMuxFrame(3, mux::Type::kRinit, 1),
-        CreateMuxFrame(5, mux::Type::kRping, 1),
-        CreateMuxFrame(7, mux::Type::kRdispatch, 1),
-        CreateMuxFrame(9, mux::Type::kRdiscarded, 1),
-        CreateMuxFrame(11, mux::Type::kRdiscarded, 1),
-        CreateMuxFrame(13, mux::Type::kRreq, 1),
-        CreateMuxFrame(15, mux::Type::kRdrain, 1),
-    };
+  std::deque<mux::Frame> reqs = {
+      // tinit check message
+      CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+      CreateMuxFrame(2, mux::Type::kTinit, 1),
+      CreateMuxFrame(4, mux::Type::kTping, 1),
+      CreateMuxFrame(6, mux::Type::kTdispatch, 1),
+      CreateMuxFrame(8, mux::Type::kTdiscardedOld, 1),
+      CreateMuxFrame(10, mux::Type::kTdiscarded, 1),
+      CreateMuxFrame(12, mux::Type::kTreq, 1),
+      CreateMuxFrame(14, mux::Type::kTdrain, 1),
+  };
+  std::deque<mux::Frame> resps = {
+      // tinit check message response
+      CreateMuxFrame(1, mux::Type::kRerrOld, 1),    CreateMuxFrame(3, mux::Type::kRinit, 1),
+      CreateMuxFrame(5, mux::Type::kRping, 1),      CreateMuxFrame(7, mux::Type::kRdispatch, 1),
+      CreateMuxFrame(9, mux::Type::kRdiscarded, 1), CreateMuxFrame(11, mux::Type::kRdiscarded, 1),
+      CreateMuxFrame(13, mux::Type::kRreq, 1),      CreateMuxFrame(15, mux::Type::kRdrain, 1),
+  };
 
-    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
-    EXPECT_EQ(result.error_count, 0);
-    EXPECT_EQ(result.records.size(), 8);
-    EXPECT_THAT(reqs, IsEmpty());
-    EXPECT_THAT(resps, IsEmpty());
+  RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_EQ(result.records.size(), 8);
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
 }
 
 TEST_F(StitchFramesTest, VerifyTleaseIsHandled) {
-    std::deque<mux::Frame> reqs = {
-        // tinit check message
-        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
-        CreateMuxFrame(2, mux::Type::kTlease, 1),
-        CreateMuxFrame(4, mux::Type::kTping, 1),
-    };
-    std::deque<mux::Frame> resps = {
-        // tinit check message response
-        CreateMuxFrame(1, mux::Type::kRerrOld, 1),
-        CreateMuxFrame(5, mux::Type::kRping, 1),
-    };
+  std::deque<mux::Frame> reqs = {
+      // tinit check message
+      CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+      CreateMuxFrame(2, mux::Type::kTlease, 1),
+      CreateMuxFrame(4, mux::Type::kTping, 1),
+  };
+  std::deque<mux::Frame> resps = {
+      // tinit check message response
+      CreateMuxFrame(1, mux::Type::kRerrOld, 1),
+      CreateMuxFrame(5, mux::Type::kRping, 1),
+  };
 
-    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+  RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
 
-    EXPECT_EQ(result.error_count, 0);
-    EXPECT_EQ(result.records.size(), 3);
-    EXPECT_EQ(mux::Type(result.records[1].req.type), mux::Type::kTlease);
-    // There is no response for Tlease so the response frame should
-    // have an uninitialized type field
-    EXPECT_EQ(result.records[1].resp.type, 0);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_EQ(result.records.size(), 3);
+  EXPECT_EQ(mux::Type(result.records[1].req.type), mux::Type::kTlease);
+  // There is no response for Tlease so the response frame should
+  // have an uninitialized type field
+  EXPECT_EQ(result.records[1].resp.type, 0);
 
-    EXPECT_THAT(reqs, IsEmpty());
-    EXPECT_THAT(resps, IsEmpty());
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
 }
 
 TEST_F(StitchFramesTest, UnmatchedResponsesAreHandled) {
-    std::deque<mux::Frame> reqs = {
-        // tinit check message
-        CreateMuxFrame(1, mux::Type::kRerrOld, 1),
-    };
-    std::deque<mux::Frame> resps = {
-        // tinit check message response
-        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
-        CreateMuxFrame(2, mux::Type::kRerrOld, 1),
-    };
+  std::deque<mux::Frame> reqs = {
+      // tinit check message
+      CreateMuxFrame(1, mux::Type::kRerrOld, 1),
+  };
+  std::deque<mux::Frame> resps = {
+      // tinit check message response
+      CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+      CreateMuxFrame(2, mux::Type::kRerrOld, 1),
+  };
 
-    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+  RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
 
-    EXPECT_EQ(result.error_count, 1);
-    EXPECT_EQ(result.records.size(), 1);
-    EXPECT_EQ(mux::Type(result.records[0].resp.type), mux::Type::kRerrOld);
+  EXPECT_EQ(result.error_count, 1);
+  EXPECT_EQ(result.records.size(), 1);
+  EXPECT_EQ(mux::Type(result.records[0].resp.type), mux::Type::kRerrOld);
 
-    EXPECT_THAT(reqs, IsEmpty());
-    EXPECT_THAT(resps, IsEmpty());
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
 }
 
 TEST_F(StitchFramesTest, UnmatchedRequestsAreNotCleanedUp) {
-    std::deque<mux::Frame> reqs = {
-        // tinit check message
-        CreateMuxFrame(0, mux::Type::kRerrOld, 1),
-        CreateMuxFrame(1, mux::Type::kTdispatch, 1),
-        CreateMuxFrame(3, mux::Type::kTdrain, 1),
-    };
-    std::deque<mux::Frame> resps = {
-        CreateMuxFrame(2, mux::Type::kRdispatch, 1),
-        CreateMuxFrame(4, mux::Type::kRdrain, 1),
-    };
+  std::deque<mux::Frame> reqs = {
+      // tinit check message
+      CreateMuxFrame(0, mux::Type::kRerrOld, 1),
+      CreateMuxFrame(1, mux::Type::kTdispatch, 1),
+      CreateMuxFrame(3, mux::Type::kTdrain, 1),
+  };
+  std::deque<mux::Frame> resps = {
+      CreateMuxFrame(2, mux::Type::kRdispatch, 1),
+      CreateMuxFrame(4, mux::Type::kRdrain, 1),
+  };
 
-    RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
+  RecordsWithErrorCount<mux::Record> result = mux::StitchFrames(&reqs, &resps);
 
-    EXPECT_EQ(result.error_count, 0);
-    EXPECT_EQ(result.records.size(), 2);
-    EXPECT_EQ(mux::Type(result.records[0].req.type), mux::Type::kTdispatch);
-    EXPECT_EQ(mux::Type(result.records[1].req.type), mux::Type::kTdrain);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_EQ(result.records.size(), 2);
+  EXPECT_EQ(mux::Type(result.records[0].req.type), mux::Type::kTdispatch);
+  EXPECT_EQ(mux::Type(result.records[1].req.type), mux::Type::kTdrain);
 
-    // Since we can't know if the response pair has arrived
-    // yet the stitcher must keep unmatched requests arround
-    EXPECT_THAT(reqs.size(), 3);
-    EXPECT_THAT(reqs[0].consumed, false);
-    EXPECT_THAT(reqs[1].consumed, true);
-    EXPECT_THAT(reqs[2].consumed, true);
+  // Since we can't know if the response pair has arrived
+  // yet the stitcher must keep unmatched requests arround
+  EXPECT_THAT(reqs.size(), 3);
+  EXPECT_THAT(reqs[0].consumed, false);
+  EXPECT_THAT(reqs[1].consumed, true);
+  EXPECT_THAT(reqs[2].consumed, true);
 
-    EXPECT_THAT(resps, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
 }
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher_test.cc
@@ -37,7 +37,7 @@ using ::testing::StrEq;
 class StitchFramesTest : public ::testing::Test {
 };
 
-mux::Frame CreateMuxFrame(uint64_t ts_ns, mux::Type type, uint32_t tag) {
+mux::Frame CreateMuxFrame(uint64_t ts_ns, mux::Type type, uint24_t tag) {
     mux::Frame frame;
     frame.timestamp_ns = ts_ns;
     frame.type = static_cast<int8_t>(type);
@@ -134,7 +134,6 @@ TEST_F(StitchFramesTest, UnmatchedRequestsAreHandled) {
         CreateMuxFrame(3, mux::Type::kTdrain, 1),
     };
     std::deque<mux::Frame> resps = {
-        // tinit check message response
         CreateMuxFrame(2, mux::Type::kRdispatch, 1),
         CreateMuxFrame(4, mux::Type::kRdrain, 1),
     };

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
@@ -139,6 +139,7 @@ struct Frame : public FrameBase {
   int8_t type = 0;
   uint24_t tag = 0;
   std::string why;
+  bool consumed = false;
   // Reply status codes. Only present in Rdispatch messages types
   int8_t reply_status = 0;
   absl::flat_hash_map<std::string, absl::flat_hash_map<std::string, std::string>> context;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
@@ -83,9 +83,7 @@ inline StatusOr<Type> GetMatchingRespType(Type req_type) {
     case Type::kTdiscarded:
       return Type::kRdiscarded;
     default:
-      LOG(DFATAL) << absl::Substitute("Unexpected request type $0",
-                                      magic_enum::enum_name(req_type));
-      return {};
+      return error::Internal("Unexpected request type $0", magic_enum::enum_name(req_type));
   }
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
@@ -63,7 +63,7 @@ inline bool IsMuxType(int8_t t) {
   return mux_type.has_value();
 }
 
-inline std::optional<Type> GetMatchingRespType(Type req_type) {
+inline StatusOr<Type> GetMatchingRespType(Type req_type) {
   switch (req_type) {
     case Type::kRerrOld:
       return Type::kRerrOld;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types_test.cc
@@ -45,7 +45,7 @@ TEST(GetMatchingRespType, ReturnsCorrespondingResponseTypes) {
   ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdrain), Type::kRdrain);
   ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdispatch), Type::kRdispatch);
   ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTreq), Type::kRreq);
-  ASSERT_DEATH([&] { GetMatchingRespType(static_cast<Type>(0)); }(), "Unexpected request type");
+  ASSERT_NOT_OK(GetMatchingRespType(static_cast<Type>(0)));
 }
 
 }  // namespace mux

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types_test.cc
@@ -45,8 +45,7 @@ TEST(GetMatchingRespType, ReturnsCorrespondingResponseTypes) {
   ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdrain), Type::kRdrain);
   ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdispatch), Type::kRdispatch);
   ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTreq), Type::kRreq);
-  // TODO(ddelnano): This does not pass because of the LOG(DFATAL) statement in GetMatchingRespType
-  /* ASSERT_NOT_OK(GetMatchingRespType(static_cast<Type>(0))); */
+  ASSERT_DEATH([&] { GetMatchingRespType(static_cast<Type>(0)); }(), "Unexpected request type");
 }
 
 }  // namespace mux

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types_test.cc
@@ -36,15 +36,17 @@ TEST(IsMuxType, CanDetectMembershipOfSmallestAndLargestTypes) {
 }
 
 TEST(GetMatchingRespType, ReturnsCorrespondingResponseTypes) {
-  ASSERT_EQ(GetMatchingRespType(Type::kRerrOld), Type::kRerrOld);
-  ASSERT_EQ(GetMatchingRespType(Type::kRerr), Type::kRerr);
-  ASSERT_EQ(GetMatchingRespType(Type::kTinit), Type::kRinit);
-  ASSERT_EQ(GetMatchingRespType(Type::kTping), Type::kRping);
-  ASSERT_EQ(GetMatchingRespType(Type::kTdiscardedOld), Type::kRdiscarded);
-  ASSERT_EQ(GetMatchingRespType(Type::kTdiscarded), Type::kRdiscarded);
-  ASSERT_EQ(GetMatchingRespType(Type::kTdrain), Type::kRdrain);
-  ASSERT_EQ(GetMatchingRespType(Type::kTdispatch), Type::kRdispatch);
-  ASSERT_EQ(GetMatchingRespType(Type::kTreq), Type::kRreq);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kRerrOld), Type::kRerrOld);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kRerr), Type::kRerr);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTinit), Type::kRinit);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTping), Type::kRping);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdiscardedOld), Type::kRdiscarded);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdiscarded), Type::kRdiscarded);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdrain), Type::kRdrain);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTdispatch), Type::kRdispatch);
+  ASSERT_OK_AND_EQ(GetMatchingRespType(Type::kTreq), Type::kRreq);
+  // TODO(ddelnano): This does not pass because of the LOG(DFATAL) statement in GetMatchingRespType
+  /* ASSERT_NOT_OK(GetMatchingRespType(static_cast<Type>(0))); */
 }
 
 }  // namespace mux


### PR DESCRIPTION
This is the next step in supporting the mux protocol whose parser was added in 93a23272d2b78cce9fb8acc835e5f3ad263aa45c (#327).
## Testing
- [x] New stitcher tests pass which verify the following cases:
  - When there are requests with missing responses those frames are not consumed
  - When there are responses with missing requests those frames are consumed
  - Consumes frames that have matching request and response pairs