### PR TITLE
Fix CLI so that it does not show results for random cluster if the targeted cluster is not healthy.

### DIFF
--- a/src/pixie_cli/pkg/cmd/get.go
+++ b/src/pixie_cli/pkg/cmd/get.go
@@ -73,7 +73,7 @@ var GetPEMsCmd = &cobra.Command{
 		clusterID := uuid.FromStringOrNil(selectedCluster)
 		var err error
 		if !allClusters && clusterID == uuid.Nil {
-			clusterID, err = vizier.GetCurrentOrFirstHealthyVizier(cloudAddr)
+			clusterID, err = vizier.GetCurrentVizier(cloudAddr)
 			if err != nil {
 				cliUtils.WithError(err).Fatal("Could not fetch healthy vizier")
 			}

--- a/src/pixie_cli/pkg/cmd/live.go
+++ b/src/pixie_cli/pkg/cmd/live.go
@@ -103,7 +103,7 @@ var LiveCmd = &cobra.Command{
 		selectedCluster, _ := cmd.Flags().GetString("cluster")
 		clusterUUID := uuid.FromStringOrNil(selectedCluster)
 		if !allClusters && clusterUUID == uuid.Nil {
-			clusterUUID, err = vizier.GetCurrentOrFirstHealthyVizier(cloudAddr)
+			clusterUUID, err = vizier.GetCurrentVizier(cloudAddr)
 			if err != nil {
 				utils.WithError(err).Fatal("Could not fetch healthy vizier")
 			}

--- a/src/pixie_cli/pkg/cmd/run.go
+++ b/src/pixie_cli/pkg/cmd/run.go
@@ -179,7 +179,7 @@ func createNewCobraCommand() *cobra.Command {
 			clusterID := uuid.FromStringOrNil(selectedCluster)
 
 			if !allClusters && clusterID == uuid.Nil {
-				clusterID, err = vizier.GetCurrentOrFirstHealthyVizier(cloudAddr)
+				clusterID, err = vizier.GetCurrentVizier(cloudAddr)
 				if err != nil {
 					utils.WithError(err).Fatal("Could not fetch healthy vizier")
 				}

--- a/src/pixie_cli/pkg/vizier/utils.go
+++ b/src/pixie_cli/pkg/vizier/utils.go
@@ -197,7 +197,7 @@ func GetCurrentVizier(cloudAddr string) (uuid.UUID, error) {
 		}
 	}
 	if clusterID == uuid.Nil {
-		return uuid.Nil, fmt.Errorf("No current Vizier exists in kubeconfig")
+		return uuid.Nil, fmt.Errorf("The current cluster in the kubeconfig does not have Pixie installed.")
 	}
 	return clusterID, nil
 }


### PR DESCRIPTION
Currently `px run`, `px live` and `px get pems` will fall back to using the the "first other known healthy cluster" if the targeted cluster is not healthy and the user has Pixie deployed to multiple clusters. Most users will probably expect to get results for the cluster in their kubeconfig and may accidentally attribute the displayed data to the targeted cluster.

This fixes https://github.com/pixie-io/pixie/issues/527 by removing most of the calls to `GetCurrentOrFirstHealthyVizier()` and instead using `GetCurrentVizier()`. Note that there is one remaining call to `GetCurrentOrFirstHealthyVizier()` for the `px update` CLI command, since I'm less familiar with how to test that. I also updated the error to make it a little more clear how the problem should be fixed. 

Test plan: Check that `px get pems`, `px run px/cluster` and `px live px/cluster` no longer return results if kubeconfig points to a cluster without Pixie installed. 
