### PR TITLE
Revert "Upgrade rules_py (#774)"

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -235,7 +235,6 @@ def _pl_cc_toolchain_deps():
     cc_toolchain_config_repo("unix_cc_toolchain_config", patch = "//bazel/cc_toolchains:unix_cc_toolchain_config.patch")
 
 def _pl_deps():
-    _bazel_repo("bazel_skylib")
     _bazel_repo("bazel_gazelle")
     _bazel_repo("io_bazel_rules_go", patches = ["//bazel/external:rules_go.patch"], patch_args = ["-p1"])
     _bazel_repo("io_bazel_rules_scala")

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -407,9 +407,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.8.0.tar.gz"],
     ),
     rules_python = dict(
-        sha256 = "8c15896f6686beb5c631a4459a3aa8392daccaab805ea899c9d14215074b60ef",
-        strip_prefix = "rules_python-0.17.3",
-        urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz"],
+        sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
+        strip_prefix = "rules_python-0.8.1",
+        urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz"],
     ),
     rules_jvm_external = dict(
         urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.2.tar.gz"],

--- a/src/datagen/pii/privy/requirements.txt
+++ b/src/datagen/pii/privy/requirements.txt
@@ -1,4 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
+--no-binary=numpy
 about-time==3.1.1
 alive-progress==2.4.1
 anyio==3.6.2


### PR DESCRIPTION

Summary: Upgrading rules_python broke the build on root containers. Reverting for now.

This reverts commit 19f46c1ccdb606103ba6155ac95ac7c9fcc44d83.

Type of change: /kind cleanup

Test Plan: Tested that `bazel build //...` works inside a root container now.
