### PR TITLE
Add the base for thriftmux scala docker images (layers) used for end to end bpf testing

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -173,6 +173,8 @@ def pl_deps():
     _com_llvm_lib()
 
     _bazel_repo("io_bazel_rules_go")
+    _bazel_repo("io_bazel_rules_scala")
+    _bazel_repo("rules_jvm_external")
     _bazel_repo("com_github_bazelbuild_buildtools")
     _bazel_repo("bazel_skylib")
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -36,7 +36,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = [
             "https://github.com/bazelbuild/rules_scala/archive/e7a948ad1948058a7a5ddfbd9d1629d6db839933.zip",
         ],
-        strip_prefix = "rules_scala-%s" % "e7a948ad1948058a7a5ddfbd9d1629d6db839933",
+        strip_prefix = "rules_scala-e7a948ad1948058a7a5ddfbd9d1629d6db839933",
     ),
     io_bazel_rules_k8s = dict(
         sha256 = "cc75cf0d86312e1327d226e980efd3599704e01099b58b3c2fc4efe5e321fcd9",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -31,6 +31,13 @@ REPOSITORY_LOCATIONS = dict(
             "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
         ],
     ),
+    io_bazel_rules_scala = dict(
+        sha256 = "76e1abb8a54f61ada974e6e9af689c59fd9f0518b49be6be7a631ce9fa45f236",
+        urls = [
+            "https://github.com/bazelbuild/rules_scala/archive/e7a948ad1948058a7a5ddfbd9d1629d6db839933.zip",
+        ],
+        strip_prefix = "rules_scala-%s" % "e7a948ad1948058a7a5ddfbd9d1629d6db839933",
+    ),
     io_bazel_rules_k8s = dict(
         sha256 = "cc75cf0d86312e1327d226e980efd3599704e01099b58b3c2fc4efe5e321fcd9",
         strip_prefix = "rules_k8s-0.3.1",
@@ -303,6 +310,11 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/USCiLab/cereal/archive/af0700efb25e7dc7af637b9e6f970dbb94813bff.tar.gz"],
         strip_prefix = "cereal-af0700efb25e7dc7af637b9e6f970dbb94813bff",
         sha256 = "6b8e8975400a84eed20dcf4490f1b16efaadbbad6d1b5ffcc5e1da3e5be1c324",
+    ),
+    rules_jvm_external = dict(
+        urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/4.2.zip"],
+        sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
+        strip_prefix = "rules_jvm_external-4.2",
     ),
 )
 

--- a/src/stirling/source_connectors/socket_tracer/testing/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/BUILD.bazel
@@ -43,6 +43,7 @@ pl_cc_test_library(
         "//src/stirling/source_connectors/socket_tracer/testing/containers:ruby_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:zookeeper_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers/pgsql:demo_client_image.tar",
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image.tar",
         "//src/stirling/testing/demo_apps/go_grpc_tls_pl/client:client_image.tar",
         "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:server_image.tar",
         "//src/stirling/testing/demo_apps/go_https/client:client_image.tar",

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images.h
@@ -239,6 +239,25 @@ class DNSServerContainer : public ContainerRunner {
   static constexpr std::string_view kReadyMessage = "all zones loaded";
 };
 
+//
+//-----------------------------------------------------------------------------
+// Mux
+//-----------------------------------------------------------------------------
+
+// A ThriftMux server
+class ThriftMuxServerContainer : public ContainerRunner {
+ public:
+  ThriftMuxServerContainer()
+      : ContainerRunner(::px::testing::BazelBinTestFilePath(kBazelImageTar), kContainerNamePrefix,
+                        kReadyMessage) {}
+
+ private:
+  static constexpr std::string_view kBazelImageTar =
+      "src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.tar";
+  static constexpr std::string_view kContainerNamePrefix = "thriftmux_server";
+  static constexpr std::string_view kReadyMessage = "Finagle version";
+};
+
 //-----------------------------------------------------------------------------
 // MySQL
 //-----------------------------------------------------------------------------

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -19,6 +19,8 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
 
+package(default_visibility = ["//src/stirling:__subpackages__"])
+
 thrift_library(
     name = "thrift_library",
     srcs = glob(["**/*.thrift"]),
@@ -74,15 +76,6 @@ scala_image(
     name = "server_image",
     srcs = glob(["**/*.scala"]),
     main_class = "Server",
-    deps = [
-        ":thriftmux_scrooge",
-    ],
-)
-
-scala_image(
-    name = "client_image",
-    srcs = glob(["**/*.scala"]),
-    main_class = "Client",
     deps = [
         ":thriftmux_scrooge",
     ],

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -1,0 +1,89 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_docker//scala:image.bzl", "scala_image")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+
+thrift_library(
+    name = "thrift_library",
+    srcs = glob(["**/*.thrift"]),
+)
+
+scala_library(
+    name = "scrooge_jars",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_twitter_finagle_core_2_13",
+        "@maven//:com_twitter_finagle_http_2_13",
+        "@maven//:com_twitter_finagle_mux_2_13",
+        "@maven//:com_twitter_finagle_thrift_2_13",
+        "@maven//:com_twitter_finagle_thriftmux_2_13",
+        "@maven//:com_twitter_scrooge_core_2_13",
+    ],
+)
+
+scala_library(
+    name = "thrift_jars",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:org_apache_thrift_libthrift",
+    ],
+)
+
+scrooge_scala_library(
+    name = "thriftmux_scrooge",
+    deps = [
+        ":thrift_library",
+    ],
+)
+
+scala_binary(
+    name = "server_bin",
+    srcs = glob(["**/*.scala"]),
+    main_class = "Server",
+    deps = [
+        ":thriftmux_scrooge",
+    ],
+)
+
+scala_binary(
+    name = "client_bin",
+    srcs = glob(["**/*.scala"]),
+    main_class = "Client",
+    deps = [
+        ":thriftmux_scrooge",
+    ],
+)
+
+scala_image(
+    name = "server_image",
+    srcs = glob(["**/*.scala"]),
+    main_class = "Server",
+    deps = [
+        ":thriftmux_scrooge",
+    ],
+)
+
+scala_image(
+    name = "client_image",
+    srcs = glob(["**/*.scala"]),
+    main_class = "Client",
+    deps = [
+        ":thriftmux_scrooge",
+    ],
+)

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
@@ -1,0 +1,7 @@
+# Thriftmux image
+
+This directory contains the build files for running a thriftmux client and server.
+
+## About the container
+
+See `mux_container_bpf_test.cc` for use case.

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
@@ -4,4 +4,14 @@ This directory contains the build files for running a thriftmux client and serve
 
 ## About the container
 
+This container can be run as a thriftmux server or client.
+
+```
+# Runs the server by default
+$ bazel run src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
+
+# Run the client. This requires using 'docker run' directly to override the default entrypoint
+$ docker run --entrypoint /usr/bin/java bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client
+```
+
 See `mux_container_bpf_test.cc` for use case.

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
@@ -1,0 +1,13 @@
+import com.twitter.util.{Await, Future}
+import com.twitter.finagle.thriftmux.thriftscala.TestService
+import com.twitter.finagle.{Thrift, ThriftMux}
+
+object Client extends App {
+  val stackClient = ThriftMux.client.withLabel("thriftmux_example")
+  val svcPerEndpoint = stackClient
+    .methodBuilder("inet!localhost:8080")
+    .servicePerEndpoint[TestService.ServicePerEndpoint]
+  val svc = ThriftMux.Client.methodPerEndpoint[TestService.ServicePerEndpoint, TestService.MethodPerEndpoint](svcPerEndpoint)
+  val r = Await.result(svc.query("String"))
+  println(r)
+}

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/server/Server.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/server/Server.scala
@@ -1,0 +1,21 @@
+import com.twitter.finagle.{Http, Service}
+import com.twitter.finagle.http
+import com.twitter.finagle.{Thrift, ThriftMux}
+import com.twitter.util.{Await, Future}
+import java.net.{InetSocketAddress, InetAddress}
+import com.twitter.finagle.thriftmux.thriftscala.TestService
+
+object Server {
+  def main(args: Array[String]): Unit = {
+    val server = ThriftMux.server
+      .serveIface(
+        new InetSocketAddress(InetAddress.getLoopbackAddress, 8080),
+        new TestService.MethodPerEndpoint {
+          def query(x: String): Future[String] = Future.value(x + x)
+          def question(y: String): Future[String] = Future.value(y + y)
+          def inquiry(z: String): Future[String] = Future.value(z + z)
+        },
+      )
+    Await.ready(server)
+  }
+}

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/thrift/testservice.thrift
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/thrift/testservice.thrift
@@ -1,0 +1,24 @@
+namespace java com.twitter.finagle.thriftmux.thriftjava
+#@namespace scala com.twitter.finagle.thriftmux.thriftscala
+
+exception InvalidQueryException {
+  1: i32 errorCode
+}
+
+service TestService {
+  string query(1: string x) throws (
+    1: InvalidQueryException ex
+  )
+
+  string question(1: string y) throws (
+    1: InvalidQueryException ex
+  )
+
+  string inquiry(1: string z) throws (
+      1: InvalidQueryException ex
+    )
+}
+
+service FanoutTestService {
+  list<string> query(1: list<string> x)
+}


### PR DESCRIPTION
This PR pulls out the thriftmux container changes necessary for #351. It also switches the build process to use bazel entirely rather than using docker directly.

## Testing
- [x] Used this change in #367 to verify that it works properly