### PR TITLE
feat: disable auto update vizier from the cli

### DIFF
--- a/src/pixie_cli/pkg/cmd/deploy.go
+++ b/src/pixie_cli/pkg/cmd/deploy.go
@@ -88,6 +88,7 @@ func init() {
 	DeployCmd.Flags().StringArray("patches", []string{}, "Custom patches to apply to Pixie yamls, for example: 'vizier-pem:{\"spec\":{\"template\":{\"spec\":{\"nodeSelector\":{\"pixie\": \"allowed\"}}}}}'")
 	DeployCmd.Flags().String("pem_flags", "", "Flags to be set on the PEM.")
 	DeployCmd.Flags().String("registry", "", "The custom image registry to use rather than Pixie's default (gcr.io).")
+	DeployCmd.Flags().BoolP("disable_auto_update", "d", false, "Disable the auto-update feature for the vizier client.")
 
 	// Flags for deploying OLM.
 	DeployCmd.Flags().String("operator_version", "", "Operator version to deploy")
@@ -127,6 +128,7 @@ var DeployCmd = &cobra.Command{
 		viper.BindPFlag("data_access", cmd.Flags().Lookup("data_access"))
 		viper.BindPFlag("datastream_buffer_size", cmd.Flags().Lookup("datastream_buffer_size"))
 		viper.BindPFlag("datastream_buffer_spike_size", cmd.Flags().Lookup("datastream_buffer_spike_size"))
+		viper.BindPFlag("disable_auto_update", cmd.Flags().Lookup("disable_auto_update"))
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {
 		if cmd.Annotations["status"] != DeploySuccess {
@@ -236,6 +238,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 
 	deployKey, _ := cmd.Flags().GetString("deploy_key")
 	useEtcdOperator, _ := cmd.Flags().GetBool("use_etcd_operator")
+	disableAutoUpdate, _ := cmd.Flags().GetBool("disable_auto_update")
 	customLabels, _ := cmd.Flags().GetString("labels")
 	customAnnotations, _ := cmd.Flags().GetString("annotations")
 	pemMemoryLimit, _ := cmd.Flags().GetString("pem_memory_limit")
@@ -426,7 +429,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 			"deployKey":            deployKey,
 			"cloudAddr":            tmplCloudAddr,
 			"clusterName":          clusterName,
-			"disableAutoUpdate":    false,
+			"disableAutoUpdate":    disableAutoUpdate,
 			"useEtcdOperator":      useEtcdOperator,
 			"devCloudNamespace":    devCloudNS,
 			"pemMemoryLimit":       pemMemoryLimit,


### PR DESCRIPTION
Signed-off-by: sgewirtz1 <sgewirtz1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/pixie-io/pixie/blob/main/CONTRIBUTING.md and https://github.com/pixie-io/pixie/blob/main/DEVELOPMENT.md.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
allows user to disable the vizier auto update feature from the px cli
#### What is the testplan for the PR:
<!--
For stylistic change that don't require tests or enhancements write: N/A.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
A new px deploy option --disable_auto_update or -d to toggle whether vizier clients should update themselves with the latest available version.
```

#### Additional documentation:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories (px-docs, etc), please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [px/docs]: <link>
- [px/website]: <link>
-->
```docs

```
