### PR TITLE
Switch to multiarch curl images.

### DIFF
--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -133,7 +133,7 @@ spec:
           mountPath: /certs
       - name: admin-create-if-not-exists
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="${ADMIN_URL}/admin/health/ready";

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -33,7 +33,7 @@ spec:
                 - linux
       initContainers:
       - name: qb-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";

--- a/k8s/vizier/base/patch_sentry.yaml
+++ b/k8s/vizier/base/patch_sentry.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
       - name: cc-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/readyz";

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -37,7 +37,7 @@ spec:
                 - linux
       initContainers:
       - name: mds-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: cloud-conn-service-account
       initContainers:
       - name: nats-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -38,7 +38,7 @@ spec:
                 - linux
       initContainers:
       - name: nats-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
@@ -57,7 +57,7 @@ spec:
         - name: PROTOCOL
           value: "http"
       - name: etcd-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           ETCD_PATH="${PL_MD_ETCD_SERVER}";

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -44,7 +44,7 @@ spec:
         effect: NoSchedule
       initContainers:
       - name: qb-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c',
           '

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: metadata-service-account
       initContainers:
       - name: nats-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
       - name: qb-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-publisher
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://jetstream-publisher.${NS}.svc.cluster.local:8080/metrics";

--- a/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       initContainers:
       - name: server-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
       - name: server-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://${SERVICE_NAME}:${SERVICE_PORT}/";


### PR DESCRIPTION

Summary: Switches curl images to use multiarch manifest lists instead of amd64 images. This way they can be deployed on clusters with mixed architectures.

Relevant Issues: #147
This is another step along the way to supporting ARM for vizier.

Type of change: /kind cleanup

Test Plan: Tested that a skaffold deploy of Pixie still works. Will test with other ARM changes to make sure deploy works on multiarch/arm clusters.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>
