### PR TITLE
Don't clean git/workspace

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -463,11 +463,6 @@ controller:
                           credentials('buildbot-ssh')
                         }
                         branch('main')
-                        extensions {
-                          cleanAfterCheckout()
-                          cleanBeforeCheckout()
-                          wipeOutWorkspace()
-                        }
                       }
                     }
                   }
@@ -493,11 +488,6 @@ controller:
                           refspec('+refs/pull/*:refs/remotes/origin/pr/*')
                         }
                         branch('^${sha1}')
-                        extensions {
-                          cleanAfterCheckout()
-                          cleanBeforeCheckout()
-                          wipeOutWorkspace()
-                        }
                       }
                     }
                     triggers {


### PR DESCRIPTION
Summary: The k8s jenkins builders should have a clean state anyway.
We don't need to call clean.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Updated jenkins with new configs.
