### PR TITLE
Synthetic PII generator - Improve Error Handling

### DIFF
--- a/src/datagen/pii/privy/.gitignore
+++ b/src/datagen/pii/privy/.gitignore
@@ -1,0 +1,4 @@
+data/
+openapi-directory-*/
+*.csv
+*.html

--- a/src/datagen/pii/privy/privy/generate/generate.py
+++ b/src/datagen/pii/privy/privy/generate/generate.py
@@ -88,8 +88,9 @@ def parse_args():
     parser.add_argument(
         "--api_specs",
         "-a",
-        required=True,
-        help="Absolute path to folder download openapi specs into. Privy checks if this folder already exists.",
+        required=False,
+        default=Path(__file__).parent,
+        help="Absolute path to folder to download openapi specs into. Privy checks if this folder already exists.",
     )
 
     parser.add_argument(

--- a/src/datagen/pii/privy/privy/hooks.py
+++ b/src/datagen/pii/privy/privy/hooks.py
@@ -71,7 +71,6 @@ class SchemaHooks:
                         name, enum, schema, type_, case.query, ParamType.QUERY
                     )
                 # todo @benkilimnik: generate cookies, headers
-                # todo @benkilimnik: loop arbitrarily deep into schema. Currently only checking first level
                 # todo @benkilimnik: parse multi-component schemas that have property params for each component
                 return case
 
@@ -129,9 +128,9 @@ class SchemaHooks:
                 return case_attr[name]
             # last resort, assign string value
             if name:
-                self.log.debug(f"{name} |could not be matched. Assigning string...| ")
-                nonpii = self.providers.get_nonpii_provider("string")
-                case_attr[name] = nonpii.template_name
+                self.log.debug(
+                    f"{name} |could not be matched. Assigning string...| ")
+                case_attr[name] = "{{string}}"
 
         def check_for_pii_keywords(self, name: str, schema: Optional[dict], type_: Optional[Union[str, bool]],
                                    case_attr: dict, parameter_type: ParamType) -> Optional[bool]:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/pixie-io/pixie/blob/main/CONTRIBUTING.md and https://github.com/pixie-io/pixie/blob/main/DEVELOPMENT.md.
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds `.gitignore` for generated data files and improves error handling during API schema parsing so that when Privy encounters an error for one API path, it does not skip the entire openapi spec, but moves on the next API path in the current spec. 

This PR also makes the command line argument `api_specs` optional for ease of use, downloading the openAPI directory to the bazel cache by default. 

#### What is the testplan for the PR:
<!--
For stylistic change that don't require tests or enhancements write: N/A.
-->
Tested in `privy/tests`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### Additional documentation:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories (px-docs, etc), please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [px/docs]: <link>
- [px/website]: <link>
-->
```docs

```
