### PR TITLE
Force openssl_trace_bpf_test to run 100 times to try to reproduce flakiness

### DIFF
--- a/ci/bpf/03_run_tests.sh
+++ b/ci/bpf/03_run_tests.sh
@@ -40,7 +40,11 @@ read -ra BAZEL_ARGS <<< "${BAZEL_ARGS}"
 bazel build "${BAZEL_ARGS[@]}" --target_pattern_file "${BUILDABLE_FILE}"
 check_retval $?
 
-bazel test "${BAZEL_ARGS[@]}" --target_pattern_file "${TEST_FILE}"
+# Temporarily override which test is run since running the openssl_trace_bpf_test
+# 230 times did not reproduce the failure.
+echo "//src/stirling/source_connectors/socket_tracer:openssl_trace_bpf_test" > "${TEST_FILE}"
+
+bazel test "${BAZEL_ARGS[@]}" --runs_per_test=50 --target_pattern_file "${TEST_FILE}"
 check_retval $?
 
 rm -rf bazel-testlogs-archive

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -438,8 +438,6 @@ pl_cc_test(
     flaky = True,
     shard_count = 2,
     tags = [
-        # TODO: This test has a <90% pass rate in CI, please fix and re-enable.
-        "disabled_flaky_test",
         "cpu:16",
         "no_asan",
         "requires_bpf",


### PR DESCRIPTION
Summary: Force openssl_trace_bpf_test to run 100 times to try to reproduce flakiness

We recently disabled the `openssl_trace_bpf_test` in #699. I've been trying to reproduce the test failures, but in 200 runs of the test it was successful 100% of the time. If we can't reproduce the failures, I think we should consider re-enabling it as is. As a final attempt to reproduce the problem, I'd like to run the test 100 times in CI and see if the issue still exists.

Relevant Issues: #699

Type of change: /kind flake

Test Plan: Verify if CI passes and then re-enable the test -  #ci:bpf-build
- [x] Verified that running the test 200 times did not reproduce the failure.
```
root@px-dev-docker-ddelnano-test-machine:/px/src/px.dev/pixie# bazel test -c opt --config=bpf --build_metadata=COMMIT_SHA=6fe385c0deeede5fdb31c2a27b7e68d8af559377 --runs_per_test=100 --test_arg='-v=2' --test_arg='--vmodule=bcc_wrapper=0' --test_arg='--vmodule=socket_trace_connector=3' --target_pattern_file bazel_tests_bpf

Target //src/stirling/source_connectors/socket_tracer:openssl_trace_bpf_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test
INFO: Elapsed time: 36510.166s, Critical Path: 2951.70s
INFO: 201 processes: 1 internal, 200 local.
INFO: Build completed successfully, 201 total actions
//src/stirling/source_connectors/socket_tracer:openssl_trace_bpf_test    PASSED in 185.9s
  Stats over 200 runs: max = 185.9s, min = 179.8s, avg = 182.5s, dev = 1.2s

Executed 1 out of 1 test: 1 test passes.

```
