### PR TITLE
Remove byteman from thriftmux container

### DIFF
--- a/bazel/external/ubuntu_packages/debs.json
+++ b/bazel/external/ubuntu_packages/debs.json
@@ -22,9 +22,5 @@
    {
       "path": "main/z/zlib/zlib1g_1.2.11.dfsg-2ubuntu9_amd64.deb",
       "checksum": "52449467942cc943d651fd16867014e9339f3657935fc09b75b3347aa5a78066"
-   },
-   {
-      "path": "universe/b/byteman/libbyteman-java_4.0.18-1_all.deb",
-      "checksum": "f442036d59e855573bbfe1abfd108cafa62073be9926066ece42867eb7e6bf43"
    }
 ]

--- a/bazel/external/ubuntu_packages/packages.bzl
+++ b/bazel/external/ubuntu_packages/packages.bzl
@@ -19,12 +19,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def download_ubuntu_packages():
     http_file(
-        name = "libbyteman-java",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libbyteman-java_4.0.18-1_all.deb"],
-        sha256 = "40d91e567da1d5369e7e7d022d3b9b88fca529a357cbd22eb737c5a9e6ea8ab4",
-        downloaded_file_path = "out.deb",
-    )
-    http_file(
         name = "libc6",
         urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libc6_2.35-0ubuntu3_amd64.deb"],
         sha256 = "16281f1199723ff302ac05fc9daa647fa1cdc420b547a3b5a83e81cb40f0aea5",
@@ -62,7 +56,6 @@ def download_ubuntu_packages():
     )
 
 packages = {
-    "libbyteman-java": "@libbyteman-java//file:out.deb",
     "libc6": "@libc6//file:out.deb",
     "libcrypt1": "@libcrypt1//file:out.deb",
     "libelf1": "@libelf1//file:out.deb",

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -62,19 +62,6 @@ pkg_tar(
     strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
 )
 
-# TODO(ddelnano): byteman is required until dealing with
-# netty's libnetty_tcnative.so's random file name is solved for.
-# See #407 for more details.
-pkg_tar(
-    name = "byteman_rule",
-    srcs = [
-        "byteman_rule.txt",
-    ],
-    mode = "0755",
-    package_dir = "/etc/byteman",
-    strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux",
-)
-
 thrift_library(
     name = "thrift_library",
     srcs = glob(["**/*.thrift"]),
@@ -140,12 +127,10 @@ container_image(
     name = "thriftmux_base",
     base = DEFAULT_JAVA_BASE,
     debs = [
-        packages["libbyteman-java"],
         packages["libcrypt1"],
     ],
     tars = [
         ":ssl_keys",
-        ":byteman_rule",
     ],
 )
 
@@ -154,8 +139,6 @@ scala_image(
     srcs = glob(["**/*.scala"]),
     base = ":thriftmux_base",
     jvm_flags = [
-        "-javaagent:/usr/share/java/byteman-4.0.18.jar=script:/etc/byteman/byteman_rule.txt,boot:/usr/share/java/byteman-4.0.18.jar",
-        "-Dorg.jboss.byteman.transform.all",
         "-Dio.netty.native.deleteLibAfterLoading=false",
     ],
     main_class = "Server",


### PR DESCRIPTION
This was a workaround that was relied on when I was testing an earlier version of #569, but it is no longer required. See the details on #407 for more background on this issue.

## Testing done
- [x] Verified that mux trace bpf test passes -- verifies that thriftmux docker image builds after these changes
```
vagrant@ubuntu-jammy:/vagrant$ ./scripts/sudo_bazel_run.sh src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test
INFO: Analyzed target //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test (4 packages loaded, 367 targets configured).

[ ... ]

StringString
'
I20220930 23:16:30.964895 10610 mux_trace_bpf_test.cc:106] Client PID: 10781
I20220930 23:16:32.576351 10610 container_runner.cc:59] docker rm -f thriftmux_server_1652818639740 &>/dev/null
[       OK ] MuxTraceTest.Capture (17824 ms)
[----------] 1 test from MuxTraceTest (17825 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (17827 ms total)
[  PASSED  ] 1 test.
I20220930 23:16:32.814891 10610 env.cc:51] Shutting down

```