### PR TITLE
Replace deprecated triggers with pipelineTriggers

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -447,11 +447,13 @@ controller:
           - script: >
               pipelineJob("pixie-oss/build-and-test-all") {
                 logRotator(30, 250)
-                triggers {
-                  githubPush()
-                }
                 properties {
                   disableConcurrentBuilds()
+                  pipelineTriggers {
+                    triggers {
+                      githubPush()
+                    }
+                  }
                 }
                 definition {
                   cpsScm {
@@ -470,12 +472,14 @@ controller:
               }
           - script: >
               pipelineJob("pixie-oss/build-and-test-pr") {
+                logRotator(30, 250)
                 properties {
                   githubProjectUrl('https://github.com/pixie-io/pixie/')
-                }
-                logRotator(30, 250)
-                triggers {
-                  githubPush()
+                  pipelineTriggers {
+                    triggers {
+                      githubPush()
+                    }
+                  }
                 }
                 definition {
                   cpsScm {


### PR DESCRIPTION
Summary: `triggers` is deprecated and will be removed in the future.
Use `pipelineTriggers` as suggested by [the migration guide](https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#pipeline-job-plugin)

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Upgraded jenkins with new configs, builds continue to trigger.