### PR TITLE
Add pixie-io to org based allowlist for test triggers

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -380,7 +380,7 @@ controller:
               manageHooks: false
               name: "gh"
           ghprbTrigger:
-            adminlist: "zasgar"
+            adminlist: "zasgar aimichelle vihangm"
             autoCloseFailedPullRequests: false
             cron: "H/5 * * * *"
             extensions:
@@ -502,6 +502,8 @@ controller:
                     triggers {
                       githubPullRequest {
                         admins(['zasgar', 'aimichelle', 'vihangm', 'jamesmbartlett'])
+                        allowMembersOfWhitelistedOrgsAsAdmin(false)
+                        orgWhitelist('pixie-io')
                         useGitHubHooks()
                       }
                     }


### PR DESCRIPTION
Summary: This ensures that changes from `pixie-io` members will trigger jenkins
builds without requiring admin approval.

Type of change: /kind cleanup

Test Plan: Ensure that changes from `pixie-io` member now trigger builds but
non admin `pixie-io` members cannot approve builds for other users.

