### PR TITLE
Upgrade scala and finagle dependencies to latest versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -139,7 +139,7 @@ thrift_deps(scala_version = scala_version)
 
 # twitter_scrooge will use incompatible versions of @scrooge_jars and @thrift_jars.
 # These bind statements ensure that the correct versions of finagle libthrift, scrooge core
-# and scrooge geneator  are used to ensure successful compilation.
+# and scrooge generator are used to ensure successful compilation.
 # See https://github.com/bazelbuild/rules_scala/issues/592 and
 # https://github.com/bazelbuild/rules_scala/pull/847 for more details.
 bind(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,11 +138,17 @@ load("//bazel:thrift.bzl", "thrift_deps")
 thrift_deps(scala_version = scala_version)
 
 # twitter_scrooge will use incompatible versions of @scrooge_jars and @thrift_jars.
-# These bind statements ensure that the correct versions of finagle libthrift are used
-# so that compilation is successful. See https://github.com/bazelbuild/rules_scala/issues/592
-# and https://github.com/bazelbuild/rules_scala/pull/847 for more details.
+# These bind statements ensure that the correct versions of finagle libthrift, scrooge core
+# and scrooge geneator  are used to ensure successful compilation.
+# See https://github.com/bazelbuild/rules_scala/issues/592 and
+# https://github.com/bazelbuild/rules_scala/pull/847 for more details.
 bind(
     name = "io_bazel_rules_scala/dependency/thrift/scrooge_core",
+    actual = "//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:scrooge_jars",
+)
+
+bind(
+    name = "io_bazel_rules_scala/dependency/thrift/scrooge_generator",
     actual = "//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:scrooge_jars",
 )
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -30,11 +30,11 @@ REPOSITORY_LOCATIONS = dict(
         ],
     ),
     io_bazel_rules_scala = dict(
-        sha256 = "0485168f15607ca3eab999ed531bd25596cf4a43b295552c80032ba0e056cd1a",
+        sha256 = "6e9191363357d30b144e7306fec74deea2c7f1de63f3ed32028838116c239e8a",
         urls = [
-            "https://github.com/bazelbuild/rules_scala/archive/9d0d4f99ff79d5d454180a1c799ff1af1d380ed2.tar.gz",
+            "https://github.com/bazelbuild/rules_scala/archive/4ba3780fcba8d26980daff4639abc6f18517308b.tar.gz",
         ],
-        strip_prefix = "rules_scala-9d0d4f99ff79d5d454180a1c799ff1af1d380ed2",
+        strip_prefix = "rules_scala-4ba3780fcba8d26980daff4639abc6f18517308b",
     ),
     io_bazel_rules_k8s = dict(
         sha256 = "a08850199d6900328ef899906717fb1dfcc6cde62701c63725748b2e6ca1d5d9",

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -20,7 +20,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 def thrift_deps(scala_version):
     twitter_scrooge()
 
-    finagle_version = "21.4.0"
+    finagle_version = "22.4.0"
     scala_minor_version = ".".join(scala_version.split(".")[:2])
 
     maven_install(
@@ -29,6 +29,7 @@ def thrift_deps(scala_version):
             "com.twitter:finagle-mux_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:finagle-core_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:scrooge-core_%s:%s" % (scala_minor_version, finagle_version),
+            "com.twitter:scrooge-generator_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:finagle-http_%s:%s" % (scala_minor_version, finagle_version),
             "org.apache.thrift:libthrift:0.10.0",
             "org.slf4j:slf4j-api:1.7.36",

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -90,6 +90,7 @@ scala_library(
         "@maven//:com_twitter_finagle_thrift_2_13",
         "@maven//:com_twitter_finagle_thriftmux_2_13",
         "@maven//:com_twitter_scrooge_core_2_13",
+        "@maven//:com_twitter_scrooge_generator_2_13",
     ],
 )
 

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/client/Client.scala
@@ -17,8 +17,7 @@ object Client {
       new File("/etc/ssl/client.key"),
     )
     val sslConfig = SslClientConfiguration(
-      None,
-      keyCredentials,
+      keyCredentials=keyCredentials,
     )
     var stackClient = if (useTls) {
       ThriftMux.client

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/server/Server.scala
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/src/main/scala/server/Server.scala
@@ -20,7 +20,7 @@ object Server {
       new File("/etc/ssl/server.key"),
     )
     val sslConfig = SslServerConfiguration(
-      keyCredentials,
+      keyCredentials=keyCredentials,
     )
     val addr = new InetSocketAddress(InetAddress.getLoopbackAddress, 8080)
     val testSvc = new TestService.MethodPerEndpoint {


### PR DESCRIPTION
With the netty (https://github.com/netty/netty/pull/12438) and netty-tcnative (https://github.com/netty/netty-tcnative/pull/731) PRs required for #407  being actively reviewed, we will need to update finagle very soon. This PR gets us to the latest version so that the subsequent upgrade will be a smaller change.