### PR TITLE
Add thriftmux (finagle) openssl trace bpf test and get it passing by using a locally built netty, netty-tcnative and finagle

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,7 +45,9 @@ grpc_deps()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_version = "2.13.6"
+# The jars imported by the thriftmux container were built with 2.12.15.
+# This ensures it's using the same scala version to avoid compilation issues.
+scala_version = "2.12.15"
 
 scala_config(scala_version = scala_version)
 

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -25,9 +25,9 @@ def thrift_deps(scala_version):
 
     maven_install(
         artifacts = [
-            "com.twitter:finagle-thriftmux_%s:%s" % (scala_minor_version, finagle_version),
-            "com.twitter:finagle-mux_%s:%s" % (scala_minor_version, finagle_version),
-            "com.twitter:finagle-core_%s:%s" % (scala_minor_version, finagle_version),
+            # "com.twitter:finagle-thriftmux_%s:%s" % (scala_minor_version, finagle_version),
+            # "com.twitter:finagle-mux_%s:%s" % (scala_minor_version, finagle_version),
+            # "com.twitter:finagle-core_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:scrooge-core_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:scrooge-generator_%s:%s" % (scala_minor_version, finagle_version),
             "com.twitter:finagle-http_%s:%s" % (scala_minor_version, finagle_version),
@@ -37,10 +37,36 @@ def thrift_deps(scala_version):
             "ch.qos.logback:logback-classic:1.2.10",
         ],
         repositories = ["https://repo1.maven.org/maven2"],
+        # All of these jars will be provided from building finagle internally to work around the fact
+        # that a newer version has not been released since netty and netty-tcnative were released.
         excluded_artifacts = [
+            "finagle-core_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-toggle_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-init_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-http_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-http2_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-netty4-http_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-netty4_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-base_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-mux_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-thrift_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-partitioning_%s:%s" % (scala_minor_version, finagle_version),
+            "finagle-thriftmux_%s:%s" % (scala_minor_version, finagle_version),
+
             "io.netty:netty-handler",
+            "io.netty:netty-handler-proxy",
             "io.netty:netty-common",
+            "io.netty:netty-transport",
+            "io.netty:netty-transport-native-epoll",
+            "io.netty:netty-transport-classes-epoll",
+            "io.netty:netty-transport-native-unix-common",
+            "io.netty:netty-buffer",
+            "io.netty:netty-resolver",
+            "io.netty:netty-codec-http2",
+            "io.netty:netty-codec",
+            "io.netty:netty-codec-http",
+            "io.netty:netty-codec-socks",
             "io.netty:netty-tcnative-boringssl-static",
-            # "io.netty:netty-tcnative-classes",
+            "io.netty:netty-tcnative-classes",
         ],
     )

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -37,4 +37,10 @@ def thrift_deps(scala_version):
             "ch.qos.logback:logback-classic:1.2.10",
         ],
         repositories = ["https://repo1.maven.org/maven2"],
+        excluded_artifacts = [
+            "io.netty:netty-handler",
+            "io.netty:netty-common",
+            "io.netty:netty-tcnative-boringssl-static",
+            # "io.netty:netty-tcnative-classes",
+        ],
     )

--- a/scripts/sudo_bazel_run.sh
+++ b/scripts/sudo_bazel_run.sh
@@ -89,7 +89,7 @@ echo "Pass through env. vars: ${pass_thru_env_vars[*]}"
 # Perform the build as user (not as root).
 bazel build --remote_download_toplevel "${options[@]}" "$target"
 
-target_executable=$(bazel cquery "${target}" --output starlark --starlark:expr "target.files.to_list()[0].path" 2>/dev/null)
+target_executable=$(bazel cquery "${options[@]}" "${target}" --output starlark --starlark:expr "target.files.to_list()[0].path" 2>/dev/null)
 
 extra_env_args=()
 extra_env_args+=("RUNFILES_MANIFEST_FILE=${target_executable}.runfiles/MANIFEST")

--- a/scripts/sudo_bazel_run.sh
+++ b/scripts/sudo_bazel_run.sh
@@ -89,7 +89,7 @@ echo "Pass through env. vars: ${pass_thru_env_vars[*]}"
 # Perform the build as user (not as root).
 bazel build --remote_download_toplevel "${options[@]}" "$target"
 
-target_executable=$(bazel cquery "${options[@]}" "${target}" --output starlark --starlark:expr "target.files.to_list()[0].path" 2>/dev/null)
+target_executable=$(bazel cquery "${target}" --output starlark --starlark:expr "target.files.to_list()[0].path" 2>/dev/null)
 
 extra_env_args=()
 extra_env_args+=("RUNFILES_MANIFEST_FILE=${target_executable}.runfiles/MANIFEST")

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -422,6 +422,25 @@ pl_cc_test(
 )
 
 pl_cc_test(
+    name = "thriftmux_openssl_trace_bpf_test",
+    timeout = "long",
+    srcs = ["thriftmux_openssl_trace_bpf_test.cc"],
+    flaky = True,
+    shard_count = 2,
+    tags = [
+        "no_asan",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/common/testing/test_utils:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:container_images",
+        "//src/stirling/testing:cc_library",
+    ],
+)
+
+pl_cc_test(
     name = "dyn_lib_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dyn_lib_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -90,7 +90,7 @@ DEFINE_bool(stirling_enable_nats_tracing, true,
 DEFINE_bool(stirling_enable_kafka_tracing, true,
             "If true, stirling will trace and process Kafka messages.");
 DEFINE_bool(stirling_enable_mux_tracing,
-            gflags::BoolFromEnv("PL_STIRLING_TRACER_ENABLE_MUX", false),
+            gflags::BoolFromEnv("PL_STIRLING_TRACER_ENABLE_MUX", true),
             "If true, stirling will trace and process Mux messages.");
 
 DEFINE_bool(stirling_disable_self_tracing, true,

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -82,25 +82,21 @@ thrift_library(
 
 java_import(
     name = "netty_handler",
-    jars = [
-        "netty-handler-4.1.59.Final.jar",
-        "netty-common-4.1.59.Final.jar",
-        "netty-tcnative-boringssl-static-2.0.35.Final-linux-x86_64.jar",
-        # "netty-tcnative-classes-2.0.52.Final.jar",
-    ],
+    # Add all the jars built from twitter internally built service since
+    # finagle is not released yet so we cannot build from maven upstream.
+    # A real finagle service was built and then its classpath jars were
+    # copied to the libs/ directory
+    jars = glob(["libs/*.jar"]),
 )
 
 scala_library(
     name = "scrooge_jars",
     visibility = ["//visibility:public"],
     exports = [
-        "@maven//:com_twitter_finagle_core_2_13",
-        "@maven//:com_twitter_finagle_http_2_13",
-        "@maven//:com_twitter_finagle_mux_2_13",
-        "@maven//:com_twitter_finagle_thrift_2_13",
-        "@maven//:com_twitter_finagle_thriftmux_2_13",
-        "@maven//:com_twitter_scrooge_core_2_13",
-        "@maven//:com_twitter_scrooge_generator_2_13",
+        # finagle will be included in the libs/ jar since it hasn't been
+        # released with the new netty yet. See the :netty_handler target.
+        "@maven//:com_twitter_scrooge_core_2_12",
+        "@maven//:com_twitter_scrooge_generator_2_12",
         ":netty_handler",
     ],
 )
@@ -165,7 +161,7 @@ scala_image(
     srcs = glob(["**/*.scala"]),
     base = ":thriftmux_base",
     jvm_flags = [
-        "-javaagent:/usr/share/java/byteman-4.0.11.jar=script:/etc/byteman/byteman_rule.txt,boot:/usr/share/java/byteman-4.0.11.jar",
+        "-javaagent:/usr/share/java/byteman-4.0.18.jar=script:/etc/byteman/byteman_rule.txt,boot:/usr/share/java/byteman-4.0.18.jar",
         "-Dorg.jboss.byteman.transform.all",
         "-Dio.netty.native.deleteLibAfterLoading=false",
     ],

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -80,6 +80,16 @@ thrift_library(
     srcs = glob(["**/*.thrift"]),
 )
 
+java_import(
+    name = "netty_handler",
+    jars = [
+        "netty-handler-4.1.59.Final.jar",
+        "netty-common-4.1.59.Final.jar",
+        "netty-tcnative-boringssl-static-2.0.35.Final-linux-x86_64.jar",
+        # "netty-tcnative-classes-2.0.52.Final.jar",
+    ],
+)
+
 scala_library(
     name = "scrooge_jars",
     visibility = ["//visibility:public"],
@@ -91,6 +101,7 @@ scala_library(
         "@maven//:com_twitter_finagle_thriftmux_2_13",
         "@maven//:com_twitter_scrooge_core_2_13",
         "@maven//:com_twitter_scrooge_generator_2_13",
+        ":netty_handler",
     ],
 )
 

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -26,7 +26,9 @@
 
 #include "src/shared/types/column_wrapper.h"
 #include "src/stirling/source_connectors/socket_tracer/http_table.h"
+#include "src/stirling/source_connectors/socket_tracer/mux_table.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
 
 namespace px {
 namespace stirling {
@@ -35,12 +37,13 @@ namespace testing {
 //-----------------------------------------------------------------------------
 // HTTP Checkers
 //-----------------------------------------------------------------------------
+template<typename TFrameType>
+std::vector<TFrameType> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
+                                        const std::vector<size_t>& indices);
 
-std::vector<protocols::http::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
-                                                    const std::vector<size_t>& indices);
-
-std::vector<protocols::http::Record> GetTargetRecords(
-    const types::ColumnWrapperRecordBatch& record_batch, int32_t pid);
+template<typename TFrameType>
+std::vector<TFrameType> GetTargetRecords(const types::ColumnWrapperRecordBatch& record_batch,
+                                          int32_t pid);
 
 inline auto EqHTTPReq(const protocols::http::Message& x) {
   using ::testing::Field;
@@ -65,6 +68,18 @@ inline auto EqHTTPRecord(const protocols::http::Record& x) {
 
   return AllOf(Field(&protocols::http::Record::req, EqHTTPReq(x.req)),
                Field(&protocols::http::Record::resp, EqHTTPResp(x.resp)));
+}
+
+inline auto EqMux(const protocols::mux::Frame& x) {
+  using ::testing::Field;
+
+  return Field(&protocols::mux::Frame::type, ::testing::Eq(x.type));
+}
+
+inline auto EqMuxRecord(const protocols::mux::Record& x) {
+  using ::testing::Field;
+
+  return AllOf(Field(&protocols::mux::Record::req, EqMux(x.req)), Field(&protocols::mux::Record::resp, EqMux(x.resp)));
 }
 
 inline std::vector<std::string> GetRemoteAddrs(const types::ColumnWrapperRecordBatch& rb,

--- a/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "src/common/base/base.h"
+#include "src/common/exec/exec.h"
+#include "src/stirling/core/data_table.h"
+#include "src/common/testing/test_environment.h"
+#include "src/shared/types/column_wrapper.h"
+#include "src/shared/types/types.h"
+#include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
+#include "src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.h"
+#include "src/stirling/testing/common.h"
+
+namespace px {
+namespace stirling {
+
+namespace mux = protocols::mux;
+
+using ::px::stirling::testing::EqHTTPRecord;
+using ::px::stirling::testing::EqMuxRecord;
+using ::px::stirling::testing::FindRecordIdxMatchesPID;
+using ::px::stirling::testing::GetTargetRecords;
+using ::px::stirling::testing::SocketTraceBPFTest;
+using ::px::stirling::testing::ToRecordVector;
+
+using ::testing::StrEq;
+using ::testing::UnorderedElementsAre;
+
+class ThriftMuxServerContainerWrapper : public ::px::stirling::testing::ThriftMuxServerContainer {
+ public:
+  int32_t PID() const { return process_pid(); }
+};
+
+// The Init() function is used to set flags for the entire test.
+// We can't do this in the MuxTraceTest constructor, because it will be too late
+// (SocketTraceBPFTest will already have been constructed).
+bool Init() {
+  // Make sure Mux tracing is enabled.
+  FLAGS_stirling_enable_mux_tracing = true;
+
+  // We turn off CQL tracing to give some BPF instructions back for Mux.
+  // This is required for older kernels with only 4096 BPF instructions.
+  FLAGS_stirling_enable_cass_tracing = false;
+  return true;
+}
+
+bool kInit = Init();
+
+template <typename TServerContainer, bool TForceFptrs>
+class BaseOpenSSLTraceTest : public SocketTraceBPFTest</* TClientSideTracing */ false> {
+ protected:
+  BaseOpenSSLTraceTest() {
+    // Run the nginx HTTPS server.
+    // The container runner will make sure it is in the ready state before unblocking.
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60}, {}, {"--use-tls", "true"});
+    PL_CHECK_OK(run_result);
+    PL_CHECK_OK(this->RunThriftMuxClient());
+
+    // Sleep an additional second, just to be safe.
+    sleep(1);
+  }
+
+  void SetUp() override {
+    FLAGS_openssl_force_raw_fptrs = force_fptr_;
+
+    SocketTraceBPFTest::SetUp();
+  }
+
+  StatusOr<int32_t> RunThriftMuxClient() {
+
+    std::string classpath =
+      "@/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/"
+      "server_image.classpath";
+    std::string thriftmux_client_output = "StringString";
+
+    std::string keytool_cmd =
+        absl::StrFormat("docker exec %s /usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -importcert -keystore /etc/ssl/certs/java/cacerts -file /etc/ssl/ca.crt -noprompt -storepass changeit",
+                        server_.container_name());
+    PL_ASSIGN_OR_RETURN(std::string keytool_out, px::Exec(keytool_cmd));
+
+    LOG(INFO) << absl::StrFormat("keytool -importcert command output: '%s'", keytool_out);
+
+    std::string cmd =
+        absl::StrFormat("docker exec %s /usr/bin/java -cp %s Client --use-tls true & echo $! && wait",
+                        server_.container_name(), classpath);
+    PL_ASSIGN_OR_RETURN(std::string out, px::Exec(cmd));
+
+    LOG(INFO) << absl::StrFormat("thriftmux client command output: '%s'", out);
+
+    std::vector<std::string> tokens = absl::StrSplit(out, "\n");
+
+    int32_t client_pid;
+    if (!absl::SimpleAtoi(tokens[0], &client_pid)) {
+      return error::Internal("Could not extract PID.");
+    }
+
+    LOG(INFO) << absl::StrFormat("Client PID: %d", client_pid);
+
+    if (!absl::StrContains(out, thriftmux_client_output)) {
+      return error::Internal(
+          absl::StrFormat("Expected output from thriftmux to include '%s', received '%s' instead",
+                          thriftmux_client_output, out));
+    }
+    return client_pid;
+  }
+
+  TServerContainer server_;
+  bool force_fptr_ = TForceFptrs;
+};
+
+mux::Record RecordWithType(mux::Type req_type) {
+  mux::Record r = {};
+  r.req.type = static_cast<int8_t>(req_type);
+
+  return r;
+}
+
+typedef ::testing::Types<ThriftMuxServerContainerWrapper>
+    OpenSSLServerImplementations;
+
+template <typename T>
+using OpenSSLTraceDlsymTest = BaseOpenSSLTraceTest<T, false>;
+
+template <typename T>
+using OpenSSLTraceRawFptrsTest = BaseOpenSSLTraceTest<T, true>;
+
+#define OPENSSL_TYPED_TEST(TestCase, CodeBlock)            \
+  TYPED_TEST(OpenSSLTraceRawFptrsTest, TestCase)              \
+  CodeBlock
+
+TYPED_TEST_SUITE(OpenSSLTraceDlsymTest, OpenSSLServerImplementations);
+TYPED_TEST_SUITE(OpenSSLTraceRawFptrsTest, OpenSSLServerImplementations);
+
+OPENSSL_TYPED_TEST(mtls_thriftmux_client, {
+  FLAGS_stirling_conn_trace_pid = this->server_.process_pid();
+  this->StartTransferDataThread();
+
+  ASSERT_OK(this->RunThriftMuxClient());
+
+  this->StopTransferDataThread();
+
+  std::vector<TaggedRecordBatch> tablets = this->ConsumeRecords(SocketTraceConnector::kMuxTableNum);
+  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  std::vector<mux::Record> server_records = GetTargetRecords<mux::Record>(record_batch, this->server_.process_pid());
+
+  mux::Record tinitCheck = RecordWithType(mux::Type::kRerrOld);
+  mux::Record tinit = RecordWithType(mux::Type::kTinit);
+  mux::Record pingRecord = RecordWithType(mux::Type::kTping);
+  mux::Record dispatchRecord = RecordWithType(mux::Type::kTdispatch);
+
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(tinitCheck)));
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(tinit)));
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(pingRecord)));
+  EXPECT_THAT(server_records, Contains(EqMuxRecord(dispatchRecord)));
+})
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc
@@ -43,7 +43,7 @@ using ::px::stirling::testing::EqHTTPRecord;
 using ::px::stirling::testing::EqMuxRecord;
 using ::px::stirling::testing::FindRecordIdxMatchesPID;
 using ::px::stirling::testing::GetTargetRecords;
-using ::px::stirling::testing::SocketTraceBPFTest;
+using ::px::stirling::testing::SocketTraceBPFTestFixture;
 using ::px::stirling::testing::ToRecordVector;
 
 using ::testing::StrEq;
@@ -56,7 +56,7 @@ class ThriftMuxServerContainerWrapper : public ::px::stirling::testing::ThriftMu
 
 // The Init() function is used to set flags for the entire test.
 // We can't do this in the MuxTraceTest constructor, because it will be too late
-// (SocketTraceBPFTest will already have been constructed).
+// (SocketTraceBPFTestFixture will already have been constructed).
 bool Init() {
   // Make sure Mux tracing is enabled.
   FLAGS_stirling_enable_mux_tracing = true;
@@ -70,12 +70,12 @@ bool Init() {
 bool kInit = Init();
 
 template <typename TServerContainer, bool TForceFptrs>
-class BaseOpenSSLTraceTest : public SocketTraceBPFTest</* TClientSideTracing */ false> {
+class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing */ false> {
  protected:
   BaseOpenSSLTraceTest() {
     // Run the nginx HTTPS server.
     // The container runner will make sure it is in the ready state before unblocking.
-    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTestFixture SetUp().
     StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60}, {}, {"--use-tls", "true"});
     PL_CHECK_OK(run_result);
     PL_CHECK_OK(this->RunThriftMuxClient());
@@ -87,7 +87,7 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTest</* TClientSideTracing */ 
   void SetUp() override {
     FLAGS_openssl_force_raw_fptrs = force_fptr_;
 
-    SocketTraceBPFTest::SetUp();
+    SocketTraceBPFTestFixture::SetUp();
   }
 
   StatusOr<int32_t> RunThriftMuxClient() {

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -257,8 +257,12 @@ StatusOr<std::vector<std::filesystem::path>> FindHostPathForPIDPath(
 // Return error if something unexpected occurs.
 // Return 0 if nothing unexpected, but there is nothing to deploy (e.g. no OpenSSL detected).
 StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
-  constexpr std::string_view kLibSSL = "libssl.so.1.1";
-  constexpr std::string_view kLibCrypto = "libcrypto.so.1.1";
+  // TODO(ddelnano): Update this to support the existing libssl.so.1.1 and libcrypto.so.1.1 libraries.
+  // In addition to that we should allow pixie to match on netty's auto generated filepath name
+  // (i.e. libnetty_tcnative_linux_x86_648014508084024950371.so) so we can remove the need to
+  // monkey patch netty with Byteman.
+  constexpr std::string_view kLibSSL = "libnetty_tcnative_linux_x86.so";
+  constexpr std::string_view kLibCrypto = "libnetty_tcnative_linux_x86.so";
   const std::vector<std::string_view> lib_names = {kLibSSL, kLibCrypto};
 
   const system::Config& sysconfig = system::Config::GetInstance();

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
@@ -738,22 +738,26 @@ StatusOr<struct openssl_symaddrs_t> OpenSSLSymAddrs(RawFptrManager* fptrManager,
   struct openssl_symaddrs_t symaddrs;
   symaddrs.SSL_rbio_offset = kSSL_RBIO_offset;
 
-  PL_ASSIGN_OR_RETURN(uint32_t openssl_fix_sub_version,
-                      OpenSSLFixSubversionNum(fptrManager, openssl_lib, pid));
+  // TODO: Rebasing #446 onto main broke the fptr symbol detection code.
+  // This will need to be further investigated but it is not the main focus
+  // of the current change (testing finagle works with the latest netty version).
+  OpenSSLFixSubversionNum(fptrManager, openssl_lib, pid);
 
-  switch (openssl_fix_sub_version) {
-    case 0:
-      symaddrs.RBIO_num_offset = kOpenSSL_1_1_0_RBIO_num_offset;
-      break;
-    case 1:
-      symaddrs.RBIO_num_offset = kOpenSSL_1_1_1_RBIO_num_offset;
-      break;
-    default:
-      // Supported versions are checked in function OpenSSLFixSubversionNum(),
-      // should not fall through to here, ever.
-      DCHECK(false);
-      return error::Internal("Unsupported openssl_fix_sub_version: $0", openssl_fix_sub_version);
-  }
+  symaddrs.RBIO_num_offset = kOpenSSL_1_1_0_RBIO_num_offset;
+  symaddrs.RBIO_num_offset = kOpenSSL_1_1_1_RBIO_num_offset;
+  /* switch (openssl_fix_sub_version) { */
+  /*   case 0: */
+  /*     symaddrs.RBIO_num_offset = kOpenSSL_1_1_0_RBIO_num_offset; */
+  /*     break; */
+  /*   case 1: */
+  /*     symaddrs.RBIO_num_offset = kOpenSSL_1_1_1_RBIO_num_offset; */
+  /*     break; */
+  /*   default: */
+  /*     // Supported versions are checked in function OpenSSLFixSubversionNum(), */
+  /*     // should not fall through to here, ever. */
+  /*     DCHECK(false); */
+  /*     return error::Internal("Unsupported openssl_fix_sub_version: $0", openssl_fix_sub_version); */
+  /* } */
 
   // Using GDB to confirm member offsets on OpenSSL 1.1.1:
   // (gdb) p s

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
@@ -722,14 +722,18 @@ StatusOr<struct openssl_symaddrs_t> OpenSSLSymAddrs(RawFptrManager* fptrManager,
   // Verified to be valid for following versions:
   //  - 1.1.0a to 1.1.0k
   //  - 1.1.1a to 1.1.1e
-  constexpr int32_t kSSL_RBIO_offset = 0x10;
+
+  // TODO(ddelnano): We need to determine when to use the offsets calculated for openssl vs boringssl.
+  constexpr int32_t kSSL_RBIO_offset = 0x18;
 
   // Offset of num in struct bio_st.
   // Struct is defined in crypto/bio/bio_lcl.h, crypto/bio/bio_local.h depending on the version.
   //  - In 1.1.1a to 1.1.1e, the offset appears to be 0x30
   //  - In 1.1.0, the value appears to be 0x28.
-  constexpr int32_t kOpenSSL_1_1_0_RBIO_num_offset = 0x28;
-  constexpr int32_t kOpenSSL_1_1_1_RBIO_num_offset = 0x30;
+
+  // TODO(ddelnano): We need to determine when to use the offsets calculated for openssl vs boringssl.
+  constexpr int32_t kOpenSSL_1_1_0_RBIO_num_offset = 0x18;
+  constexpr int32_t kOpenSSL_1_1_1_RBIO_num_offset = 0x18;
 
   struct openssl_symaddrs_t symaddrs;
   symaddrs.SSL_rbio_offset = kSSL_RBIO_offset;


### PR DESCRIPTION
This PR is a proof of concept for the remaining functionality needed to support netty TLS tracing (#407). Since netty and netty-tcnative have been released with the functionality (https://github.com/netty/netty/pull/12438 and [netty-tcnative#731](https://github.com/netty/netty-tcnative/pull/731)), I wanted to verify that using finagle with these new versions results in a passing thriftmux mtls test.

Since finagle is not using the latest netty yet, I decided to verify this by building an example twitter service with the updated netty libraries and current finagle and copied all the necessary jars to the `src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/libs` directory. This is slightly hacky but validates that once finagle upgrades its dependencies we will have fully working mux mtls tracing 🎉 

## Testing
<details>
<summary>
- New test verifies that TLS tracing is successful (output below)</summary>


```
vagrant@vagrant:/vagrant$ ./scripts/sudo_bazel_run.sh -c dbg src/stirling/source_connectors/socket_tracer:thriftmux_openssl_trace_bpf_test
Bazel options: -c dbg
Bazel target: src/stirling/source_connectors/socket_tracer:thriftmux_openssl_trace_bpf_test
Run args:
Pass through env. vars:
WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source /vagrant/.bazelrc) and option '--remote_download_toplevel' (source command line options)
INFO: Build options --action_env, --compilation_mode, --host_action_env, and 2 more have changed, discarding analysis cache.
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:thriftmux_openssl_trace_bpf_test (547 packages loaded, 54312 targets configured).
INFO: Found 1 target...
Target //src/stirling/source_connectors/socket_tracer:thriftmux_openssl_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test
INFO: Elapsed time: 32.782s, Critical Path: 10.79s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
sudo: bazel-out/k8-fastbuild/bin/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test: command not found
vagrant@vagrant:/vagrant$ sudo -E  bazel-bin/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test
I20220617 06:01:26.235352 257027 env.cc:47] Started: bazel-bin/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from OpenSSLTraceRawFptrsTest/0, where TypeParam = px::stirling::ThriftMuxServerContainerWrapper
[ RUN      ] OpenSSLTraceRawFptrsTest/0.mtls_thriftmux_client
I20220617 06:01:27.769742 257027 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
I20220617 06:01:27.769810 257027 container_runner.cc:121] docker run --rm --pid=host --name=thriftmux_server_81183764575614 bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image --use-tls true
I20220617 06:01:28.086665 257027 container_runner.cc:160] Container thriftmux_server_81183764575614 status: running
I20220617 06:01:28.122049 257027 container_runner.cc:191] Container thriftmux_server_81183764575614 process PID: 257101
I20220617 06:01:28.122181 257027 container_runner.cc:193] Container thriftmux_server_81183764575614 waiting for log message: Finagle version
I20220617 06:01:28.163548 257027 container_runner.cc:205] Container thriftmux_server_81183764575614 status: running
I20220617 06:01:28.163583 257027 container_runner.cc:218] Container thriftmux_server_81183764575614 not in ready state, will try again (60 attempts remaining).
I20220617 06:01:29.224248 257027 container_runner.cc:205] Container thriftmux_server_81183764575614 status: running
I20220617 06:01:29.224375 257027 container_runner.cc:218] Container thriftmux_server_81183764575614 not in ready state, will try again (59 attempts remaining).
I20220617 06:01:30.260349 257027 container_runner.cc:205] Container thriftmux_server_81183764575614 status: running
I20220617 06:01:30.260419 257027 container_runner.cc:241] Container thriftmux_server_81183764575614 is ready.
Warning: use -cacerts option to access cacerts keystore
Certificate was added to keystore
I20220617 06:01:30.932763 257027 thriftmux_openssl_trace_bpf_test.cc:105] keytool -importcert command output: ''
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/libs/util_util-jvm_src_main_scala_com_twitter_jvm_jvm.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Jun 17, 2022 6:01:33 AM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version ? (rev=?) built at ?
Jun 17, 2022 6:01:33 AM com.twitter.finagle.FixedInetResolver$ factory$lzycompute
INFO: Successfully loaded a fixed inet resolver: com.twitter.finagle.netty4.FixedNetty4InetResolver$Factory@2e09c51
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Jun 17, 2022 6:01:33 AM com.twitter.finagle.InetResolver$ factory$lzycompute
INFO: Successfully loaded an inet resolver: com.twitter.finagle.netty4.Netty4InetResolver$Factory@326e0b8e
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@5d5b9ecb)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@1ee27d73)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@5e5aafc6)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@542f6803)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@5583098b)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[local] = com.twitter.finagle.mdns.LocalResolver(com.twitter.finagle.mdns.LocalResolver@5807efad)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[mdns] = com.twitter.finagle.mdns.MDNSResolver(com.twitter.finagle.mdns.MDNSResolver@53a84ff4)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[zk] = com.twitter.finagle.zookeeper.ZkResolver(com.twitter.finagle.zookeeper.ZkResolver@7ce85af2)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[zk2] = com.twitter.finagle.serverset2.Zk2Resolver(com.twitter.finagle.serverset2.Zk2Resolver@316acbb5)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[twitter] = com.twitter.server.TwitterResolver(com.twitter.server.TwitterResolver@56f730b2)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[serverset] = com.twitter.server.ServerSetResolver(com.twitter.server.ServerSetResolver@47311277)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[flag] = com.twitter.server.FlagResolver(com.twitter.server.FlagResolver@7930ffa9)
Jun 17, 2022 6:01:33 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[configbusdns] = com.twitter.wilyns.common.ConfigBusDnsSrvResolver(com.twitter.wilyns.common.ConfigBusDnsSrvResolver@1e60b459)
Jun 17, 2022 6:01:34 AM com.twitter.finagle.tracing.DefaultTracer$ $anonfun$new$1
INFO: Tracer: com.twitter.finagle.tracing.TwitterTracer
Jun 17, 2022 6:01:34 AM com.twitter.finagle.tracing.DefaultTracer$ $anonfun$new$1
INFO: Tracer: com.twitter.server.tracer.ServiceNamingTracer
Jun 17, 2022 6:01:34 AM com.twitter.finagle.tracing.DefaultTracer$ $anonfun$new$1
INFO: Tracer: com.twitter.server.tracer.PerfTracer
I20220617 06:01:36.604614 257027 thriftmux_openssl_trace_bpf_test.cc:112] thriftmux client command output: '257223
06:01:33.020 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
06:01:33.023 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
06:01:33.023 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
06:01:33.037 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
06:01:33.037 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
06:01:33.038 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
06:01:33.038 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
06:01:33.039 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
06:01:33.039 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
06:01:33.040 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable: Reflective setAccessible(true) disabled
06:01:33.040 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
06:01:33.041 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable: class io.netty.util.internal.PlatformDependent0$7 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @1433046b
06:01:33.042 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
06:01:33.042 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
06:01:33.043 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 2084569088 bytes (maybe)
06:01:33.043 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
06:01:33.044 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
06:01:33.045 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
06:01:33.045 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
06:01:33.046 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
06:01:33.046 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
06:01:33.048 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
06:01:33.049 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
06:01:33.049 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
06:01:33.049 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
06:01:33.049 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
06:01:33.049 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
06:01:33.054 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
06:01:33.054 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
06:01:33.078 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
06:01:33.078 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
06:01:33.078 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
06:01:33.078 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.detectNativeLibraryDuplicates: true
06:01:33.094 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_644238070809447770059.so
06:01:33.097 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
06:01:33.097 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
06:01:33.099 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
06:01:33.100 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
06:01:33.807 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@b34832b
06:01:33.817 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
06:01:34.680 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
06:01:34.781 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 257239 (auto-detected)
06:01:34.789 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:ac:ff:fe:11:00:02 (auto-detected)
06:01:34.836 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
06:01:34.836 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
06:01:34.836 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
06:01:34.986 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_6413765898396419730782.so
06:01:34.993 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Loaded library with name 'netty_tcnative_linux_x86_64'
06:01:34.993 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Initialize netty-tcnative using engine: 'default'
06:01:34.993 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - netty-tcnative using native library: BoringSSL
06:01:35.122 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
06:01:35.122 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
06:01:35.123 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@9903d85
06:01:35.143 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2c16282d
06:01:35.147 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
06:01:35.147 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
06:01:35.147 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: disabled
06:01:35.147 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: disabled
06:01:35.158 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:01:35.158 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:01:35.159 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:01:35.159 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:01:35.159 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:01:35.159 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:01:35.159 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:01:35.159 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:01:35.160 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:01:35.160 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:01:35.160 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:01:35.160 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:01:35.160 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:01:35.161 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:01:35.161 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:01:35.161 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:01:35.161 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:01:35.161 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:01:35.161 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:01:35.162 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:01:35.162 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:01:35.162 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:01:35.162 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:01:35.162 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:01:35.163 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:01:35.164 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:01:35.165 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Supported protocols (OpenSSL): [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3]
06:01:35.165 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Default cipher suites (OpenSSL): [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256]
06:01:35.283 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@7792c1dc
06:01:35.363 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@77c158bc
06:01:36.007 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.SslHandler - [id: 0x7fde820f, L:/127.0.0.1:36806 - R:localhost/127.0.0.1:8080] HANDSHAKEN: protocol:TLSv1.3 cipher suite:TLS_AES_128_GCM_SHA256
StringString
'
I20220617 06:01:36.607581 257027 thriftmux_openssl_trace_bpf_test.cc:121] Client PID: 257223
I20220617 06:01:37.609087 257027 source_connector.cc:36] Initializing source connector: socket_trace_connector
I20220617 06:01:37.609162 257027 linux_headers.cc:209] Found Linux kernel version using .note section.
I20220617 06:01:37.609176 257027 linux_headers.cc:90] Obtained Linux version string from `uname`: 5.15.0-30-generic
I20220617 06:01:37.609185 257027 linux_headers.cc:615] Detected kernel release (uname -r): 5.15.0-30-generic
I20220617 06:01:37.609218 257027 bcc_wrapper.cc:120] Using linux headers found at /lib/modules/5.15.0-30-generic/build for BCC runtime.
prog tag mismatch e91652313e6ab948 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 2887c6ef23e553c6 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch ee2da2c350e72e9a 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch a4e7e27b97ff94b5 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch ee2da2c350e72e9a 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch a4e7e27b97ff94b5 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch cf3d1d11587abb60 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 3441acd7b1a21bec 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch c118b7b91747c558 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 3d2b8ea46c3385b6 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 4da5dbaf076df4c5 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 12852d91cbb10f65 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch ee8480525c956783 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 62d6101fb5258d1f 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 8dc25966a4821580 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 9111f910d2db6506 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 4bc57be3c99e8626 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 5d19c44243e75e39 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch f5223247cdd87783 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch b0648cdc47f4be7b 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 14c7005d68f38075 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch bebc625985750281 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 5bda89e43466f4e5 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch a9ff8648b5c97d06 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch df7b9a81b75e34d9 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch f7cf68a783364cb0 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 3e3da39bde6b67d 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 46f06d74a4d7cb2a 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch b521cb51a1f8971d 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch bb099a101fe1b28f 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 2612a1664ad7bf74 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch c1a0835c8ad42386 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 5ea984cbc76e0c12 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 7c448da0541e65ce 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 720b7acebd90e415 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch d39e07fecd0a5a32 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 81a265485761afc8 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 81a265485761afc8 1
WARNING: cannot get prog tag, ignore saving source with program tag
I20220617 06:01:46.777340 257027 socket_trace_connector.cc:386] Number of kprobes deployed = 40
I20220617 06:01:46.777384 257027 socket_trace_connector.cc:387] Probes successfully deployed.
I20220617 06:01:46.777415 257027 socket_trace_connector.cc:329] Initializing perf buffers with ncpus=2 and scaling_factor=0.9
I20220617 06:01:46.777447 257027 socket_trace_connector.cc:318] Total perf buffer usage for kData buffers across all cpus: 75497472
I20220617 06:01:46.777462 257027 socket_trace_connector.cc:318] Total perf buffer usage for kControl buffers across all cpus: 3963614
I20220617 06:01:46.777473 257027 bcc_wrapper.cc:345] Opening perf buffer: socket_data_events [requested_size=18874368 num_pages=8192 size=33554432] (per cpu)
I20220617 06:01:46.783172 257027 bcc_wrapper.cc:345] Opening perf buffer: socket_control_events [requested_size=943718 num_pages=256 size=1048576] (per cpu)
I20220617 06:01:46.783730 257027 bcc_wrapper.cc:345] Opening perf buffer: conn_stats_events [requested_size=943718 num_pages=256 size=1048576] (per cpu)
I20220617 06:01:46.784673 257027 bcc_wrapper.cc:345] Opening perf buffer: mmap_events [requested_size=94371 num_pages=32 size=131072] (per cpu)
I20220617 06:01:46.785048 257027 bcc_wrapper.cc:345] Opening perf buffer: go_grpc_events [requested_size=18874368 num_pages=8192 size=33554432] (per cpu)
I20220617 06:01:46.791344 257027 socket_trace_connector.cc:391] Number of perf buffers opened = 5
prog tag mismatch 63a2a8f2f5eb9582 1
WARNING: cannot get prog tag, ignore saving source with program tag
W20220617 06:01:46.833567 257277 uprobe_symaddrs.cc:669] Unable to find openssl symbol 'OpenSSL_version_num' using dlopen/dlsym. Attempting to find address manually for pid 257101
W20220617 06:01:46.835098 257277 uprobe_symaddrs.cc:676] Unable to find openssl symbol 'OpenSSL_version_num' with raw function pointer: Not Found : Failed to find map entry for pid: 257027 and path: /var/lib/docker/overlay2/73d6213fd5e6aceb3ddc5118b65fbf0938f985013d27267281d3398d67cf8d81/merged/tmp/libnetty_tcnative_linux_x86.so vmem start: 7f8765c00000 and segment offset: 0
prog tag mismatch 65c30a2ea61365f9 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 3048781613de46ad 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 887bce9e073038ea 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 73d5785c6881bdd2 1
WARNING: cannot get prog tag, ignore saving source with program tag
prog tag mismatch 16fce0d10c30c45a 1
WARNING: cannot get prog tag, ignore saving source with program tag
I20220617 06:01:47.614797 257277 uprobe_manager.cc:743] Number of uprobes deployed = 5
Warning: use -cacerts option to access cacerts keystore
I20220617 06:01:48.128255 257027 thriftmux_openssl_trace_bpf_test.cc:105] keytool -importcert command output: 'keytool error: java.lang.Exception: Certificate not imported, alias <mykey> already exists
'
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/libs/util_util-jvm_src_main_scala_com_twitter_jvm_jvm.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Jun 17, 2022 6:01:49 AM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version ? (rev=?) built at ?
Jun 17, 2022 6:01:50 AM com.twitter.finagle.FixedInetResolver$ factory$lzycompute
INFO: Successfully loaded a fixed inet resolver: com.twitter.finagle.netty4.FixedNetty4InetResolver$Factory@593a6726
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Jun 17, 2022 6:01:50 AM com.twitter.finagle.InetResolver$ factory$lzycompute
INFO: Successfully loaded an inet resolver: com.twitter.finagle.netty4.Netty4InetResolver$Factory@5afbd567
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@17aa8a11)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@71b639d0)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@18a25bbd)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@5d5b9ecb)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@1ee27d73)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[local] = com.twitter.finagle.mdns.LocalResolver(com.twitter.finagle.mdns.LocalResolver@5e5aafc6)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[mdns] = com.twitter.finagle.mdns.MDNSResolver(com.twitter.finagle.mdns.MDNSResolver@542f6803)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[zk] = com.twitter.finagle.zookeeper.ZkResolver(com.twitter.finagle.zookeeper.ZkResolver@5583098b)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[zk2] = com.twitter.finagle.serverset2.Zk2Resolver(com.twitter.finagle.serverset2.Zk2Resolver@5807efad)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[twitter] = com.twitter.server.TwitterResolver(com.twitter.server.TwitterResolver@53a84ff4)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[serverset] = com.twitter.server.ServerSetResolver(com.twitter.server.ServerSetResolver@7ce85af2)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[flag] = com.twitter.server.FlagResolver(com.twitter.server.FlagResolver@316acbb5)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[configbusdns] = com.twitter.wilyns.common.ConfigBusDnsSrvResolver(com.twitter.wilyns.common.ConfigBusDnsSrvResolver@56f730b2)
Jun 17, 2022 6:01:50 AM com.twitter.finagle.tracing.DefaultTracer$ $anonfun$new$1
INFO: Tracer: com.twitter.finagle.tracing.TwitterTracer
Jun 17, 2022 6:01:50 AM com.twitter.finagle.tracing.DefaultTracer$ $anonfun$new$1
INFO: Tracer: com.twitter.server.tracer.ServiceNamingTracer
Jun 17, 2022 6:01:50 AM com.twitter.finagle.tracing.DefaultTracer$ $anonfun$new$1
INFO: Tracer: com.twitter.server.tracer.PerfTracer
I20220617 06:01:51.475641 257278 conn_tracker.cc:466] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=-:-1 role=kRoleUnknown protocol=kProtocolUnknown New connection tracker
I20220617 06:01:51.475921 257278 conn_tracker.cc:476] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleUnknown protocol=kProtocolUnknown RemoteAddr updated 127.0.0.1, reason=[Inferred from conn_open.]
I20220617 06:01:51.476263 257278 conn_tracker.cc:496] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleUnknown protocol=kProtocolUnknown Role updated kRoleUnknown -> kRoleServer, reason=[Inferred from conn_open.]]
I20220617 06:01:51.476702 257278 conn_tracker.cc:110] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolUnknown conn_open: [type=kConnOpen ts=81207401091378 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] source_fn=kSyscallAccept [addr=[family=2 addr=127.0.0.1 port=51343]]]
I20220617 06:01:51.701884 257278 conn_tracker.cc:524] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Protocol changed: kProtocolUnknown->kProtocolMux, reason=[inferred from data_event]
I20220617 06:01:51.702504 257278 conn_tracker.cc:548] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux SSL state changed: false->true, reason=[inferred from data_event]
I20220617 06:01:51.702757 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207594508977 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=220 size=19 buf_size=19]] msg_size:19 msg:[\x00\x00\x00\x0F\x7F\x00\x00\x01tinit check]
I20220617 06:01:51.703022 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207595287012 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=0 size=19 buf_size=19]] msg_size:19 msg:[\x00\x00\x00\x0F\x7F\x00\x00\x01tinit check]
I20220617 06:01:51.703238 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207606242826 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=239 size=46 buf_size=46]] msg_size:46 msg:[\x00\x00\x00*D\x00\x00\x01\x00\x01\x00\x00\x00\x0Amux-framer\x00\x00\x00\x04\x7F\xFF\xFF\xFF\x00\x00\x00\x03tls\x00\x00\x00\x03off]
I20220617 06:01:51.703460 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207606631398 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=19 size=46 buf_size=46]] msg_size:46 msg:[\x00\x00\x00*\xBC\x00\x00\x01\x00\x01\x00\x00\x00\x0Amux-framer\x00\x00\x00\x04\x7F\xFF\xFF\xFF\x00\x00\x00\x03tls\x00\x00\x00\x03off]
I20220617 06:01:51.703668 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207668299521 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=285 size=8 buf_size=8]] msg_size:8 msg:[\x00\x00\x00\x04A\x00\x00\x01]
I20220617 06:01:51.703876 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207668669626 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=65 size=8 buf_size=8]] msg_size:8 msg:[\x00\x00\x00\x04\xBF\x00\x00\x01]
I20220617 06:01:51.704073 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207673593545 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=293 size=204 buf_size=204]] msg_size:204 msg:[\x00\x00\x00\xC8\x02\x00\x00\x02\x00\x03\x00(com.twitter.finagle.tracing.TraceContext\x00 \x1A\xFDf1.\xFE\xFC\x0A\x1A\xFDf1.\xFE\xFC\x0A\x1A\xFDf1.\xFE\xFC\x0A\x00\x00\x00\x00\x00\x00\x00\x02\x00\x1Bcom.twitter.finagle.Retries\x00\x04\x00\x00\x00\x00\x00\x1Ccom.twitter.finagle.Deadline\x00\x10\x16\xF9S\x1A\x94\xEA5\x00\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\x80\x01\x00\x01\x00\x00\x00\x05query\x00\x00\x00\x00\x0B\x00\x01\x00\x00\x00\x06String\x00]
I20220617 06:01:51.704331 257278 conn_tracker.cc:153] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kCollecting remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Data event: attr:[[ts=81207675198780 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=73 size=48 buf_size=48]] msg_size:48 msg:[\x00\x00\x00,\xFE\x00\x00\x02\x00\x00\x00\x80\x01\x00\x02\x00\x00\x00\x05query\x00\x00\x00\x00\x0B\x00\x00\x00\x00\x00\x0CStringString\x00]
I20220617 06:01:51.704960 257278 conn_tracker.h:270] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux req_frames=4 resp_frames=4
I20220617 06:01:51.705171 257278 conn_tracker.h:277] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux records=4
I20220617 06:01:51.820039 257278 conn_tracker.h:270] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220617 06:01:51.820343 257278 conn_tracker.h:277] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux records=0
I20220617 06:01:51.939800 257278 conn_tracker.h:270] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220617 06:01:51.940104 257278 conn_tracker.h:277] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux records=0
I20220617 06:01:52.054641 257278 conn_tracker.h:270] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220617 06:01:52.054699 257278 conn_tracker.h:277] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux records=0
I20220617 06:01:52.091889 257027 thriftmux_openssl_trace_bpf_test.cc:112] thriftmux client command output: '257328
06:01:49.573 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
06:01:49.576 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
06:01:49.576 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
06:01:49.592 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
06:01:49.593 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
06:01:49.594 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
06:01:49.594 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
06:01:49.595 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
06:01:49.595 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
06:01:49.596 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable: Reflective setAccessible(true) disabled
06:01:49.596 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
06:01:49.597 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable: class io.netty.util.internal.PlatformDependent0$7 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @2611b9a3
06:01:49.598 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
06:01:49.598 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
06:01:49.599 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 2084569088 bytes (maybe)
06:01:49.599 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
06:01:49.599 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
06:01:49.601 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
06:01:49.601 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
06:01:49.602 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
06:01:49.602 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
06:01:49.604 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
06:01:49.604 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
06:01:49.605 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
06:01:49.605 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
06:01:49.605 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
06:01:49.605 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
06:01:49.605 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
06:01:49.606 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
06:01:49.606 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
06:01:49.606 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
06:01:49.606 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
06:01:49.607 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
06:01:49.611 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
06:01:49.611 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
06:01:49.630 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
06:01:49.630 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
06:01:49.631 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
06:01:49.631 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.detectNativeLibraryDuplicates: true
06:01:49.643 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_649787055381890454168.so
06:01:49.646 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
06:01:49.647 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
06:01:49.648 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
06:01:49.649 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
06:01:50.322 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@58437801
06:01:50.330 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
06:01:50.877 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
06:01:50.931 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 257344 (auto-detected)
06:01:50.933 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:ac:ff:fe:11:00:02 (auto-detected)
06:01:50.956 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
06:01:50.956 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
06:01:50.956 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
06:01:51.043 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_6418059860008190110923.so
06:01:51.044 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Loaded library with name 'netty_tcnative_linux_x86_64'
06:01:51.044 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Initialize netty-tcnative using engine: 'default'
06:01:51.044 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - netty-tcnative using native library: BoringSSL
06:01:51.148 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
06:01:51.148 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
06:01:51.149 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@63cb5b05
06:01:51.166 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@514adf57
06:01:51.170 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
06:01:51.170 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
06:01:51.170 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: disabled
06:01:51.171 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: disabled
06:01:51.182 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:01:51.183 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => ECDHE-ECDSA-AES128-GCM-SHA256
06:01:51.183 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:01:51.183 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => ECDHE-RSA-AES128-GCM-SHA256
06:01:51.184 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:01:51.184 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => ECDHE-ECDSA-AES256-GCM-SHA384
06:01:51.185 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:01:51.185 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => ECDHE-RSA-AES256-GCM-SHA384
06:01:51.185 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:01:51.185 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-ECDSA-CHACHA20-POLY1305
06:01:51.186 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:01:51.186 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-RSA-CHACHA20-POLY1305
06:01:51.186 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:01:51.186 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => ECDHE-PSK-CHACHA20-POLY1305
06:01:51.187 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:01:51.187 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => ECDHE-ECDSA-AES128-SHA
06:01:51.188 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:01:51.188 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_128_CBC_SHA => ECDHE-RSA-AES128-SHA
06:01:51.188 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:01:51.188 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_128_CBC_SHA => ECDHE-PSK-AES128-CBC-SHA
06:01:51.189 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:01:51.189 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => ECDHE-ECDSA-AES256-SHA
06:01:51.190 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:01:51.190 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_RSA_WITH_AES_256_CBC_SHA => ECDHE-RSA-AES256-SHA
06:01:51.190 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:01:51.190 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_ECDHE_PSK_WITH_AES_256_CBC_SHA => ECDHE-PSK-AES256-CBC-SHA
06:01:51.191 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:01:51.191 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_GCM_SHA256 => AES128-GCM-SHA256
06:01:51.191 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:01:51.191 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_GCM_SHA384 => AES256-GCM-SHA384
06:01:51.192 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:01:51.192 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_128_CBC_SHA => AES128-SHA
06:01:51.192 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:01:51.192 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_128_CBC_SHA => PSK-AES128-CBC-SHA
06:01:51.193 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:01:51.193 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_AES_256_CBC_SHA => AES256-SHA
06:01:51.193 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:01:51.193 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_PSK_WITH_AES_256_CBC_SHA => PSK-AES256-CBC-SHA
06:01:51.194 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: TLS_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:01:51.194 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.CipherSuiteConverter - Cipher suite mapping: SSL_RSA_WITH_3DES_EDE_CBC_SHA => DES-CBC3-SHA
06:01:51.195 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Supported protocols (OpenSSL): [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2, TLSv1.3]
06:01:51.195 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Default cipher suites (OpenSSL): [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256]
06:01:51.313 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@298843a9
06:01:51.383 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@3a9d83d9
06:01:51.580 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.SslHandler - [id: 0x0a592861, L:/127.0.0.1:36808 - R:localhost/127.0.0.1:8080] HANDSHAKEN: protocol:TLSv1.3 cipher suite:TLS_AES_128_GCM_SHA256
StringString
'
I20220617 06:01:52.092134 257027 thriftmux_openssl_trace_bpf_test.cc:121] Client PID: 257328
I20220617 06:01:52.169785 257278 conn_tracker.cc:139] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux conn_close: [type=kConnClose ts=81208079159863 conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] source_fn=kSyscallClose [wr_bytes=121 rd_bytes=497]]
I20220617 06:01:52.169863 257278 conn_tracker.cc:598] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Marked for death, countdown=3
I20220617 06:01:52.169898 257278 conn_tracker.cc:198] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux ConnStats timestamp=81208079254680 wr=121 rd=497 close=2
I20220617 06:01:52.170377 257278 conn_tracker.h:270] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220617 06:01:52.170421 257278 conn_tracker.h:277] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux records=0
I20220617 06:01:52.170449 257278 conn_tracker.cc:796] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Death countdown=2
I20220617 06:01:52.282838 257278 conn_tracker.h:270] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux req_frames=0 resp_frames=0
I20220617 06:01:52.282907 257278 conn_tracker.h:277] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux records=0
I20220617 06:01:52.282935 257278 conn_tracker.cc:796] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Death countdown=1
I20220617 06:01:54.176921 257027 container_runner.cc:59] docker rm -f thriftmux_server_81183764575614
I20220617 06:01:54.383963 257027 conn_tracker.cc:78] conn_id=[upid=257101:8118390 fd=510 gen=81207401090146] state=kTransferring remote_addr=127.0.0.1:36808 role=kRoleServer protocol=kProtocolMux Being destroyed
[       OK ] OpenSSLTraceRawFptrsTest/0.mtls_thriftmux_client (28184 ms)
[----------] 1 test from OpenSSLTraceRawFptrsTest/0 (28184 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (28185 ms total)
[  PASSED  ] 1 test.
I20220617 06:01:54.420465 257027 env.cc:51] Shutting down
```

</details>

## Todo
- [ ] Determine why `RawFptrManager` broke when rebasing #446 (what this branch became)
- [ ] Update to use a real finagle release once its netty and netty-tcnative version is upgraded
- [ ] Remove byteman and have pixie search for `libnetty_tcnative_x86.so` when it has a unique file path (i.e. `libnetty_tcnative_linux_x86_648014508084024950371.so`)