### PR TITLE
Prevent pgsql stitcher from assuming that a matching response will exist when a request is seen

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -282,8 +282,6 @@ pl_cc_test(
     flaky = True,
     shard_count = 2,
     tags = [
-        # TODO: This test has a <90% pass rate in CI, please fix and re-enable.
-        "disabled_flaky_test",
         "cpu:16",
         "no_asan",
         "requires_bpf",

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc
@@ -130,7 +130,10 @@ Status FillQueryResp(MsgDeqIter* resp_iter, const MsgDeqIter& end, QueryReqResp:
     }
   }
 
-  // Move the iterator pass the last message.
+  // TODO(ddelnano): This iterator incrementing should likely happen
+  // after the InvalidArgument error is returned below. This should only
+  // impact the case when there is an error, but we are leaving as is
+  // avoid a larger change without further verification.
   if (*resp_iter != end) {
     ++(*resp_iter);
   }
@@ -204,6 +207,10 @@ Status HandleQuery(const RegularMessage& msg, MsgDeqIter* resp_iter, const MsgDe
     }
   }
 
+  // TODO(ddelnano): This iterator incrementing should likely happen
+  // after the InvalidArgument error is returned below. This should only
+  // impact the case when there is an error, but we are leaving as is
+  // avoid a larger change without further verification.
   if (*resp_iter != end) {
     ++(*resp_iter);
   }

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc
@@ -35,12 +35,6 @@ namespace pgsql {
 
 namespace {
 
-void AdvanceIterBeyondTimestamp(MsgDeqIter* start, const MsgDeqIter& end, uint64_t ts) {
-  while (*start != end && (*start)->timestamp_ns < ts) {
-    ++(*start);
-  }
-}
-
 template <typename TElemType>
 class DequeView {
  public:
@@ -97,6 +91,7 @@ Status FillQueryResp(MsgDeqIter* resp_iter, const MsgDeqIter& end, QueryReqResp:
       }
 
       PX_RETURN_IF_ERROR(ParseCmdCmpl(*iter, &resp->cmd_cmpl));
+      iter->consumed = true;
       break;
     }
 
@@ -108,6 +103,7 @@ Status FillQueryResp(MsgDeqIter* resp_iter, const MsgDeqIter& end, QueryReqResp:
       }
 
       PX_RETURN_IF_ERROR(ParseErrResp(*iter, &resp->err_resp));
+      iter->consumed = true;
       break;
     }
 
@@ -119,12 +115,18 @@ Status FillQueryResp(MsgDeqIter* resp_iter, const MsgDeqIter& end, QueryReqResp:
       }
 
       PX_RETURN_IF_ERROR(ParseRowDesc(*iter, &resp->row_desc));
+      iter->consumed = true;
     }
 
+    // The response to a SELECT query (or other queries that return row sets, such as EXPLAIN or
+    // SHOW) normally consists of RowDescription, zero or more DataRow messages, and then
+    // CommandComplete. Therefore we should not break out of the for loop once the first DataRow
+    // message is parsed.
     if (iter->tag == Tag::kDataRow) {
       DataRow data_row;
       PX_RETURN_IF_ERROR(ParseDataRow(*iter, &data_row));
       resp->data_rows.push_back(std::move(data_row));
+      iter->consumed = true;
     }
   }
 
@@ -157,12 +159,15 @@ Status HandleQuery(const RegularMessage& msg, MsgDeqIter* resp_iter, const MsgDe
     if (iter->tag == Tag::kEmptyQueryResponse) {
       found_resp = true;
       req_resp->resp.timestamp_ns = iter->timestamp_ns;
+      iter->consumed = true;
       break;
     }
 
     if (iter->tag == Tag::kCmdComplete) {
       found_resp = true;
       PX_RETURN_IF_ERROR(ParseCmdCmpl(*iter, &req_resp->resp.cmd_cmpl));
+
+      iter->consumed = true;
       req_resp->resp.timestamp_ns = req_resp->resp.cmd_cmpl.timestamp_ns;
       break;
     }
@@ -170,6 +175,8 @@ Status HandleQuery(const RegularMessage& msg, MsgDeqIter* resp_iter, const MsgDe
     if (iter->tag == Tag::kErrResp) {
       found_resp = true;
       PX_RETURN_IF_ERROR(ParseErrResp(*iter, &req_resp->resp.err_resp));
+
+      iter->consumed = true;
       req_resp->resp.timestamp_ns = req_resp->resp.err_resp.timestamp_ns;
       break;
     }
@@ -179,13 +186,19 @@ Status HandleQuery(const RegularMessage& msg, MsgDeqIter* resp_iter, const MsgDe
       req_resp->resp.cmd_cmpl.timestamp_ns = iter->timestamp_ns;
       PX_RETURN_IF_ERROR(ParseRowDesc(*iter, &req_resp->resp.row_desc));
 
+      iter->consumed = true;
       req_resp->resp.timestamp_ns = req_resp->resp.row_desc.timestamp_ns;
     }
 
+    // The response to a SELECT query (or other queries that return row sets, such as EXPLAIN or
+    // SHOW) normally consists of RowDescription, zero or more DataRow messages, and then
+    // CommandComplete. Therefore we should not break out of the for loop once the first DataRow
+    // message is parsed.
     if (iter->tag == Tag::kDataRow) {
       DataRow data_row;
       PX_RETURN_IF_ERROR(ParseDataRow(*iter, &data_row));
 
+      iter->consumed = true;
       req_resp->resp.timestamp_ns = data_row.timestamp_ns;
       req_resp->resp.data_rows.push_back(std::move(data_row));
     }
@@ -234,6 +247,7 @@ Status HandleParse(const RegularMessage& msg, MsgDeqIter* resp_iter, const MsgDe
     PX_RETURN_IF_ERROR(ParseErrResp(*iter, &err_resp));
     req_resp->resp.msg = err_resp;
   }
+  iter->consumed = true;
 
   return Status::OK();
 }
@@ -279,6 +293,8 @@ Status HandleBind(const RegularMessage& bind_msg, MsgDeqIter* resp_iter, const M
     req_resp->resp.msg = std::move(err_resp);
   }
 
+  iter->consumed = true;
+
   return Status::OK();
 }
 
@@ -296,6 +312,7 @@ Status FillStmtDescResp(MsgDeqIter* resp_iter, const MsgDeqIter& end, DescReqRes
   if (iter->tag == Tag::kErrResp) {
     resp->is_err_resp = true;
     PX_RETURN_IF_ERROR(ParseErrResp(*iter, &resp->err_resp));
+    iter->consumed = true;
     return Status::OK();
   }
 
@@ -307,11 +324,16 @@ Status FillStmtDescResp(MsgDeqIter* resp_iter, const MsgDeqIter& end, DescReqRes
   *resp_iter = iter + 1;
 
   if (iter->tag == Tag::kRowDesc) {
-    return ParseRowDesc(*iter, &resp->row_desc);
+    auto s = ParseRowDesc(*iter, &resp->row_desc);
+    if (s.ok()) {
+      iter->consumed = true;
+    }
+    return s;
   }
 
   if (iter->tag == Tag::kNoData) {
     resp->is_no_data = true;
+    iter->consumed = true;
     return Status::OK();
   }
 
@@ -373,9 +395,7 @@ Status HandleExecute(const RegularMessage& msg, MsgDeqIter* resps_begin,
   TReqRespType req_resp;                                  \
   auto status = expr;                                     \
   if (status.ok()) {                                      \
-    RegularMessage req;                                   \
-    req.tag = cur_iter->tag;                              \
-    req.timestamp_ns = req_resp.req.timestamp_ns;         \
+    req.consumed = true;                                  \
     DCHECK_NE(req.timestamp_ns, 0U);                      \
     req.payload = req_resp.req.ToString();                \
     RegularMessage resp;                                  \
@@ -384,6 +404,7 @@ Status HandleExecute(const RegularMessage& msg, MsgDeqIter* resps_begin,
     resp.payload = req_resp.resp.ToString();              \
     records.push_back({std::move(req), std::move(resp)}); \
   } else {                                                \
+    VLOG(2) << "Encountered error: " << status;           \
     ++error_count;                                        \
   }
 
@@ -409,43 +430,40 @@ RecordsWithErrorCount<pgsql::Record> StitchFrames(std::deque<pgsql::RegularMessa
   //
   // TODO(yzhao): Research batch and pipeline mode and confirm their behaviors.
   while (req_iter != reqs->end() && resp_iter != resps->end()) {
-    // First advance response iterator to be at or later than the request's time stamp.
-    AdvanceIterBeyondTimestamp(&resp_iter, resps->end(), req_iter->timestamp_ns);
-
-    auto cur_iter = req_iter++;
+    auto& req = *req_iter;
+    ++req_iter;
+    if (resp_iter->consumed) {
+      continue;
+    }
 
     // TODO(yzhao): Use a map to encode request type and the actions to find the response.
-    // So we can get rid of the switch statement. That also include AdvanceIterBeyondTimestamp()
-    // into the handler functions, such that the logic is more grouped.
-    switch (cur_iter->tag) {
+    // So we can get rid of the switch statement.
+    switch (req.tag) {
       case Tag::kReadyForQuery:
       case Tag::kSync:
       case Tag::kCopyFail:
       case Tag::kClose:
       case Tag::kPasswd:
-        VLOG(1) << "Ignore tag: " << static_cast<char>(cur_iter->tag);
+        VLOG(1) << "Ignore tag: " << static_cast<char>(req.tag);
         break;
       case Tag::kQuery: {
-        CALL_HANDLER(QueryReqResp, HandleQuery(*cur_iter, &resp_iter, resps->end(), &req_resp));
+        CALL_HANDLER(QueryReqResp, HandleQuery(req, &resp_iter, resps->end(), &req_resp));
         break;
       }
       case Tag::kParse: {
-        CALL_HANDLER(ParseReqResp,
-                     HandleParse(*cur_iter, &resp_iter, resps->end(), &req_resp, state));
+        CALL_HANDLER(ParseReqResp, HandleParse(req, &resp_iter, resps->end(), &req_resp, state));
         break;
       }
       case Tag::kBind: {
-        CALL_HANDLER(BindReqResp,
-                     HandleBind(*cur_iter, &resp_iter, resps->end(), &req_resp, state));
+        CALL_HANDLER(BindReqResp, HandleBind(req, &resp_iter, resps->end(), &req_resp, state));
         break;
       }
       case Tag::kDesc: {
-        CALL_HANDLER(DescReqResp, HandleDesc(*cur_iter, &resp_iter, resps->end(), &req_resp));
+        CALL_HANDLER(DescReqResp, HandleDesc(req, &resp_iter, resps->end(), &req_resp));
         break;
       }
       case Tag::kExecute: {
-        CALL_HANDLER(ExecReqResp,
-                     HandleExecute(*cur_iter, &resp_iter, resps->end(), &req_resp, state));
+        CALL_HANDLER(ExecReqResp, HandleExecute(req, &resp_iter, resps->end(), &req_resp, state));
         break;
       }
       case Tag::kTerminate: {
@@ -453,14 +471,26 @@ RecordsWithErrorCount<pgsql::Record> StitchFrames(std::deque<pgsql::RegularMessa
         break;
       }
       default:
-        LOG_EVERY_N(WARNING, 100) << "Unhandled or invalid tag: "
-                                  << static_cast<char>(cur_iter->tag);
+        LOG_EVERY_N(WARNING, 100) << "Unhandled or invalid tag: " << static_cast<char>(req.tag);
         break;
     }
   }
 
-  reqs->erase(reqs->begin(), req_iter);
-  resps->erase(resps->begin(), resp_iter);
+  auto it = reqs->begin();
+  while (it != reqs->end()) {
+    if (!(*it).consumed) {
+      break;
+    }
+    it++;
+  }
+
+  // Since postgres is an in-order protocol, remove the consumed requests and
+  // all responses. We assume if a response is accessible, the matching request
+  // would have been seen already.
+  // TODO(ddelnano): Standarize this across protocols at a later time. See
+  // https://github.com/pixie-io/pixie/issues/733 for more details.
+  reqs->erase(reqs->begin(), it);
+  resps->clear();
 
   return {records, error_count};
 }

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc
@@ -432,9 +432,6 @@ RecordsWithErrorCount<pgsql::Record> StitchFrames(std::deque<pgsql::RegularMessa
   while (req_iter != reqs->end() && resp_iter != resps->end()) {
     auto& req = *req_iter;
     ++req_iter;
-    if (resp_iter->consumed) {
-      continue;
-    }
 
     // TODO(yzhao): Use a map to encode request type and the actions to find the response.
     // So we can get rid of the switch statement.

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/types.h
@@ -154,6 +154,7 @@ struct RegularMessage : public FrameBase {
   Tag tag = Tag::kUnknown;
   int32_t len = 0;
   std::string payload;
+  bool consumed = false;
 
   size_t ByteSize() const override { return 5 + payload.size(); }
 


### PR DESCRIPTION
Summary: Prevent pgsql stitcher from assuming that a matching response will exist when a request is seen

The pgsql_trace_bpf_test has been flaky and led us to disabling it recently #697. This phab addresses the underlying issue so the test is more reliable.

The source of the flakiness is due to how the pgsql stitcher works. It previously assumed that when it sees a request that the matching response exists during the same invocation to StitchFrames. For our test harness, this is true the majority of the time. However, there are times where stirling sees the request in isolation, calls StitchFrames and then receives the response by the second call to StitchFrames. The previous stitcher implementation discards all requests at the [end of a run](https://github.com/pixie-io/pixie/blob/28a762a31673ee2e3956693df7871393bcacf156/src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.cc#L462), so when this happens we lose the request and can never match the lone response on the next StitchFrames invocation. This results in all of the test cases occasionally seeing the following error:

```
	src/stirling/source_connectors/socket_tracer/pgsql_trace_bpf_test.cc:219: Failure
Expected equality of these values:
  tablets.size()
    Which is: 0
  1
```

While this test was flaky, this detected a real bug in our stitcher and further demonstrates why having a true end to end test is valuable even if it's not as reproducible.

Relevant Issues: Fixes #697

Type of change: /kind bug

Test Plan: See the items below

- Compared the syscall and user space buffers in the failing ([P278](https://phab.corp.pixielabs.ai/P278)) and passing cases ([P279](https://phab.corp.pixielabs.ai/P279)). Specifically see how stirling's buffer for the initial server response is contains [CCREATE FUNCTION](https://phab.corp.pixielabs.ai/P279$5404) ([Command Complete 'B'](https://www.postgresql.org/docs/8.2/protocol-message-formats.html)) when the test passes, but [does not](https://phab.corp.pixielabs.ai/P278$3893) when the test fails. This results in the failing case seeing [14 frames](https://phab.corp.pixielabs.ai/P278$3896), while the passing case sees all [16 frames](https://phab.corp.pixielabs.ai/P279$5407)
- Ran the end to end test with --runs_per_test=10 (20 total runs) and verified it's no longer flaky ([P281](https://phab.corp.pixielabs.ai/P281))
- Verified the unit test fails on main so this flaky behavior would get caught outside of the end to end test

Changelog Message:

```release-note
Fixes a bug where postgres requests could be dropped causing missing protocol traces
```