### PR TITLE
[Added latency calculations to AMQP records.

### DIFF
--- a/src/pxl_scripts/px/amqp_data/amqp_data.pxl
+++ b/src/pxl_scripts/px/amqp_data/amqp_data.pxl
@@ -38,6 +38,7 @@ def amqp_data(start_time: str, source_filter: str, destination_filter: str):
         "resp_msg",
         "source",
         "destination",
+        "latency",
     ]
     return df
 

--- a/src/stirling/source_connectors/socket_tracer/amqp_table.h
+++ b/src/stirling/source_connectors/socket_tracer/amqp_table.h
@@ -74,10 +74,7 @@ static constexpr DataElement kAMQPElements[] = {
          types::DataType::STRING,
          types::SemanticType::ST_NONE,
          types::PatternType::GENERAL},
-        {"latency", "AMQP latency",
-         types::DataType::INT64,
-         types::SemanticType::ST_NONE,
-         types::PatternType::GENERAL},
+        canonical_data_elements::kLatencyNS,
 };
 // clang-format on
 

--- a/src/stirling/source_connectors/socket_tracer/amqp_table.h
+++ b/src/stirling/source_connectors/socket_tracer/amqp_table.h
@@ -74,6 +74,10 @@ static constexpr DataElement kAMQPElements[] = {
          types::DataType::STRING,
          types::SemanticType::ST_NONE,
          types::PatternType::GENERAL},
+        {"latency", "AMQP latency",
+         types::DataType::INT64,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL},
 };
 // clang-format on
 
@@ -84,6 +88,7 @@ DEFINE_PRINT_TABLE(AMQP)
 constexpr int kAMQPTimeIdx = kAMQPTable.ColIndex("time_");
 constexpr int kAMQPUUIDIdx = kAMQPTable.ColIndex("upid");
 constexpr int kAMQPFrameType = kAMQPTable.ColIndex("frame_type");
+constexpr int kAMQPLatencyIdx = kAMQPTable.ColIndex("latency");
 
 constexpr int kAMQPReqClassId = kAMQPTable.ColIndex("req_class_id");
 constexpr int kAMQPReqMethodId = kAMQPTable.ColIndex("req_method_id");

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1098,8 +1098,8 @@ int64_t AMQPCalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns
   }
 
   if (req_timestamp_ns > 0 && resp_timestamp_ns > 0) {
-    latency_ns = std::max(resp_timestamp_ns, req_timestamp_ns) -
-                 std::min(resp_timestamp_ns, resp_timestamp_ns);
+    latency_ns = std::max(req_timestamp_ns, resp_timestamp_ns) -
+                 std::min(req_timestamp_ns, resp_timestamp_ns);
   }
 
   return latency_ns;

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1100,9 +1100,6 @@ int64_t AMQPCalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns
   if (req_timestamp_ns > 0 && resp_timestamp_ns > 0) {
     latency_ns = std::max(resp_timestamp_ns, req_timestamp_ns) -
                  std::min(resp_timestamp_ns, resp_timestamp_ns);
-    LOG_IF_EVERY_N(WARNING, latency_ns < 0, 100)
-        << absl::Substitute("Negative latency implies req resp mismatch [t_req=$0, t_resp=$1].",
-                            req_timestamp_ns, resp_timestamp_ns);
   }
 
   return latency_ns;

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1089,21 +1089,22 @@ int64_t CalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns) {
 int64_t AMQPCalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns,
                              bool req_synchronous, bool resp_synchronous) {
   int64_t latency_ns = 0;
-  if (!req_synchronous){
-    return latency_ns;
-  } 
-  
-  if (!resp_synchronous){
+  if (!req_synchronous) {
     return latency_ns;
   }
-  
+
+  if (!resp_synchronous) {
+    return latency_ns;
+  }
+
   if (req_timestamp_ns > 0 && resp_timestamp_ns > 0) {
-    latency_ns = std::max(resp_timestamp_ns, req_timestamp_ns) - std::min(resp_timestamp_ns, resp_timestamp_ns);
+    latency_ns = std::max(resp_timestamp_ns, req_timestamp_ns) -
+                 std::min(resp_timestamp_ns, resp_timestamp_ns);
     LOG_IF_EVERY_N(WARNING, latency_ns < 0, 100)
         << absl::Substitute("Negative latency implies req resp mismatch [t_req=$0, t_resp=$1].",
                             req_timestamp_ns, resp_timestamp_ns);
   }
-  
+
   return latency_ns;
 }
 
@@ -1368,7 +1369,8 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("req_msg")>(entry.req.msg);
   r.Append<r.ColIndex("resp_msg")>(entry.resp.msg);
   r.Append<r.ColIndex("latency")>(
-      AMQPCalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns, entry.req.synchronous, entry.resp.synchronous));
+      AMQPCalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns, entry.req.synchronous,
+                           entry.resp.synchronous));
 }
 
 namespace {

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1086,22 +1086,18 @@ int64_t CalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns) {
   return latency_ns;
 }
 
-int64_t AMQPCalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns,
-                             bool req_synchronous, bool resp_synchronous) {
-  int64_t latency_ns = 0;
-  if (!req_synchronous) {
-    return latency_ns;
+int64_t AMQPCalculateLatency(const int64_t req_timestamp_ns, const int64_t resp_timestamp_ns,
+                             const bool req_synchronous, const bool resp_s ynchronous) {
+
+  if(!req_synchronous || !resp_syncrhonous) {
+    return 0;
   }
 
-  if (!resp_synchronous) {
-    return latency_ns;
+  if(req_timestamp_ns <= 0 || resp_timestamp_ns <= 0) {
+    return 0;
   }
-
-  if (req_timestamp_ns > 0 && resp_timestamp_ns > 0) {
-    latency_ns = std::max(req_timestamp_ns, resp_timestamp_ns) -
-                 std::min(req_timestamp_ns, resp_timestamp_ns);
-  }
-
+  
+  latency_ns = std::max(req_timestamp_ns, resp_timestamp_ns) - std::min(req_timestamp_ns, resp_timestamp_ns);
   return latency_ns;
 }
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1087,9 +1087,9 @@ int64_t CalculateLatency(int64_t req_timestamp_ns, int64_t resp_timestamp_ns) {
 }
 
 int64_t AMQPCalculateLatency(const int64_t req_timestamp_ns, const int64_t resp_timestamp_ns,
-                             const bool req_synchronous, const bool resp_s ynchronous) {
+                             const bool req_synchronous, const bool resp_synchronous) {
 
-  if(!req_synchronous || !resp_syncrhonous) {
+  if(!req_synchronous || !resp_synchronous) {
     return 0;
   }
 
@@ -1097,7 +1097,7 @@ int64_t AMQPCalculateLatency(const int64_t req_timestamp_ns, const int64_t resp_
     return 0;
   }
   
-  latency_ns = std::max(req_timestamp_ns, resp_timestamp_ns) - std::min(req_timestamp_ns, resp_timestamp_ns);
+  const int64_t latency_ns = std::max(req_timestamp_ns, resp_timestamp_ns) - std::min(req_timestamp_ns, resp_timestamp_ns);
   return latency_ns;
 }
 


### PR DESCRIPTION
This pull request adds latency calculation logic to AMQP and a corresponding field "latency" is added to the AMQP table to reflect the calculated latency.

NOTE: For asynchronous AMQP frames since calculating latency is not required so i've used zero latency for the async frames.


#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:

This PR adds latency calculation to AMQP protocol.

#### What is the testplan for the PR:

```
bazle test src/striling/source_connectors/socket_tracer/...

```

![image](https://user-images.githubusercontent.com/98730919/207837254-4ea1f490-a9c0-4ae2-9ecf-3b8f8d15b649.png)

_truncated for readability_


#### Which issue(s) this PR fixes:


Fixes  https://github.com/pixie-io/pixie/issues/651
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE

```

#### Additional documentation:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories (px-docs, etc), please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [px/docs]: <link>
- [px/website]: <link>
-->
```docs
NONE
```
