### PR TITLE
Move mux bpf test helper functions to protocol_checkers for later reuse

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/dyn_lib_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/dyn_lib_trace_bpf_test.cc
@@ -183,7 +183,7 @@ TEST_F(DynLibTraceTest, TraceDynLoadedOpenSSL) {
       ASSERT_TRUE(absl::SimpleAtoi(pid_str, &worker_pid));
       LOG(INFO) << absl::Substitute("Worker thread PID: $0", worker_pid);
 
-      std::vector<http::Record> records = GetTargetRecords(record_batch, worker_pid);
+      std::vector<http::Record> records = GetTargetRecords<http::Record>(record_batch, worker_pid);
 
       EXPECT_THAT(records,
                   UnorderedElementsAre(EqHTTPRecord(expected_record), EqHTTPRecord(expected_record),
@@ -192,7 +192,8 @@ TEST_F(DynLibTraceTest, TraceDynLoadedOpenSSL) {
 
     // Check client-side tracing results.
     {
-      std::vector<http::Record> records = GetTargetRecords(record_batch, client.process_pid());
+      std::vector<http::Record> records =
+          GetTargetRecords<http::Record>(record_batch, client.process_pid());
 
       EXPECT_THAT(records,
                   UnorderedElementsAre(EqHTTPRecord(expected_record), EqHTTPRecord(expected_record),

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -107,7 +107,8 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTrac
     types::ColumnWrapperRecordBatch record_batch = tablets[0].records;
     std::vector<size_t> server_record_indices =
         FindRecordIdxMatchesPID(record_batch, kHTTPUPIDIdx, pid);
-    std::vector<http::Record> http_records = ToRecordVector(record_batch, server_record_indices);
+    std::vector<http::Record> http_records =
+        ToRecordVector<http::Record>(record_batch, server_record_indices);
     std::vector<std::string> remote_addresses =
         testing::GetRemoteAddrs(record_batch, server_record_indices);
     return {std::move(http_records), std::move(remote_addresses)};

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.cc
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.cc
@@ -26,11 +26,13 @@ namespace stirling {
 namespace testing {
 
 namespace http = protocols::http;
+namespace mux = protocols::mux;
 
 //-----------------------------------------------------------------------------
 // HTTP Checkers
 //-----------------------------------------------------------------------------
 
+template <>
 std::vector<http::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
                                          const std::vector<size_t>& indices) {
   std::vector<http::Record> result;
@@ -44,17 +46,38 @@ std::vector<http::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& 
     r.resp.resp_status = rb[kHTTPRespStatusIdx]->Get<types::Int64Value>(idx).val;
     r.resp.resp_message = rb[kHTTPRespMessageIdx]->Get<types::StringValue>(idx);
     r.resp.body = rb[kHTTPRespBodyIdx]->Get<types::StringValue>(idx);
-
     result.push_back(r);
   }
   return result;
 }
 
+template <>
+std::vector<protocols::mux::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
+                                                   const std::vector<size_t>& indices) {
+  std::vector<mux::Record> result;
+
+  for (const auto& idx : indices) {
+    mux::Record r;
+    r.req.type = static_cast<int8_t>(rb[kMuxReqTypeIdx]->Get<types::Int64Value>(idx).val);
+    result.push_back(r);
+  }
+  return result;
+}
+
+template <>
 std::vector<http::Record> GetTargetRecords(const types::ColumnWrapperRecordBatch& record_batch,
                                            int32_t pid) {
   std::vector<size_t> target_record_indices =
       FindRecordIdxMatchesPID(record_batch, kHTTPUPIDIdx, pid);
-  return ToRecordVector(record_batch, target_record_indices);
+  return ToRecordVector<http::Record>(record_batch, target_record_indices);
+}
+
+template <>
+std::vector<mux::Record> GetTargetRecords(const types::ColumnWrapperRecordBatch& record_batch,
+                                          int32_t pid) {
+  std::vector<size_t> target_record_indices =
+      FindRecordIdxMatchesPID(record_batch, kMuxUPIDIdx, pid);
+  return ToRecordVector<mux::Record>(record_batch, target_record_indices);
 }
 
 }  // namespace testing

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -26,7 +26,9 @@
 
 #include "src/shared/types/column_wrapper.h"
 #include "src/stirling/source_connectors/socket_tracer/http_table.h"
+#include "src/stirling/source_connectors/socket_tracer/mux_table.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
 
 namespace px {
 namespace stirling {
@@ -35,12 +37,13 @@ namespace testing {
 //-----------------------------------------------------------------------------
 // HTTP Checkers
 //-----------------------------------------------------------------------------
+template <typename TFrameType>
+std::vector<TFrameType> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
+                                       const std::vector<size_t>& indices);
 
-std::vector<protocols::http::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
-                                                    const std::vector<size_t>& indices);
-
-std::vector<protocols::http::Record> GetTargetRecords(
-    const types::ColumnWrapperRecordBatch& record_batch, int32_t pid);
+template <typename TFrameType>
+std::vector<TFrameType> GetTargetRecords(const types::ColumnWrapperRecordBatch& record_batch,
+                                         int32_t pid);
 
 inline auto EqHTTPReq(const protocols::http::Message& x) {
   using ::testing::Field;
@@ -65,6 +68,19 @@ inline auto EqHTTPRecord(const protocols::http::Record& x) {
 
   return AllOf(Field(&protocols::http::Record::req, EqHTTPReq(x.req)),
                Field(&protocols::http::Record::resp, EqHTTPResp(x.resp)));
+}
+
+inline auto EqMux(const protocols::mux::Frame& x) {
+  using ::testing::Field;
+
+  return Field(&protocols::mux::Frame::type, ::testing::Eq(x.type));
+}
+
+inline auto EqMuxRecord(const protocols::mux::Record& x) {
+  using ::testing::Field;
+
+  return AllOf(Field(&protocols::mux::Record::req, EqMux(x.req)),
+               Field(&protocols::mux::Record::resp, EqMux(x.resp)));
 }
 
 inline std::vector<std::string> GetRemoteAddrs(const types::ColumnWrapperRecordBatch& rb,


### PR DESCRIPTION
This PR splits out helper functions used in #569 into its own change. The goal is to refactor this code so it can be shared by the existing `mux_trace_bpf_test.cc` and the new [thriftmux_openssl_trace_bpf_test.cc](https://github.com/pixie-io/pixie/blob/58c7228bb0db64377ce18b289388f0b06117d7ca/src/stirling/source_connectors/socket_tracer/thriftmux_openssl_trace_bpf_test.cc) one.

## Testing done
<details>
<summary>

Verified that the tests that use `GetTargetRecords` pass (calling code needed to have type specified in certain cases)

</summary>

```
vagrant@vagrant:/vagrant$ ./scripts/sudo_bazel_run.sh -c dbg src/stirling/source_connectors/socket_tracer:mysql_trace_bpf_test
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:mysql_trace_bpf_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src/stirling/source_connectors/socket_tracer:mysql_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/mysql_trace_bpf_test
INFO: Elapsed time: 1.648s, Critical Path: 0.23s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh /bin/bash -c '"$@"' /bin/bash sudo src/stirling/source_connectors/socket_tracer/mysql_tr
INFO: Build completed successfully, 1 total action
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/stirling/source_connectors/socket_tracer:mysql_trace_bpf_test
-----------------------------------------------------------------------------
I20220828 21:25:07.632316 175541 env.cc:47] Started: src/stirling/source_connectors/socket_tracer/mysql_trace_bpf_test
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from MySQLTraceTest
[ RUN      ] MySQLTraceTest.mysql_capture
I20220828 21:25:08.308492 175541 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers:mysql_image
I20220828 21:25:08.487255 175541 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers:mysql_connector_image
I20220828 21:25:08.488194 175541 mysql_trace_bpf_test.cc:68] src/stirling/source_connectors/socket_tracer/protocols/mysql/testing/script.sql
I20220828 21:25:08.488229 175541 container_runner.cc:121] docker run --rm --pid=host --env=MYSQL_ALLOW_EMPTY_PASSWORD=1 --env=MYSQL_ROOT_HOST=% --name=mysql_server_155562795034614 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:mysql_image
I20220828 21:25:08.779332 175541 container_runner.cc:160] Container mysql_server_155562795034614 status: running
I20220828 21:25:08.807281 175541 container_runner.cc:191] Container mysql_server_155562795034614 process PID: 175630
I20220828 21:25:08.807304 175541 container_runner.cc:193] Container mysql_server_155562795034614 waiting for log message: /usr/sbin/mysqld: ready for connections. Version: '8.0.13'  socket: '/var/lib/mysql/mysql.sock'  port: 3306
I20220828 21:25:08.847151 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:08.847172 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (90 attempts remaining).
I20220828 21:25:09.880456 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:09.880475 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (89 attempts remaining).
I20220828 21:25:10.932876 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:10.932895 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (88 attempts remaining).
I20220828 21:25:11.970101 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:11.970121 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (87 attempts remaining).
I20220828 21:25:12.998668 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:12.998687 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (86 attempts remaining).
I20220828 21:25:14.027604 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:14.027650 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (85 attempts remaining).
I20220828 21:25:15.093022 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:15.093466 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (84 attempts remaining).
I20220828 21:25:16.119621 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:16.119640 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (83 attempts remaining).
I20220828 21:25:17.146777 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:17.146798 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (82 attempts remaining).
I20220828 21:25:18.171206 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:18.171228 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (81 attempts remaining).
I20220828 21:25:19.210976 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:19.210995 175541 container_runner.cc:218] Container mysql_server_155562795034614 not in ready state, will try again (80 attempts remaining).
I20220828 21:25:20.259757 175541 container_runner.cc:205] Container mysql_server_155562795034614 status: running
I20220828 21:25:20.259778 175541 container_runner.cc:241] Container mysql_server_155562795034614 is ready.
I20220828 21:25:21.265427 175541 source_connector.cc:36] Initializing source connector: socket_trace_connector
I20220828 21:25:21.265476 175541 linux_headers.cc:209] Found Linux kernel version using .note section.
I20220828 21:25:21.265484 175541 linux_headers.cc:90] Obtained Linux version string from `uname`: 5.15.0-30-generic
I20220828 21:25:21.265489 175541 linux_headers.cc:599] Detected kernel release (uname -r): 5.15.0-30-generic
I20220828 21:25:21.265528 175541 bcc_wrapper.cc:121] Using linux headers found at /lib/modules/5.15.0-30-generic/build for BCC runtime.
I20220828 21:25:21.265580 175541 bcc_wrapper.cc:170] Initializing BPF program ...
I20220828 21:25:37.107583 175541 scoped_timer.h:48] Timer(init_bpf_program) : 15.84 s
I20220828 21:25:38.229673 175541 socket_trace_connector.cc:404] Number of kprobes deployed = 40
I20220828 21:25:38.229740 175541 socket_trace_connector.cc:405] Probes successfully deployed.
I20220828 21:25:38.229780 175541 socket_trace_connector.cc:340] Initializing perf buffers with ncpus=2 and scaling_factor=0.9
I20220828 21:25:38.229822 175541 socket_trace_connector.cc:329] Total perf buffer usage for kData buffers across all cpus: 188743680
I20220828 21:25:38.229838 175541 socket_trace_connector.cc:329] Total perf buffer usage for kControl buffers across all cpus: 3963614
I20220828 21:25:38.318094 175541 socket_trace_connector.cc:409] Number of perf buffers opened = 8
I20220828 21:25:39.392230 175541 mysql_trace_bpf_test.cc:107] Client PID: 176006
I20220828 21:25:39.818269 175541 mysql_trace_bpf_test.cc:107] Client PID: 176036
I20220828 21:25:40.182610 175541 container_runner.cc:121] docker run --rm --pid=host --network=container:mysql_server_155562795034614 --name=mysql_client_155594489419874 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:mysql_connector_image /scripts/script.py
I20220828 21:25:40.374620 175541 container_runner.cc:160] Container mysql_client_155594489419874 status: running
I20220828 21:25:40.402963 175541 container_runner.cc:191] Container mysql_client_155594489419874 process PID: 176086
I20220828 21:25:40.402984 175541 container_runner.cc:193] Container mysql_client_155594489419874 waiting for log message: pid
I20220828 21:25:40.449826 175541 container_runner.cc:205] Container mysql_client_155594489419874 status: running
I20220828 21:25:40.449844 175541 container_runner.cc:218] Container mysql_client_155594489419874 not in ready state, will try again (60 attempts remaining).
Error: No such object: mysql_client_155594489419874
I20220828 21:25:41.495496 175541 container_runner.cc:205] Container mysql_client_155594489419874 status:
I20220828 21:25:41.495523 175541 container_runner.cc:241] Container mysql_client_155594489419874 is ready.
I20220828 21:25:41.495539 175541 mysql_trace_bpf_test.cc:123] Script output
pid=176086
[(1, 'First0', 'Last0', 'M'), (2, 'First1', 'Last1', 'F'), (3, 'First2', 'Last2', 'M')]
I20220828 21:25:41.495563 175541 mysql_trace_bpf_test.cc:143] Client PID: 176086
W20220828 21:25:44.160920 175541 subprocess.cc:218] Failed to send signal=9 to pid=176041, error=No such process
I20220828 21:25:44.160976 175541 container_runner.cc:59] docker rm -f mysql_client_155594489419874
Error: No such container: mysql_client_155594489419874
I20220828 21:25:44.193986 175541 container_runner.cc:59] docker rm -f mysql_server_155562795034614
[       OK ] MySQLTraceTest.mysql_capture (37011 ms)
[----------] 1 test from MySQLTraceTest (37012 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (37012 ms total)
[  PASSED  ] 1 test.
I20220828 21:25:44.644934 175541 env.cc:51] Shutting down


vagrant@vagrant:/vagrant$ ./scripts/sudo_bazel_run.sh -c dbg src/stirling/source_connectors/socket_tracer:dyn_lib_trace_bpf_test
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:dyn_lib_trace_bpf_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
[6,858 / 6,860] Compiling src/stirling/source_connectors/socket_tracer/dyn_lib_tr
[6,858 / 6,860] Compiling src/stirling/source_connectors/socket_tracer/dyn_lib_tr
[6,858 / 6,860] Compiling src/stirling/source_connectors/socket_tracer/dyn_lib_tr
[6,858 / 6,860] Compiling src/stirling/source_connectors/socket_tracer/dyn_lib_tr
[6,859 / 6,860] Linking src/stirling/source_connectors/socket_tracer/dyn_lib_trac
[6,859 / 6,860] Linking src/stirling/source_connectors/socket_tracer/dyn_lib_trac
[6,859 / 6,860] Linking src/stirling/source_connectors/socket_tracer/dyn_lib_trac
[6,859 / 6,860] Linking src/stirling/source_connectors/socket_tracer/dyn_lib_trac
[6,859 / 6,860] Linking src/stirling/source_connectors/socket_tracer/dyn_lib_trac
[6,859 / 6,860] Linking src/stirling/source_connectors/socket_tracer/dyn_lib_trac
Target //src/stirling/source_connectors/socket_tracer:dyn_lib_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/dyn_lib_trace_bpf_test
INFO: Elapsed time: 22.538s, Critical Path: 20.74s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh /bin/bash -c '"$@"' /bin/bash sudo src/stirling/source_connectors/socket_tracer/dyn_lib_
INFO: Build completed successfully, 3 total actions
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/stirling/source_connectors/socket_tracer:dyn_lib_trace_bpf_test
-----------------------------------------------------------------------------
I20220828 21:22:02.307286 173015 env.cc:47] Started: src/stirling/source_connectors/socket_tracer/dyn_lib_trace_bpf_test
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DynLibTraceTest
[ RUN      ] DynLibTraceTest.TraceDynLoadedOpenSSL
I20220828 21:22:02.307564 173015 source_connector.cc:36] Initializing source connector: socket_trace_connector
I20220828 21:22:02.307585 173015 linux_headers.cc:209] Found Linux kernel version using .note section.
I20220828 21:22:02.307590 173015 linux_headers.cc:90] Obtained Linux version string from `uname`: 5.15.0-30-generic
I20220828 21:22:02.307595 173015 linux_headers.cc:599] Detected kernel release (uname -r): 5.15.0-30-generic
I20220828 21:22:02.307616 173015 bcc_wrapper.cc:121] Using linux headers found at /lib/modules/5.15.0-30-generic/build for BCC runtime.
I20220828 21:22:02.307688 173015 bcc_wrapper.cc:170] Initializing BPF program ...
I20220828 21:22:17.228394 173015 scoped_timer.h:48] Timer(init_bpf_program) : 14.92 s
I20220828 21:22:18.072218 173015 socket_trace_connector.cc:404] Number of kprobes deployed = 40
I20220828 21:22:18.072238 173015 socket_trace_connector.cc:405] Probes successfully deployed.
I20220828 21:22:18.072257 173015 socket_trace_connector.cc:340] Initializing perf buffers with ncpus=2 and scaling_factor=0.9
I20220828 21:22:18.072324 173015 socket_trace_connector.cc:329] Total perf buffer usage for kData buffers across all cpus: 188743680
I20220828 21:22:18.072330 173015 socket_trace_connector.cc:329] Total perf buffer usage for kControl buffers across all cpus: 3963614
I20220828 21:22:18.143486 173015 socket_trace_connector.cc:409] Number of perf buffers opened = 8
I20220828 21:22:19.198894 173015 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers:nginx_openssl_1_1_0_image
I20220828 21:22:21.579730 173015 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers:ruby_image
I20220828 21:22:21.579775 173015 container_runner.cc:121] docker run --rm --pid=host --name=nginx_155395886587629 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:nginx_openssl_1_1_0_image
Error: No such object: nginx_155395886587629
I20220828 21:22:21.808806 173015 container_runner.cc:160] Container nginx_155395886587629 status:
I20220828 21:22:21.808827 173015 container_runner.cc:169] Container nginx_155395886587629 not yet running, will try again (60 attempts remaining).
I20220828 21:22:22.132608 173188 uprobe_manager.cc:925] Number of uprobes deployed = 5
I20220828 21:22:22.840461 173015 container_runner.cc:160] Container nginx_155395886587629 status: running
I20220828 21:22:22.871012 173015 container_runner.cc:191] Container nginx_155395886587629 process PID: 173160
I20220828 21:22:22.871031 173015 container_runner.cc:193] Container nginx_155395886587629 waiting for log message:
I20220828 21:22:22.902166 173015 container_runner.cc:205] Container nginx_155395886587629 status: running
I20220828 21:22:22.902186 173015 container_runner.cc:241] Container nginx_155395886587629 is ready.
I20220828 21:22:22.910908 173015 container_runner.cc:121] docker run --rm --pid=host --network=container:nginx_155395886587629 --name=ruby_155397217722776 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:ruby_image ruby -e
          require 'net/http'
          require 'uri'

          # Let Stirling discover ruby when it has not yet loaded OpenSSL.
          sleep(1)

          uri = URI.parse('https://localhost:443/index.html')
          http = Net::HTTP.new(uri.host, uri.port)
          http.use_ssl = true
          http.verify_mode = OpenSSL::SSL::VERIFY_NONE # This line dynamically loads OpenSSL libs.

          # Give enough time for uprobes to load.
          sleep(5)

          # Make multiple requests, so we can check we trace them all.
          $i = 0
          while $i < 3 do
            request = Net::HTTP::Get.new(uri.request_uri)
            response = http.request(request)
            p response.body

            $i += 1
          end
I20220828 21:22:23.109984 173015 container_runner.cc:160] Container ruby_155397217722776 status: running
I20220828 21:22:23.152187 173015 container_runner.cc:191] Container ruby_155397217722776 process PID: 173270
I20220828 21:22:23.152213 173015 container_runner.cc:193] Container ruby_155397217722776 waiting for log message:
I20220828 21:22:23.199023 173015 container_runner.cc:205] Container ruby_155397217722776 status: running
I20220828 21:22:23.199086 173015 container_runner.cc:241] Container ruby_155397217722776 is ready.
I20220828 21:22:24.401472 173307 uprobe_manager.cc:925] Number of uprobes deployed = 5
I20220828 21:22:43.756953 173015 dyn_lib_trace_bpf_test.cc:184] Worker thread PID: 173189
W20220828 21:22:43.758270 173015 subprocess.cc:218] Failed to send signal=9 to pid=173220, error=No such process
I20220828 21:22:43.758301 173015 container_runner.cc:59] docker rm -f ruby_155397217722776
Error: No such container: ruby_155397217722776
I20220828 21:22:43.791913 173015 container_runner.cc:59] docker rm -f nginx_155395886587629
[       OK ] DynLibTraceTest.TraceDynLoadedOpenSSL (44649 ms)
[----------] 1 test from DynLibTraceTest (44649 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (44649 ms total)
[  PASSED  ] 1 test.
I20220828 21:22:46.956455 173015 env.cc:51] Shutting down


vagrant@vagrant:/vagrant$ ./scripts/sudo_bazel_run.sh -c dbg src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test
INFO: Elapsed time: 12.138s, Critical Path: 10.50s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh /bin/bash -c '"$@"' /bin/bash sudo src/stirling/source_connectors/socket_tracer/mux_trac
INFO: Build completed successfully, 3 total actions
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test
-----------------------------------------------------------------------------
I20220828 21:04:22.363904 165081 env.cc:47] Started: src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from MuxTraceTest
[ RUN      ] MuxTraceTest.Capture
I20220828 21:04:23.999078 165081 container_runner.cc:43] The image bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image already exists, renaming the old one with ID sha256:61746da6eaa760a7115c7be982012099fc1db40140c22c2b0e1156fc935aece0 to empty string
Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
I20220828 21:04:23.999121 165081 container_runner.cc:121] docker run --rm --pid=host --name=thriftmux_server_154318305934249 bazel/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image
Error: No such object: thriftmux_server_154318305934249
I20220828 21:04:24.147850 165081 container_runner.cc:160] Container thriftmux_server_154318305934249 status:
I20220828 21:04:24.147871 165081 container_runner.cc:169] Container thriftmux_server_154318305934249 not yet running, will try again (60 attempts remaining).
I20220828 21:04:25.218195 165081 container_runner.cc:160] Container thriftmux_server_154318305934249 status: running
I20220828 21:04:25.266408 165081 container_runner.cc:191] Container thriftmux_server_154318305934249 process PID: 165177
I20220828 21:04:25.266430 165081 container_runner.cc:193] Container thriftmux_server_154318305934249 waiting for log message: Finagle version
I20220828 21:04:25.295708 165081 container_runner.cc:205] Container thriftmux_server_154318305934249 status: running
I20220828 21:04:25.295727 165081 container_runner.cc:218] Container thriftmux_server_154318305934249 not in ready state, will try again (59 attempts remaining).
I20220828 21:04:26.347692 165081 container_runner.cc:205] Container thriftmux_server_154318305934249 status: running
I20220828 21:04:26.347735 165081 container_runner.cc:241] Container thriftmux_server_154318305934249 is ready.
I20220828 21:04:26.348078 165081 source_connector.cc:36] Initializing source connector: socket_trace_connector
I20220828 21:04:26.348106 165081 linux_headers.cc:209] Found Linux kernel version using .note section.
I20220828 21:04:26.348111 165081 linux_headers.cc:90] Obtained Linux version string from `uname`: 5.15.0-30-generic
I20220828 21:04:26.348115 165081 linux_headers.cc:599] Detected kernel release (uname -r): 5.15.0-30-generic
I20220828 21:04:26.349164 165081 bcc_wrapper.cc:121] Using linux headers found at /lib/modules/5.15.0-30-generic/build for BCC runtime.
I20220828 21:04:26.349217 165081 bcc_wrapper.cc:170] Initializing BPF program ...
I20220828 21:04:41.028756 165081 scoped_timer.h:48] Timer(init_bpf_program) : 14.68 s
I20220828 21:04:41.871552 165081 socket_trace_connector.cc:404] Number of kprobes deployed = 40
I20220828 21:04:41.871572 165081 socket_trace_connector.cc:405] Probes successfully deployed.
I20220828 21:04:41.871590 165081 socket_trace_connector.cc:340] Initializing perf buffers with ncpus=2 and scaling_factor=0.9
I20220828 21:04:41.871613 165081 socket_trace_connector.cc:329] Total perf buffer usage for kData buffers across all cpus: 188743680
I20220828 21:04:41.871618 165081 socket_trace_connector.cc:329] Total perf buffer usage for kControl buffers across all cpus: 3963614
I20220828 21:04:41.924054 165081 socket_trace_connector.cc:409] Number of perf buffers opened = 8
I20220828 21:04:43.324312 165081 linux_headers.cc:209] Found Linux kernel version using .note section.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.twitter.jvm.Hotspot (file:/app/maven/v1/https/repo1.maven.org/maven2/com/twitter/util-jvm_2.13/22.7.0/util-jvm_2.13-22.7.0.jar) to field sun.management.ManagementFactoryHelper.jvm
WARNING: Please consider reporting this to the maintainers of com.twitter.jvm.Hotspot
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Aug 28, 2022 9:04:44 PM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version 22.7.0 (rev=4d10525ef4fe89732bcfec6286fac7fe426e9082) built at 20220728-183850
Aug 28, 2022 9:04:45 PM com.twitter.finagle.FixedInetResolver$ factory$lzycompute
INFO: Successfully loaded a fixed inet resolver: com.twitter.finagle.netty4.FixedNetty4InetResolver$Factory@2015b2cd
Aug 28, 2022 9:04:45 PM com.twitter.finagle.BaseResolver inetResolver$lzycompute
INFO: Using default inet resolver
Aug 28, 2022 9:04:45 PM com.twitter.finagle.InetResolver$ factory$lzycompute
INFO: Successfully loaded an inet resolver: com.twitter.finagle.netty4.Netty4InetResolver$Factory@5fac521d
Aug 28, 2022 9:04:45 PM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[inet] = com.twitter.finagle.InetResolver(com.twitter.finagle.InetResolver@61f39bb)
Aug 28, 2022 9:04:45 PM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fixedinet] = com.twitter.finagle.FixedInetResolver(com.twitter.finagle.FixedInetResolver@249e0271)
Aug 28, 2022 9:04:45 PM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[neg] = com.twitter.finagle.NegResolver$(com.twitter.finagle.NegResolver$@4893b344)
Aug 28, 2022 9:04:45 PM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[nil] = com.twitter.finagle.NilResolver$(com.twitter.finagle.NilResolver$@53a665ad)
Aug 28, 2022 9:04:45 PM com.twitter.finagle.BaseResolver $anonfun$resolvers$3
INFO: Resolver[fail] = com.twitter.finagle.FailResolver$(com.twitter.finagle.FailResolver$@2c0b4c83)
I20220828 21:04:46.631839 165081 mux_trace_bpf_test.cc:97] thriftmux client command output: '165263
21:04:44.442 [main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
21:04:44.445 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
21:04:44.445 [main] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
21:04:44.459 [main] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
21:04:44.460 [main] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 11
21:04:44.462 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
21:04:44.463 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
21:04:44.463 [main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.storeFence: available
21:04:44.463 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
21:04:44.464 [main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable: Reflective setAccessible(true) disabled
21:04:44.464 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
21:04:44.465 [main] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable: class io.netty.util.internal.PlatformDependent0$7 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @700fb871
21:04:44.467 [main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): unavailable
21:04:44.467 [main] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
21:04:44.469 [main] DEBUG io.netty.util.internal.PlatformDependent - maxDirectMemory: 2084569088 bytes (maybe)
21:04:44.469 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
21:04:44.469 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
21:04:44.471 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: -1 bytes
21:04:44.471 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
21:04:44.472 [main] DEBUG io.netty.util.internal.CleanerJava9 - java.nio.ByteBuffer.cleaner(): available
21:04:44.472 [main] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
21:04:44.474 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 8
21:04:44.474 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 8
21:04:44.474 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
21:04:44.474 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: false
21:04:44.475 [main] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
21:04:44.479 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
21:04:44.479 [main] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
21:04:44.521 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.workdir: /tmp (io.netty.tmpdir)
21:04:44.525 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.deleteLibAfterLoading: true
21:04:44.525 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.tryPatchShadedId: true
21:04:44.526 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - -Dio.netty.native.detectNativeLibraryDuplicates: true
21:04:44.548 [main] DEBUG io.netty.util.internal.NativeLibraryLoader - Successfully loaded the library /tmp/libnetty_transport_native_epoll_x86_6414725502873957161257.so
21:04:44.551 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
21:04:44.551 [main] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
21:04:44.553 [main] DEBUG io.netty.util.NetUtilInitializations - Loopback interface: lo (lo, 127.0.0.1)
21:04:44.554 [main] DEBUG io.netty.util.NetUtil - /proc/sys/net/core/somaxconn: 4096
21:04:45.186 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@2e23c180
21:04:45.196 [main] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
21:04:45.653 [main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 4
21:04:45.712 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 165279 (auto-detected)
21:04:45.713 [main] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 02:42:ac:ff:fe:11:00:02 (auto-detected)
21:04:45.726 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
21:04:45.727 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
21:04:45.727 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
21:04:45.840 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: disabled
21:04:45.840 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: disabled
21:04:45.840 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.chunkSize: disabled
21:04:45.840 [finagle/netty4-1-1] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.blocking: disabled
21:04:45.845 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkAccessible: true
21:04:45.845 [finagle/netty4-1-1] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.checkBounds: true
21:04:45.846 [finagle/netty4-1-1] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@5e8460db
StringString
'
I20220828 21:04:46.631901 165081 mux_trace_bpf_test.cc:106] Client PID: 165263
I20220828 21:04:48.326997 165081 container_runner.cc:59] docker rm -f thriftmux_server_154318305934249
[       OK ] MuxTraceTest.Capture (26201 ms)
[----------] 1 test from MuxTraceTest (26201 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (26201 ms total)
[  PASSED  ] 1 test.
I20220828 21:04:48.565760 165081 env.cc:51] Shutting down

```
</details>

I couldn't find a way to add the mux equivalents of `ToRecordVector` and `GetTargetRecords` without updating the client code. Omitting that change resulted in the following error.
```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc:110:46: error: no matching function for call to 'ToRecordVector'
    std::vector<http::Record> http_records = ToRecordVector(record_batch, server_record_indices);
                                             ^~~~~~~~~~~~~~
./src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h:41:25: note: candidate template ignored: couldn't infer template argument 'TFrameType'
std::vector<TFrameType> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
```

Please let me know if you are aware of a way to avoid this problem.