### PR TITLE
Update internal LBs to be internal on AKS

### DIFF
--- a/k8s/cloud/base/vzconn_service.yaml
+++ b/k8s/cloud/base/vzconn_service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     cloud.google.com/load-balancer-type: internal
     cloud.google.com/app-protocols: '{"tcp-http2":"HTTP2"}'
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 spec:
   type: LoadBalancer
   ports:

--- a/k8s/cloud/overlays/exposed_services_ilb/proxy_service.yaml
+++ b/k8s/cloud/overlays/exposed_services_ilb/proxy_service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-proxy-service
   annotations:
     cloud.google.com/load-balancer-type: internal
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 spec:
   type: LoadBalancer
   ports:

--- a/k8s/cloud/overlays/exposed_services_ilb/vzconn_service.yaml
+++ b/k8s/cloud/overlays/exposed_services_ilb/vzconn_service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     cloud.google.com/load-balancer-type: internal
     cloud.google.com/app-protocols: '{"tcp-http2":"HTTP2"}'
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The load balancer resources in AKS are external by default whereas the load balancers in GKE are internal. The correct default is internal.

This PR adds the annotation specified in [Azure's AKS docs](https://learn.microsoft.com/en-us/azure/aks/internal-lb#create-an-internal-load-balancer) so that the load balancers for the vzconn and cloud-proxy services are assigned internal IP addresses.

This now matches the behavior of the load balancers in a GKE environment.

#### What is the testplan for the PR:
Verify internal IP addresses for the vzconn and cloud-proxy services when creating a new self-hosted Pixie on AKS.

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?
```release-note
Vzconn and cloud proxy service Load Balancers are internal by default under AKS
```

#### Additional documentation:
N/A
