### PR TITLE
Fix operator release build to work in OSS Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ stashList = []
 
 // Flag controlling if coverage job is enabled.
 isMainCodeReviewRun =  (env.JOB_NAME == 'pixie-oss/build-and-test-pr')
+isReleaseRun = env.JOB_NAME.startsWith('pixie-release/')
 
 isMainRun =  (env.JOB_NAME == 'pixie-main/build-and-test-all')
 isNightlyTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regression')
@@ -63,7 +64,7 @@ isNightlyBPFTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regres
 isOSSMainRun = (env.JOB_NAME == 'pixie-oss/build-and-test-all')
 isOSSCloudBuildRun = env.JOB_NAME.startsWith('pixie-oss/cloud/')
 isOSSCodeReviewRun = env.JOB_NAME == 'pixie-oss/build-and-test-pr'
-isOSSRun = isOSSMainRun || isOSSCloudBuildRun || isOSSCodeReviewRun
+isOSSRun = isOSSMainRun || isOSSCloudBuildRun || isOSSCodeReviewRun || isReleaseRun
 
 isCLIBuildRun =  env.JOB_NAME.startsWith('pixie-release/cli/')
 isOperatorBuildRun = env.JOB_NAME.startsWith('pixie-release/operator/')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1476,19 +1476,19 @@ def buildScriptForOperatorRelease = {
       pxbuildWithSourceK8s('build-and-push-operator', true) {
         container('pxbuild') {
           withKubeConfig([
-            credentialsId: K8S_PROD_CREDS,
-            serverUrl: K8S_PROD_CLUSTER, namespace: 'default'
-          ]) {
+          //   credentialsId: K8S_PROD_CREDS,
+          //   serverUrl: K8S_PROD_CLUSTER, namespace: 'default'
+          // ]) {
             sh './ci/operator_build_release.sh'
             stashOnGCS('versions', 'src/utils/artifacts/artifact_db_updater/VERSIONS.json')
             stashList.add('versions')
-          }
+          // }
         }
       }
     }
-    stage('Update versions databases') {
-      updateAllVersionsDB()
-    }
+    // stage('Update versions databases') {
+    //   updateAllVersionsDB()
+    // }
   }
   catch (err) {
     currentBuild.result = 'FAILURE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1475,7 +1475,7 @@ def buildScriptForOperatorRelease = {
     stage('Build & Push Artifacts') {
       pxbuildWithSourceK8s('build-and-push-operator', true) {
         container('pxbuild') {
-          withKubeConfig([
+          // withKubeConfig([
           //   credentialsId: K8S_PROD_CREDS,
           //   serverUrl: K8S_PROD_CLUSTER, namespace: 'default'
           // ]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,7 +276,7 @@ def sendCloudReleaseSlackNotification(String profile) {
 }
 
 def postBuildActions = {
-  if (!isOSSCodeReviewRun) {
+  if (!isOSSRun) {
     sendSlackNotification()
   }
 }
@@ -1475,20 +1475,12 @@ def buildScriptForOperatorRelease = {
     stage('Build & Push Artifacts') {
       pxbuildWithSourceK8s('build-and-push-operator', true) {
         container('pxbuild') {
-          // withKubeConfig([
-          //   credentialsId: K8S_PROD_CREDS,
-          //   serverUrl: K8S_PROD_CLUSTER, namespace: 'default'
-          // ]) {
-            sh './ci/operator_build_release.sh'
-            stashOnGCS('versions', 'src/utils/artifacts/artifact_db_updater/VERSIONS.json')
-            stashList.add('versions')
-          // }
+          sh './ci/operator_build_release.sh'
+          stashOnGCS('versions', 'src/utils/artifacts/artifact_db_updater/VERSIONS.json')
+          stashList.add('versions')
         }
       }
     }
-    // stage('Update versions databases') {
-    //   updateAllVersionsDB()
-    // }
   }
   catch (err) {
     currentBuild.result = 'FAILURE'

--- a/ci/operator_build_release.sh
+++ b/ci/operator_build_release.sh
@@ -47,8 +47,7 @@ if [[ $release_tag == *"-"* ]]; then
   deleter_image_path="gcr.io/pixie-oss/pixie-dev/operator/vizier_deleter:${release_tag}"
   channel="dev"
   channels="dev"
-  # TODO(vihang/michelle): Revisit this bucket.
-  bucket="pixie-prod-artifacts"
+  bucket="pixie-dev"
   # The previous version should be the 1st item in the tags. Since this is a non-release build,
   # the first item in the tags is the previous release.
   prev_tag=$(echo "$tags" | sed -n '1 p')

--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -267,6 +267,7 @@ controller:
   - ghprb:1.42.2
   - script-security:1229.v4880b_b_e905a_6
   - basic-branch-build-strategies:71.vc1421f89888e
+  - kubernetes-cli:1.12.0
   # Set to false to download the minimum required version of all dependencies.
   installLatestPlugins: true
 


### PR DESCRIPTION
Summary: We are moving our release builds to our OSS Jenkins instance. Previous PRs created the release build in the Jenkins instance using jcasc. This change updates the Jenkinsfile so that the release build runs properly in the env.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Create an operator rc, ensure the build runs.
