### PR TITLE
Add missing selector fields for postgres deployments

### DIFF
--- a/k8s/cloud_deps/dev/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/dev/postgres/postgres_deployment.yaml
@@ -4,6 +4,9 @@ kind: Deployment
 metadata:
   name: postgres
 spec:
+  selector:
+    matchLabels:
+      name: postgres
   template:
     metadata:
       labels:

--- a/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
@@ -4,6 +4,9 @@ kind: Deployment
 metadata:
   name: postgres
 spec:
+  selector:
+    matchLabels:
+      name: postgres
   template:
     metadata:
       labels:


### PR DESCRIPTION
Summary: The postgres deployment was matching all pods in the pl-cloud app due
to the missing name selector. This fixes the same.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: When using k9s and selecting the postgres deployment, only the
postgres pod is listed now.

