### PR TITLE
Use seeded random to fix GoHTTPTraceTest.LargePostMessage

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/http_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/http_trace_bpf_test.cc
@@ -132,19 +132,16 @@ TEST_F(GoHTTPTraceTest, LargePostMessage) {
       AllOf(HasSubstr(R"("Accept-Encoding":"gzip")"),
             HasSubstr(absl::Substitute(R"(Host":"localhost:$0")", go_http_fixture_.server_port())),
             ContainsRegex(R"(User-Agent":"Go-http-client/.+")")));
-  // TODO(oazizi): random data isn't consistent across go versions. Switch to non-random data or
-  // update the assertion to not look at the contents.
-
-  // EXPECT_THAT(
-  //     std::string(record_batch[kHTTPReqBodyIdx]->Get<types::StringValue>(target_record_idx)),
-  //     StrEq(
-  //         "{\"data\":"
-  //         "\"XVlBzgbaiCMRAjWwhTHctcuAxhxKQFDaFpLSjFbcXoEFfRsWxPLDnJObCsNVlgTeMaPEZQleQYhYzRyWJjPjzp"
-  //         "fRFEgmotaFetHsbZRjxAwnwekrBEmfdzdcEkXBAkjQZLCtTMtTCoaNatyyiNKAReKJyiXJrscctNswYNsGRussVm"
-  //         "aozFZBsbOJiFQGZsnwTKSmVoiGLOpbUOpEdKupdOMeRVjaRzLNTXYeUCWKsXbGyRAOmBTvKSJfjzaLbtZsyMGeuD"
-  //         "tRzQMDQiYCOhgHOvgSeycJPJHYNufNjJhhjUVRuSqfgqVMkPYVkURUpiFvIZRgBmyArKCtzkjkZIvaBjMkXVbWGv"
-  //         "bqzgexyALBsdjSGpngCwFkDifIBuufFMoWdiTskZoQJMqrTICTojIYxyeSxZyfroRODMbNDRZnPNRWCJPMHDtJmH"
-  //         "AYORsUfUMApsVgzHblmYYtEjVgwfFbbGGcnqbaEREunUZjQXmZOtaRLUtmYgmSVYB... [TRUNCATED]"));
+  EXPECT_THAT(
+      std::string(record_batch[kHTTPReqBodyIdx]->Get<types::StringValue>(target_record_idx)),
+      StrEq(
+          "{\"data\":"
+          "\"XVlBzgbaiCMRAjWwhTHctcuAxhxKQFDaFpLSjFbcXoEFfRsWxPLDnJObCsNVlgTeMaPEZQleQYhYzRyWJjPjzp"
+          "fRFEgmotaFetHsbZRjxAwnwekrBEmfdzdcEkXBAkjQZLCtTMtTCoaNatyyiNKAReKJyiXJrscctNswYNsGRussVm"
+          "aozFZBsbOJiFQGZsnwTKSmVoiGLOpbUOpEdKupdOMeRVjaRzLNTXYeUCWKsXbGyRAOmBTvKSJfjzaLbtZsyMGeuD"
+          "tRzQMDQiYCOhgHOvgSeycJPJHYNufNjJhhjUVRuSqfgqVMkPYVkURUpiFvIZRgBmyArKCtzkjkZIvaBjMkXVbWGv"
+          "bqzgexyALBsdjSGpngCwFkDifIBuufFMoWdiTskZoQJMqrTICTojIYxyeSxZyfroRODMbNDRZnPNRWCJPMHDtJmH"
+          "AYORsUfUMApsVgzHblmYYtEjVgwfFbbGGcnqbaEREunUZjQXmZOtaRLUtmYgmSVYB... [TRUNCATED]"));
   EXPECT_THAT(record_batch[kHTTPReqBodySizeIdx]->Get<types::Int64Value>(target_record_idx).val,
               131096);
 }

--- a/src/stirling/testing/demo_apps/go_http/go_http_client/main.go
+++ b/src/stirling/testing/demo_apps/go_http/go_http_client/main.go
@@ -33,12 +33,13 @@ import (
 	"time"
 )
 
+var r = rand.New(rand.NewSource(1))
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func randStringRunes(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[r.Intn(len(letterRunes))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
Summary: go 1.20 changed the default random seeding. Since we do
actually want a seeded random for this test server/client, this
change ensures that we explicitly use a seeded random.

Relevant Issues: Fixes #757

Type of change: /kind bug

Test Plan: The disabled test assertion now passes again.
