### PR TITLE
Fix privy build issues due to missing pip dependencies (setuptools, wheel)

### DIFF
--- a/src/datagen/pii/privy/requirements.txt
+++ b/src/datagen/pii/privy/requirements.txt
@@ -26,7 +26,6 @@ fake-http-header==0.1.2
 Faker==13.15.0
 faker_airtravel==0.4
 filelock==3.8.0
-# latest release lacks "add_unk" option for unknown tokens. Hence installing from source
 flair @ git+https://github.com/flairNLP/flair.git@d4ed67bf663e4066517f00397412510d90043653
 flatbuffers==1.12
 fonttools==4.34.4
@@ -67,12 +66,17 @@ multidict==6.0.2
 murmurhash==1.0.8
 networkx==2.8.6
 numpy==1.23.2
+nvidia-cublas-cu11==11.10.3.66
+nvidia-cuda-nvrtc-cu11==11.7.99
+nvidia-cuda-runtime-cu11==11.7.99
+nvidia-cudnn-cu11==8.5.0.96
 overrides==3.1.0
 packaging==21.3
 pandas==1.3.5
 pathy==0.6.2
 phonenumbers==8.12.54
 Pillow==9.3.0
+pip==22.0.2
 plotly==5.9.0
 pluggy==1.0.0
 pptree==3.1
@@ -107,6 +111,7 @@ scikit-learn==1.0.2
 scipy==1.9.1
 segtok==1.5.11
 sentencepiece==0.1.97
+setuptools==59.6.0
 six==1.16.0
 sklearn==0.0
 sklearn-crfsuite==0.3.6
@@ -142,6 +147,7 @@ urllib3==1.26.10
 wasabi==0.10.1
 wcwidth==0.2.5
 Werkzeug==2.1.2
+wheel==0.37.1
 Wikipedia-API==0.5.4
 wordcloud==1.8.2.2
 wrapt==1.14.1

--- a/src/datagen/pii/privy/requirements.txt
+++ b/src/datagen/pii/privy/requirements.txt
@@ -26,6 +26,7 @@ fake-http-header==0.1.2
 Faker==13.15.0
 faker_airtravel==0.4
 filelock==3.8.0
+# latest release lacks "add_unk" option for unknown tokens. Hence installing from source
 flair @ git+https://github.com/flairNLP/flair.git@d4ed67bf663e4066517f00397412510d90043653
 flatbuffers==1.12
 fonttools==4.34.4


### PR DESCRIPTION
Summary: Fix privy build issues due to missing pip dependencies (setuptools, wheel)

Privy uses pytorch which needs the `setuptools` and `wheel` pip packages to build properly. This was discovered while working on #753

Type of change: /kind bug

Test Plan: Verified that Privy's failing build on main is no longer present

```
# Verify privy build fails due to missing setuptools repository. The pip_parse rule creates a bazel repository for each pip package and so a missing _setuptools repository indicates it wasn't pip installed

ddelnano@turing:~/code/pixie/src/datagen/pii/privy$ bazel build //privy:all
ERROR: /home/ddelnano/code/pixie/src/datagen/pii/privy/privy/BUILD.bazel:22:11: no such package '@privy_deps_setuptools//': The repository '@privy_deps_setuptools' could not be resolved: Repository '@privy_deps_setuptools' is not defined and referenced by '//privy:privy_library'
ERROR: Analysis of target '//privy:privy_library' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.369s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (6 packages loaded, 0 targets configured)
    currently loading: @privy_deps_phonenumbers// ... (3 packages)
    Fetching repository @privy_deps_langdetect; starting
    Fetching repository @privy_deps_spacy_loggers; starting
    Fetching repository @privy_deps_transformers; starting
    Fetching repository @privy_deps_pydantic; starting
    Fetching repository @privy_deps_pathy; starting
    Fetching repository @privy_deps_future; starting
    Fetching repository @privy_deps_deprecated; starting
    Fetching repository @privy_deps_kaleido; starting ... (24 fetches)

# Verify that the setuptools and wheel packages are missing
ddelnano@turing:~/code/pixie/src/datagen/pii/privy$ diff <(pip freeze --all) requirements.txt
28a29
> # latest release lacks "add_unk" option for unknown tokens. Hence installing from source
69,72d69
< nvidia-cublas-cu11==11.10.3.66
< nvidia-cuda-nvrtc-cu11==11.7.99
< nvidia-cuda-runtime-cu11==11.7.99
< nvidia-cudnn-cu11==8.5.0.96
79d75
< pip==22.0.2
114d109
< setuptools==59.6.0
150d144
< wheel==0.37.1

# Add those dependencies and verify the build succeeds
ddelnano@turing:~/code/pixie/src/datagen/pii/privy$ pip freeze --all > requirements.txt

ddelnano@turing:~/code/pixie/src/datagen/pii/privy$ bazel build //privy:all
INFO: Analyzed target //privy:privy_library (154 packages loaded, 37596 targets configured).
INFO: Found 1 target...
Target //privy:privy_library up-to-date (nothing to build)
INFO: Elapsed time: 41.372s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```