### PR TITLE
Fix coverage build

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -52,7 +52,7 @@ ContainsWithRelativeOrder(std::vector<Record> actual_records, Records... expecte
   using ::testing::Contains;
 
   std::vector<size_t> record_indices;
-  for (const Record record : {expected_records...}) {
+  for (const Record& record : {expected_records...}) {
     EXPECT_THAT(actual_records, Contains(record));
 
     // No need to check that it matches since previous assert will cover that


### PR DESCRIPTION
Summary: Our coverage build uses gcc in dbg mode and was failing due to
a `range-loop-construct` warning. This fixes the warning by using a reference
type in the test.

Relevant Issues: N/A

Type of change: /kind bug
/kind failing-test

Test Plan: `bazel coverage --remote_download_outputs=all --combined_report=lcov //src/stirling/source_connectors/socket_tracer:redis_trace_bpf_test`
no longer fails to build.

