### PR TITLE
Fix data-table bug with anchors

### DIFF
--- a/src/ui/src/components/data-table/data-table.tsx
+++ b/src/ui/src/components/data-table/data-table.tsx
@@ -148,6 +148,9 @@ const useDataTableStyles = makeStyles((theme: Theme) => createStyles({
     maxHeight: '100%',
     width: '100%',
     lineHeight: `${ROW_HEIGHT_PX}px`,
+    '& a': {
+      whiteSpace: 'nowrap', 
+    },
   },
   start: { textAlign: 'left' },
   end: { textAlign: 'right' },


### PR DESCRIPTION
Long values are hidden in data-tables:
![image (3)](https://user-images.githubusercontent.com/67504894/179021903-4bb6ebbc-ab75-4c1c-9991-85e79f7f0103.png)
It can be fixed if anchors in cells will have "white-space: nowrap" property set:
![2022-07-14_12-00-53](https://user-images.githubusercontent.com/67504894/179022477-ae243347-b096-49c5-8569-e5c4ef68a791.gif)

