### PR TITLE
Simplify operator etcd repair

### DIFF
--- a/src/operator/controllers/monitor.go
+++ b/src/operator/controllers/monitor.go
@@ -37,7 +37,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
@@ -50,7 +49,6 @@ import (
 	"px.dev/pixie/src/operator/apis/px.dev/v1alpha1"
 	pixiev1alpha1 "px.dev/pixie/src/operator/apis/px.dev/v1alpha1"
 	"px.dev/pixie/src/shared/status"
-	"px.dev/pixie/src/utils/shared/k8s"
 )
 
 const (
@@ -628,7 +626,7 @@ func (m *VizierMonitor) repairVizier(state *vizierState) error {
 		}
 
 		log.Info("NATS pod was successfully deleted")
-	} else if state.Reason == status.MetadataPVCMissing || state.Reason == status.MetadataPVCStorageClassUnavailable || state.Reason == status.MetadataPVCPendingBinding || state.Reason == status.MetadataStatefulSetPodPending {
+	} else if state.Reason == status.MetadataPVCStorageClassUnavailable {
 		log.WithField("reason", state.Reason).Info("Switching to etcd backed metadata store")
 
 		vz := &pixiev1alpha1.Vizier{}
@@ -646,114 +644,6 @@ func (m *VizierMonitor) repairVizier(state *vizierState) error {
 		}
 
 		log.Info("Successfully switched to etcd backed metadata store")
-	} else if state.Reason == status.TLSCertsExpired {
-		vz := &pixiev1alpha1.Vizier{}
-		err := m.vzGet(context.Background(), m.namespacedName, vz)
-		if err != nil {
-			log.WithError(err).Error("Failed to get vizier")
-			return err
-		}
-
-		err = deployCerts(context.Background(), m.namespace, vz, m.clientset, m.restConfig, true)
-		if err != nil {
-			log.WithError(err).Error("Failed to update certs")
-		}
-		m.certState = okState()
-
-		log.Info("Bouncing Vizier pods to get certs update")
-		err = k8s.DeletePods(m.clientset, m.namespace, "")
-		if err != nil {
-			return err
-		}
-	} else if state.Reason == status.ControlPlanePodsPending || state.Reason == status.ControlPlaneFailedToSchedule {
-		// This repair state attempts to clean-up an auto-repair state that was not successful.
-		// In this state, the operator tried to switch a pvc based metadata store to etcd, but failed because
-		// we didn't properly clean up the metadata statefulset and didn't properly setup the etcd deployment.
-		// The failed state thus has two different types of metadata running: the pvc based metadata and the
-		// etc based metadata, and one of them is not operational.
-
-		// This code tries to reconcile that failure: if the pvc-metadata is  functioning, then we
-		// force the system to use the pvc-metadata deployment. If the pvc-metadata is not functional,
-		// then we force the system to use the etcd-metadata deployment.
-		_, err := m.clientset.AppsV1().Deployments(m.namespace).Get(m.ctx, "vizier-metadata", metav1.GetOptions{})
-		// No deployment found, so we are not in the failed repair state.
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		if err != nil {
-			log.WithError(err).Error("Failed to get vizer-metadata deployment")
-			return err
-		}
-		_, err = m.clientset.AppsV1().StatefulSets(m.namespace).Get(m.ctx, "vizier-metadata", metav1.GetOptions{})
-		// No statefulset found, so we are not in the failed repair state.
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		if err != nil {
-			log.WithError(err).Error("Failed to get vizer-metadata statefulset")
-			return err
-		}
-		// Now this means both the deployment and statefulset exist, so we are in the failed repair state.
-		// We need to determine whether the pvc-metadata is functioning or not, and then force the system
-		// to use the functioning metadata store.
-		metadataStatefulsetIsRunning := false
-		// Get the pods owned by the deployment.
-		podList, err := m.clientset.CoreV1().Pods(m.namespace).List(m.ctx, metav1.ListOptions{
-			LabelSelector: "name=vizier-metadata",
-		})
-		if err != nil {
-			log.WithError(err).Error("Failed to list pods that belong to vizier-metadata")
-			return err
-		}
-		for _, pod := range podList.Items {
-			for _, ownerRef := range pod.OwnerReferences {
-				if !(ownerRef.Kind == "StatefulSet" && ownerRef.Name == "vizier-metadata") {
-					continue
-				}
-				metadataStatefulsetIsRunning = pod.Status.Phase == v1.PodRunning
-				break
-			}
-			if metadataStatefulsetIsRunning {
-				break
-			}
-		}
-		log.Infof("Discovered a failed repair state, forcing a %s-based metadata store", func() string {
-			if metadataStatefulsetIsRunning {
-				return "pvc"
-			}
-			return "etcd"
-		}())
-
-		// Update the spec to use etcd operator and clear the checksum
-		// so we force an auto-update.
-		vz := &pixiev1alpha1.Vizier{}
-		err = m.vzGet(context.Background(), m.namespacedName, vz)
-		if err != nil {
-			log.WithError(err).Error("Failed to get vizier")
-			return err
-		}
-		newEtcdOperatorState := !metadataStatefulsetIsRunning
-
-		// If the statefulset is not running but we're using the etcd operator, we should
-		// force a re-run of the deployment to clean up extra state.
-		if vz.Spec.UseEtcdOperator == newEtcdOperatorState {
-			if len(vz.Status.Checksum) > 2 {
-				vz.Status.Checksum = vz.Status.Checksum[2:]
-			}
-			err = m.vzUpdate(context.Background(), vz)
-			if err != nil {
-				log.WithError(err).Error("Failed to update status with empty checksum")
-				return err
-			}
-		} else {
-			// If the statefulset is running, then we should not use the etcd operator.
-			vz.Spec.UseEtcdOperator = newEtcdOperatorState
-			err = m.vzSpecUpdate(context.Background(), vz)
-			if err != nil {
-				log.WithError(err).Error("Failed to update spec to use etcd metadata")
-				return err
-			}
-		}
 	}
 	return nil
 }

--- a/src/operator/controllers/monitor_test.go
+++ b/src/operator/controllers/monitor_test.go
@@ -464,23 +464,8 @@ func TestMonitor_repairVizier_PVC(t *testing.T) {
 		updateCalled bool
 	}{
 		{
-			name:         "MetadataPVCMissing",
-			state:        &vizierState{Reason: status.MetadataPVCMissing},
-			updateCalled: true,
-		},
-		{
 			name:         "MetadataPVCStorageClassUnavailable",
 			state:        &vizierState{Reason: status.MetadataPVCStorageClassUnavailable},
-			updateCalled: true,
-		},
-		{
-			name:         "MetadataPVCPendingBinding",
-			state:        &vizierState{Reason: status.MetadataPVCPendingBinding},
-			updateCalled: true,
-		},
-		{
-			name:         "MetadataStatefulSetPodPending",
-			state:        &vizierState{Reason: status.MetadataStatefulSetPodPending},
 			updateCalled: true,
 		},
 		{
@@ -1309,31 +1294,8 @@ func TestMonitor_repairVizier_consolidateVizierDeployments(t *testing.T) {
 				makePod("vizier-metadata-9dk39aj", v1.PodPending, "Deployment"),
 			},
 			hasEtcdOperator:   true,
-			repairCallsUpdate: true,
+			repairCallsUpdate: false,
 			forceUpdate:       false,
-		},
-		{
-			name:  "UseEtcdOperator - persistent not running leads to etcd",
-			state: &vizierState{Reason: status.ControlPlanePodsPending},
-			pods: []runtime.Object{
-				&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vizier-metadata",
-						Namespace: "pl",
-					},
-				},
-				&appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vizier-metadata",
-						Namespace: "pl",
-					},
-				},
-				makePod("vizier-metadata-0", v1.PodPending, "StatefulSet"),
-				makePod("vizier-metadata-9dk39aj", v1.PodPending, "Deployment"),
-			},
-			hasEtcdOperator:   true,
-			repairCallsUpdate: true,
-			forceUpdate:       true,
 		},
 		{
 			name:  "!UseEtcdOperator - persistent running defaults to persistent",
@@ -1355,30 +1317,7 @@ func TestMonitor_repairVizier_consolidateVizierDeployments(t *testing.T) {
 				makePod("vizier-metadata-9dk39aj", v1.PodRunning, "Deployment"),
 			},
 			hasEtcdOperator:   false,
-			repairCallsUpdate: true,
-			forceUpdate:       true,
-		},
-		{
-			name:  "!UseEtcdOperator - persistent not running leads to etcd",
-			state: &vizierState{Reason: status.ControlPlanePodsPending},
-			pods: []runtime.Object{
-				&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vizier-metadata",
-						Namespace: "pl",
-					},
-				},
-				&appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vizier-metadata",
-						Namespace: "pl",
-					},
-				},
-				makePod("vizier-metadata-0", v1.PodPending, "StatefulSet"),
-				makePod("vizier-metadata-9dk39aj", v1.PodPending, "Deployment"),
-			},
-			hasEtcdOperator:   false,
-			repairCallsUpdate: true,
+			repairCallsUpdate: false,
 			forceUpdate:       false,
 		},
 		{


### PR DESCRIPTION
Summary: The operator tries to be smart by trying to switch the user to an etcd-based deployment based on some conditions, as long as they have been in that state for over 5 mins. These checks may be too hasty, as sometimes a user's cluster may just be slower for various reasons. This leads to some users getting unexpectedly moved to an etcd-based deploy.
There is also some extra logic to fix a state that users could have gotten into because of auto-repair. Now that the operator has been out in the wild for sometime, we can clean up this extra logic for cleanliness/simplification.

A followup PR is coming to attempt to fix etcd-based deploys which may have gotten to a bad state (lost quorum)

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Skaffold deploy operator

