### PR TITLE
Add finagle demo to pixie cli

### DIFF
--- a/demos/BUILD.bazel
+++ b/demos/BUILD.bazel
@@ -18,6 +18,13 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@px//demos:demo_upload.bzl", "demo_upload")
 
 pkg_tar(
+    name = "px-finagle",
+    srcs = glob(["finagle/*"]),
+    extension = "tar.gz",
+    strip_prefix = "finagle",
+)
+
+pkg_tar(
     name = "px-kafka",
     srcs = glob(["kafka/*"]),
     extension = "tar.gz",
@@ -39,6 +46,7 @@ pkg_tar(
 )
 
 ARCHIVES = [
+    ":px-finagle",
     ":px-kafka",
     ":px-sock-shop",
     ":px-online-boutique",

--- a/demos/README.md
+++ b/demos/README.md
@@ -31,7 +31,7 @@ bazel run //demos:upload_prod_demo
 
 1. Clone `https://github.com/pixie-io/microservice-kafka` and switch to the `pixie` branch.
 
-2. (optional) Build the container images & update the individual yaml files.
+2. (optional) Build the container image & update the individual yaml files.
 
 3. Build a single yaml file for the demo:
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -43,7 +43,7 @@ kustomize build . >  kafka.yaml
 
 ## Updating the `px-finagle` demo
 
-1. Clone `https://github.com/pixie-labs/finagle-helloworld`
+1. Clone `https://github.com/pixie-io/finagle-helloworld`
 
 2. (optional) Build the container images & update the individual yaml files.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -41,6 +41,21 @@ kustomize build . >  kafka.yaml
 
 4. Copy the yaml file to `pixie/demos/kafka`.
 
+## Updating the `px-finagle` demo
+
+1. Clone `https://github.com/pixie-labs/finagle-helloworld`
+
+2. (optional) Build the container images & update the individual yaml files.
+
+3. Build a single yaml file for the demo:
+
+```
+kustomize . > finagle.yaml
+```
+
+4. Copy the yaml file to `pixie/demos/finagle`.
+
+
 ## Updating the `px-online-boutique` demo
 
 Our custom `adservice` image includes the `-XX:+PreserveFramePointer` Java option. To build our custom `adservice` image:

--- a/demos/finagle/LICENSE
+++ b/demos/finagle/LICENSE
@@ -1,0 +1,27 @@
+This code is originally from: https://github.com/SedarG/finagle-helloworld.
+Copyright is held by original copyright owners.
+
+Original License Noted Below.
+----------------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2022 Sedar Gokbulut
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/demos/finagle/finagle.yaml
+++ b/demos/finagle/finagle.yaml
@@ -3,6 +3,27 @@ kind: Namespace
 metadata:
   name: px-finagle
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker/docker-compose.yml
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: finagle-server
+  name: finagle-server
+  namespace: px-finagle
+spec:
+  ports:
+  - name: "9992"
+    port: 9992
+    targetPort: 9992
+  selector:
+    io.kompose.service: finagle-server
+status:
+  loadBalancer: {}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,6 +34,7 @@ metadata:
   labels:
     io.kompose.service: finagle-client
   name: finagle-client
+  namespace: px-finagle
 spec:
   replicas: 1
   selector:
@@ -47,6 +69,7 @@ metadata:
   labels:
     io.kompose.service: finagle-server
   name: finagle-server
+  namespace: px-finagle
 spec:
   replicas: 1
   selector:
@@ -65,6 +88,8 @@ spec:
       containers:
       - image: gcr.io/pixie-prod/demos/finagle/server:1.0
         name: finagle-server
+        ports:
+        - containerPort: 9992
         resources: {}
       restartPolicy: Always
 status: {}

--- a/demos/finagle/finagle.yaml
+++ b/demos/finagle/finagle.yaml
@@ -53,7 +53,7 @@ spec:
       containers:
       - args:
         - client/run
-        image: gcr.io/pixie-prod/demos/finagle/client:1.0
+        image: gcr.io/pixie-prod/demos/finagle/hello:1.0
         name: finagle-client
         resources: {}
       restartPolicy: Always
@@ -86,7 +86,7 @@ spec:
         io.kompose.service: finagle-server
     spec:
       containers:
-      - image: gcr.io/pixie-prod/demos/finagle/server:1.0
+      - image: gcr.io/pixie-prod/demos/finagle/hello:1.0
         name: finagle-server
         ports:
         - containerPort: 9992

--- a/demos/finagle/finagle.yaml
+++ b/demos/finagle/finagle.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: px-finagle
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker/docker-compose.yml
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: finagle-client
+  name: finagle-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: finagle-client
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ../docker/docker-compose.yml
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: finagle-client
+    spec:
+      containers:
+      - args:
+        - client/run
+        image: gcr.io/pixie-prod/demos/finagle/client:1.0
+        name: finagle-client
+        resources: {}
+      restartPolicy: Always
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker/docker-compose.yml
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: finagle-server
+  name: finagle-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: finagle-server
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ../docker/docker-compose.yml
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: finagle-server
+    spec:
+      containers:
+      - image: gcr.io/pixie-prod/demos/finagle/server:1.0
+        name: finagle-server
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -38,7 +38,7 @@
     "px-finagle": {
         "description": "Microservice demo that generates thriftmux traffic with finagle",
         "instructions": [
-            "Traffic will be continuously generated to ensure data is visible.",
+            "Use the px/mux_data script to view the traffic that is continuously generated.",
             "Mux tracing is only enabled on newer kernels (>= 5.2) by default.",
             "Make sure your system meets these requirements before deploying."
         ]

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -34,5 +34,13 @@
             "To turn off the invoicing delay, run:",
             "   kubectl exec -n px-kafka $INVC_POD -c invoicing -- kill -USR2 $INVC_PID"
         ]
+    },
+    "px-finagle": {
+        "description": "Microservice demo that generates thriftmux traffic with finagle",
+        "instructions": [
+            "Traffic will be continuously generated to ensure data is visible.",
+            "Mux tracing is only enabled on newer kernels (>= 5.2) by default.",
+            "Make sure your system meets these requirements before deploying."
+        ]
     }
 }

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -36,7 +36,7 @@
         ]
     },
     "px-finagle": {
-        "description": "Microservice demo that generates thriftmux traffic with finagle",
+        "description": "Microservice demo that generates thriftmux traffic with finagle.",
         "instructions": [
             "Use the px/mux_data script to view the traffic that is continuously generated.",
             "Mux tracing is only enabled on newer kernels (>= 5.2) by default.",


### PR DESCRIPTION
Once #569 is merged, mux tracing will be enabled by default (on kernels >= 5.2). This unblocks adding a finagle demo to the pixie cli. I thought this would be a good addition especially with the eBPF talk later this month.

As part of Twitter's hackathon week, we created [sedarG/finagle-helloworld](https://github.com/sedarG/finagle-helloworld) to demonstrate Pixie's mux protocol tracing. I've modified that repo to match the same setup as the [pixie-labs/microservice-kafka](https://github.com/pixie-labs/microservice-kafka) repo (using kompose, kustomize, etc).

## Testing
- [x] docker-compose example works locally
- [x] Verify that the client and server work on minikube
 1. Set docker client to use minikube cluster -- `eval $(minikube docker-env)`
 2. Build docker image from [sedarG/finagle-helloworld](https://github.com/sedarG/finagle-helloworld) -- `cd finagle-helloworld; docker build -t finagle-server .`
 4. Create `finagle-client` docker image -- `docker tag finagle-server finagle-client`
 5. Update k8s manifest to use `finagle-client` and `finagle-server` as the images and deploy -- `kubectl apply -f demos/finagle/finagle.yaml`
 6. Verify that the finagle-client container logs show successful requests

```
[tw-mbp-ddelnano pixie (ddelnano/add-finagle-demo)]% docker ps | grep finagle
612048c824dd   53b86303c71e                                          "sbt client/run"         2 minutes ago       Up About a minute             k8s_finagle-client_finagle-client-76f887b768-vg2s6_px-finagle_89b131c1-899c-4f98-9d8a-b03235544d40_1
8919609f58de   53b86303c71e                                          "sbt server/run"         2 minutes ago       Up 2 minutes                  k8s_finagle-server_finagle-server-77b8865ccd-c8gwn_px-finagle_d25e033c-eb50-40e0-bf00-e8acfa97c7a3_0
c0a685805ba2   k8s.gcr.io/pause:3.6                                  "/pause"                 2 minutes ago       Up 2 minutes                  k8s_POD_finagle-server-77b8865ccd-c8gwn_px-finagle_d25e033c-eb50-40e0-bf00-e8acfa97c7a3_0
eb70f031138b   k8s.gcr.io/pause:3.6                                  "/pause"                 3 minutes ago       Up 3 minutes                  k8s_POD_finagle-client-76f887b768-vg2s6_px-finagle_89b131c1-899c-4f98-9d8a-b03235544d40_0
[tw-mbp-ddelnano pixie (ddelnano/add-finagle-demo)]% docker logs -f 612048c824dd
[ ... ]
Hello Ding!
Hello Ding!
```

## Todo
- [x] Rebase once the mux_frame_type_name UDF (#609) and the mux_data pxl script (#612) are available
- [x] Fix DNS issues when running on minikube
- [x] Fork [sedarG/finagle-helloworld](https://github.com/sedarG/finagle-helloworld) to pixie-labs org
- [x] Push docker images to Pixie repository before merging (`gcr.io/pixie-prod/demos/finagle/hello:1.0`
- [ ] Verify demo works with `px demo deploy px-finagle` once preceding items are resolved