### PR TITLE
Add yarn cache to lint runner

### DIFF
--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -26,6 +26,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 100
+    - name: Yarn cache
+      uses: actions/cache@v3
+      with:
+        path: ./src/ui/.yarn
+        key: build-cache-${{hashFiles('src/ui/yarn.lock')}}
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - name: Fetch main


### PR DESCRIPTION
Summary: eslint requires node deps to be installed. This ensures
that they are cached if possible.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: The linter action should see some speedup when UI code
is linted.