### PR TITLE
Fix missing backslash on the etcd command

### DIFF
--- a/k8s/vizier_deps/base/etcd/etcd_statefulset.yaml
+++ b/k8s/vizier_deps/base/etcd/etcd_statefulset.yaml
@@ -166,7 +166,7 @@ spec:
                 --client-cert-auth=true \
                 --trusted-ca-file=/etc/etcdtls/member/server-tls/server-ca.crt \
                 --cert-file=/etc/etcdtls/member/server-tls/server.crt \
-                --key-file=/etc/etcdtls/member/server-tls/server.key
+                --key-file=/etc/etcdtls/member/server-tls/server.key \
                 --max-request-bytes 2000000 \
                 --max-wals 1 \
                 --max-snapshots 1 \
@@ -199,7 +199,7 @@ spec:
               --client-cert-auth=true \
               --trusted-ca-file=/etc/etcdtls/member/server-tls/server-ca.crt \
               --cert-file=/etc/etcdtls/member/server-tls/server.crt \
-              --key-file=/etc/etcdtls/member/server-tls/server.key
+              --key-file=/etc/etcdtls/member/server-tls/server.key \
               --max-request-bytes 2000000 \
               --max-wals 1 \
               --max-snapshots 1 \


### PR DESCRIPTION
Signed-off-by: rosenlo <rosenluov@gmail.com>

Summary: Fix missing backslash on the etcd command

Relevant Issues: #775

Type of change: /kind bug

Test Plan: N/A

Changelog Message:

```release-note
Fix missing backslash on the etcd command
```