### PR TITLE
Ensure TraceMode::OnNewerKernel doesn't cause older kernels to fail to load BPF programs due to instruction length

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/BUILD.bazel
@@ -70,7 +70,6 @@ pl_cc_test(
         "ENABLE_DNS_TRACING=true",
         "ENABLE_REDIS_TRACING=true",
         "ENABLE_NATS_TRACING=true",
-        "ENABLE_MUX_TRACING=true",
         "ENABLE_MONGO_TRACING=true",
         "ENABLE_AMQP_TRACING=true",
     ],


### PR DESCRIPTION
This is to fix the final issue that is blocking #569 from merging. That PR causes the 'trace_bpf' tests to break on older kernels since they run into the following error:

```
I20220929 06:56:47.804983 39215 scoped_timer.h:48] Timer(init_bpf_program) : 7.72 s
bpf: Argument list too long. Program  too large (4143 insns), at most 4096 insns
```

## Testing
- [x] Verified that setting mux tracing to `TraceMode::OnForNewerKernel` results in a failing dns_trace_bpf_test
```
# Verify running older kernel
vagrant@ubuntu-jammy:/vagrant$ uname -r
4.14.190-0414190-generic

# Verify that mux tracing is set to OnForNewerKernel and that build fails
[tw-mbp-ddelnano pixie (main)]% git diff
diff --git a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
index 55e164526..ef9c90505 100644
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
:...skipping...
diff --git a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
index 55e164526..ef9c90505 100644
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -92,7 +92,7 @@ DEFINE_int32(stirling_enable_nats_tracing, px::stirling::TraceMode::On,
 DEFINE_int32(stirling_enable_kafka_tracing, px::stirling::TraceMode::On,
              "If true, stirling will trace and process Kafka messages.");
 DEFINE_int32(stirling_enable_mux_tracing,
-             gflags::Uint32FromEnv("PL_STIRLING_TRACER_ENABLE_MUX", px::stirling::TraceMode::Off),
+             gflags::Uint32FromEnv("PL_STIRLING_TRACER_ENABLE_MUX", px::stirling::TraceMode::OnForNewerKernel),
              "If true, stirling will trace and process Mux messages.");
 DEFINE_int32(stirling_enable_amqp_tracing, px::stirling::TraceMode::On,
              "If true, stirling will trace and process AMQP messages.");

vagrant@ubuntu-jammy:/vagrant$ ./scripts/sudo_bazel_run.sh src/stirling/source_connectors/socket_tracer:dns_trace_bpf_test

[ ... ]

I20220929 06:56:40.086163 39215 bcc_wrapper.cc:170] Initializing BPF program ...
I20220929 06:56:47.804983 39215 scoped_timer.h:48] Timer(init_bpf_program) : 7.72 s
bpf: Argument list too long. Program  too large (4143 insns), at most 4096 insns

./src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h:53: Failure
Value of: IsOK(::px::StatusAdapter(source_->Init()))
  Actual: false (Internal : Failed to load syscall__probe_ret_writev: -1)
Expected: true
I20220929 06:56:47.966348 39215 container_runner.cc:59] docker rm -f dns_server_5212549039180 &>/dev/null
[  FAILED  ] DNSTraceTest.Capture (10385 ms)
[----------] 1 test from DNSTraceTest (10385 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (10386 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DNSTraceTest.Capture

 1 FAILED TEST
I20220929 06:56:48.926362 39215 env.cc:51] Shutting down


```
- [x] Verified that using the `TransferSpec.enabled` member results in passing 'trace_bpf' tests
```

vagrant@ubuntu-jammy:/vagrant$ ./scripts/sudo_bazel_run.sh src/stirling/source_connectors/socket_tracer:dns_trace_bpf_test
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:dns_trace_bpf_test (1 packages loaded, 18 targets configured).
INFO: Found 1 target...
Target //src/stirling/source_connectors/socket_tracer:dns_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/dns_trace_bpf_test
INFO: Elapsed time: 21.479s, Critical Path: 19.60s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh /bin/bash -c '"$@"' /bin/bash sudo src/stirling/source_connecto
INFO: Build completed successfully, 3 total actions
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/stirling/source_connectors/socket_tracer:dns_trace_bpf_test
-----------------------------------------------------------------------------
I20220929 06:49:58.761350 38191 env.cc:47] Started: src/stirling/source_connectors/socket_tracer/dns_trace_bpf_test
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DNSTraceTest
[ RUN      ] DNSTraceTest.Capture
I20220929 06:49:59.054795 38191 container_runner.cc:43] Loaded image: bazel/src/stirling/source_connectors/socket_tracer/testing/containers:dns_image
I20220929 06:49:59.054845 38191 container_runner.cc:121] docker run --rm --pid=host --name=dns_server_4812758043585 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:dns_image
Error: No such object: dns_server_4812758043585
I20220929 06:49:59.112987 38191 container_runner.cc:160] Container dns_server_4812758043585 status:
I20220929 06:49:59.113023 38191 container_runner.cc:169] Container dns_server_4812758043585 not yet running, will try again (150 attempts remaining).
I20220929 06:50:00.151767 38191 container_runner.cc:160] Container dns_server_4812758043585 status: running
I20220929 06:50:00.184393 38191 container_runner.cc:191] Container dns_server_4812758043585 process PID: 38271
I20220929 06:50:00.184419 38191 container_runner.cc:193] Container dns_server_4812758043585 waiting for log message: all zones loaded
I20220929 06:50:00.215521 38191 container_runner.cc:205] Container dns_server_4812758043585 status: running
I20220929 06:50:00.215564 38191 container_runner.cc:241] Container dns_server_4812758043585 is ready.
I20220929 06:50:00.215884 38191 linux_headers.cc:209] Found Linux kernel version using .note section.
I20220929 06:50:00.215905 38191 source_connector.cc:35] Initializing source connector: socket_trace_connector
I20220929 06:50:00.215925 38191 linux_headers.cc:90] Obtained Linux version string from `uname`: 4.14.190-0414190-generic
I20220929 06:50:00.215930 38191 linux_headers.cc:635] Detected kernel release (uname -r): 4.14.190-0414190-generic
I20220929 06:50:00.215972 38191 bcc_wrapper.cc:121] Using linux headers found at /lib/modules/4.14.190-0414190-generic/build for BCC runtime.
I20220929 06:50:00.216204 38191 bcc_wrapper.cc:170] Initializing BPF program ...
I20220929 06:50:08.467154 38191 scoped_timer.h:48] Timer(init_bpf_program) : 8.25 s
I20220929 06:50:08.990618 38191 socket_trace_connector.cc:414] Number of kprobes deployed = 40
I20220929 06:50:08.990645 38191 socket_trace_connector.cc:415] Probes successfully deployed.
I20220929 06:50:08.990670 38191 socket_trace_connector.cc:341] Initializing perf buffers with ncpus=2 and scaling_factor=0.9
I20220929 06:50:08.990701 38191 socket_trace_connector.cc:330] Total perf buffer usage for kData buffers across all cpus: 188743680
I20220929 06:50:08.990708 38191 socket_trace_connector.cc:330] Total perf buffer usage for kControl buffers across all cpus: 3963614
I20220929 06:50:09.013547 38191 socket_trace_connector.cc:419] Number of perf buffers opened = 8
I20220929 06:50:10.007171 38191 dns_trace_bpf_test.cc:69] 38369

; <<>> DiG 9.16.6 <<>> @127.0.0.1 server.dnstest.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18103
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; COOKIE: 808783425387894701000000633540219b9d647ec327f732 (good)
;; QUESTION SECTION:
;server.dnstest.com.            IN      A

;; ANSWER SECTION:
server.dnstest.com.     86400   IN      A       192.168.32.200

;; Query time: 0 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Thu Sep 29 06:50:10 UTC 2022
;; MSG SIZE  rcvd: 91

I20220929 06:50:10.246033 38191 dns_trace_bpf_test.cc:76] PrintDNSTable(rb):  time_:[2022-09-29 06:50:10] upid:[{0:38271:481350}] remote_addr:[127.0.0.1] remote_port:[35852] trace_role:[2] req_header:[{"txid":18103,"qr":0,"opcode":0,"aa":0,"tc":0,"rd":1,"ra":0,"ad":1,"cd":0,"rcode":0,"num_queries":1,"num_answers":0,"num_auth":0,"num_addl":1}] req_body:[{"queries":[{"name":"server.dnstest.com","type":"A"}]}] resp_header:[{"txid":18103,"qr":1,"opcode":0,"aa":1,"tc":0,"rd":1,"ra":1,"ad":0,"cd":0,"rcode":0,"num_queries":1,"num_answers":1,"num_auth":0,"num_addl":1}] resp_body:[{"answers":[{"name":"server.dnstest.com","type":"A","addr":"192.168.32.200"}]}] latency:[0.000255725 seconds] px_info_:[conn_tracker=conn_id=[upid=38271:481350 fd=24 gen=4823706079035] state=kTransferring remote_addr=127.0.0.1:35852 role=kRoleServer protocol=kProtocolDNS ssl=false record=req=[header={"txid":18103,"qr":0,"opcode":0,"aa":0,"tc":0,"rd":1,"ra":0,"ad":1,"cd":0,"rcode":0,"num_queries":1,"num_answers":0,"num_auth":0,"num_addl":1} query={"queries":[{"name":"server.dnstest.com","type":"A"}]} timestamp_ns=1664434210002883682] resp=[header={"txid":18103,"qr":1,"opcode":0,"aa":1,"tc":0,"rd":1,"ra":1,"ad":0,"cd":0,"rcode":0,"num_queries":1,"num_answers":1,"num_auth":0,"num_addl":1} query={"answers":[{"name":"server.dnstest.com","type":"A","addr":"192.168.32.200"}]} timestamp_ns=1664434210003139407]]
 time_:[2022-09-29 06:50:10] upid:[{0:38369:482369}] remote_addr:[127.0.0.1] remote_port:[53] trace_role:[1] req_header:[{"txid":18103,"qr":0,"opcode":0,"aa":0,"tc":0,"rd":1,"ra":0,"ad":1,"cd":0,"rcode":0,"num_queries":1,"num_answers":0,"num_auth":0,"num_addl":1}] req_body:[{"queries":[{"name":"server.dnstest.com","type":"A"}]}] resp_header:[{"txid":18103,"qr":1,"opcode":0,"aa":1,"tc":0,"rd":1,"ra":1,"ad":0,"cd":0,"rcode":0,"num_queries":1,"num_answers":1,"num_auth":0,"num_addl":1}] resp_body:[{"answers":[{"name":"server.dnstest.com","type":"A","addr":"192.168.32.200"}]}] latency:[0.000438671 seconds] px_info_:[conn_tracker=conn_id=[upid=38369:482369 fd=20 gen=4823705940629] state=kTransferring remote_addr=127.0.0.1:53 role=kRoleClient protocol=kProtocolDNS ssl=false record=req=[header={"txid":18103,"qr":0,"opcode":0,"aa":0,"tc":0,"rd":1,"ra":0,"ad":1,"cd":0,"rcode":0,"num_queries":1,"num_answers":0,"num_auth":0,"num_addl":1} query={"queries":[{"name":"server.dnstest.com","type":"A"}]} timestamp_ns=1664434210002772880] resp=[header={"txid":18103,"qr":1,"opcode":0,"aa":1,"tc":0,"rd":1,"ra":1,"ad":0,"cd":0,"rcode":0,"num_queries":1,"num_answers":1,"num_auth":0,"num_addl":1} query={"answers":[{"name":"server.dnstest.com","type":"A","addr":"192.168.32.200"}]} timestamp_ns=1664434210003211551]]
I20220929 06:50:13.040186 38191 container_runner.cc:59] docker rm -f dns_server_4812758043585 &>/dev/null
[       OK ] DNSTraceTest.Capture (14620 ms)
[----------] 1 test from DNSTraceTest (14620 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (14620 ms total)
[  PASSED  ] 1 test.
I20220929 06:50:13.381927 38191 env.cc:51] Shutting down

```