### PR TITLE
[github actions] Add github action to lint filenames.

### DIFF
--- a/.github/workflows/filename_linter.yaml
+++ b/.github/workflows/filename_linter.yaml
@@ -1,0 +1,33 @@
+---
+name: 'filename-linter'
+on:
+  pull_request:
+jobs:
+  check-files-changed:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2.11.1
+      id: changes
+      with:
+        filters: |
+          src: &src
+          - '**/*.cc'
+          - '**/*.h'
+          - '**/*.hpp'
+          - '**/*.go'
+          - '**/*.proto'
+          - '**/*.py'
+          - '**/*.sh'
+          hyphenated:
+          - *src
+          - '**-**'
+          private:
+          - '**/*private*/**'
+          - '**/*private*'
+    - name: Fail on private
+      if: ${{ steps.changes.outputs.private == 'true' }}
+      run: echo "This repo disallows dirnames or filenames with 'private' in it." && exit 1
+    - name: Fail on hyphens
+      if: ${{ steps.changes.outputs.hyphenated == 'true' }}
+      run: echo "This repo disallows hyphens in dirnames or filenames. Use underscores instead." && exit 1


### PR DESCRIPTION
Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>

Description:
Adds a github action workflow to lint filenames, including blocking any private code from accidentally being committed to the repo, and blocking filenames with hyphens.

Relevant Issues:

Type of change:
/kind cleanup

Test Plan:
Tested the github action in a test repo: JamesMBartlett/test_repo.

