### PR TITLE
[build/sysroots] Allow building docker images with sysroots. 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("//bazel:repositories.bzl", "list_pl_deps")
 load("//bazel/cc_toolchains:llvm_libs.bzl", "llvm_variant_repo_name", "llvm_variant_setting_label", "llvm_variants")
+load("//bazel/cc_toolchains/sysroots:images.bzl", "sysroot_runtime_image")
 load("//bazel/external/ubuntu_packages:packages.bzl", "packages")
 
 licenses(["restricted"])
@@ -142,16 +143,32 @@ filegroup(
 )
 
 container_image(
-    name = "pl_go_base_image",
+    name = "pl_go_base_image_default",
+    base = "@base_image//image",
+    debs = pl_cc_base_packages,
+)
+
+container_image(
+    name = "pl_cc_base_image_default",
     base = "@base_image//image",
     debs = pl_cc_base_packages,
     visibility = ["//visibility:public"],
 )
 
+sysroot_runtime_image(
+    name = "pl_go_base_image",
+    default_image = ":pl_go_base_image_default",
+    visibility = ["//visibility:public"],
+)
+
+sysroot_runtime_image(
+    name = "pl_cc_base_image_no_extra_files",
+    default_image = ":pl_cc_base_image_default",
+)
+
 container_image(
     name = "pl_cc_base_image",
-    base = "@base_image//image",
-    debs = pl_cc_base_packages,
+    base = ":pl_cc_base_image_no_extra_files",
     files = [
         "//:embedding.proto",
         "//:sentencepiece.proto",

--- a/bazel/cc_toolchains/sysroots/BUILD.bazel
+++ b/bazel/cc_toolchains/sysroots/BUILD.bazel
@@ -13,3 +13,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+load("//bazel/cc_toolchains/sysroots:sysroots.bzl", "pl_sysroot_settings")
+
+pl_sysroot_settings()

--- a/bazel/cc_toolchains/sysroots/build/sysroot.BUILD
+++ b/bazel/cc_toolchains/sysroots/build/sysroot.BUILD
@@ -51,11 +51,18 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "tar",
+    srcs = ["{tar_path}"],
+    visibility = ["//visibility:public"],
+)
+
 sysroot_toolchain(
     name = "sysroot_toolchain",
     architecture = "{target_arch}",
     files = ":all_files",
     path = "{path_to_this_repo}",
+    tar = ":tar",
 )
 
 toolchain(

--- a/bazel/cc_toolchains/sysroots/images.bzl
+++ b/bazel/cc_toolchains/sysroots/images.bzl
@@ -1,0 +1,83 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@io_bazel_rules_docker//container:container.bzl", _container = "container")
+load("@io_bazel_rules_docker//container:providers.bzl", "ImageInfo")
+
+def _forward_default_image(ctx):
+    target = ctx.attr.default_image
+    providers = [target[p] for p in [ImageInfo, InstrumentedFilesInfo] if p in target]
+
+    for name in _container.image.outputs:
+        # We are required to produce the predefined outputs,
+        # but they're only used for the sysroot version, not for this forwarding.
+        ctx.actions.write(getattr(ctx.outputs, name), "")
+
+    default_info = target[DefaultInfo]
+
+    orig_exe = default_info.files_to_run.executable
+    new_executable_path = "{name}_/{basename}".format(
+        name = ctx.attr.name,
+        basename = orig_exe.basename,
+    )
+    new_executable = ctx.actions.declare_file(new_executable_path)
+    ctx.actions.symlink(
+        output = new_executable,
+        target_file = orig_exe,
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles()
+    runfiles = runfiles.merge(default_info.default_runfiles)
+    runfiles = runfiles.merge(default_info.data_runfiles)
+    providers.append(
+        DefaultInfo(
+            files = default_info.files,
+            runfiles = runfiles,
+            executable = new_executable,
+        ),
+    )
+    return providers
+
+def _image_from_sysroot_info(ctx, sysroot_info):
+    tars = sysroot_info.tar.to_list()
+    architecture = sysroot_info.architecture
+    return _container.image.implementation(ctx, tars = tars, architecture = architecture)
+
+def _sysroot_variant_image_factory(variant):
+    def _impl(ctx):
+        sysroot_toolchain = ctx.toolchains["//bazel/cc_toolchains/sysroots/{variant}:toolchain_type".format(variant = variant)]
+        if sysroot_toolchain == None:
+            return _forward_default_image(ctx)
+        return _image_from_sysroot_info(ctx, sysroot_toolchain.sysroot)
+
+    return rule(
+        name = "sysroot_{variant}_image".format(variant = variant),
+        implementation = _impl,
+        attrs = dicts.add(_container.image.attrs, {
+            "default_image": attr.label(mandatory = True, doc = "Default container_image to use if no sysroot toolchain is found"),
+        }),
+        outputs = _container.image.outputs,
+        cfg = _container.image.cfg,
+        executable = True,
+        toolchains = [
+            "@io_bazel_rules_docker//toolchains/docker:toolchain_type",
+            config_common.toolchain_type("//bazel/cc_toolchains/sysroots/{variant}:toolchain_type".format(variant = variant), mandatory = False),
+        ],
+    )
+
+sysroot_runtime_image = _sysroot_variant_image_factory("runtime")
+sysroot_test_image = _sysroot_variant_image_factory("test")

--- a/bazel/cc_toolchains/sysroots/runtime/sysroot.BUILD
+++ b/bazel/cc_toolchains/sysroots/runtime/sysroot.BUILD
@@ -18,9 +18,18 @@ load("@px//bazel/cc_toolchains/sysroots:sysroots.bzl", "sysroot_toolchain")
 
 filegroup(
     name = "all_files",
-    srcs = glob([
-        "**",
-    ]),
+    srcs = glob(
+        [
+            "**",
+        ],
+        exclude = ["{tar_path}"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "tar",
+    srcs = ["{tar_path}"],
     visibility = ["//visibility:public"],
 )
 
@@ -29,6 +38,7 @@ sysroot_toolchain(
     architecture = "{target_arch}",
     files = ":all_files",
     path = "{path_to_this_repo}",
+    tar = ":tar",
 )
 
 toolchain(

--- a/bazel/cc_toolchains/sysroots/test/sysroot.BUILD
+++ b/bazel/cc_toolchains/sysroots/test/sysroot.BUILD
@@ -18,9 +18,18 @@ load("@px//bazel/cc_toolchains/sysroots:sysroots.bzl", "sysroot_toolchain")
 
 filegroup(
     name = "all_files",
-    srcs = glob([
-        "**",
-    ]),
+    srcs = glob(
+        [
+            "**",
+        ],
+        exclude = ["{tar_path}"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "tar",
+    srcs = ["{tar_path}"],
     visibility = ["//visibility:public"],
 )
 
@@ -29,6 +38,7 @@ sysroot_toolchain(
     architecture = "{target_arch}",
     files = ":all_files",
     path = "{path_to_this_repo}",
+    tar = ":tar",
 )
 
 toolchain(

--- a/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
@@ -80,7 +80,10 @@ cc_static_musl_binary(
 
 filegroup(
     name = "agent",
-    srcs = ["px-java-agent"],
+    srcs = select({
+        "@platforms//cpu:aarch64": [],
+        "//conditions:default": ["px-java-agent"],
+    }),
     visibility = [
         # Add visibility at top-level so that we can include
         # the lib in the pem image.


### PR DESCRIPTION
Summary: Adds support for building images using the sysroot configs (--config=x86_64_sysroot or --config=aarch64_sysroot).
This means we can now build our images targetting aarch64!

Relevant Issues: https://github.com/pixie-io/pixie/issues/147

Type of change: /kind build

Test Plan: Tested that `pem_image` builds under both `--config=x86_64_sysroot` and `--config=aarch64_sysroot`.
Also, tested that the built image doesn't have any shared library loading issues.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>