### PR TITLE
Remove unused github trigger for PR jobs

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -475,11 +475,6 @@ controller:
                 logRotator(30, 250)
                 properties {
                   githubProjectUrl('https://github.com/pixie-io/pixie/')
-                  pipelineTriggers {
-                    triggers {
-                      githubPush()
-                    }
-                  }
                 }
                 definition {
                   cpsScm {
@@ -499,7 +494,12 @@ controller:
                         admins(['zasgar', 'aimichelle', 'vihangm', 'jamesmbartlett'])
                         allowMembersOfWhitelistedOrgsAsAdmin(false)
                         orgWhitelist('pixie-io')
-                        useGitHubHooks()
+                        useGitHubHooks(true)
+                        extensions {
+                          cancelBuildsOnUpdate {
+                            overrideGlobal(true)
+                          }
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
Summary: Remove githubPush trigger. ghprb adds it's own hooks.
Also cancel builds when a new one is queued.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Update jenkins with new config.
