### PR TITLE
Restrict token permissions to readonly for workflows

### DIFF
--- a/.github/workflows/copybara_px_api.yaml
+++ b/.github/workflows/copybara_px_api.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
     - 'main'
+permissions:
+  contents: read
 jobs:
   run-copybara:
     runs-on: ubuntu-latest

--- a/.github/workflows/filename_linter.yaml
+++ b/.github/workflows/filename_linter.yaml
@@ -2,8 +2,13 @@
 name: 'filename-linter'
 on:
   pull_request:
+permissions:
+  contents: read
 jobs:
   check-files-changed:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pr_description_linter.yaml
+++ b/.github/workflows/pr_description_linter.yaml
@@ -3,6 +3,8 @@ name: pr-description-linter
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
+permissions:
+  contents: read
 jobs:
   lint-pr-description:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -2,6 +2,8 @@
 name: pr-linter
 on:
   pull_request
+permissions:
+  contents: read
 jobs:
   get-linter-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Summary: These issues were flagged by CLOMonitor. Restrict permissions to Read
only.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: All workflows should continue to run.

