### PR TITLE
Upgrade finagle to version that includes tls tracing compatible netty-tcnative

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -155,7 +155,15 @@ pxapi_py_doc_install_deps()
 
 # Setup thrift: used for building Stirling tracing targets.
 load("//bazel:thrift.bzl", "thrift_deps")
+load("//bazel:netty.bzl", "fetch_netty_tcnative_jars")
 
+# TODO(ddelnano): Remove once rules_jvm_external is no longer impacted.
+# Recent netty-tcnative releases cause rules_jvm_external to fail with a
+# cyclic dependency issue due to its use of multi-classifiers. This is fixed
+# by installing the netty jars manually and then overriding maven to use them. See
+# https://github.com/bazelbuild/rules_jvm_external/issues/704 for more details.
+netty_tcnative_version = "2.0.53.Final"
+fetch_netty_tcnative_jars(netty_tcnative_version)
 thrift_deps(scala_version = scala_version)
 
 # twitter_scrooge will use incompatible versions of @scrooge_jars and @thrift_jars.

--- a/bazel/netty.bzl
+++ b/bazel/netty.bzl
@@ -1,0 +1,55 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+def fetch_netty_tcnative_jars(version):
+
+    http_jar(
+        name = "netty_tcnative_boringssl_static",
+        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s.jar" % (version, version),
+        sha256 = "0d8d16adadb19e065a5ac05738f0c2503c685cf3edafba14f7a1c246aafa09ef",
+    )
+
+    http_jar(
+        name = "netty_tcnative_boringssl_static_osx_x86_64",
+        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-osx-x86_64.jar" % (version, version),
+        sha256 = "51b43e8e178e94de9ec27017e03173dfb19bd1aaf15677a90347188cf60e799b",
+    )
+
+    http_jar(
+        name = "netty_tcnative_boringssl_static_osx_aarch_64",
+        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-osx-aarch_64.jar" % (version, version),
+        sha256 = "9d9cf706e89b81e07e9983a06b8ff5348a658a89752ec6f426925cc645e54b54",
+    )
+
+    http_jar(
+        name = "netty_tcnative_boringssl_static_linux_x86_64",
+        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-linux-x86_64.jar" % (version, version),
+        sha256 = "83e3357da5567a93cb5ff6cb807d70573359d7ef9676fa8169405121bae05723",
+    )
+
+    http_jar(
+        name = "netty_tcnative_boringssl_static_linux_aarch_64",
+        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-linux-aarch_64.jar" % (version, version),
+        sha256 = "ce3d12e3ae2ad0b9225df347b55715b0ad24342d0195bb238f5e3f60b3f6b868",
+    )
+
+    http_jar(
+        name = "netty_tcnative_boringssl_static_windows_x86_64",
+        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-windows-x86_64.jar" % (version, version),
+        sha256 = "e348fcfab697ffc30bacc083e9393e5b6bd398029acac1a570e53267f89804a3",
+    )

--- a/bazel/netty.bzl
+++ b/bazel/netty.bzl
@@ -17,7 +17,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 
 def fetch_netty_tcnative_jars(version):
-
     http_jar(
         name = "netty_tcnative_boringssl_static",
         url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s.jar" % (version, version),

--- a/bazel/netty.bzl
+++ b/bazel/netty.bzl
@@ -24,18 +24,6 @@ def fetch_netty_tcnative_jars(version):
     )
 
     http_jar(
-        name = "netty_tcnative_boringssl_static_osx_x86_64",
-        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-osx-x86_64.jar" % (version, version),
-        sha256 = "51b43e8e178e94de9ec27017e03173dfb19bd1aaf15677a90347188cf60e799b",
-    )
-
-    http_jar(
-        name = "netty_tcnative_boringssl_static_osx_aarch_64",
-        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-osx-aarch_64.jar" % (version, version),
-        sha256 = "9d9cf706e89b81e07e9983a06b8ff5348a658a89752ec6f426925cc645e54b54",
-    )
-
-    http_jar(
         name = "netty_tcnative_boringssl_static_linux_x86_64",
         url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-linux-x86_64.jar" % (version, version),
         sha256 = "83e3357da5567a93cb5ff6cb807d70573359d7ef9676fa8169405121bae05723",
@@ -45,10 +33,4 @@ def fetch_netty_tcnative_jars(version):
         name = "netty_tcnative_boringssl_static_linux_aarch_64",
         url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-linux-aarch_64.jar" % (version, version),
         sha256 = "ce3d12e3ae2ad0b9225df347b55715b0ad24342d0195bb238f5e3f60b3f6b868",
-    )
-
-    http_jar(
-        name = "netty_tcnative_boringssl_static_windows_x86_64",
-        url = "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/%s/netty-tcnative-boringssl-static-%s-windows-x86_64.jar" % (version, version),
-        sha256 = "e348fcfab697ffc30bacc083e9393e5b6bd398029acac1a570e53267f89804a3",
     )

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
@@ -40,10 +39,10 @@ def thrift_deps(scala_version):
         repositories = ["https://repo1.maven.org/maven2"],
         override_targets = {
             "io.netty:netty-tcnative-boringssl-static": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static",
-            "io.netty:netty-tcnative-boringssl-static:osx-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
-            "io.netty:netty-tcnative-boringssl-static:osx-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_x86_64",
             "io.netty:netty-tcnative-boringssl-static:linux-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
             "io.netty:netty-tcnative-boringssl-static:linux-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_x86_64",
+            "io.netty:netty-tcnative-boringssl-static:osx-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
+            "io.netty:netty-tcnative-boringssl-static:osx-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_x86_64",
             "io.netty:netty-tcnative-boringssl-static:windows-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_windows_x86_64",
         },
     )

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -14,9 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 
 def thrift_deps(scala_version):
     twitter_scrooge()
@@ -40,10 +40,10 @@ def thrift_deps(scala_version):
         repositories = ["https://repo1.maven.org/maven2"],
         override_targets = {
             "io.netty:netty-tcnative-boringssl-static": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static",
-            "io.netty:netty-tcnative-boringssl-static:osx-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_x86_64",
             "io.netty:netty-tcnative-boringssl-static:osx-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
-            "io.netty:netty-tcnative-boringssl-static:windows-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_windows_x86_64",
-            "io.netty:netty-tcnative-boringssl-static:linux-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_x86_64",
+            "io.netty:netty-tcnative-boringssl-static:osx-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_x86_64",
             "io.netty:netty-tcnative-boringssl-static:linux-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
+            "io.netty:netty-tcnative-boringssl-static:linux-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_x86_64",
+            "io.netty:netty-tcnative-boringssl-static:windows-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_windows_x86_64",
         },
     )

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -41,8 +41,5 @@ def thrift_deps(scala_version):
             "io.netty:netty-tcnative-boringssl-static": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static",
             "io.netty:netty-tcnative-boringssl-static:linux-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
             "io.netty:netty-tcnative-boringssl-static:linux-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_x86_64",
-            "io.netty:netty-tcnative-boringssl-static:osx-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
-            "io.netty:netty-tcnative-boringssl-static:osx-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_x86_64",
-            "io.netty:netty-tcnative-boringssl-static:windows-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_windows_x86_64",
         },
     )

--- a/bazel/thrift.bzl
+++ b/bazel/thrift.bzl
@@ -16,11 +16,12 @@
 
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 
 def thrift_deps(scala_version):
     twitter_scrooge()
 
-    finagle_version = "22.4.0"
+    finagle_version = "22.7.0"
     scala_minor_version = ".".join(scala_version.split(".")[:2])
 
     maven_install(
@@ -37,4 +38,12 @@ def thrift_deps(scala_version):
             "ch.qos.logback:logback-classic:1.2.10",
         ],
         repositories = ["https://repo1.maven.org/maven2"],
+        override_targets = {
+            "io.netty:netty-tcnative-boringssl-static": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static",
+            "io.netty:netty-tcnative-boringssl-static:osx-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_x86_64",
+            "io.netty:netty-tcnative-boringssl-static:osx-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
+            "io.netty:netty-tcnative-boringssl-static:windows-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_windows_x86_64",
+            "io.netty:netty-tcnative-boringssl-static:linux-x86_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_x86_64",
+            "io.netty:netty-tcnative-boringssl-static:linux-aarch_64": "@//src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps:io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
+        },
     )

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_java//java:defs.bzl", "java_image")
+load("@rules_java//java:defs.bzl", "java_import")
 
 java_import(
     name = "io_netty_netty_tcnative_boringssl_static_osx_x86_64",

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
@@ -1,3 +1,21 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_java//java:defs.bzl", "java_image")
+
 java_import(
     name = "io_netty_netty_tcnative_boringssl_static_osx_x86_64",
     jars = ["@netty_tcnative_boringssl_static_osx_x86_64//jar:downloaded.jar"],

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
@@ -17,20 +17,6 @@
 load("@rules_java//java:defs.bzl", "java_import")
 
 java_import(
-    name = "io_netty_netty_tcnative_boringssl_static_osx_x86_64",
-    jars = ["@netty_tcnative_boringssl_static_osx_x86_64//jar:downloaded.jar"],
-    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.53.Final"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
-    name = "io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
-    jars = ["@netty_tcnative_boringssl_static_osx_aarch_64//jar:downloaded.jar"],
-    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.53.Final"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
     name = "io_netty_netty_tcnative_boringssl_static_linux_x86_64",
     jars = ["@netty_tcnative_boringssl_static_linux_x86_64//jar:downloaded.jar"],
     tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.53.Final"],
@@ -41,13 +27,6 @@ java_import(
     name = "io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
     jars = ["@netty_tcnative_boringssl_static_linux_aarch_64//jar:downloaded.jar"],
     tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.53.Final"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
-    name = "io_netty_netty_tcnative_boringssl_static_windows_x86_64",
-    jars = ["@netty_tcnative_boringssl_static_windows_x86_64//jar:downloaded.jar"],
-    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.53.Final"],
     visibility = ["//visibility:public"],
 )
 
@@ -64,9 +43,6 @@ java_import(
     deps = [
         ":io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
         ":io_netty_netty_tcnative_boringssl_static_linux_x86_64",
-        ":io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
-        ":io_netty_netty_tcnative_boringssl_static_osx_x86_64",
-        ":io_netty_netty_tcnative_boringssl_static_windows_x86_64",
         "@maven//:io_netty_netty_tcnative_classes",
     ],
 )

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/netty_deps/BUILD.bazel
@@ -1,0 +1,54 @@
+java_import(
+    name = "io_netty_netty_tcnative_boringssl_static_osx_x86_64",
+    jars = ["@netty_tcnative_boringssl_static_osx_x86_64//jar:downloaded.jar"],
+    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.53.Final"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
+    jars = ["@netty_tcnative_boringssl_static_osx_aarch_64//jar:downloaded.jar"],
+    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.53.Final"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "io_netty_netty_tcnative_boringssl_static_linux_x86_64",
+    jars = ["@netty_tcnative_boringssl_static_linux_x86_64//jar:downloaded.jar"],
+    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.53.Final"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
+    jars = ["@netty_tcnative_boringssl_static_linux_aarch_64//jar:downloaded.jar"],
+    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.53.Final"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "io_netty_netty_tcnative_boringssl_static_windows_x86_64",
+    jars = ["@netty_tcnative_boringssl_static_windows_x86_64//jar:downloaded.jar"],
+    tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.53.Final"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "io_netty_netty_tcnative_boringssl_static",
+    jars = [
+        "@netty_tcnative_boringssl_static//jar:downloaded.jar",
+    ],
+    tags = [
+        "maven_coordinates=io.netty:netty-tcnative-boringssl-static:2.0.53.Final",
+        "maven_url=https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.53.Final/netty-tcnative-boringssl-static-2.0.53.Final.jar",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":io_netty_netty_tcnative_boringssl_static_linux_aarch_64",
+        ":io_netty_netty_tcnative_boringssl_static_linux_x86_64",
+        ":io_netty_netty_tcnative_boringssl_static_osx_aarch_64",
+        ":io_netty_netty_tcnative_boringssl_static_osx_x86_64",
+        ":io_netty_netty_tcnative_boringssl_static_windows_x86_64",
+        "@maven//:io_netty_netty_tcnative_classes",
+    ],
+)


### PR DESCRIPTION
This PR upgrades finagle to install a version that includes the netty changes I upstreamed (https://github.com/netty/netty/pull/12438, https://github.com/netty/netty-tcnative/pull/731) to support #407. Once this is upgraded, the next step is to refresh #463.

## Testing
- [x] Ran the [thriftmux container](https://github.com/pixie-io/pixie/blob/0bb6f8c0c6d6e44378fce6b48f6222fcf980d44a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/README.md) and verified that the logs of the client show that netty tcnative is used (improperly installed netty tcnative will silently succeed)
```
vagrant@vagrant:/vagrantbazel run -c dbg src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image

vagrant@vagrant:/vagrant$ docker run -it bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image --use-tls true

# Run client inside the server container and see netty-tcnative is used successfully
/ # /usr/bin/java -cp @/app/px/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/server_image.classpath Client --use-tls true 2>&1 | grep -i tcnative
01:03:03.586 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_64685160139595718633.so
01:03:03.587 [finagle/netty4-1-1] DEBUG io.netty.util.internal.NativeLibraryLoader - Loaded library with name 'netty_tcnative_linux_x86_64'
01:03:03.587 [finagle/netty4-1-1] DEBUG io.netty.handler.ssl.OpenSsl - Initialize netty-tcnative using engine: 'default'

```