### PR TITLE
Fix indentation

### DIFF
--- a/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: DSN
           # yamllint disable-line rule:line-length
           value: postgres://$(PL_POSTGRES_USERNAME):$(PL_POSTGRES_PASSWORD)@$(PL_POSTGRES_HOSTNAME):$(PL_POSTGRES_PORT)/$(PL_POSTGRES_DB)?sslmode=disable&max_conns=20&max_idle_conns=4
-          imagePullPolicy: IfNotPresent
+        imagePullPolicy: IfNotPresent
         image: oryd/hydra:v1.9.2-sqlite
         volumeMounts:
         - mountPath: /etc/config/hydra

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: DSN
           # yamllint disable-line rule:line-length
           value: postgres://$(PL_POSTGRES_USERNAME):$(PL_POSTGRES_PASSWORD)@$(PL_POSTGRES_HOSTNAME):$(PL_POSTGRES_PORT)/$(PL_POSTGRES_DB)?sslmode=disable&max_conns=20&max_idle_conns=4
-          imagePullPolicy: IfNotPresent
+        imagePullPolicy: IfNotPresent
         image: oryd/kratos:v0.5.5
         resources: {}
         volumeMounts:
@@ -112,7 +112,7 @@ spec:
           value: $(AUTH_LOGIN_URL)
         - name: SELFSERVICE_FLOWS_ERROR_UI_URL
           value: https://$(PL_WORK_DOMAIN)/auth/password/error
-          imagePullPolicy: IfNotPresent
+        imagePullPolicy: IfNotPresent
         image: oryd/kratos:v0.5.5
         ports:
         - containerPort: 4433


### PR DESCRIPTION
```
kustomize build k8s/cloud/public/ | kubectl apply -f -

error: error validating "STDIN": error validating data: ValidationError(Deployment.spec.template.spec.initContainers[0].env[5]): unknown field "imagePullPolicy" in io.k8s.api.core.v1.EnvVar; if you choose to ignore these errors, turn validation off with --validate=false
```
