### PR TITLE
Fix buildURL in jcasc

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -510,7 +510,7 @@ controller:
                   }
                 }
               }
-      buildURL: |-
+      buildurl: |-
         unclassified:
           location:
             adminAddress: "Jenkins <build@pixielabs.ai>"


### PR DESCRIPTION
Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>

Summary: Updated the jcasc key for cleanliness, but it turned out to be an invalid key. This fixes it.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deploy jenkins

