### PR TITLE
Reduce redis_trace_bpf_test flakiness by asserting ordering of expected redis records

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -384,8 +384,6 @@ pl_cc_test(
     srcs = ["redis_trace_bpf_test.cc"],
     flaky = True,
     tags = [
-        # TODO: This test has a <90% pass rate in CI, please fix and re-enable.
-        "disabled_flaky_test",
         "cpu:16",
         "requires_bpf",
     ],


### PR DESCRIPTION
Summary: Reduce redis_trace_bpf_test flakiness by asserting ordering of expected redis records

The redis_trace_bpf_test test has two sources of flakiness:
* VerifyBatchedCommands sometimes receives >200 traces rather than the 19 expected ones (P263). See the "which has 222 elements" output in the paste
* VerifyCommand test failures due to completely missing traces. This manifests by the error seen below:
```
src/stirling/source_connectors/socket_tracer/redis_trace_bpf_test.cc:253 Expected equality of these values: tablets.size() Which is: 0 1
src/stirling/source_connectors/socket_tracer/redis_trace_bpf_test.cc:253
Expected equality of these values:
  tablets.size()
    Which is: 0
  1
``` 

This change addresses the first issue since it is responsible for the vast majority of test failures. I looked at the buildbuddy logs and verified that this issue caused 9 of 12 failures the last week the test was running. I initially thought the redis container was returning denyoom responses, but later discovered this is due to the redis-cli's `command` req. Our test tries to [erase](https://github.com/pixie-io/pixie/blob/d0e38daeab4cbd8f4fe91d728f634fc654b19607/src/stirling/source_connectors/socket_tracer/redis_trace_bpf_test.cc#L127-L136) these records, but it appears to be unsuccessful in certain cases.

Our previous test assertion required that we received an extremely strict number of traces and order, so when the `command` req erasing fails the test flakes. This change introduces a new assertion `ContainsWithRelativeOrder` that will ensure the expected traces are in order, but does not require the 'array' to have an exact match (length and element positioning).

Relevant Issues: Fixes #696 and identified #734

Type of change: /kind failing-test

Test Plan: Ran the following items
- Ran the test with `--runs_per_test=50` and only saw a single failure ([P262](https://phab.corp.pixielabs.ai/P262)). The single failure was due to the second issue mentioned in the summary (as seen in the paste).
- Verified that `ContainsWithRelativeOrder`'s failure output identifies a missing element easily ([P270](https://phab.corp.pixielabs.ai/P270))
- Verified that `ContainsWithRelativeOrder`'s failure output identifies an out of order element easily ([P269](https://phab.corp.pixielabs.ai/P269))

Please see [D12941](https://phab.corp.pixielabs.ai/D12941) for additional details since it was created in flight during the GitHub migration.