### PR TITLE
fix(logical_planner_test.cc): healthz filter

### DIFF
--- a/src/carnot/planner/logical_planner_test.cc
+++ b/src/carnot/planner/logical_planner_test.cc
@@ -266,7 +266,7 @@ df.failure = df.resp_status >= 400
 df.timestamp = px.bin(df.time_, px.seconds(num_seconds))
 df[k8s_object] = df.ctx[k8s_object]
 filter_pods = px.contains(df[k8s_object], match_name)
-filter_out_conds = ((df.req_path != '/health' or not filter_health) and (
+filter_out_conds = ((df.req_path != '/healthz' or not filter_health) and (
     df.req_path != '/readyz' or not filter_readyz)) and (
     df[ip] != '-' or not filter_dash)
 


### PR DESCRIPTION
The standard health endpoint for Kubernetes apps is `/healthz` (rather than `/health`).

See https://github.com/pixie-io/pixie/commit/588f2541d7f4bc901cb39a1f5009941d09025fb0

Signed-off-by: lloydchang <lloydchang@gmail.com>