### PR TITLE
fix: Run Docker Script for Mac

### DIFF
--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -30,13 +30,20 @@ resetcolor="\e[0m"
 
 # Docker image information.
 docker_image_base=gcr.io/pixie-oss/pixie-dev-public/dev_image_with_extras
+os="$(uname)"
 version=$(grep DOCKER_IMAGE_TAG "${workspace_root}/docker.properties" | cut -d= -f2)
 docker_image_with_tag="${docker_image_base}:${version}"
-docker_host_gid=$(getent group docker | awk -F: '{print $3}')
 
-if [[ -z "${docker_host_gid}" ]]; then
-    echo "${red}Docker needs to be enabled in order to run the dev container.{$resetcolor}"
-    exit 1
+# Skip checking docker group for Mac because group is not required for docker-machine in Mac.
+if [[ "${os}" != "Darwin" ]]; then
+    docker_host_gid=$(getent group docker | awk -F: '{print $3}')
+    if [[ -z "${docker_host_gid}" ]]; then
+        echo "${red}Docker needs to be enabled in order to run the dev container.{$resetcolor}"
+        exit 1
+    fi
+else 
+    # Set PX_DOCKER_RUN_AS_ROOT to True for Mac
+    PX_DOCKER_RUN_AS_ROOT=True
 fi
 
 shell=/bin/bash


### PR DESCRIPTION
Signed-off-by: Shardul Srivastava <shardul.srivastava007@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/pixie-io/pixie/blob/main/CONTRIBUTING.md and https://github.com/pixie-io/pixie/blob/main/DEVELOPMENT.md.
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR attempts to fix the `scripts/run_docker.sh` script for Mac users.

#### What is the testplan for the PR:
<!--
For stylistic change that don't require tests or enhancements write: N/A.
-->

#### Which issue(s) this PR fixes:


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/pixie-io/pixie/issues/707

#### Special notes for your reviewer:
While adding a few conditions around checking os and setting the value allows me to run the script for Mac, however, after scripts runs successfully and inside the container terminal there is a warning:

```bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

I believe we need to build a separate base image for `arm64` architecture by passing `--platform linux/arm64` and use that as the base image for Mac.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories (px-docs, etc), please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [px/docs]: <link>
- [px/website]: <link>
-->
```docs

```
