### PR TITLE
Ensure that non-Phabricator code review builds check for tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -512,7 +512,7 @@ def checkoutAndInitialize() {
       deleteDir()
       checkout scm
       initializeRepoState()
-      if (isPhabricatorTriggeredBuild()) {
+      if (isPhabricatorTriggeredBuild() || isOSSCodeReviewRun) {
         def logMessage = sh(
           script: 'git log origin/main..',
           returnStdout: true,


### PR DESCRIPTION
Summary: We use #ci based tagging to trigger bpf builds on some runs. This
change ensures that it works for our new non Phabricator model.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Ensure that builds on a PR with #ci tags trigger the bpf builds.

