### PR TITLE
Fix prototool linter

### DIFF
--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - name: Fetch main
-      run: git fetch origin main
+      run: git fetch origin main:main
     - name: Check merge base
       run: git merge-base origin/main HEAD  # This is what arc uses to determine what changes to lint.
     - name: Run arc lint


### PR DESCRIPTION
Summary: The prototool linter relies on a local branch called main
to compare against. This ensures it exists so that prototool
can work.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: PRs with proto changes should not fail lint after this.
