### PR TITLE
Integrate mux parser into stirling

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -173,6 +173,24 @@ pl_cc_test(
 )
 
 pl_cc_test(
+    name = "mux_trace_bpf_test",
+    timeout = "moderate",
+    srcs = ["mux_trace_bpf_test.cc"],
+    flaky = True,
+    tags = [
+        "no_asan",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/common/testing/test_utils:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/protocols/test_output_generator:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/testing:cc_library",
+    ],
+)
+
+pl_cc_test(
     name = "mysql_trace_bpf_test",
     timeout = "moderate",
     srcs = ["mysql_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
@@ -541,7 +541,7 @@ static __inline enum message_type_t infer_mux_message(const char* buf, size_t co
   }
 
   if (tag < 1 || tag > ((1 << 23) - 1)) {
-       return kUnknown;
+    return kUnknown;
   }
 
   return msg_type;

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
@@ -487,6 +487,54 @@ static __inline bool is_redis_message(const char* buf, size_t count) {
   return true;
 }
 
+static __inline enum message_type_t infer_mux_message(const char* buf, size_t count) {
+  static const int8_t kTreq = 1;
+  static const int8_t kRreq = -1;
+  static const int8_t kTdispatch = 2;
+  static const int8_t kRdispatch = -2;
+  static const int8_t kTdrain = 64;
+  static const int8_t kRdrain = -64;
+  static const int8_t kTping = 65;
+  static const int8_t kRping = -65;
+  static const int8_t kTdiscarded = 66;
+  static const int8_t kRdiscarded = -66;
+  static const int8_t kTlease = 67;
+  static const int8_t kTinit = 68;
+  static const int8_t kRinit = -68;
+  static const int8_t kRerr = -128;
+  static const int8_t kTdiscardedOld = -62;
+  static const int8_t kRerrOld = 127;
+
+  if (count < 8) {
+    return kUnknown;
+  }
+
+  int8_t mux_type = buf[4];
+  switch (mux_type) {
+    case kTreq:
+    case kTdispatch:
+    case kTdrain:
+    case kTping:
+    case kTdiscarded:
+    case kTinit:
+    case kTlease:
+    case kTdiscardedOld:
+    // TODO(ddelnano): Verify if this should be a req or a resp
+    case kRerrOld:
+      return kRequest;
+    case kRreq:
+    case kRdispatch:
+    case kRdrain:
+    case kRping:
+    case kRdiscarded:
+    case kRinit:
+    case kRerr:
+      return kResponse;
+    default:
+      return kUnknown;
+  }
+}
+
 // NATS messages are in texts. The role is inferred from the message type.
 // See https://github.com/nats-io/docs/blob/master/nats_protocol/nats-protocol.md
 //
@@ -555,6 +603,8 @@ static __inline struct protocol_message_t infer_protocol(const char* buf, size_t
     inferred_message.protocol = kProtocolPGSQL;
   } else if ((inferred_message.type = infer_mysql_message(buf, count, conn_info)) != kUnknown) {
     inferred_message.protocol = kProtocolMySQL;
+  } else if ((inferred_message.type = infer_mux_message(buf, count)) != kUnknown) {
+    inferred_message.protocol = kProtocolMux;
   } else if ((inferred_message.type = infer_kafka_message(buf, count, conn_info)) != kUnknown) {
     inferred_message.protocol = kProtocolKafka;
   } else if ((inferred_message.type = infer_dns_message(buf, count)) != kUnknown) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
@@ -487,6 +487,10 @@ static __inline bool is_redis_message(const char* buf, size_t count) {
   return true;
 }
 
+// TODO(ddelnano): Mux protocol traffic is currently misidentified as ssh. Since
+// stirling doesn't have ssh support yet, but will need to be addressed. In addition,
+// mux seems to send the header and body on its protocol in two separate syscalls on
+// the server side.
 static __inline enum message_type_t infer_mux_message(const char* buf, size_t count) {
   // mux's on the wire format causes false positives for protocol inference
   // In order to address this, we only infer mux messages by the
@@ -525,14 +529,6 @@ static __inline enum message_type_t infer_mux_message(const char* buf, size_t co
       break;
     default:
       return kUnknown;
-  }
-
-  // Since protocol inference only has access to data from a given syscall
-  // it's possible we cannot read enough data to more confidently classify
-  // if it's the mux protocol. Therefore return what our best guess
-  // is if we cannot provide a stronger guarantee
-  if (count < length) {
-    return msg_type;
   }
 
   if (mux_type == kRerr || mux_type == kRerrOld) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h
@@ -536,28 +536,18 @@ static __inline enum message_type_t infer_mux_message(const char* buf, size_t co
   }
 
   if (mux_type == kRerr || mux_type == kRerrOld) {
-    if (
-      buf[length-5] != 'c' ||
-      buf[length-4] != 'h' ||
-      buf[length-3] != 'e' ||
-      buf[length-2] != 'c' ||
-      buf[length-1] != 'k'
-    ) return kUnknown;
+    if (buf[length - 5] != 'c' || buf[length - 4] != 'h' || buf[length - 3] != 'e' ||
+        buf[length - 2] != 'c' || buf[length - 1] != 'k')
+      return kUnknown;
   }
 
   if (mux_type == kRinit || mux_type == kTinit) {
-    if (
-      buf[mux_framer_pos]     != 'm' ||
-      buf[mux_framer_pos + 1] != 'u' ||
-      buf[mux_framer_pos + 2] != 'x' ||
-      buf[mux_framer_pos + 3] != '-' ||
-      buf[mux_framer_pos + 4] != 'f' ||
-      buf[mux_framer_pos + 5] != 'r' ||
-      buf[mux_framer_pos + 6] != 'a' ||
-      buf[mux_framer_pos + 7] != 'm' ||
-      buf[mux_framer_pos + 8] != 'e' ||
-      buf[mux_framer_pos + 9] != 'r'
-    ) return kUnknown;
+    if (buf[mux_framer_pos] != 'm' || buf[mux_framer_pos + 1] != 'u' ||
+        buf[mux_framer_pos + 2] != 'x' || buf[mux_framer_pos + 3] != '-' ||
+        buf[mux_framer_pos + 4] != 'f' || buf[mux_framer_pos + 5] != 'r' ||
+        buf[mux_framer_pos + 6] != 'a' || buf[mux_framer_pos + 7] != 'm' ||
+        buf[mux_framer_pos + 8] != 'e' || buf[mux_framer_pos + 9] != 'r')
+      return kUnknown;
   }
 
   if (tag < 1 || tag > ((1 << 23) - 1)) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
@@ -377,8 +377,8 @@ TEST(ProtocolInferenceTest, Mux) {
   constexpr uint8_t kReqFrame[] = {
     // mux length (15 bytes)
     0x00, 0x00, 0x00, 0x0f,
-    // Tdrain type
-    0x40,
+    // RerrOld type
+    0x7f,
     // tag
     0x00, 0x00, 0x01,
     // why
@@ -388,8 +388,8 @@ TEST(ProtocolInferenceTest, Mux) {
   constexpr uint8_t kResp[] = {
     // mux length (15 bytes)
     0x00, 0x00, 0x00, 0x0f,
-    // RerrOld type
-    0x7f,
+    // Rerr type
+    0x80,
     // tag
     0x00, 0x00, 0x01,
     // why
@@ -402,12 +402,8 @@ TEST(ProtocolInferenceTest, Mux) {
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
   EXPECT_EQ(protocol_message.type, kRequest);
 
-  /* protocol_message = infer_protocol(reinterpret_cast<const char*>(kReqHeaderFrame), */
-  /*                                   sizeof(kReqHeaderFrame), &conn_info); */
-  /* EXPECT_EQ(protocol_message.protocol, kProtocolUnknown); */
-
   protocol_message =
       infer_protocol(reinterpret_cast<const char*>(kResp), sizeof(kResp), &conn_info);
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
-  EXPECT_EQ(protocol_message.type, kRequest);
+  EXPECT_EQ(protocol_message.type, kResponse);
 }

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
@@ -374,7 +374,7 @@ TEST(ProtocolInferenceTest, Mux) {
   struct conn_info_t conn_info = {};
 
   // clang-format off
-  constexpr uint8_t kReqFrame[] = {
+  constexpr uint8_t kRerrReqFrame[] = {
     // mux length (15 bytes)
     0x00, 0x00, 0x00, 0x0f,
     // RerrOld type
@@ -385,7 +385,7 @@ TEST(ProtocolInferenceTest, Mux) {
     0x74, 0x69, 0x6e, 0x69, 0x74, 0x20, 0x63, 0x68, 0x65, 0x63, 0x6b,
   };
 
-  constexpr uint8_t kResp[] = {
+  constexpr uint8_t kRerrResp[] = {
     // mux length (15 bytes)
     0x00, 0x00, 0x00, 0x0f,
     // Rerr type
@@ -395,15 +395,59 @@ TEST(ProtocolInferenceTest, Mux) {
     // why
     0x74, 0x69, 0x6e, 0x69, 0x74, 0x20, 0x63, 0x68, 0x65, 0x63, 0x6b,
   };
+
+  constexpr uint8_t kTinitReqFrame[] = {
+    // mux length (42 bytes)
+    0x00, 0x00, 0x00, 0x2a,
+    // Tinit type
+    0x44,
+    // tag
+    0x00, 0x00, 0x01,
+    // TODO(ddelnano): figure out what these 6 bytes
+    // are for T/Rinit messages
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x0a,
+    // m     u     x     -     f     r     a     m     e     r
+    0x6d, 0x75, 0x78, 0x2d, 0x66, 0x72, 0x61, 0x6d, 0x65, 0x72,
+    // Rest of the Rinit frame
+    0x00, 0x00, 0x00, 0x04, 0x7f, 0xff, 0xff, 0xff,
+    0x00, 0x00, 0x00, 0x03, 0x74, 0x6c, 0x73, 0x00, 0x00, 0x00, 0x03, 0x6f, 0x66, 0x66,
+  };
+
+  constexpr uint8_t kRinitResp[] = {
+    // mux length (42 bytes)
+    0x00, 0x00, 0x00, 0x2a,
+    // Rinit type
+    0xbc,
+    // tag
+    0x00, 0x00, 0x01,
+    // TODO(ddelnano): figure out what these 6 bytes
+    // are for T/Rinit messages
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x0a,
+    // m     u     x     -     f     r     a     m     e     r
+    0x6d, 0x75, 0x78, 0x2d, 0x66, 0x72, 0x61, 0x6d, 0x65, 0x72,
+    // Rest of the Rinit frame
+    0x00, 0x00, 0x00, 0x04, 0x7f, 0xff, 0xff, 0xff,
+    0x00, 0x00, 0x00, 0x03, 0x74, 0x6c, 0x73, 0x00, 0x00, 0x00, 0x03, 0x6f, 0x66, 0x66,
+  };
   // clang-format on
 
   auto protocol_message =
-      infer_protocol(reinterpret_cast<const char*>(kReqFrame), sizeof(kReqFrame), &conn_info);
+      infer_protocol(reinterpret_cast<const char*>(kRerrReqFrame), sizeof(kRerrReqFrame), &conn_info);
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
   EXPECT_EQ(protocol_message.type, kRequest);
 
   protocol_message =
-      infer_protocol(reinterpret_cast<const char*>(kResp), sizeof(kResp), &conn_info);
+      infer_protocol(reinterpret_cast<const char*>(kRerrResp), sizeof(kRerrResp), &conn_info);
+  EXPECT_EQ(protocol_message.protocol, kProtocolMux);
+  EXPECT_EQ(protocol_message.type, kResponse);
+
+  protocol_message =
+      infer_protocol(reinterpret_cast<const char*>(kTinitReqFrame), sizeof(kTinitReqFrame), &conn_info);
+  EXPECT_EQ(protocol_message.protocol, kProtocolMux);
+  EXPECT_EQ(protocol_message.type, kRequest);
+
+  protocol_message =
+      infer_protocol(reinterpret_cast<const char*>(kRinitResp), sizeof(kRinitResp), &conn_info);
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
   EXPECT_EQ(protocol_message.type, kResponse);
 }

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
@@ -409,5 +409,5 @@ TEST(ProtocolInferenceTest, Mux) {
   protocol_message =
       infer_protocol(reinterpret_cast<const char*>(kResp), sizeof(kResp), &conn_info);
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
-  EXPECT_EQ(protocol_message.type, kResponse);
+  EXPECT_EQ(protocol_message.type, kRequest);
 }

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
@@ -369,3 +369,45 @@ TEST(ProtocolInferenceTest, NATS) {
   constexpr std::string_view kERRMessage = "-ERR {} \r\n";
   EXPECT_EQ(call(kERRMessage), kResponse);
 }
+
+TEST(ProtocolInferenceTest, Mux) {
+  struct conn_info_t conn_info = {};
+
+  // clang-format off
+  constexpr uint8_t kReqFrame[] = {
+    // mux length (15 bytes)
+    0x00, 0x00, 0x00, 0x0f,
+    // Tdrain type
+    0x40,
+    // tag
+    0x00, 0x00, 0x01,
+    // why
+    0x74, 0x69, 0x6e, 0x69, 0x74, 0x20, 0x63, 0x68, 0x65, 0x63, 0x6b,
+  };
+
+  constexpr uint8_t kResp[] = {
+    // mux length (15 bytes)
+    0x00, 0x00, 0x00, 0x0f,
+    // RerrOld type
+    0x7f,
+    // tag
+    0x00, 0x00, 0x01,
+    // why
+    0x74, 0x69, 0x6e, 0x69, 0x74, 0x20, 0x63, 0x68, 0x65, 0x63, 0x6b,
+  };
+  // clang-format on
+
+  auto protocol_message =
+      infer_protocol(reinterpret_cast<const char*>(kReqFrame), sizeof(kReqFrame), &conn_info);
+  EXPECT_EQ(protocol_message.protocol, kProtocolMux);
+  EXPECT_EQ(protocol_message.type, kRequest);
+
+  /* protocol_message = infer_protocol(reinterpret_cast<const char*>(kReqHeaderFrame), */
+  /*                                   sizeof(kReqHeaderFrame), &conn_info); */
+  /* EXPECT_EQ(protocol_message.protocol, kProtocolUnknown); */
+
+  protocol_message =
+      infer_protocol(reinterpret_cast<const char*>(kResp), sizeof(kResp), &conn_info);
+  EXPECT_EQ(protocol_message.protocol, kProtocolMux);
+  EXPECT_EQ(protocol_message.type, kResponse);
+}

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
@@ -431,8 +431,8 @@ TEST(ProtocolInferenceTest, Mux) {
   };
   // clang-format on
 
-  auto protocol_message =
-      infer_protocol(reinterpret_cast<const char*>(kRerrReqFrame), sizeof(kRerrReqFrame), &conn_info);
+  auto protocol_message = infer_protocol(reinterpret_cast<const char*>(kRerrReqFrame),
+                                         sizeof(kRerrReqFrame), &conn_info);
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
   EXPECT_EQ(protocol_message.type, kRequest);
 
@@ -441,8 +441,8 @@ TEST(ProtocolInferenceTest, Mux) {
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
   EXPECT_EQ(protocol_message.type, kResponse);
 
-  protocol_message =
-      infer_protocol(reinterpret_cast<const char*>(kTinitReqFrame), sizeof(kTinitReqFrame), &conn_info);
+  protocol_message = infer_protocol(reinterpret_cast<const char*>(kTinitReqFrame),
+                                    sizeof(kTinitReqFrame), &conn_info);
   EXPECT_EQ(protocol_message.protocol, kProtocolMux);
   EXPECT_EQ(protocol_message.type, kRequest);
 

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
@@ -59,6 +59,7 @@ enum traffic_protocol_t {
   kProtocolNATS = 8,
   kProtocolMongo = 9,
   kProtocolKafka = 10,
+  kProtocolMux = 11,
 
 // We use magic enum to iterate through protocols in C++ land,
 // and don't want the C-enum-size trick to show up there.

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
@@ -611,6 +611,7 @@ auto CreateTraceRoles() {
   res.Set(kProtocolNATS, {kRoleServer});
   res.Set(kProtocolMongo, {kRoleServer});
   res.Set(kProtocolKafka, {kRoleServer});
+  res.Set(kProtocolMux, {kRoleServer});
   DCHECK(res.AreAllKeysSet());
   return res;
 }

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker_test.cc
@@ -787,7 +787,9 @@ INSTANTIATE_TEST_SUITE_P(
         UpdateStateParam{kProtocolMongo, kRoleClient, ConnTracker::State::kCollecting},
         UpdateStateParam{kProtocolMongo, kRoleServer, ConnTracker::State::kTransferring},
         UpdateStateParam{kProtocolKafka, kRoleClient, ConnTracker::State::kCollecting},
-        UpdateStateParam{kProtocolKafka, kRoleServer, ConnTracker::State::kTransferring}));
+        UpdateStateParam{kProtocolKafka, kRoleServer, ConnTracker::State::kTransferring},
+        UpdateStateParam{kProtocolMux, kRoleClient, ConnTracker::State::kCollecting},
+        UpdateStateParam{kProtocolMux, kRoleServer, ConnTracker::State::kTransferring}));
 
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -192,6 +192,8 @@ void DataStream::ProcessBytesToFrames(message_type_t type, TStateType* state) {
 // PROTOCOL_LIST: Requires update on new protocols.
 template void DataStream::ProcessBytesToFrames<protocols::http::Message, protocols::NoState>(
     message_type_t type, protocols::NoState* state);
+template void DataStream::ProcessBytesToFrames<protocols::mux::Frame, protocols::NoState>(
+    message_type_t type, protocols::NoState* state);
 template void
 DataStream::ProcessBytesToFrames<protocols::mysql::Packet, protocols::mysql::StateWrapper>(
     message_type_t type, protocols::mysql::StateWrapper* state);

--- a/src/stirling/source_connectors/socket_tracer/mux_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mux_table.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <map>
+
+#include "src/stirling/core/types.h"
+#include "src/stirling/source_connectors/socket_tracer/canonical_types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
+
+namespace px {
+namespace stirling {
+
+// clang-format off
+static constexpr DataElement kMuxElements[] = {
+        canonical_data_elements::kTime,
+        canonical_data_elements::kUPID,
+        canonical_data_elements::kRemoteAddr,
+        canonical_data_elements::kRemotePort,
+        canonical_data_elements::kTraceRole,
+        {"req_type", "Mux message request type",
+         types::DataType::INT64,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL_ENUM},
+        {"resp_type", "Mux message response type",
+         types::DataType::INT64,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL_ENUM},
+        {"tag", "Mux message request tag",
+         types::DataType::INT64,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL_ENUM},
+        canonical_data_elements::kLatencyNS,
+#ifndef NDEBUG
+        canonical_data_elements::kPXInfo,
+#endif
+};
+// clang-format on
+
+static constexpr auto kMuxTable =
+    DataTableSchema("mux_events", "Mux request-response pair events", kMuxElements);
+DEFINE_PRINT_TABLE(Mux)
+
+static constexpr int kMuxUPIDIdx = kMuxTable.ColIndex("upid");
+static constexpr int kMuxReqTypeIdx = kMuxTable.ColIndex("req_type");
+static constexpr int kMuxRespTypeIdx = kMuxTable.ColIndex("resp_type");
+static constexpr int kMuxTagIdx = kMuxTable.ColIndex("tag");
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/mux_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mux_table.h
@@ -38,14 +38,6 @@ static constexpr DataElement kMuxElements[] = {
          types::DataType::INT64,
          types::SemanticType::ST_NONE,
          types::PatternType::GENERAL_ENUM},
-        {"resp_type", "Mux message response type",
-         types::DataType::INT64,
-         types::SemanticType::ST_NONE,
-         types::PatternType::GENERAL_ENUM},
-        {"tag", "Mux message request tag",
-         types::DataType::INT64,
-         types::SemanticType::ST_NONE,
-         types::PatternType::GENERAL_ENUM},
         canonical_data_elements::kLatencyNS,
 #ifndef NDEBUG
         canonical_data_elements::kPXInfo,
@@ -59,8 +51,6 @@ DEFINE_PRINT_TABLE(Mux)
 
 static constexpr int kMuxUPIDIdx = kMuxTable.ColIndex("upid");
 static constexpr int kMuxReqTypeIdx = kMuxTable.ColIndex("req_type");
-static constexpr int kMuxRespTypeIdx = kMuxTable.ColIndex("resp_type");
-static constexpr int kMuxTagIdx = kMuxTable.ColIndex("tag");
 
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/mux_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mux_table.h
@@ -45,6 +45,11 @@ static constexpr DataElement kMuxElements[] = {
 };
 // clang-format on
 
+// TODO(ddelnano): We may choose to augment the mux table with any
+// nested thrift data during thriftmux (apache thrift over mux)
+// or choose to store thrift data separately. stirling does not
+// have support for handling nested protcols so this will require
+// more discussion.
 static constexpr auto kMuxTable =
     DataTableSchema("mux_events", "Mux request-response pair events", kMuxElements);
 DEFINE_PRINT_TABLE(Mux)

--- a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
@@ -114,7 +114,7 @@ std::vector<mux::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& r
   return result;
 }
 
-mux::Record GetRecordWithTagAndType(uint24_t tag, mux::Type req_type, mux::Type resp_type) {
+mux::Record RecordWithTagAndType(uint24_t tag, mux::Type req_type, mux::Type resp_type) {
   mux::Record r = {};
   r.req.tag = tag;
   r.req.type = static_cast<int8_t>(req_type);
@@ -160,11 +160,11 @@ TEST_F(MuxTraceTest, Capture) {
 
   std::vector<mux::Record> server_records = GetTargetRecords(record_batch, server_.process_pid());
 
-  mux::Record tinitCheck = GetRecordWithTagAndType(1, mux::Type::kRerrOld, mux::Type::kRerrOld);
-  mux::Record tinit = GetRecordWithTagAndType(1, mux::Type::kTinit, mux::Type::kRinit);
-  mux::Record pingRecord = GetRecordWithTagAndType(1, mux::Type::kTping, mux::Type::kRping);
+  mux::Record tinitCheck = RecordWithTagAndType(1, mux::Type::kRerrOld, mux::Type::kRerrOld);
+  mux::Record tinit = RecordWithTagAndType(1, mux::Type::kTinit, mux::Type::kRinit);
+  mux::Record pingRecord = RecordWithTagAndType(1, mux::Type::kTping, mux::Type::kRping);
   mux::Record dispatchRecord =
-      GetRecordWithTagAndType(2, mux::Type::kTdispatch, mux::Type::kRdispatch);
+      RecordWithTagAndType(2, mux::Type::kTdispatch, mux::Type::kRdispatch);
 
   EXPECT_THAT(server_records, Contains(EqMuxRecord(tinitCheck)));
   EXPECT_THAT(server_records, Contains(EqMuxRecord(tinit)));

--- a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <absl/strings/str_replace.h>
+
+#include "src/common/base/base.h"
+#include "src/common/base/test_utils.h"
+#include "src/common/exec/exec.h"
+#include "src/common/testing/testing.h"
+#include "src/shared/types/column_wrapper.h"
+#include "src/shared/types/types.h"
+#include "src/stirling/core/data_table.h"
+#include "src/stirling/core/output.h"
+#include "src/stirling/source_connectors/socket_tracer/mux_table.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
+#include "src/stirling/testing/common.h"
+
+namespace px {
+namespace stirling {
+
+namespace mux = protocols::mux;
+
+using ::px::stirling::testing::ColWrapperSizeIs;
+using ::px::stirling::testing::FindRecordIdxMatchesPID;
+using ::px::stirling::testing::FindRecordsMatchingPID;
+using ::px::stirling::testing::SocketTraceBPFTest;
+using ::testing::AllOf;
+using ::testing::UnorderedElementsAre;
+using ::testing::UnorderedElementsAreArray;
+
+using ::testing::Each;
+using ::testing::Field;
+using ::testing::MatchesRegex;
+
+class MuxTraceTest : public SocketTraceBPFTest</* TClientSideTracing */ true> {
+ protected:
+  MuxTraceTest() {
+    // The container runner will make sure it is in the ready state before unblocking.
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+
+    // Run the thriftmux server and then the thriftmux client container
+    PL_CHECK_OK(server_.Run(std::chrono::seconds{60}));
+  }
+
+  std::string thriftmux_client_output = "StringString";
+
+  std::string classpath =
+      "@/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/"
+      "server_image.classpath";
+
+  StatusOr<int32_t> RunThriftMuxClient() {
+    std::string cmd =
+        absl::StrFormat("docker exec %s /usr/bin/java -cp %s Client & echo $! && wait",
+                        server_.container_name(), classpath);
+    PL_ASSIGN_OR_RETURN(std::string out, px::Exec(cmd));
+
+    LOG(INFO) << absl::StrFormat("thriftmux client command output: '%s'", out);
+
+    std::vector<std::string> tokens = absl::StrSplit(out, "\n");
+
+    int32_t client_pid;
+    if (!absl::SimpleAtoi(tokens[0], &client_pid)) {
+      return error::Internal("Could not extract PID.");
+    }
+
+    LOG(INFO) << absl::StrFormat("Client PID: %d", client_pid);
+
+    if (tokens[1] != thriftmux_client_output) {
+      return error::Internal(
+          absl::StrFormat("Expected output from thriftmux to be '%s', received '%s' instead",
+                          thriftmux_client_output, tokens[1]));
+    }
+    return client_pid;
+  }
+
+  ::px::stirling::testing::ThriftMuxServerContainer server_;
+};
+
+std::vector<mux::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
+                                        const std::vector<size_t>& indices) {
+  std::vector<mux::Record> result;
+
+  for (const auto& idx : indices) {
+    mux::Record r;
+    uint24_t tag = static_cast<uint24_t>(rb[kMuxTagIdx]->Get<types::Int64Value>(idx).val);
+    r.req.tag = tag;
+    r.req.type = static_cast<int8_t>(rb[kMuxReqTypeIdx]->Get<types::Int64Value>(idx).val);
+    r.resp.tag = tag;
+    r.resp.type = static_cast<int8_t>(rb[kMuxRespTypeIdx]->Get<types::Int64Value>(idx).val);
+    result.push_back(r);
+  }
+  return result;
+}
+
+std::vector<mux::Record> GetTargetRecords(const types::ColumnWrapperRecordBatch& record_batch,
+                                          int32_t pid) {
+  std::vector<size_t> target_record_indices =
+      FindRecordIdxMatchesPID(record_batch, kMuxUPIDIdx, pid);
+  return ToRecordVector(record_batch, target_record_indices);
+}
+
+inline auto EqMux(const mux::Frame& x) {
+  return AllOf(Field(&mux::Frame::type, ::testing::Eq(x.type)),
+               Field(&mux::Frame::tag, ::testing::Eq(x.tag)));
+}
+
+inline auto EqMuxRecord(const mux::Record& x) {
+  return AllOf(Field(&mux::Record::req, EqMux(x.req)), Field(&mux::Record::resp, EqMux(x.resp)));
+}
+
+//-----------------------------------------------------------------------------
+// Test Scenarios
+//-----------------------------------------------------------------------------
+
+TEST_F(MuxTraceTest, Capture) {
+  StartTransferDataThread();
+
+  ASSERT_OK(RunThriftMuxClient());
+
+  StopTransferDataThread();
+
+  // Grab the data from Stirling.
+  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kMuxTableNum);
+  ASSERT_FALSE(tablets.empty());
+  types::ColumnWrapperRecordBatch record_batch = tablets[0].records;
+
+  std::vector<mux::Record> server_records = GetTargetRecords(record_batch, server_.process_pid());
+
+  mux::Record expected = {};
+  expected.req.tag = 1;
+  expected.req.type = 127;
+  expected.resp.tag = 1;
+  expected.resp.type = 127;
+
+  // TODO(ddelnano): Figure out why only the Rerr message is recorded.
+  // There should be a Tinit/Rinit, Tdispatch/Rdispatch and Tping/Rping as well
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(expected)));
+}
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
@@ -124,9 +124,7 @@ std::vector<mux::Record> GetTargetRecords(const types::ColumnWrapperRecordBatch&
   return ToRecordVector(record_batch, target_record_indices);
 }
 
-inline auto EqMux(const mux::Frame& x) {
-  return Field(&mux::Frame::type, ::testing::Eq(x.type));
-}
+inline auto EqMux(const mux::Frame& x) { return Field(&mux::Frame::type, ::testing::Eq(x.type)); }
 
 inline auto EqMuxRecord(const mux::Record& x) {
   return AllOf(Field(&mux::Record::req, EqMux(x.req)), Field(&mux::Record::resp, EqMux(x.resp)));

--- a/src/stirling/source_connectors/socket_tracer/protocols/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/BUILD.bazel
@@ -39,6 +39,7 @@ pl_cc_library(
         "//src/stirling/source_connectors/socket_tracer/protocols/http:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/http2:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/kafka:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/protocols/mux:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/mysql:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/nats:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/pgsql:cc_library",

--- a/src/stirling/source_connectors/socket_tracer/protocols/stitchers.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/stitchers.h
@@ -24,6 +24,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/http2/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/kafka/stitcher.h"  // IWYU pragma: export
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/mysql/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/nats/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.h"  // IWYU pragma: export

--- a/src/stirling/source_connectors/socket_tracer/protocols/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/types.h
@@ -26,6 +26,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/http2/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/kafka/common/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mysql/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/nats/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/pgsql/types.h"
@@ -40,6 +41,7 @@ namespace protocols {
 using FrameDequeVariant = std::variant<std::monostate,
                                        std::deque<cass::Frame>,
                                        std::deque<http::Message>,
+                                       std::deque<mux::Frame>,
                                        std::deque<mysql::Packet>,
                                        std::deque<pgsql::RegularMessage>,
                                        std::deque<dns::Frame>,

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -851,7 +851,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
   r.Append<r.ColIndex("req_type")>(entry.req.type);
   r.Append<r.ColIndex("resp_type")>(entry.resp.type);
-  r.Append<r.ColIndex("tag")>(int32_t(entry.req.tag));
+  r.Append<r.ColIndex("tag")>(static_cast<int32_t>(entry.req.tag));
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns));
 #ifndef NDEBUG

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -86,6 +86,8 @@ DEFINE_bool(stirling_enable_nats_tracing, true,
             "If true, stirling will trace and process NATS messages.");
 DEFINE_bool(stirling_enable_kafka_tracing, true,
             "If true, stirling will trace and process Kafka messages.");
+DEFINE_bool(stirling_enable_mux_tracing, true,
+            "If true, stirling will trace and process Mux messages.");
 
 DEFINE_bool(stirling_disable_self_tracing, true,
             "If true, stirling will not trace and process syscalls made by itself.");
@@ -164,6 +166,10 @@ void SocketTraceConnector::InitProtocolTransferSpecs() {
                                     kKafkaTableNum,
                                     {kRoleClient, kRoleServer},
                                     TRANSFER_STREAM_PROTOCOL(kafka)}},
+      {kProtocolMux, TransferSpec{FLAGS_stirling_enable_mux_tracing,
+                                  kMuxTableNum,
+                                  {kRoleClient, kRoleServer},
+                                  TRANSFER_STREAM_PROTOCOL(mux)}},
       {kProtocolUnknown, TransferSpec{false /*enabled*/,
                                       // Unknown protocols attached to HTTP table so that they run
                                       // their cleanup functions, but the use of nullptr transfer_fn
@@ -826,6 +832,28 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns));
   r.Append<r.ColIndex("req_cmd")>(ToString(entry.req.tag, /* is_req */ true));
+#ifndef NDEBUG
+  r.Append<r.ColIndex("px_info_")>(ToString(conn_tracker.conn_id()));
+#endif
+}
+
+template <>
+void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
+                                         protocols::mux::Record entry, DataTable* data_table) {
+  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
+                conn_tracker.conn_id().upid.start_time_ticks);
+
+  DataTable::RecordBuilder<&kMuxTable> r(data_table, entry.resp.timestamp_ns);
+  r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
+  r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
+  r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
+  r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("req_type")>(entry.req.type);
+  r.Append<r.ColIndex("resp_type")>(entry.resp.type);
+  r.Append<r.ColIndex("tag")>(int32_t(entry.req.tag));
+  r.Append<r.ColIndex("latency")>(
+      CalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns));
 #ifndef NDEBUG
   r.Append<r.ColIndex("px_info_")>(ToString(conn_tracker.conn_id()));
 #endif

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -850,8 +850,6 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
   r.Append<r.ColIndex("req_type")>(entry.req.type);
-  r.Append<r.ColIndex("resp_type")>(entry.resp.type);
-  r.Append<r.ColIndex("tag")>(static_cast<int32_t>(entry.req.tag));
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns));
 #ifndef NDEBUG

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -58,6 +58,7 @@ DECLARE_bool(stirling_enable_dns_tracing);
 DECLARE_bool(stirling_enable_redis_tracing);
 DECLARE_bool(stirling_enable_nats_tracing);
 DECLARE_bool(stirling_enable_kafka_tracing);
+DECLARE_bool(stirling_enable_mux_tracing);
 DECLARE_bool(stirling_disable_self_tracing);
 DECLARE_string(stirling_role_to_trace);
 
@@ -72,7 +73,7 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   static constexpr std::string_view kName = "socket_tracer";
   static constexpr auto kTables =
       MakeArray(kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable,
-                kRedisTable, kNATSTable, kKafkaTable);
+                kRedisTable, kNATSTable, kKafkaTable, kMuxTable);
 
   static constexpr uint32_t kConnStatsTableNum = TableNum(kTables, kConnStatsTable);
   static constexpr uint32_t kHTTPTableNum = TableNum(kTables, kHTTPTable);
@@ -83,6 +84,7 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   static constexpr uint32_t kRedisTableNum = TableNum(kTables, kRedisTable);
   static constexpr uint32_t kNATSTableNum = TableNum(kTables, kNATSTable);
   static constexpr uint32_t kKafkaTableNum = TableNum(kTables, kKafkaTable);
+  static constexpr uint32_t kMuxTableNum = TableNum(kTables, kMuxTable);
 
   static constexpr auto kSamplingPeriod = std::chrono::milliseconds{200};
   // TODO(yzhao): This is not used right now. Eventually use this to control data push frequency.
@@ -341,6 +343,7 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   FRIEND_TEST(SocketTraceConnectorTest, ConnectionCleanupInactiveDead);
   FRIEND_TEST(SocketTraceConnectorTest, ConnectionCleanupInactiveAlive);
   FRIEND_TEST(SocketTraceConnectorTest, ConnectionCleanupNoProtocol);
+  FRIEND_TEST(SocketTraceConnectorTest, MuxBasic);
   FRIEND_TEST(SocketTraceConnectorTest, MySQLPrepareExecuteClose);
   FRIEND_TEST(SocketTraceConnectorTest, MySQLQuery);
   FRIEND_TEST(SocketTraceConnectorTest, MySQLMultipleCommands);

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -343,7 +343,6 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   FRIEND_TEST(SocketTraceConnectorTest, ConnectionCleanupInactiveDead);
   FRIEND_TEST(SocketTraceConnectorTest, ConnectionCleanupInactiveAlive);
   FRIEND_TEST(SocketTraceConnectorTest, ConnectionCleanupNoProtocol);
-  FRIEND_TEST(SocketTraceConnectorTest, MuxBasic);
   FRIEND_TEST(SocketTraceConnectorTest, MySQLPrepareExecuteClose);
   FRIEND_TEST(SocketTraceConnectorTest, MySQLQuery);
   FRIEND_TEST(SocketTraceConnectorTest, MySQLMultipleCommands);

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_tables.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_tables.h
@@ -25,6 +25,7 @@
 #include "src/stirling/source_connectors/socket_tracer/dns_table.h"
 #include "src/stirling/source_connectors/socket_tracer/http_table.h"
 #include "src/stirling/source_connectors/socket_tracer/kafka_table.h"
+#include "src/stirling/source_connectors/socket_tracer/mux_table.h"
 #include "src/stirling/source_connectors/socket_tracer/mysql_table.h"
 #include "src/stirling/source_connectors/socket_tracer/nats_table.h"
 #include "src/stirling/source_connectors/socket_tracer/pgsql_table.h"

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images.h
@@ -253,12 +253,10 @@ class DNSServerContainer : public ContainerRunner {
   static constexpr std::string_view kReadyMessage = "all zones loaded";
 };
 
-//
 //-----------------------------------------------------------------------------
 // Mux
 //-----------------------------------------------------------------------------
 
-// A ThriftMux server
 class ThriftMuxServerContainer : public ContainerRunner {
  public:
   ThriftMuxServerContainer()

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images.h
@@ -253,6 +253,25 @@ class DNSServerContainer : public ContainerRunner {
   static constexpr std::string_view kReadyMessage = "all zones loaded";
 };
 
+//
+//-----------------------------------------------------------------------------
+// Mux
+//-----------------------------------------------------------------------------
+
+// A ThriftMux server
+class ThriftMuxServerContainer : public ContainerRunner {
+ public:
+  ThriftMuxServerContainer()
+      : ContainerRunner(::px::testing::BazelBinTestFilePath(kBazelImageTar), kContainerNamePrefix,
+                        kReadyMessage) {}
+
+ private:
+  static constexpr std::string_view kBazelImageTar =
+      "src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.tar";
+  static constexpr std::string_view kContainerNamePrefix = "thriftmux_server";
+  static constexpr std::string_view kReadyMessage = "Finagle version";
+};
+
 //-----------------------------------------------------------------------------
 // Mux
 //-----------------------------------------------------------------------------

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images.h
@@ -273,23 +273,6 @@ class ThriftMuxServerContainer : public ContainerRunner {
 };
 
 //-----------------------------------------------------------------------------
-// Mux
-//-----------------------------------------------------------------------------
-
-class ThriftMuxServerContainer : public ContainerRunner {
- public:
-  ThriftMuxServerContainer()
-      : ContainerRunner(::px::testing::BazelBinTestFilePath(kBazelImageTar), kContainerNamePrefix,
-                        kReadyMessage) {}
-
- private:
-  static constexpr std::string_view kBazelImageTar =
-      "src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.tar";
-  static constexpr std::string_view kContainerNamePrefix = "thriftmux_server";
-  static constexpr std::string_view kReadyMessage = "Finagle version";
-};
-
-//-----------------------------------------------------------------------------
 // MySQL
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
This is my second attempt at integrating the mux parser into stirling. I'm opening this preemptively to show that the testing for #366 was successful, but we need to merge that PR first and rebase to pull out the docker image related changes. 

## Todo
- [x] Fix issue that is causing a subset of mux data from being collected
- [x] Debug why a bug in Tping/Rping parsing causes the mux stitcher to lose data 
  - Incorrectly stripping the buffer caused the Tdispatch/Rdispatch frames to go missing. Fixing that bug causes all of the frames to exist except the Rping/Tping (since the Rping isn't parsed correctly). After looking at this again with more experience debugging this problem, I'm able to verify that the stitcher behaves as expected even with the Rping parser bug
- [x] Decrease false positive rate of mux protocol inference. I attempted to do this by parsing more of the mux message when the entire frame is available.
- [x] Avoid mutating mux stitcher deques by using iterators
- [ ] Understand T/Rinit message structure better (6 unknown bytes) and update the mux parser accordingly