### PR TITLE
[actions] Add pxapi copybara action.

### DIFF
--- a/.github/workflows/copybara_px_api.yaml
+++ b/.github/workflows/copybara_px_api.yaml
@@ -1,0 +1,25 @@
+---
+name: pxapi-copybara
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - 'main'
+jobs:
+  run-copybara:
+    runs-on: ubuntu-latest
+    container:
+      image: gcr.io/pixie-oss/pixie-dev-public/copybara:20210420
+    steps:
+    - uses: actions/checkout@v3
+    - id: create-ssh-key
+      env:
+        COPYBARA_SSH_KEY: ${{ secrets.COPYBARA_SSH_KEY }}
+      run: echo "$COPYBARA_SSH_KEY" > /tmp/sshkey && chmod 600 /tmp/sshkey
+    - id: pxapi-copybara
+      env:
+        COPYBARA_GPG_KEY: ${{ secrets.COPYBARA_GPG_KEY }}
+        COPYBARA_GPG_KEY_ID: ${{ secrets.COPYBARA_GPG_KEY_ID }}
+      run: >
+        GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /tmp/sshkey'
+        ./ci/run_copybara.sh tools/copybara/pxapi_go/copy.bara.sky

--- a/ci/run_copybara.sh
+++ b/ci/run_copybara.sh
@@ -31,7 +31,7 @@ fi
 git config --global user.name ${git_committer_name}
 git config --global user.email ${git_committer_email}
 
-gpg --no-tty --batch --import "${COPYBARA_GPG_KEY_FILE}"
+echo "${COPYBARA_GPG_KEY}" | gpg --no-tty --batch --import
 git config --global user.signingkey "${COPYBARA_GPG_KEY_ID}"
 git config --global commit.gpgsign true
 


### PR DESCRIPTION
Summary: Adds github action to run copybara to the pxapi.go repo.
The pxapi.go repo is a copy of the src/api/go tree. This copybara was previously done on Jenkins, moving it over to github actions.

Type of change: /kind feature

Test Plan: Will test with `workflow_dispatch`.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>
