### PR TITLE
Move jcasc for buildURL lower

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -510,6 +510,11 @@ controller:
                   }
                 }
               }
+      buildURL: |-
+        unclassified:
+          location:
+            adminAddress: "Jenkins <build@pixielabs.ai>"
+            url: "https://jenkins.px.dev/"
         # yamllint enable rule:indentation
     # Allows adding to the top-level security JCasC section. For legacy,  default the chart includes
     # apiToken configurations


### PR DESCRIPTION
Summary: When Jenkins restarts, the buildURL often gets cleared out. We can use jcasc to populate the build URL.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deploy to Jenkins