### PR TITLE
Enable mux tracing on newer kernels (>= 5.2)

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -96,7 +96,8 @@ DEFINE_int32(stirling_enable_nats_tracing, px::stirling::TraceMode::On,
 DEFINE_int32(stirling_enable_kafka_tracing, px::stirling::TraceMode::On,
              "If true, stirling will trace and process Kafka messages.");
 DEFINE_int32(stirling_enable_mux_tracing,
-             gflags::Uint32FromEnv("PL_STIRLING_TRACER_ENABLE_MUX", px::stirling::TraceMode::Off),
+             gflags::Uint32FromEnv("PL_STIRLING_TRACER_ENABLE_MUX",
+                                   px::stirling::TraceMode::OnForNewerKernel),
              "If true, stirling will trace and process Mux messages.");
 DEFINE_int32(stirling_enable_amqp_tracing, px::stirling::TraceMode::On,
              "If true, stirling will trace and process AMQP messages.");


### PR DESCRIPTION
This is possible now that #603 is complete. See the Testing done section of that PR where I verified that we no longer receive the following error on older kernels when additional protocols use `TraceMode::OnForNewerKernel`:

```
I20220929 06:56:47.804983 39215 scoped_timer.h:48] Timer(init_bpf_program) : 7.72 s
bpf: Argument list too long. Program  too large (4143 insns), at most 4096 insns
```