### PR TITLE
fix: catalog operator param error

### DIFF
--- a/k8s/operator/helm/templates/00_olm.yaml
+++ b/k8s/operator/helm/templates/00_olm.yaml
@@ -124,10 +124,10 @@ spec:
           command:
           - /bin/catalog
           args:
-          - '-namespace'
+          - '--namespace'
           - {{ .Values.olmNamespace }}
-          - -configmapServerImage={{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-{{ else }}quay.io/operator-framework/{{ end }}configmap-operator-registry:latest
-          - -util-image
+          - --configmapServerImage={{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-{{ else }}quay.io/operator-framework/{{ end }}configmap-operator-registry:latest
+          - --util-image
           -  {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-olm{{ else }}quay.io/operator-framework/olm@sha256:b706ee6583c4c3cf8059d44234c8a4505804adcc742bcddb3d1e2f6eff3d6519{{ end }}
           image: {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-olm{{ else }}quay.io/operator-framework/olm@sha256:b706ee6583c4c3cf8059d44234c8a4505804adcc742bcddb3d1e2f6eff3d6519{{ end }}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: Asher Liu <root@viper.run>

```console
catalog -h
```

current param will cause error:
![image](https://user-images.githubusercontent.com/31346321/217197339-e5702a3a-23ee-4334-9d08-21a698c3f43f.png)

