### PR TITLE
gRPC-C bugfix / Added explicit writing of null terminators to grpc-c metadata

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/grpc_c_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/grpc_c_trace.c
@@ -746,6 +746,9 @@ static inline int fill_metadata_from_mdelem_list(const grpc_mdelem_list* const m
       return -1;
     }
 
+    // to_copy was already validated against the target size, so verifier is happy
+    metadata->items[i].key[to_copy] = '\0';
+
     // Get the value.
     if (0 != get_data_ptr_from_slice((grpc_slice*)(mdelem_data + GRPC_SLICE_SIZE), &current_length,
                                      &current_bytes)) {
@@ -762,6 +765,9 @@ static inline int fill_metadata_from_mdelem_list(const grpc_mdelem_list* const m
     if (0 != bpf_probe_read(metadata->items[i].value, to_copy, current_bytes)) {
       return -1;
     }
+
+    // to_copy was already validated against the target size, so verifier is happy
+    metadata->items[i].value[to_copy] = '\0';
 
     // Go forward in the linked list of mdelems.
     if (0 != BPF_PROBE_READ_VAR(current_linked_mdelem, (void*)(current_linked_mdelem + 0x8))) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/grpc_c.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/grpc_c.h
@@ -57,8 +57,8 @@ static_assert((sizeof(struct grpc_c_data_slice_t) % 8) == 0,
 #endif
 
 struct grpc_c_metadata_item_t {
-  char key[MAXIMUM_LENGTH_OF_KEY_IN_METADATA];
-  char value[MAXIMUM_LENGTH_OF_VALUE_IN_METADATA];
+  char key[MAXIMUM_LENGTH_OF_KEY_IN_METADATA+1];      // +1 for null terminator
+  char value[MAXIMUM_LENGTH_OF_VALUE_IN_METADATA+1];  // +1 for null terminator
 };
 
 struct grpc_c_metadata_t {


### PR DESCRIPTION
Current implementation of the grpc_c probes doesn't zero-out the metadata buffers (HTTP2 headers) between traces. Therefore, old header data could be wrongly appended to new header data if the old header was longer than the new one. 

To solve this, we explicitly add a null terminator at the end of the new header being read, so that the leftovers from previous headers are ignored. 