### PR TITLE
Update thriftmux test container to support tls via a command line flag

### DIFF
--- a/bazel/pl_workspace.bzl
+++ b/bazel/pl_workspace.bzl
@@ -53,6 +53,7 @@ def _package_manager_setup():
             "libssl1.1",
             "libgcc1",
             "libcrypt1",
+            "libbyteman-java",
         ],
         sources = ["@debian_sid//file:Packages.json"],
     )

--- a/bazel/pl_workspace.bzl
+++ b/bazel/pl_workspace.bzl
@@ -52,6 +52,7 @@ def _package_manager_setup():
             "libsasl2-2",
             "libssl1.1",
             "libgcc1",
+            "libcrypt1",
         ],
         sources = ["@debian_sid//file:Packages.json"],
     )

--- a/bazel/pl_workspace.bzl
+++ b/bazel/pl_workspace.bzl
@@ -53,6 +53,9 @@ def _package_manager_setup():
             "libssl1.1",
             "libgcc1",
             "libcrypt1",
+            # TODO(ddelnano): byteman is required until dealing with
+            # netty's libnetty_tcnative.so's random file name is solved for.
+            # See #407 for more details.
             "libbyteman-java",
         ],
         sources = ["@debian_sid//file:Packages.json"],

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -31,6 +31,9 @@ def thrift_deps(scala_version):
             "com.twitter:scrooge-core_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:finagle-http_%s:%s" % (scala_minor_version, finagle_version),
             "org.apache.thrift:libthrift:0.10.0",
+            "org.slf4j:slf4j-api:1.7.36",
+            "ch.qos.logback:logback-core:1.2.10",
+            "ch.qos.logback:logback-classic:1.2.10",
         ],
         repositories = ["https://repo1.maven.org/maven2"],
     )

--- a/src/common/testing/test_utils/cert_generator/cert_generator.go
+++ b/src/common/testing/test_utils/cert_generator/cert_generator.go
@@ -114,7 +114,12 @@ func generateAndWriteCertPair(ca *x509.Certificate, caKey *rsa.PrivateKey, certP
 	if err != nil {
 		panic(err)
 	}
-	err = pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	// TODO(ddelnano): Add flag for configuring which private key type to use (PKCS1 vs PKCS8).
+	b, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		panic(err)
+	}
+	err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: b})
 	if err != nil {
 		panic(err)
 	}

--- a/src/common/testing/test_utils/cert_generator/cert_generator.go
+++ b/src/common/testing/test_utils/cert_generator/cert_generator.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
 	"time"
@@ -114,14 +115,28 @@ func generateAndWriteCertPair(ca *x509.Certificate, caKey *rsa.PrivateKey, certP
 	if err != nil {
 		panic(err)
 	}
-	// TODO(ddelnano): Add flag for configuring which private key type to use (PKCS1 vs PKCS8).
-	b, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		panic(err)
-	}
-	err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: b})
-	if err != nil {
-		panic(err)
+
+	keyType := viper.GetString("secret_key_type")
+	if keyType == "pkcs1" {
+
+		err = pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+		if err != nil {
+			panic(err)
+		}
+
+	} else if keyType == "pkcs8" {
+
+		b, err := x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			panic(err)
+		}
+
+		err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: b})
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		panic(fmt.Sprintf("Unsupported private key type: %s"))
 	}
 	err = keyOut.Close()
 	if err != nil {
@@ -135,6 +150,7 @@ func main() {
 	pflag.String("client_key", "", "Path where to write client.key")
 	pflag.String("server_crt", "", "Path where to write server.crt")
 	pflag.String("server_key", "", "Path where to write server.key")
+	pflag.String("secret_key_type", "pkcs1", "Which private key type to use. Possible options include pkcs1, pkcs8")
 
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)

--- a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
@@ -102,10 +102,10 @@ class MuxTraceTest : public SocketTraceBPFTest</* TClientSideTracing */ true> {
 
     LOG(INFO) << absl::StrFormat("Client PID: %d", client_pid);
 
-    if (tokens[1] != thriftmux_client_output) {
+    if (!absl::StrContains(out, thriftmux_client_output)) {
       return error::Internal(
-          absl::StrFormat("Expected output from thriftmux to be '%s', received '%s' instead",
-                          thriftmux_client_output, tokens[1]));
+          absl::StrFormat("Expected output from thriftmux to include '%s', received '%s' instead",
+                          thriftmux_client_output, out));
     }
     return client_pid;
   }

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -14,12 +14,58 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+load("@io_bazel_rules_docker//java:image.bzl", "DEFAULT_JAVA_BASE", "jar_app_layer")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//container:container.bzl", "container_layer", "container_image")
+
 load("@io_bazel_rules_docker//scala:image.bzl", "scala_image")
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
+
+genrule(
+    name = "certs",
+    outs = [
+        "ca.crt",
+        "client.crt",
+        "client.key",
+        "server.crt",
+        "server.key",
+    ],
+    cmd = """
+        $(location //src/common/testing/test_utils/cert_generator:cert_generator) \
+        --ca_crt $(location ca.crt) \
+        --client_crt $(location client.crt) \
+        --client_key $(location client.key) \
+        --server_crt $(location server.crt) \
+        --server_key $(location server.key)
+    """,
+    tools = [
+        "//src/common/testing/test_utils/cert_generator",
+    ],
+)
+
+pkg_tar(
+    name = "ssl_keys",
+    srcs = [
+        "ca.crt",
+        "client.crt",
+        "client.key",
+        "server.crt",
+        "server.key",
+    ],
+    package_dir = "/etc/ssl",
+    mode = "0755",
+    strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
+)
+
+# container_layer(
+#     name = "ssl_keys_layer",
+#     directory = "/etc/ssl",
+#     tars = [":ssl_keys"],
+# )
 
 thrift_library(
     name = "thrift_library",
@@ -72,8 +118,15 @@ scala_binary(
     ],
 )
 
+container_image(
+    name = "thriftmux_base",
+    base = DEFAULT_JAVA_BASE,
+    tars = [":ssl_keys"],
+)
+
 scala_image(
     name = "server_image",
+    base = ":thriftmux_base",
     srcs = glob(["**/*.scala"]),
     main_class = "Server",
     deps = [

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+load("@package_bundle//file:packages.bzl", "packages")
 load("@io_bazel_rules_docker//java:image.bzl", "DEFAULT_JAVA_BASE", "jar_app_layer")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//container:container.bzl", "container_layer", "container_image")
@@ -100,6 +101,15 @@ scrooge_scala_library(
     ],
 )
 
+scala_library(
+    name = "logging",
+    deps = [
+        "@maven//:org_slf4j_slf4j_api",
+        "@maven//:ch_qos_logback_logback_core",
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
+)
+
 scala_binary(
     name = "server_bin",
     srcs = glob(["**/*.scala"]),
@@ -122,6 +132,9 @@ container_image(
     name = "thriftmux_base",
     base = DEFAULT_JAVA_BASE,
     tars = [":ssl_keys"],
+    debs = [
+        packages["libcrypt1"],
+    ]
 )
 
 scala_image(
@@ -131,5 +144,6 @@ scala_image(
     main_class = "Server",
     deps = [
         ":thriftmux_scrooge",
+        ":logging",
     ],
 )

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -62,11 +62,15 @@ pkg_tar(
     strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
 )
 
-# container_layer(
-#     name = "ssl_keys_layer",
-#     directory = "/etc/ssl",
-#     tars = [":ssl_keys"],
-# )
+pkg_tar(
+    name = "byteman_rule",
+    srcs = [
+        "byteman_rule.txt",
+    ],
+    package_dir = "/etc/byteman",
+    mode = "0755",
+    strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
+)
 
 thrift_library(
     name = "thrift_library",
@@ -131,8 +135,12 @@ scala_binary(
 container_image(
     name = "thriftmux_base",
     base = DEFAULT_JAVA_BASE,
-    tars = [":ssl_keys"],
+    tars = [
+        ":ssl_keys",
+        ":byteman_rule",
+    ],
     debs = [
+        packages["libbyteman-java"],
         packages["libcrypt1"],
     ]
 )
@@ -141,6 +149,11 @@ scala_image(
     name = "server_image",
     base = ":thriftmux_base",
     srcs = glob(["**/*.scala"]),
+    jvm_flags = [
+        "-javaagent:/usr/share/java/byteman-4.0.11.jar=script:/etc/byteman/byteman_rule.txt,boot:/usr/share/java/byteman-4.0.11.jar",
+        "-Dorg.jboss.byteman.transform.all",
+        "-Dio.netty.native.deleteLibAfterLoading=false",
+    ],
     main_class = "Server",
     deps = [
         ":thriftmux_scrooge",

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -41,7 +41,8 @@ genrule(
         --client_crt $(location client.crt) \
         --client_key $(location client.key) \
         --server_crt $(location server.crt) \
-        --server_key $(location server.key)
+        --server_key $(location server.key) \
+        --secret_key_type pkcs8
     """,
     tools = [
         "//src/common/testing/test_utils/cert_generator",
@@ -62,6 +63,8 @@ pkg_tar(
     strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
 )
 
+# TODO(ddelnano): byteman is required until dealing with
+# netty's libnetty_tcnative.so's random file name is solved for.
 pkg_tar(
     name = "byteman_rule",
     srcs = [

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -65,6 +65,7 @@ pkg_tar(
 
 # TODO(ddelnano): byteman is required until dealing with
 # netty's libnetty_tcnative.so's random file name is solved for.
+# See #407 for more details.
 pkg_tar(
     name = "byteman_rule",
     srcs = [

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -17,8 +17,7 @@
 load("@package_bundle//file:packages.bzl", "packages")
 load("@io_bazel_rules_docker//java:image.bzl", "DEFAULT_JAVA_BASE", "jar_app_layer")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//container:container.bzl", "container_layer", "container_image")
-
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
 load("@io_bazel_rules_docker//scala:image.bzl", "scala_image")
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
@@ -58,8 +57,8 @@ pkg_tar(
         "server.crt",
         "server.key",
     ],
-    package_dir = "/etc/ssl",
     mode = "0755",
+    package_dir = "/etc/ssl",
     strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
 )
 
@@ -71,8 +70,8 @@ pkg_tar(
     srcs = [
         "byteman_rule.txt",
     ],
-    package_dir = "/etc/byteman",
     mode = "0755",
+    package_dir = "/etc/byteman",
     strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
 )
 
@@ -112,9 +111,9 @@ scrooge_scala_library(
 scala_library(
     name = "logging",
     deps = [
-        "@maven//:org_slf4j_slf4j_api",
-        "@maven//:ch_qos_logback_logback_core",
         "@maven//:ch_qos_logback_logback_classic",
+        "@maven//:ch_qos_logback_logback_core",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 
@@ -139,20 +138,20 @@ scala_binary(
 container_image(
     name = "thriftmux_base",
     base = DEFAULT_JAVA_BASE,
+    debs = [
+        packages["libbyteman-java"],
+        packages["libcrypt1"],
+    ],
     tars = [
         ":ssl_keys",
         ":byteman_rule",
     ],
-    debs = [
-        packages["libbyteman-java"],
-        packages["libcrypt1"],
-    ]
 )
 
 scala_image(
     name = "server_image",
-    base = ":thriftmux_base",
     srcs = glob(["**/*.scala"]),
+    base = ":thriftmux_base",
     jvm_flags = [
         "-javaagent:/usr/share/java/byteman-4.0.11.jar=script:/etc/byteman/byteman_rule.txt,boot:/usr/share/java/byteman-4.0.11.jar",
         "-Dorg.jboss.byteman.transform.all",
@@ -160,7 +159,7 @@ scala_image(
     ],
     main_class = "Server",
     deps = [
-        ":thriftmux_scrooge",
         ":logging",
+        ":thriftmux_scrooge",
     ],
 )

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
@@ -10,8 +10,12 @@ This container can be run as a thriftmux server or client.
 # Runs the server by default
 $ bazel run src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
 
+# Add TLS certs to java keystore
+docker exec -it ${container_id} /usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -importcert -keystore /etc/ssl/certs/java/cacerts -file /etc/ssl/ca.crt -noprompt -storepass changeit
+
 # Run the client. This requires using 'docker run' directly to override the default entrypoint
 $ docker run --entrypoint /usr/bin/java bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client
 ```
 
 See `mux_container_bpf_test.cc` for use case.
+

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
@@ -23,4 +23,3 @@ $ docker exec -it ${container_id} /usr/bin/java -cp @/app/px/src/stirling/source
 ```
 
 See `mux_container_bpf_test.cc` for use case.
-

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md
@@ -10,11 +10,16 @@ This container can be run as a thriftmux server or client.
 # Runs the server by default
 $ bazel run src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
 
+# Run the client. This requires using 'docker run' directly to override the default entrypoint
+$ docker exec -it ${container_id} /usr/bin/java -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client
+
+# Run the server and client with TLS enabled
+$ bazel run src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image -- --use-tls true
+
 # Add TLS certs to java keystore
 docker exec -it ${container_id} /usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -importcert -keystore /etc/ssl/certs/java/cacerts -file /etc/ssl/ca.crt -noprompt -storepass changeit
 
-# Run the client. This requires using 'docker run' directly to override the default entrypoint
-$ docker run --entrypoint /usr/bin/java bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client
+$ docker exec -it ${container_id} /usr/bin/java -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client --use-tls true
 ```
 
 See `mux_container_bpf_test.cc` for use case.

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/byteman_rule.txt
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/byteman_rule.txt
@@ -1,0 +1,9 @@
+RULE Create predictable dynamic library path for tcnative
+CLASS io.netty.util.internal.PlatformDependent
+METHOD createTempFile
+AT ENTRY
+BIND filePath:String = $1;
+     isTcNativeLib:boolean = filePath.contains("tcnative");
+IF isTcNativeLib
+DO return new File("/tmp/libnetty_tcnative_linux_x86.so")
+ENDRULE

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
@@ -1,9 +1,26 @@
 import com.twitter.util.{Await, Future}
 import com.twitter.finagle.thriftmux.thriftscala.TestService
+import com.twitter.finagle.ssl._
+import com.twitter.finagle.ssl.client.SslClientConfiguration
 import com.twitter.finagle.{Thrift, ThriftMux}
 
+import java.io.File;
+
 object Client extends App {
-  val stackClient = ThriftMux.client.withLabel("thriftmux_example")
+  // TODO(ddelnano): Add flag that determines if TLS should be used rather than
+  // hardcoding TLS being enabled
+  val keyCredentials = KeyCredentials.CertAndKey(
+    new File("/etc/ssl/client.crt"),
+    new File("/etc/ssl/client.key"),
+  )
+  val sslConfig = SslClientConfiguration(
+    None,
+    keyCredentials,
+  )
+  val stackClient = ThriftMux.client
+    .withLabel("thriftmux_example")
+    .withTransport
+    .tls(sslConfig)
   val svcPerEndpoint = stackClient
     .methodBuilder("inet!localhost:8080")
     .servicePerEndpoint[TestService.ServicePerEndpoint]

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
@@ -6,25 +6,34 @@ import com.twitter.finagle.{Thrift, ThriftMux}
 
 import java.io.File;
 
-object Client extends App {
-  // TODO(ddelnano): Add flag that determines if TLS should be used rather than
-  // hardcoding TLS being enabled
-  val keyCredentials = KeyCredentials.CertAndKey(
-    new File("/etc/ssl/client.crt"),
-    new File("/etc/ssl/client.key"),
-  )
-  val sslConfig = SslClientConfiguration(
-    None,
-    keyCredentials,
-  )
-  val stackClient = ThriftMux.client
-    .withLabel("thriftmux_example")
-    .withTransport
-    .tls(sslConfig)
-  val svcPerEndpoint = stackClient
-    .methodBuilder("inet!localhost:8080")
-    .servicePerEndpoint[TestService.ServicePerEndpoint]
-  val svc = ThriftMux.Client.methodPerEndpoint[TestService.ServicePerEndpoint, TestService.MethodPerEndpoint](svcPerEndpoint)
-  val r = Await.result(svc.query("String"))
-  println(r)
+object Client {
+  def main(args: Array[String]): Unit = {
+    var useTls = false
+    args.grouped(2).toList.collect {
+      case Array("--use-tls", tls: String) => useTls = tls.toBoolean
+    }
+    val keyCredentials = KeyCredentials.CertAndKey(
+      new File("/etc/ssl/client.crt"),
+      new File("/etc/ssl/client.key"),
+    )
+    val sslConfig = SslClientConfiguration(
+      None,
+      keyCredentials,
+    )
+    var stackClient = if (useTls) {
+      ThriftMux.client
+        .withLabel("thriftmux_example")
+        .withTransport
+        .tls(sslConfig)
+    } else {
+      ThriftMux.client
+        .withLabel("thriftmux_example")
+    }
+    val svcPerEndpoint = stackClient
+      .methodBuilder("inet!localhost:8080")
+      .servicePerEndpoint[TestService.ServicePerEndpoint]
+    val svc = ThriftMux.Client.methodPerEndpoint[TestService.ServicePerEndpoint, TestService.MethodPerEndpoint](svcPerEndpoint)
+    val r = Await.result(svc.query("String"))
+    println(r)
+  }
 }

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/server/Server.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/server/Server.scala
@@ -1,13 +1,28 @@
 import com.twitter.finagle.{Http, Service}
 import com.twitter.finagle.http
 import com.twitter.finagle.{Thrift, ThriftMux}
+import com.twitter.finagle.ssl._
+import com.twitter.finagle.ssl.server.SslServerConfiguration
 import com.twitter.util.{Await, Future}
 import java.net.{InetSocketAddress, InetAddress}
 import com.twitter.finagle.thriftmux.thriftscala.TestService
 
+import java.io.File;
+
 object Server {
   def main(args: Array[String]): Unit = {
+    // TODO(ddelnano): Add flag that determines if TLS should be used rather than
+    // hardcoding TLS being enabled
+    val keyCredentials = KeyCredentials.CertAndKey(
+      new File("/etc/ssl/server.crt"),
+      new File("/etc/ssl/server.key"),
+    )
+    val sslConfig = SslServerConfiguration(
+      keyCredentials,
+    )
     val server = ThriftMux.server
+      .withTransport
+      .tls(sslConfig)
       .serveIface(
         new InetSocketAddress(InetAddress.getLoopbackAddress, 8080),
         new TestService.MethodPerEndpoint {


### PR DESCRIPTION
This is one of the fundamental changes needed for adding tls tracing for netty as specified in #407. This container will used in the `openssl_trace_bpf_test` acceptance test once the feature support for #407 is closer to completion. I'm opening this while the functionality is still in development to merge changes in smaller pieces.

## Testing
- [x] Verify `mux_trace_bpf_test` still works

<details><summary>output</summary>
1. Re-enable the thriftmux test
 
```
vagrant@vagrant:/vagrant$ git diff
diff --git a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
index 8bcbfea94..5458ee1da 100644
--- a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
@@ -149,7 +149,7 @@ inline auto EqMuxRecord(const mux::Record& x) {
 // Test Scenarios
 //-----------------------------------------------------------------------------

-TEST_F(MuxTraceTest, DISABLED_Capture) {
+TEST_F(MuxTraceTest, Capture) {
   // Uncomment to enable tracing
   // FLAGS_stirling_conn_trace_pid = server_.process_pid();
   StartTransferDataThread();
diff --git a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
index b34ab359f..fb3ce84c8 100644
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -89,7 +89,7 @@ DEFINE_bool(stirling_enable_nats_tracing, true,
 DEFINE_bool(stirling_enable_kafka_tracing, true,
             "If true, stirling will trace and process Kafka messages.");
 DEFINE_bool(stirling_enable_mux_tracing,
-            gflags::BoolFromEnv("PL_STIRLING_TRACER_ENABLE_MUX", false),
+            gflags::BoolFromEnv("PL_STIRLING_TRACER_ENABLE_MUX", true),
             "If true, stirling will trace and process Mux messages.");

 DEFINE_bool(stirling_disable_self_tracing, true,
```

3. Verify test is successful

```
vagrant@vagrant:/vagrant$ ./scripts/sudo_bazel_run.sh src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test 2>&1
Bazel options:
Bazel target: src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test
Run args:
Pass through env. vars:
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test
INFO: Elapsed time: 16.549s, Critical Path: 16.14s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
I20220317 05:45:35.164465 226720 env.cc:47] Started: /home/vagrant/.cache/bazel/_bazel_vagrant/6ad5fdbcbf2eaa93bd62f92333a2e6e5/execroot/px/bazel-out/k8-fastbuild/bin/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from MuxTraceTest
[ RUN      ] MuxTraceTest.Capture
W20220317 05:45:35.164556 226720 test_environment.cc:44] This test uses bazel-generated test files, but is not being run through bazel. It will only run correctly from repo ToT.
I20220317 05:45:35.953534 226720 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
I20220317 05:45:35.953596 226720 container_runner.cc:118] docker run --pid=host --name thriftmux_server_324443891881711 bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
Error: No such object: thriftmux_server_324443891881711
I20220317 05:45:36.130111 226720 container_runner.cc:143] Container thriftmux_server_324443891881711 status:
I20220317 05:45:36.130147 226720 container_runner.cc:152] Container thriftmux_server_324443891881711 not yet running, will try again (60 attempts remaining).
I20220317 05:45:37.183566 226720 container_runner.cc:143] Container thriftmux_server_324443891881711 status: running
I20220317 05:45:37.245250 226720 container_runner.cc:182] Container thriftmux_server_324443891881711 process PID: 226816
I20220317 05:45:37.245296 226720 container_runner.cc:184] Container thriftmux_server_324443891881711 waiting for log message: Finagle version
I20220317 05:45:37.315589 226720 container_runner.cc:196] Container thriftmux_server_324443891881711 status: running
I20220317 05:45:37.315660 226720 container_runner.cc:209] Container thriftmux_server_324443891881711 not in ready state, will try again (59 attempts remaining).
I20220317 05:45:38.384140 226720 container_runner.cc:196] Container thriftmux_server_324443891881711 status: running
I20220317 05:45:38.384232 226720 container_runner.cc:232] Container thriftmux_server_324443891881711 is ready.
I20220317 05:45:38.384459 226720 source_connector.cc:36] Initializing source connector: socket_trace_connector
I20220317 05:45:38.384490 226720 linux_headers.cc:209] Found Linux kernel version using .note section.
I20220317 05:45:38.384500 226720 linux_headers.cc:90] Obtained Linux version string from `uname`: 5.4.0-80-generic
I20220317 05:45:38.384505 226720 linux_headers.cc:582] Detected kernel release (uname -r): 5.4.0-80-generic
I20220317 05:45:38.384527 226720 bcc_wrapper.cc:133] Using linux headers found at /lib/modules/5.4.0-80-generic/build for BCC runtime.
I20220317 05:45:46.942701 226720 socket_trace_connector.cc:378] Number of kprobes deployed = 40
I20220317 05:45:46.942739 226720 socket_trace_connector.cc:379] Probes successfully deployed.
I20220317 05:45:46.942765 226720 socket_trace_connector.cc:321] Initializing perf buffers with ncpus=2 and scaling_factor=0.9
I20220317 05:45:46.942793 226720 socket_trace_connector.cc:310] Total perf buffer usage for kData buffers across all cpus: 75497472
I20220317 05:45:46.942802 226720 socket_trace_connector.cc:310] Total perf buffer usage for kControl buffers across all cpus: 3963614
I20220317 05:45:46.942955 226720 bcc_wrapper.cc:332] Opening perf buffer: socket_data_events [requested_size=18874368 num_pages=8192 size=33554432] (per cpu)
I20220317 05:45:46.947800 226720 bcc_wrapper.cc:332] Opening perf buffer: socket_control_events [requested_size=943718 num_pages=256 size=1048576] (per cpu)
I20220317 05:45:46.948325 226720 bcc_wrapper.cc:332] Opening perf buffer: conn_stats_events [requested_size=943718 num_pages=256 size=1048576] (per cpu)
I20220317 05:45:46.948679 226720 bcc_wrapper.cc:332] Opening perf buffer: mmap_events [requested_size=94371 num_pages=32 size=131072] (per cpu)
I20220317 05:45:46.948875 226720 bcc_wrapper.cc:332] Opening perf buffer: go_grpc_events [requested_size=18874368 num_pages=8192 size=33554432] (per cpu)
I20220317 05:45:46.953632 226720 socket_trace_connector.cc:383] Number of perf buffers opened = 5
I20220317 05:45:47.604174 226928 uprobe_manager.cc:716] Number of uprobes deployed = 5
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/maven/v1/https/repo1.maven.org/maven2/com/twitter/util-jvm_2.13/21.4.0/util-jvm_2.13-21.4.0.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Mar 17, 2022 5:45:49 AM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version 21.4.0 (rev=f8ee0eb9803b9221ffdc8301b9160cfa622220c4) built at 20210427-203740
Mar 17, 2022 5:45:49 AM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Mar 17, 2022 5:45:49 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@5d7835a8)
Mar 17, 2022 5:45:49 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@736048ed)
Mar 17, 2022 5:45:49 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@1976f537)
Mar 17, 2022 5:45:49 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@45f421c)
Mar 17, 2022 5:45:49 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@1816e24a)
I20220317 05:45:50.473412 226720 mux_trace_bpf_test.cc:94] thriftmux client command output: '226932
05:45:48.989 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
05:45:48.991 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
05:45:48.992 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
05:45:49.004 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
05:45:49.004 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
05:45:49.005 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
05:45:49.006 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
05:45:49.006 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
05:45:49.008 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
        at io.netty.util.internal.ReflectionUtil.trySetAccessible(ReflectionUtil.java:31)
        at io.netty.util.internal.PlatformDependent0$4.run(PlatformDependent0.java:238)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:232)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:29)
        at Client.main(Client.scala)
05:45:49.009 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
05:45:49.010 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @3591009c
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
        at java.base/java.lang.reflect.Method.invoke(Method.java:558)
        at io.netty.util.internal.PlatformDependent0$6.run(PlatformDependent0.java:352)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:343)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:29)
        at Client.main(Client.scala)
05:45:49.010 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
05:45:49.010 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
05:45:49.011 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 2088763392 bytes (maybe)
05:45:49.011 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
05:45:49.011 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
05:45:49.012 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
05:45:49.013 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
05:45:49.013 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
05:45:49.014 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
05:45:49.015 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
05:45:49.016 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
05:45:49.016 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
05:45:49.016 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
05:45:49.016 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
05:45:49.016 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
05:45:49.016 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
05:45:49.017 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
05:45:49.017 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
05:45:49.017 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
05:45:49.017 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: true
05:45:49.018 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
05:45:49.021 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
05:45:49.022 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
05:45:49.032 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
05:45:49.032 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
05:45:49.033 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
05:45:49.045 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_6414451370166188337215.so
05:45:49.047 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
05:45:49.047 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
05:45:49.049 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
05:45:49.050 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
05:45:49.243 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@67c119b7
05:45:49.252 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
05:45:49.677 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
05:45:49.714 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 226950 (auto-detected)
05:45:49.715 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:ac:ff:fe:11:00:02 (auto-detected)
05:45:49.729 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
05:45:49.729 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
05:45:49.729 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
05:45:49.829 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
05:45:49.829 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxSharedCapacityFactor: disabled
05:45:49.829 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.linkCapacity: disabled
05:45:49.829 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
05:45:49.829 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.delayedQueue.ratio: disabled
05:45:49.834 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
05:45:49.834 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
05:45:49.834 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@1c60deb4
StringString
'
I20220317 05:45:50.473558 226720 mux_trace_bpf_test.cc:103] Client PID: 226932
I20220317 05:45:52.725414 226720 container_runner.cc:59] docker rm -f thriftmux_server_324443891881711
[       OK ] MuxTraceTest.Capture (17800 ms)
[----------] 1 test from MuxTraceTest (17800 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (17800 ms total)
[  PASSED  ] 1 test.
I20220317 05:45:52.964696 226720 env.cc:51] Shutting down
```

</details>

- [x] Verified that finagle crashes without a pkcs8 key
<details><summary>output</summary>

```bash
vagrant@ubuntu2004:~$ docker exec -it 645b93648095   /usr/bin/java -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client  --use-tls true
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/maven/v1/https/repo1.maven.org/maven2/com/twitter/util-jvm_2.13/21.4.0/util-jvm_2.13-21.4.0.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
06:24:45.626 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
06:24:45.631 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
06:24:45.631 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
06:24:45.650 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
06:24:45.650 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
06:24:45.652 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
06:24:45.652 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
06:24:45.653 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
06:24:45.656 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
        at io.netty.util.internal.ReflectionUtil.trySetAccessible(ReflectionUtil.java:31)
        at io.netty.util.internal.PlatformDependent0$4.run(PlatformDependent0.java:238)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:232)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:24)
        at Client.main(Client.scala)
06:24:45.659 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
06:24:45.660 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @3591009c
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
        at java.base/java.lang.reflect.Method.invoke(Method.java:558)
        at io.netty.util.internal.PlatformDependent0$6.run(PlatformDependent0.java:352)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:343)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:24)
        at Client.main(Client.scala)
06:24:45.669 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
06:24:45.670 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
06:24:45.672 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 1033895936 bytes (maybe)
06:24:45.672 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
06:24:45.673 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
06:24:45.674 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
06:24:45.675 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
06:24:45.676 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
06:24:45.677 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
06:24:45.680 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
06:24:45.680 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
06:24:45.680 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
06:24:45.681 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
06:24:45.681 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
06:24:45.681 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
06:24:45.681 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
06:24:45.682 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
06:24:45.682 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
06:24:45.683 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
06:24:45.683 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: true
06:24:45.683 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
06:24:45.689 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
06:24:45.689 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
06:24:45.707 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
06:24:45.708 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
06:24:45.708 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
06:24:45.727 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_6415367768552464555058.so
06:24:45.732 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
06:24:45.732 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
06:24:45.735 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
06:24:45.736 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
Mar 16, 2022 6:24:45 AM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version 21.4.0 (rev=f8ee0eb9803b9221ffdc8301b9160cfa622220c4) built at 20210427-203740
06:24:45.977 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2ca5f1ed
06:24:45.987 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
Mar 16, 2022 6:24:46 AM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Mar 16, 2022 6:24:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@1976f537)
Mar 16, 2022 6:24:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@45f421c)
Mar 16, 2022 6:24:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@1816e24a)
Mar 16, 2022 6:24:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@6940f685)
Mar 16, 2022 6:24:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@47b179d7)
06:24:46.532 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
06:24:46.578 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 54 (auto-detected)
06:24:46.581 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:b3:ff:fe:27:57:17 (auto-detected)
06:24:46.599 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
06:24:46.600 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
06:24:46.601 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
06:24:46.672 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_647994788693553449458.so
06:24:46.682 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Initialize netty-tcnative using engine: 'default'
06:24:46.683 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - netty-tcnative using native library: BoringSSL
06:24:46.849 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
06:24:46.850 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
06:24:46.850 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@258bea75
06:24:46.897 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@34c07e38
06:24:46.906 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
06:24:46.906 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxSharedCapacityFactor: disabled
06:24:46.908 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.linkCapacity: disabled
06:24:46.909 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
06:24:46.912 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.delayedQueue.ratio: disabled
06:24:46.936 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:24:46.937 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:24:46.938 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:24:46.938 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:24:46.940 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:24:46.940 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:24:46.942 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:24:46.943 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:24:46.944 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:24:46.944 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:24:46.945 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:24:46.946 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:24:46.947 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:24:46.948 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:24:46.949 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:24:46.949 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:24:46.950 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:24:46.951 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:24:46.952 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:24:46.953 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:24:46.954 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:24:46.955 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:24:46.956 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:24:46.963 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:24:46.965 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:24:46.965 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:24:46.966 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:24:46.967 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:24:46.967 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:24:46.968 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:24:46.969 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:24:46.970 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:24:46.971 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:24:46.973 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:24:46.974 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:24:46.974 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:24:46.975 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:24:46.975 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:24:46.976 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:24:46.976 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:24:46.979 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Supported protocols (OpenSSL): [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3]
06:24:46.980 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Default cipher suites (OpenSSL): [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384]
Mar 16, 2022 6:24:47 AM com.twitter.util.security.Pkcs8EncodedKeySpecFile logException
WARNING: PKCS8EncodedKeySpec (client.key) failed to load: PemBytes (client.key) failed to load: Missing -----BEGIN PRIVATE KEY-----.
Mar 16, 2022 6:24:47 AM com.twitter.util.security.PrivateKeyFile logException
WARNING: PrivateKeyFile (client.key) failed to load: PemBytes (client.key) failed to load: Missing -----BEGIN PRIVATE KEY-----.
06:24:47.025 [finagle/netty4-1-1] WARN io.netty.channel.ChannelInitializer - Failed to initialize a channel. Closing: [id: 0xcbfd9ab3]
com.twitter.finagle.ssl.SslConfigurationException: com.twitter.util.security.InvalidPemFormatException: PemBytes (client.key) failed to load: Missing -----BEGIN PRIVATE KEY-----. Remote Info: Not Available
        at com.twitter.finagle.netty4.ssl.Netty4SslConfigurations$.unwrapTryContextBuilder(Netty4SslConfigurations.scala:91)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientSslConfigurations$.startClientWithKey(Netty4ClientSslConfigurations.scala:78)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientSslConfigurations$.createClientContext(Netty4ClientSslConfigurations.scala:87)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientEngineFactory.apply(Netty4ClientEngineFactory.scala:29)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientSslChannelInitializer.$anonfun$initChannel$1(Netty4ClientSslChannelInitializer.scala:141)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientSslChannelInitializer.$anonfun$initChannel$1$adapted(Netty4ClientSslChannelInitializer.scala:138)
        at scala.Option.foreach(Option.scala:437)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientSslChannelInitializer.initChannel(Netty4ClientSslChannelInitializer.scala:138)
        at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129)
        at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112)
        at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:938)
        at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
        at io.netty.channel.DefaultChannelPipeline.addFirst(DefaultChannelPipeline.java:181)
        at io.netty.channel.DefaultChannelPipeline.addFirst(DefaultChannelPipeline.java:152)
        at com.twitter.finagle.netty4.channel.AbstractNetty4ClientChannelInitializer.initChannel(AbstractNetty4ClientChannelInitializer.scala:88)
        at com.twitter.finagle.netty4.channel.RawNetty4ClientChannelInitializer.initChannel(RawNetty4ClientChannelInitializer.scala:18)
        at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129)
        at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112)
        at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:938)
        at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
        at io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46)
        at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463)
        at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115)
        at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650)
        at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:502)
        at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:417)
        at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:474)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:387)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at com.twitter.finagle.util.BlockingTimeTrackingThreadFactory$$anon$1.run(BlockingTimeTrackingThreadFactory.scala:23)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.twitter.util.security.InvalidPemFormatException: PemBytes (client.key) failed to load: Missing -----BEGIN PRIVATE KEY-----
        at com.twitter.util.security.PemBytes.readEncodedMessages(PemBytes.scala:99)
        at com.twitter.util.security.PemBytes.readEncodedMessage(PemBytes.scala:50)
        at com.twitter.util.security.PemBytes.readDecodedMessage(PemBytes.scala:41)
        at com.twitter.util.security.PemBytes.$anonfun$readMessage$3(PemBytes.scala:120)
        at com.twitter.util.Try$.apply(Try.scala:26)
        at com.twitter.util.security.PemBytes.$anonfun$readMessage$2(PemBytes.scala:120)
        at com.twitter.util.Return.flatMap(Try.scala:302)
        at com.twitter.util.security.PemBytes.readMessage(PemBytes.scala:120)
        at com.twitter.util.security.Pkcs8EncodedKeySpecFile.$anonfun$readPkcs8EncodedKeySpec$1(Pkcs8EncodedKeySpecFile.scala:29)
        at com.twitter.util.Return.flatMap(Try.scala:302)
        at com.twitter.util.security.Pkcs8EncodedKeySpecFile.readPkcs8EncodedKeySpec(Pkcs8EncodedKeySpecFile.scala:27)
        at com.twitter.util.security.PrivateKeyFile.readPrivateKey(PrivateKeyFile.scala:36)
        at com.twitter.finagle.netty4.ssl.client.Netty4ClientSslConfigurations$.startClientWithKey(Netty4ClientSslConfigurations.scala:61)
        ... 35 common frames omitted
Mar 16, 2022 6:24:47 AM com.twitter.util.security.Pkcs8EncodedKeySpecFile logException
WARNING: PKCS8EncodedKeySpec (client.key) failed to load: PemBytes (client.key) failed to load: Missing -----BEGIN PRIVATE KEY-----.

```

</details>

- [x] Ran thriftmux server and client with defaults applied (no tls) using the instructions in the thriftmux README file

<details><summary> output</summary>

```bash
vagrant@ubuntu2004:/vagrant$ docker exec -it cfb788122c36   /usr/bin/java -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/maven/v1/https/repo1.maven.org/maven2/com/twitter/util-jvm_2.13/21.4.0/util-jvm_2.13-21.4.0.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
06:33:37.177 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
06:33:37.182 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
06:33:37.182 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
06:33:37.201 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
06:33:37.202 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
06:33:37.206 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
06:33:37.208 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
06:33:37.208 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
06:33:37.212 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
        at io.netty.util.internal.ReflectionUtil.trySetAccessible(ReflectionUtil.java:31)
        at io.netty.util.internal.PlatformDependent0$4.run(PlatformDependent0.java:238)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:232)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:29)
        at Client.main(Client.scala)
06:33:37.214 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
06:33:37.216 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @3591009c
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
        at java.base/java.lang.reflect.Method.invoke(Method.java:558)
        at io.netty.util.internal.PlatformDependent0$6.run(PlatformDependent0.java:352)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:343)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:29)
        at Client.main(Client.scala)
06:33:37.217 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
06:33:37.218 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
06:33:37.219 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 1033895936 bytes (maybe)
06:33:37.220 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
06:33:37.220 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
06:33:37.222 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
06:33:37.223 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
06:33:37.224 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
06:33:37.225 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
06:33:37.228 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
06:33:37.228 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
06:33:37.229 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
06:33:37.229 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
06:33:37.230 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
06:33:37.231 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
06:33:37.231 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
06:33:37.231 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
06:33:37.232 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
06:33:37.232 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
06:33:37.233 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: true
06:33:37.234 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
06:33:37.240 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
06:33:37.240 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
06:33:37.259 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
06:33:37.259 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
06:33:37.260 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
06:33:37.283 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_6414587171407885317838.so
06:33:37.289 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
06:33:37.289 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
06:33:37.298 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
06:33:37.299 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
Mar 16, 2022 6:33:37 AM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version 21.4.0 (rev=f8ee0eb9803b9221ffdc8301b9160cfa622220c4) built at 20210427-203740
06:33:37.556 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@67c119b7
06:33:37.566 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
Mar 16, 2022 6:33:37 AM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Mar 16, 2022 6:33:37 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@5d7835a8)
Mar 16, 2022 6:33:37 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@736048ed)
Mar 16, 2022 6:33:37 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@1976f537)
Mar 16, 2022 6:33:37 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@45f421c)
Mar 16, 2022 6:33:37 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@1816e24a)
06:33:38.026 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
06:33:38.076 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 28 (auto-detected)
06:33:38.079 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:b3:ff:fe:27:57:17 (auto-detected)
06:33:38.098 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
06:33:38.098 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
06:33:38.099 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
06:33:38.323 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
06:33:38.323 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxSharedCapacityFactor: disabled
06:33:38.323 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.linkCapacity: disabled
06:33:38.324 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
06:33:38.324 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.delayedQueue.ratio: disabled
06:33:38.341 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
06:33:38.342 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
06:33:38.342 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@7c50fcf1
StringString

```

</details>


- [x] Ran thriftmux server and client with tls enabled using the instructions in the thriftmux README file

<details><summary>output</summary>

```bash
vagrant@ubuntu2004:/vagrant$ docker exec -it 415c5cfd4324   /usr/bin/java -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client  --use-tls true
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/maven/v1/https/repo1.maven.org/maven2/com/twitter/util-jvm_2.13/21.4.0/util-jvm_2.13-21.4.0.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
06:32:46.310 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
06:32:46.315 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
06:32:46.316 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
06:32:46.335 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
06:32:46.336 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
06:32:46.340 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
06:32:46.342 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
06:32:46.344 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
06:32:46.348 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
        at io.netty.util.internal.ReflectionUtil.trySetAccessible(ReflectionUtil.java:31)
        at io.netty.util.internal.PlatformDependent0$4.run(PlatformDependent0.java:238)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:232)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:24)
        at Client.main(Client.scala)
06:32:46.357 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
06:32:46.359 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @3591009c
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
        at java.base/java.lang.reflect.Method.invoke(Method.java:558)
        at io.netty.util.internal.PlatformDependent0$6.run(PlatformDependent0.java:352)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:343)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:24)
        at Client.main(Client.scala)
06:32:46.364 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
06:32:46.364 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
06:32:46.366 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 1033895936 bytes (maybe)
06:32:46.367 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
06:32:46.367 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
06:32:46.370 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
06:32:46.370 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
06:32:46.371 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
06:32:46.372 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
06:32:46.375 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
06:32:46.376 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
06:32:46.376 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
06:32:46.376 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
06:32:46.377 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
06:32:46.378 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
06:32:46.378 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
06:32:46.378 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
06:32:46.378 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
06:32:46.379 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
06:32:46.379 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: true
06:32:46.380 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
06:32:46.389 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
06:32:46.389 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
06:32:46.411 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
06:32:46.411 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
06:32:46.412 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
06:32:46.434 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_6411885189294251958039.so
06:32:46.438 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
06:32:46.439 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
06:32:46.442 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
06:32:46.443 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
Mar 16, 2022 6:32:46 AM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version 21.4.0 (rev=f8ee0eb9803b9221ffdc8301b9160cfa622220c4) built at 20210427-203740
06:32:46.683 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2ca5f1ed
06:32:46.692 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
Mar 16, 2022 6:32:46 AM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Mar 16, 2022 6:32:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@736048ed)
Mar 16, 2022 6:32:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@1976f537)
Mar 16, 2022 6:32:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@45f421c)
Mar 16, 2022 6:32:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@1816e24a)
Mar 16, 2022 6:32:46 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@6940f685)
06:32:47.170 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
06:32:47.221 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 52 (auto-detected)
06:32:47.223 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:b3:ff:fe:27:57:17 (auto-detected)
06:32:47.243 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
06:32:47.244 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
06:32:47.244 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
06:32:47.315 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_6416928481051211554022.so
06:32:47.316 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Initialize netty-tcnative using engine: 'default'
06:32:47.316 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - netty-tcnative using native library: BoringSSL
06:32:47.498 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
06:32:47.499 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
06:32:47.499 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@4efeade
06:32:47.537 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@7e9ce6da
06:32:47.544 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
06:32:47.544 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxSharedCapacityFactor: disabled
06:32:47.545 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.linkCapacity: disabled
06:32:47.545 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
06:32:47.546 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.delayedQueue.ratio: disabled
06:32:47.571 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:32:47.572 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:32:47.572 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:32:47.572 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:32:47.573 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:32:47.574 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:32:47.574 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:32:47.575 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:32:47.576 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:32:47.577 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:32:47.577 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:32:47.577 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:32:47.578 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:32:47.578 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:32:47.579 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:32:47.579 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:32:47.580 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:32:47.581 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:32:47.582 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:32:47.582 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:32:47.583 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:32:47.583 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:32:47.584 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:32:47.584 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:32:47.585 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:32:47.585 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:32:47.586 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:32:47.586 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:32:47.586 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:32:47.587 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:32:47.588 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:32:47.592 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:32:47.593 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:32:47.594 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:32:47.594 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:32:47.595 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:32:47.596 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:32:47.597 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:32:47.598 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:32:47.598 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:32:47.600 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Supported protocols (OpenSSL): [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3]
06:32:47.601 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Default cipher suites (OpenSSL): [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384]
06:32:47.817 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@215743a4
06:32:47.955 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@38373bb4
06:32:49.271 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.SslHandler - [id: 0xa158a5cd, L:/127.0.0.1:36376 - R:localhost/127.0.0.1:8080] HANDSHAKEN: protocol:TLSv1.3 cipher suite:TLS_AES_128_GCM_SHA256
StringString

```

</summary>