### PR TITLE
Fix license header

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/http/body_decoder_benchmark.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/body_decoder_benchmark.cc
@@ -1,17 +1,17 @@
 /*
- * Copyright © 2018- Pixie Labs Inc.
- * Copyright © 2020- New Relic, Inc.
- * All Rights Reserved.
+ * Copyright 2018- The Pixie Authors.
  *
- * NOTICE:  All information contained herein is, and remains
- * the property of New Relic Inc. and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Pixie Labs Inc. and its suppliers and
- * may be covered by U.S. and Foreign Patents, patents in process,
- * and are protected by trade secret or copyright law. Dissemination
- * of this information or reproduction of this material is strictly
- * forbidden unless prior written permission is obtained from
- * New Relic, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Summary: This file had an incorrect license applied to it.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: N/A

