### PR TITLE
Update Pull request template with more context on the "Type of change" field

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,8 @@ Add one of the following kinds:
 /kind documentation
 /kind feature
 
+Each type must include the entire "/kind {type}" text and not just the label.
+
 Optionally add one or more of the following kinds if applicable:
 /kind api-change
 /kind deprecation


### PR DESCRIPTION
Summary: Update Pull request template with more context on the "Type of change" field

Relevant Issues: N/A

Type of change: /kind documentation

Test Plan:

When I created my first PR with the new workflow (#735), I was confused on if the `/kind ` prefix mattered. A description like this would have cleared up my confusion.