### PR TITLE
Fix chef on macOS

### DIFF
--- a/tools/chef/cookbooks/px_dev/recipes/linters.rb
+++ b/tools/chef/cookbooks/px_dev/recipes/linters.rb
@@ -50,18 +50,21 @@ common_remote_bin 'bazel' do
   bin_name 'bazel_core'
 end
 
-remote_file '/tmp/clang-linters.deb' do
-  source node['clang-linters']['deb']
-  mode '0644'
-  checksum node['clang-linters']['deb_sha256']
+if platform_family?('debian')
+  remote_file '/tmp/clang-linters.deb' do
+    source node['clang-linters']['deb']
+    mode '0644'
+    checksum node['clang-linters']['deb_sha256']
+  end
+
+  dpkg_package 'clang-linters' do
+    source '/tmp/clang-linters.deb'
+    action :install
+    version node['clang-linters']['version']
+  end
+
+  file '/tmp/clang-linters.deb' do
+    action :delete
+  end
 end
 
-dpkg_package 'clang-linters' do
-  source '/tmp/clang-linters.deb'
-  action :install
-  version node['clang-linters']['version']
-end
-
-file '/tmp/clang-linters.deb' do
-  action :delete
-end

--- a/tools/chef/cookbooks/px_dev/recipes/python.rb
+++ b/tools/chef/cookbooks/px_dev/recipes/python.rb
@@ -19,8 +19,9 @@ if node.platform_family?('debian')
   apt_package ['python3-pip', 'python3.10', 'python3.10-dev'] do
     action :upgrade
   end
+
+  execute 'python alternatives selection' do
+    command 'update-alternatives --install /usr/bin/python python /usr/bin/python3 100'
+  end
 end
 
-execute 'python alternatives selection' do
-  command 'update-alternatives --install /usr/bin/python python /usr/bin/python3 100'
-end

--- a/tools/chef/cookbooks/px_dev_extras/attributes/mac_os_x.rb
+++ b/tools/chef/cookbooks/px_dev_extras/attributes/mac_os_x.rb
@@ -66,7 +66,7 @@ default['opm']['sha256'] =
 default['packer']['download_path'] =
   'https://releases.hashicorp.com/packer/1.7.8/packer_1.7.8_darwin_amd64.zip'
 default['packer']['sha256'] =
-  'f8abe5d8660be2e6bea04bbb165ede4026e66f2f48ae5f076f9ea858699357ae'
+  '4435f3ab48eb0759f52cc9773182746f004ab0cc697efa23731c77b109d25b64'
 
 default['skaffold']['download_path'] =
   'https://storage.googleapis.com/skaffold/releases/v2.0.4/skaffold-darwin-amd64'


### PR DESCRIPTION
Summary: This fixes chef runs on macOS

Type of change: /kind bug

Test Plan: Ran chef on a macOS machine. Ensured it ran to completion.

