### PR TITLE
Add thriftmux (finagle) openssl trace bpf test and get it passing by using a locally built netty and netty-tcnative

### DIFF
--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -36,4 +36,10 @@ def thrift_deps(scala_version):
             "ch.qos.logback:logback-classic:1.2.10",
         ],
         repositories = ["https://repo1.maven.org/maven2"],
+        excluded_artifacts = [
+            "io.netty:netty-handler",
+            "io.netty:netty-common",
+            "io.netty:netty-tcnative-boringssl-static",
+            # "io.netty:netty-tcnative-classes",
+        ],
     )

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -422,6 +422,25 @@ pl_cc_test(
 )
 
 pl_cc_test(
+    name = "thriftmux_openssl_trace_bpf_test",
+    timeout = "long",
+    srcs = ["thriftmux_openssl_trace_bpf_test.cc"],
+    flaky = True,
+    shard_count = 2,
+    tags = [
+        "no_asan",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/common/testing/test_utils:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:container_images",
+        "//src/stirling/testing:cc_library",
+    ],
+)
+
+pl_cc_test(
     name = "dyn_lib_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dyn_lib_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -90,7 +90,7 @@ DEFINE_bool(stirling_enable_nats_tracing, true,
 DEFINE_bool(stirling_enable_kafka_tracing, true,
             "If true, stirling will trace and process Kafka messages.");
 DEFINE_bool(stirling_enable_mux_tracing,
-            gflags::BoolFromEnv("PL_STIRLING_TRACER_ENABLE_MUX", false),
+            gflags::BoolFromEnv("PL_STIRLING_TRACER_ENABLE_MUX", true),
             "If true, stirling will trace and process Mux messages.");
 
 DEFINE_bool(stirling_disable_self_tracing, true,

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -80,6 +80,16 @@ thrift_library(
     srcs = glob(["**/*.thrift"]),
 )
 
+java_import(
+    name = "netty_handler",
+    jars = [
+        "netty-handler-4.1.59.Final.jar",
+        "netty-common-4.1.59.Final.jar",
+        "netty-tcnative-boringssl-static-2.0.35.Final-linux-x86_64.jar",
+        # "netty-tcnative-classes-2.0.52.Final.jar",
+    ],
+)
+
 scala_library(
     name = "scrooge_jars",
     visibility = ["//visibility:public"],
@@ -90,6 +100,7 @@ scala_library(
         "@maven//:com_twitter_finagle_thrift_2_13",
         "@maven//:com_twitter_finagle_thriftmux_2_13",
         "@maven//:com_twitter_scrooge_core_2_13",
+        ":netty_handler",
     ],
 )
 

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -26,7 +26,9 @@
 
 #include "src/shared/types/column_wrapper.h"
 #include "src/stirling/source_connectors/socket_tracer/http_table.h"
+#include "src/stirling/source_connectors/socket_tracer/mux_table.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
 
 namespace px {
 namespace stirling {
@@ -35,12 +37,13 @@ namespace testing {
 //-----------------------------------------------------------------------------
 // HTTP Checkers
 //-----------------------------------------------------------------------------
+template<typename TFrameType>
+std::vector<TFrameType> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
+                                        const std::vector<size_t>& indices);
 
-std::vector<protocols::http::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
-                                                    const std::vector<size_t>& indices);
-
-std::vector<protocols::http::Record> GetTargetRecords(
-    const types::ColumnWrapperRecordBatch& record_batch, int32_t pid);
+template<typename TFrameType>
+std::vector<TFrameType> GetTargetRecords(const types::ColumnWrapperRecordBatch& record_batch,
+                                          int32_t pid);
 
 inline auto EqHTTPReq(const protocols::http::Message& x) {
   using ::testing::Field;
@@ -65,6 +68,18 @@ inline auto EqHTTPRecord(const protocols::http::Record& x) {
 
   return AllOf(Field(&protocols::http::Record::req, EqHTTPReq(x.req)),
                Field(&protocols::http::Record::resp, EqHTTPResp(x.resp)));
+}
+
+inline auto EqMux(const protocols::mux::Frame& x) {
+  using ::testing::Field;
+
+  return Field(&protocols::mux::Frame::type, ::testing::Eq(x.type));
+}
+
+inline auto EqMuxRecord(const protocols::mux::Record& x) {
+  using ::testing::Field;
+
+  return AllOf(Field(&protocols::mux::Record::req, EqMux(x.req)), Field(&protocols::mux::Record::resp, EqMux(x.resp)));
 }
 
 inline std::vector<std::string> GetRemoteAddrs(const types::ColumnWrapperRecordBatch& rb,

--- a/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "src/common/base/base.h"
+#include "src/common/exec/exec.h"
+#include "src/stirling/core/data_table.h"
+#include "src/common/testing/test_environment.h"
+#include "src/shared/types/column_wrapper.h"
+#include "src/shared/types/types.h"
+#include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
+#include "src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.h"
+#include "src/stirling/testing/common.h"
+
+namespace px {
+namespace stirling {
+
+namespace mux = protocols::mux;
+
+using ::px::stirling::testing::EqHTTPRecord;
+using ::px::stirling::testing::EqMuxRecord;
+using ::px::stirling::testing::FindRecordIdxMatchesPID;
+using ::px::stirling::testing::GetTargetRecords;
+using ::px::stirling::testing::SocketTraceBPFTest;
+using ::px::stirling::testing::ToRecordVector;
+
+using ::testing::StrEq;
+using ::testing::UnorderedElementsAre;
+
+class ThriftMuxServerContainerWrapper : public ::px::stirling::testing::ThriftMuxServerContainer {
+ public:
+  int32_t PID() const { return process_pid(); }
+};
+
+// The Init() function is used to set flags for the entire test.
+// We can't do this in the MuxTraceTest constructor, because it will be too late
+// (SocketTraceBPFTest will already have been constructed).
+bool Init() {
+  // Make sure Mux tracing is enabled.
+  FLAGS_stirling_enable_mux_tracing = true;
+
+  // We turn off CQL tracing to give some BPF instructions back for Mux.
+  // This is required for older kernels with only 4096 BPF instructions.
+  FLAGS_stirling_enable_cass_tracing = false;
+  return true;
+}
+
+bool kInit = Init();
+
+template <typename TServerContainer, bool TForceFptrs>
+class BaseOpenSSLTraceTest : public SocketTraceBPFTest</* TClientSideTracing */ false> {
+ protected:
+  BaseOpenSSLTraceTest() {
+    // Run the nginx HTTPS server.
+    // The container runner will make sure it is in the ready state before unblocking.
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60}, {}, {"--use-tls", "true"});
+    PL_CHECK_OK(run_result);
+    PL_CHECK_OK(this->RunThriftMuxClient());
+
+    // Sleep an additional second, just to be safe.
+    sleep(1);
+  }
+
+  void SetUp() override {
+    FLAGS_openssl_force_raw_fptrs = force_fptr_;
+
+    SocketTraceBPFTest::SetUp();
+  }
+
+  StatusOr<int32_t> RunThriftMuxClient() {
+
+    std::string classpath =
+      "@/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/"
+      "server_image.classpath";
+    std::string thriftmux_client_output = "StringString";
+
+    std::string keytool_cmd =
+        absl::StrFormat("docker exec %s /usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -importcert -keystore /etc/ssl/certs/java/cacerts -file /etc/ssl/ca.crt -noprompt -storepass changeit",
+                        server_.container_name());
+    PL_ASSIGN_OR_RETURN(std::string keytool_out, px::Exec(keytool_cmd));
+
+    LOG(INFO) << absl::StrFormat("keytool -importcert command output: '%s'", keytool_out);
+
+    std::string cmd =
+        absl::StrFormat("docker exec %s /usr/bin/java -cp %s Client --use-tls true & echo $! && wait",
+                        server_.container_name(), classpath);
+    PL_ASSIGN_OR_RETURN(std::string out, px::Exec(cmd));
+
+    LOG(INFO) << absl::StrFormat("thriftmux client command output: '%s'", out);
+
+    std::vector<std::string> tokens = absl::StrSplit(out, "\n");
+
+    int32_t client_pid;
+    if (!absl::SimpleAtoi(tokens[0], &client_pid)) {
+      return error::Internal("Could not extract PID.");
+    }
+
+    LOG(INFO) << absl::StrFormat("Client PID: %d", client_pid);
+
+    if (!absl::StrContains(out, thriftmux_client_output)) {
+      return error::Internal(
+          absl::StrFormat("Expected output from thriftmux to include '%s', received '%s' instead",
+                          thriftmux_client_output, out));
+    }
+    return client_pid;
+  }
+
+  TServerContainer server_;
+  bool force_fptr_ = TForceFptrs;
+};
+
+mux::Record RecordWithType(mux::Type req_type) {
+  mux::Record r = {};
+  r.req.type = static_cast<int8_t>(req_type);
+
+  return r;
+}
+
+typedef ::testing::Types<ThriftMuxServerContainerWrapper>
+    OpenSSLServerImplementations;
+
+template <typename T>
+using OpenSSLTraceDlsymTest = BaseOpenSSLTraceTest<T, false>;
+
+template <typename T>
+using OpenSSLTraceRawFptrsTest = BaseOpenSSLTraceTest<T, true>;
+
+#define OPENSSL_TYPED_TEST(TestCase, CodeBlock)            \
+  TYPED_TEST(OpenSSLTraceRawFptrsTest, TestCase)              \
+  CodeBlock
+
+TYPED_TEST_SUITE(OpenSSLTraceDlsymTest, OpenSSLServerImplementations);
+TYPED_TEST_SUITE(OpenSSLTraceRawFptrsTest, OpenSSLServerImplementations);
+
+OPENSSL_TYPED_TEST(mtls_thriftmux_client, {
+  FLAGS_stirling_conn_trace_pid = this->server_.process_pid();
+  this->StartTransferDataThread();
+
+  ASSERT_OK(this->RunThriftMuxClient());
+
+  this->StopTransferDataThread();
+
+  std::vector<TaggedRecordBatch> tablets = this->ConsumeRecords(SocketTraceConnector::kMuxTableNum);
+  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  std::vector<mux::Record> server_records = GetTargetRecords<mux::Record>(record_batch, this->server_.process_pid());
+
+  mux::Record tinitCheck = RecordWithType(mux::Type::kRerrOld);
+  mux::Record tinit = RecordWithType(mux::Type::kTinit);
+  mux::Record pingRecord = RecordWithType(mux::Type::kTping);
+  mux::Record dispatchRecord = RecordWithType(mux::Type::kTdispatch);
+
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(tinitCheck)));
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(tinit)));
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(pingRecord)));
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(dispatchRecord)));
+})
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -257,8 +257,12 @@ StatusOr<std::vector<std::filesystem::path>> FindHostPathForPIDPath(
 // Return error if something unexpected occurs.
 // Return 0 if nothing unexpected, but there is nothing to deploy (e.g. no OpenSSL detected).
 StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
-  constexpr std::string_view kLibSSL = "libssl.so.1.1";
-  constexpr std::string_view kLibCrypto = "libcrypto.so.1.1";
+  // TODO(ddelnano): Update this to support the existing libssl.so.1.1 and libcrypto.so.1.1 libraries.
+  // In addition to that we should allow pixie to match on netty's auto generated filepath name
+  // (i.e. libnetty_tcnative_linux_x86_648014508084024950371.so) so we can remove the need to
+  // monkey patch netty with Byteman.
+  constexpr std::string_view kLibSSL = "libnetty_tcnative_linux_x86.so";
+  constexpr std::string_view kLibCrypto = "libnetty_tcnative_linux_x86.so";
   const std::vector<std::string_view> lib_names = {kLibSSL, kLibCrypto};
 
   const system::Config& sysconfig = system::Config::GetInstance();

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
@@ -722,14 +722,18 @@ StatusOr<struct openssl_symaddrs_t> OpenSSLSymAddrs(RawFptrManager* fptrManager,
   // Verified to be valid for following versions:
   //  - 1.1.0a to 1.1.0k
   //  - 1.1.1a to 1.1.1e
-  constexpr int32_t kSSL_RBIO_offset = 0x10;
+
+  // TODO(ddelnano): We need to determine when to use the offsets calculated for openssl vs boringssl.
+  constexpr int32_t kSSL_RBIO_offset = 0x18;
 
   // Offset of num in struct bio_st.
   // Struct is defined in crypto/bio/bio_lcl.h, crypto/bio/bio_local.h depending on the version.
   //  - In 1.1.1a to 1.1.1e, the offset appears to be 0x30
   //  - In 1.1.0, the value appears to be 0x28.
-  constexpr int32_t kOpenSSL_1_1_0_RBIO_num_offset = 0x28;
-  constexpr int32_t kOpenSSL_1_1_1_RBIO_num_offset = 0x30;
+
+  // TODO(ddelnano): We need to determine when to use the offsets calculated for openssl vs boringssl.
+  constexpr int32_t kOpenSSL_1_1_0_RBIO_num_offset = 0x18;
+  constexpr int32_t kOpenSSL_1_1_1_RBIO_num_offset = 0x18;
 
   struct openssl_symaddrs_t symaddrs;
   symaddrs.SSL_rbio_offset = kSSL_RBIO_offset;


### PR DESCRIPTION
This PR is a proof of concept for the remaining functionality needed to support netty TLS tracing (#407). This PR uses netty and netty-tcnative jars built from the following branches (https://github.com/netty/netty-tcnative/pull/731 and https://github.com/netty/netty/pull/12438) and demonstrates that Pixie is able to intercept the request and response data despite using mtls finagle services.

## Testing
-  [x] New test verifies that netty TLS tracing is successful (output below)

```
vagrant@vagrant:/vagrant$ ./scripts/sudo_bazel_run.sh -c dbg src/stirling/source_connectors/socket_tracer:thriftmux_openssl_trace_bpf_test

[ ... ]

I20220531 20:40:57.226110 633419 conn_tracker.cc:110] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolUnknown conn_open: [type=kConnOpen ts=438642685041322 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] source_fn=kSyscallAccept [addr=[family=2 addr=127.0.0.1 port=9918]]]
I20220531 20:40:57.444905 633419 conn_tracker.cc:524] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Protocol changed: kProtocolUnknown->kProtocolMux, reason=[inferred from data_event]
I20220531 20:40:57.446892 633419 conn_tracker.cc:548] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux SSL state changed: false->true, reason=[inferred from data_event]
I20220531 20:40:57.447631 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438642949314509 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=218 size=19 buf_size=19]] msg_size:19 msg:[\x00\x00\x00\x0F\x7F\x00\x00\x01tinit check]
I20220531 20:40:57.447942 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438642949683822 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=0 size=19 buf_size=19]] msg_size:19 msg:[\x00\x00\x00\x0F\x7F\x00\x00\x01tinit check]
I20220531 20:40:57.448066 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438642952816339 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=237 size=46 buf_size=46]] msg_size:46 msg:[\x00\x00\x00*D\x00\x00\x01\x00\x01\x00\x00\x00\x0Amux-framer\x00\x00\x00\x04\x7F\xFF\xFF\xFF\x00\x00\x00\x03tls\x00\x00\x00\x03off]
I20220531 20:40:57.448184 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kCollecting remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438642953113601 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=19 size=46 buf_size=46]] msg_size:46 msg:[\x00\x00\x00*\xBC\x00\x00\x01\x00\x01\x00\x00\x00\x0Amux-framer\x00\x00\x00\x04\x7F\xFF\xFF\xFF\x00\x00\x00\x03tls\x00\x00\x00\x03off]
I20220531 20:40:57.448617 633419 conn_tracker.h:270] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux req_frames=2 resp_frames=2
I20220531 20:40:57.448765 633419 conn_tracker.h:277] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux records=2
I20220531 20:40:57.558565 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438643029393686 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=283 size=8 buf_size=8]] msg_size:8 msg:[\x00\x00\x00\x04A\x00\x00\x01]
I20220531 20:40:57.558804 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438643029653924 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=65 size=8 buf_size=8]] msg_size:8 msg:[\x00\x00\x00\x04\xBF\x00\x00\x01]
I20220531 20:40:57.558976 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438643042717271 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=291 size=204 buf_size=204]] msg_size:204 msg:[\x00\x00\x00\xC8\x02\x00\x00\x02\x00\x03\x00(com.twitter.finagle.tracing.TraceContext\x00 \x9F\x18\x9A\x7FGF)\xBB\x9F\x18\x9A\x7FGF)\xBB\x9F\x18\x9A\x7FGF)\xBB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1Bcom.twitter.finagle.Retries\x00\x04\x00\x00\x00\x00\x00\x1Ccom.twitter.finagle.Deadline\x00\x10\x16\xF4K5\xC6\xB6J\xC0\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\x80\x01\x00\x01\x00\x00\x00\x05query\x00\x00\x00\x00\x0B\x00\x01\x00\x00\x00\x06String\x00]
I20220531 20:40:57.559165 633419 conn_tracker.cc:153] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=438643043946400 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=73 size=48 buf_size=48]] msg_size:48 msg:[\x00\x00\x00,\xFE\x00\x00\x02\x00\x00\x00\x80\x01\x00\x02\x00\x00\x00\x05query\x00\x00\x00\x00\x0B\x00\x00\x00\x00\x00\x0CStringString\x00]
I20220531 20:40:57.559701 633419 conn_tracker.h:270] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux req_frames=2 resp_frames=2
I20220531 20:40:57.559826 633419 conn_tracker.h:277] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux records=2
I20220531 20:40:57.669531 633419 conn_tracker.h:270] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220531 20:40:57.669718 633419 conn_tracker.h:277] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux records=0
I20220531 20:40:57.779081 633419 conn_tracker.h:270] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220531 20:40:57.779264 633419 conn_tracker.h:277] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux records=0
I20220531 20:40:57.887400 633147 thriftmux_openssl_trace_bpf_test.cc:112] thriftmux client command output: '633467
20:40:56.112 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
20:40:56.116 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
20:40:56.116 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
20:40:56.135 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
20:40:56.136 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
20:40:56.136 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
20:40:56.137 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
20:40:56.137 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
20:40:56.138 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
        at io.netty.util.internal.ReflectionUtil.trySetAccessible(ReflectionUtil.java:31)
        at io.netty.util.internal.PlatformDependent0$4.run(PlatformDependent0.java:238)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:232)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:24)
        at Client.main(Client.scala)
20:40:56.139 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
20:40:56.140 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @3591009c
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
        at java.base/java.lang.reflect.Method.invoke(Method.java:558)
        at io.netty.util.internal.PlatformDependent0$6.run(PlatformDependent0.java:352)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:343)
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:294)
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:93)
        at io.netty.buffer.PooledByteBufAllocator.<clinit>(PooledByteBufAllocator.java:110)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.$anonfun$exportMetrics$1(exportNetty4MetricsAndRegistryEntries.scala:45)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.netty4.exportNetty4MetricsAndRegistryEntries$.apply(exportNetty4MetricsAndRegistryEntries.scala:144)
        at com.twitter.finagle.netty4.Netty4Init.apply$mcV$sp(Netty4Init.scala:73)
        at com.twitter.finagle.Init$.$anonfun$once$2(Init.scala:98)
        at com.twitter.finagle.Init$.$anonfun$once$2$adapted(Init.scala:96)
        at scala.collection.immutable.Vector.foreach(Vector.scala:1856)
        at com.twitter.finagle.Init$.$anonfun$once$1(Init.scala:96)
        at com.twitter.concurrent.Once$$anon$1.apply$mcV$sp(Once.scala:23)
        at com.twitter.finagle.Init$.apply(Init.scala:131)
        at com.twitter.finagle.client.StackClient$.endpointStack(StackClient.scala:101)
        at com.twitter.finagle.client.StackClient$.newStack(StackClient.scala:286)
        at com.twitter.finagle.Mux$Client$.<clinit>(Mux.scala:158)
        at com.twitter.finagle.Mux$.client(Mux.scala:309)
        at com.twitter.finagle.ThriftMux$.<clinit>(ThriftMux.scala:136)
        at Client$.main(Client.scala:24)
        at Client.main(Client.scala)
20:40:56.140 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
20:40:56.140 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
20:40:56.140 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 2088763392 bytes (maybe)
20:40:56.140 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
20:40:56.141 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
20:40:56.142 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
20:40:56.142 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
20:40:56.142 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
20:40:56.142 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
20:40:56.144 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: true
20:40:56.145 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
20:40:56.148 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
20:40:56.149 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
20:40:56.160 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
20:40:56.160 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
20:40:56.160 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
20:40:56.175 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_648742828098284244458.so
20:40:56.176 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
20:40:56.177 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
20:40:56.178 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
20:40:56.179 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
20:40:56.374 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2ca5f1ed
20:40:56.381 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
20:40:56.704 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
20:40:56.736 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 633484 (auto-detected)
20:40:56.738 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:ac:ff:fe:11:00:02 (auto-detected)
20:40:56.750 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
20:40:56.750 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
20:40:56.750 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
20:40:56.903 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_644745938825833084343.so
20:40:56.904 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Initialize netty-tcnative using engine: 'default'
20:40:56.904 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - netty-tcnative using native library: BoringSSL
20:40:56.966 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
20:40:56.966 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
20:40:56.966 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2d133f82
20:40:56.981 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2b5ba5c6
20:40:56.985 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
20:40:56.985 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxSharedCapacityFactor: disabled
20:40:56.985 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.linkCapacity: disabled
20:40:56.985 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
20:40:56.985 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.delayedQueue.ratio: disabled
20:40:56.993 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
20:40:56.993 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
20:40:56.993 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
20:40:56.993 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
20:40:56.994 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
20:40:56.995 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
20:40:56.996 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
20:40:56.996 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
20:40:56.996 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
20:40:56.996 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
20:40:56.996 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
20:40:56.996 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
20:40:56.997 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
20:40:56.998 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
20:40:56.998 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
20:40:56.998 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
20:40:57.000 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
20:40:57.000 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
20:40:57.000 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
20:40:57.000 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
20:40:57.000 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Supported protocols (OpenSSL): [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3]
20:40:57.000 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Default cipher suites (OpenSSL): [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384]
20:40:57.096 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@746c5926
20:40:57.139 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@46cd7121
20:40:57.406 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.SslHandler - [id: 0xa9c555e7, L:/127.0.0.1:48678 - R:localhost/127.0.0.1:8080] HANDSHAKEN: protocol:TLSv1.3 cipher suite:TLS_AES_128_GCM_SHA256
StringString
'
I20220531 20:40:57.888101 633147 thriftmux_openssl_trace_bpf_test.cc:121] Client PID: 633467
I20220531 20:40:57.891284 633419 conn_tracker.cc:139] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux conn_close: [type=kConnClose ts=438643409005540 conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] source_fn=kSyscallClose [wr_bytes=121 rd_bytes=495]]
I20220531 20:40:57.891332 633419 conn_tracker.cc:598] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Marked for death, countdown=3
I20220531 20:40:57.891355 633419 conn_tracker.cc:198] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux ConnStats timestamp=438643409012518 wr=121 rd=495 close=2
I20220531 20:40:57.891691 633419 conn_tracker.h:270] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220531 20:40:57.891824 633419 conn_tracker.h:277] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux records=0
I20220531 20:40:57.891937 633419 conn_tracker.cc:796] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Death countdown=2
I20220531 20:40:58.003444 633419 conn_tracker.h:270] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220531 20:40:58.003654 633419 conn_tracker.h:277] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux records=0
I20220531 20:40:58.003779 633419 conn_tracker.cc:796] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Death countdown=1
I20220531 20:40:59.704216 633147 container_runner.cc:59] docker rm -f thriftmux_server_438622741729428
I20220531 20:40:59.906308 633147 conn_tracker.cc:78] conn_id=[upid=633230:43862295 fd=114 gen=438642685040706] state=kTransferring remote_addr=127.0.0.1:48678 role=kRoleServer protocol=kProtocolMux Being destroyed
[       OK ] OpenSSLTraceRawFptrsTest/0.mtls_thriftmux_client (23809 ms)
[----------] 1 test from OpenSSLTraceRawFptrsTest/0 (23809 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (23811 ms total)
[  PASSED  ] 1 test.
I20220531 20:40:59.939134 633147 env.cc:51] Shutting down
```

## Future work
- [ ] Follow up with netty team about upstreaming the netty and netty-tcnative changes
- [ ] Address TODO comments in 