### PR TITLE
Add utility that allows us to quit QEMU on test completion

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/exit/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/exit/BUILD.bazel
@@ -19,6 +19,6 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "exit",
     srcs = ["exit.c"],
-    features = ["fully_static_link"],
+    features = ["fully_static_link", "-asan", "-tsan", "-msan"],
     linkstatic = True,
 )

--- a/bazel/test_runners/qemu_with_kernel/exit/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/exit/BUILD.bazel
@@ -19,6 +19,11 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "exit",
     srcs = ["exit.c"],
-    features = ["fully_static_link", "-asan", "-tsan", "-msan"],
+    features = [
+        "fully_static_link",
+        "-asan",
+        "-tsan",
+        "-msan",
+    ],
     linkstatic = True,
 )

--- a/bazel/test_runners/qemu_with_kernel/exit/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/exit/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "exit",
+    srcs = ["exit.c"],
+    features = ["fully_static_link"],
+    linkstatic = True,
+)

--- a/bazel/test_runners/qemu_with_kernel/exit/exit.c
+++ b/bazel/test_runners/qemu_with_kernel/exit/exit.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/io.h>
+#include <unistd.h>
+
+#define EXIT_PORT 0xf4
+
+int main(int argc, char** argv) {
+  int status;
+  if (argc != 2) {
+    exit(1);
+  }
+  status = atoi(argv[1]);
+
+  if (ioperm(EXIT_PORT, 4, 1)) {
+    perror("ioperm");
+    exit(1);
+  }
+
+  unsigned char statusb = (unsigned char)status;
+  // Since we can't output 0, we output 2*status + 1.
+  outb((status << 1) | 0x01, EXIT_PORT);
+  // Should never get here.
+  printf(
+      "Exit failed. Make sure to include '-device isa-debug-exit,iobase=0xf4,iosize=0x4'"
+      " in the qemu command?\n");
+  exit(1);
+}


### PR DESCRIPTION
Summary: This write a value to the exit ISA buffer in qemu to quit and return the status code. We'll be using this to return the test status.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: verified the binary is static `ldd exit` and checked it works in qemu.
