### PR TITLE
Add pixie-operator pod logs to collect-logs cmd

### DIFF
--- a/src/utils/shared/k8s/selector.go
+++ b/src/utils/shared/k8s/selector.go
@@ -35,3 +35,18 @@ func VizierLabelSelector() metav1.LabelSelector {
 		},
 	}
 }
+
+// OperatorLabelSelector returns a K8s selector that matches the label of the
+// Pixie Operator.
+func OperatorLabelSelector() metav1.LabelSelector {
+	return metav1.LabelSelector{
+		MatchLabels: make(map[string]string),
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			metav1.LabelSelectorRequirement{
+				Key:      "olm.catalogSource",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"pixie-operator-index"},
+			},
+		},
+	}
+}


### PR DESCRIPTION
It essentially makes a new query to the `kube-apiserver` with the `olm.catalogSource=pixie-operator-index` label filter and merges the new results with the old.

Fixes #559