### PR TITLE
Add global.cluster recognition for clusterName

### DIFF
--- a/k8s/operator/helm/templates/04_vizier.yaml
+++ b/k8s/operator/helm/templates/04_vizier.yaml
@@ -14,7 +14,9 @@ spec:
   cloudAddr: {{ .Values.cloudAddr }}
   disableAutoUpdate: {{ .Values.disableAutoUpdate }}
   useEtcdOperator: {{ .Values.useEtcdOperator }}
-  {{- if .Values.clusterName }}
+  {{- if .Values.global.cluster }}
+  clusterName: {{ .Values.global.cluster }}
+  {{- else if .Values.clusterName }}
   clusterName: {{ .Values.clusterName }}
   {{- end }}
   {{- if .Values.devCloudNamespace }}

--- a/k8s/operator/helm/templates/04_vizier.yaml
+++ b/k8s/operator/helm/templates/04_vizier.yaml
@@ -34,7 +34,9 @@ spec:
   {{- if .Values.patches }}
   patches: {{ .Values.patches | toYaml | nindent 4 }}
   {{- end }}
-  {{- if .Values.registry }}
+  {{- if .Values.global.images.registry }}
+  registry: {{ .Values.global.images.registry }}
+  {{- else if .Values.registry }}
   registry: {{ .Values.registry }}
   {{- end}}
   {{- if .Values.dataCollectorParams }}


### PR DESCRIPTION
Signed-off-by: Max Lemieux <mlemieux@newrelic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/pixie-io/pixie/blob/main/CONTRIBUTING.md and https://github.com/pixie-io/pixie/blob/main/DEVELOPMENT.md.
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, when this chart is installed as a subchart, the `pixie-chart.clusterName` value must still be set, although other charts may already set a required value `global.cluster` to store the cluster name. 

As a person installing the chart bundle as a subchart, this is not a great experience as I must enter the same value twice - only for this value.

#### What is the testplan for the PR:
<!--
For stylistic change that don't require tests or enhancements write: N/A.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This change makes it unnecessary to set `pixie-chart.clusterName` for the chart bundle, as long as `global.cluster` is set.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories (px-docs, etc), please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [px/docs]: <link>
- [px/website]: <link>
-->
```docs

```
