### PR TITLE
Update Jenkins CASC to use blue ocean urls

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -394,6 +394,7 @@ controller:
                     result: SUCCESS
                 showMatrixStatus: false
                 startedStatus: "Jenkins Build Running"
+                statusUrl: "$RUN_DISPLAY_URL"
             githubAuth:
               - credentialsId: "github-buildbot-api-token"
                 serverAPIUrl: "https://api.github.com"


### PR DESCRIPTION
Summary: This should directly link to blue ocean instead of classic jenkins
which works better with our buildstages. Also remove unused plugin.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check the jenkins link on this github PR.

