### PR TITLE
Update Google test to latest version

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -83,9 +83,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/bazelbuild/rules_docker/archive/refs/tags/v0.22.0.tar.gz"],
     ),
     com_google_googletest = dict(
-        sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
-        strip_prefix = "googletest-release-1.10.0",
-        urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
+        sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
+        strip_prefix = "googletest-release-1.11.0",
+        urls = ["https://github.com/google/googletest/archive/release-1.11.0.tar.gz"],
     ),
     com_github_grpc_grpc = dict(
         sha256 = "27dd2fc5c9809ddcde8eb6fa1fa278a3486566dfc28335fca13eb8df8bd3b958",


### PR DESCRIPTION
Gives us better printers for unique_ptr, shared_ptr and variant types

Signed-off-by: Daniel Fernandez <dfernandez@newrelic.com>