### PR TITLE
Use git status porcelain instead of diff-index to check state of tree

### DIFF
--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -38,8 +38,7 @@ jobs:
       shell: bash
       # yamllint disable rule:indentation
       run: |
-        git diff-index --quiet HEAD -- || retval=$?
-        if [[ $retval -ne 0 ]]; then
+        if [[ $(git status --porcelain=v1 | wc -l) -ne 0 ]]; then
           echo "Please apply the autofix patches suggested by arc lint."
           echo "Changed files:"
           git diff --name-only


### PR DESCRIPTION
Summary: `diff-index` triggers on touched files. `git status --porcelain` is
simpler to use instead.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Lint runs should only fail if there are changes.
