### PR TITLE
[actions] Remove broken hyphen check.

### DIFF
--- a/.github/workflows/filename_linter.yaml
+++ b/.github/workflows/filename_linter.yaml
@@ -11,23 +11,9 @@ jobs:
       id: changes
       with:
         filters: |
-          src: &src
-          - '**/*.cc'
-          - '**/*.h'
-          - '**/*.hpp'
-          - '**/*.go'
-          - '**/*.proto'
-          - '**/*.py'
-          - '**/*.sh'
-          hyphenated:
-          - *src
-          - '**-**'
           private:
           - '**/*private*/**'
           - '**/*private*'
     - name: Fail on private
       if: ${{ steps.changes.outputs.private == 'true' }}
       run: echo "This repo disallows dirnames or filenames with 'private' in it." && exit 1
-    - name: Fail on hyphens
-      if: ${{ steps.changes.outputs.hyphenated == 'true' }}
-      run: echo "This repo disallows hyphens in dirnames or filenames. Use underscores instead." && exit 1


### PR DESCRIPTION
Summary: Removes hyphen check from the filename linter. We can add it back in later, but it currently fails on any changes to source files, so removing it for now.

Type of change: /kind bug

Test Plan: Tested that the hyphen check currently fails on source files.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>