### PR TITLE
Add libcrypt1 to CC base image so PEM can dlopen netty shared libraries

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -108,6 +108,7 @@ buildifier(
 
 pl_cc_base_packages = [
     packages["libc6"],
+    packages["libcrypt1"],
     packages["libelf1"],
     packages["liblzma5"],
     packages["libtinfo6"],


### PR DESCRIPTION
#### What type of PR is this?

Feature -- this addresses an issue that prevents a k8s PEM from tracing netty applications using TLS.

#### What this PR does / why we need it:

With #407's previous PRs merged, we thought that netty TLS tracing is fully functional. It turns out there are a few remaining issues (documented [here](https://github.com/pixie-io/pixie/issues/407#issuecomment-1281240803)).

#### What is the testplan for the PR:

- Deployed pixie to minikube, enabled `FLAGS_openssl_raw_fptrs_enabled` and updated striling's [StirlingImpl::GetContext()](https://github.com/pixie-io/pixie/blob/9d0620f71729a89d25b09c36307286ec558a285a/src/stirling/stirling.cc#L422) to always return a `SystemWideStandaloneContext` object.
- Ran the `src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux:server_image` image manually to generate encrypted traffic
- Used `stirling_ctrl` to enable debug logging for the server's pid
- Verified that finagle TLS tracing was working after those changes
```
I20221017 17:54:24.759876 624027 conn_tracker.h:271] conn_id=[upid=458961:777207 fd=143 gen=13416457246767] state=kTransferring remote_addr=127.0.0.1:39556 role=kRoleServer protocol=kProtocolMux ssl=true req_frames=3 resp_frames=3
I20221017 17:54:24.759899 624027 conn_tracker.h:278] conn_id=[upid=458961:777207 fd=143 gen=13416457246767] state=kTransferring remote_addr=127.0.0.1:39556 role=kRoleServer protocol=kProtocolMux ssl=true records=3
I20221017 17:54:24.966593 624027 conn_tracker.cc:150] conn_id=[upid=458961:777207 fd=143 gen=13416457246767] state=kTransferring remote_addr=127.0.0.1:39556 role=kRoleServer protocol=kProtocolMux ssl=true Data event: attr:[[ts=13416621420623 conn_id=[upid=458961:777207 fd=143 gen=13416457246767] protocol=kProtocolMux role=kRoleServer dir=kIngress ssl=true source_fn=kSSLRead pos=293 size=204 buf_size=204]] msg_size:204 msg:[\x00\x00\x00\xC8\x02\x00\x00\x02\x00\x03\x00(com.twitter.finagle.tracing.TraceContext\x00 \x8F\x95G\x88\x85z\xF4J\x8F\x95G\x88\x85z\xF4J\x8F\x95G\x88\x85z\xF4J\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1Bcom.twitter.finagle.Retries\x00\x04\x00\x00\x00\x00\x00\x1Ccom.twitter.finagle.Deadline\x00\x10\x17\x1E\xEC\xCA\x0F\x11@\x80\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\x80\x01\x00\x01\x00\x00\x00\x05query\x00\x00\x00\x00\x0B\x00\x01\x00\x00\x00\x06String\x00]
I20221017 17:54:24.966631 624027 conn_tracker.cc:150] conn_id=[upid=458961:777207 fd=143 gen=13416457246767] state=kTransferring remote_addr=127.0.0.1:39556 role=kRoleServer protocol=kProtocolMux ssl=true Data event: attr:[[ts=13416622005181 conn_id=[upid=458961:777207 fd=143 gen=13416457246767] protocol=kProtocolMux role=kRoleServer dir=kEgress ssl=true source_fn=kSSLWrite pos=73 size=48 buf_size=48]] msg_size:48 msg:[\x00\x00\x00,\xFE\x00\x00\x02\x00\x00\x00\x80\x01\x00\x02\x00\x00\x00\x05query\x00\x00\x00\x00\x0B\x00\x00\x00\x00\x00\x0CStringString\x00]

```

I'll be opening up other PRs to address the other two issues: updating `FLAGS_openssl_raw_fptrs_enabled`'s default value and fixing the UPID discovery issue

#### Does this PR introduce a user-facing change?

Not until the other issues are addressed.

