### PR TITLE
Add auto-repair for crashing etcd in operator

### DIFF
--- a/src/operator/controllers/monitor.go
+++ b/src/operator/controllers/monitor.go
@@ -341,7 +341,7 @@ func getEtcdState(pods *concurrentPodMap) *vizierState {
 			continue
 		}
 		for _, c := range pod.pod.Status.ContainerStatuses {
-			if c.State.Waiting != nil && c.State.Waiting.Reason == "CrashLoopBackOff" {
+			if c.State.Waiting != nil && c.State.Waiting.Reason == "CrashLoopBackOff" && c.RestartCount >= 5 {
 				return &vizierState{Reason: status.EtcdPodsCrashing}
 			}
 		}

--- a/src/operator/controllers/monitor.go
+++ b/src/operator/controllers/monitor.go
@@ -703,6 +703,10 @@ func (m *VizierMonitor) repairVizier(state *vizierState) error {
 	} else if state.Reason == status.TLSCertsExpired {
 		vz := &pixiev1alpha1.Vizier{}
 		err := m.vzGet(context.Background(), m.namespacedName, vz)
+		if err != nil {
+			log.WithError(err).Error("failed to fetch Vizier")
+			return err
+		}
 
 		err = deployCerts(context.Background(), m.namespace, vz, m.clientset, m.restConfig, true)
 		if err != nil {

--- a/src/operator/controllers/monitor.go
+++ b/src/operator/controllers/monitor.go
@@ -673,18 +673,18 @@ func (m *VizierMonitor) repairVizier(state *vizierState) error {
 	} else if state.Reason == status.TLSCertsExpired {
 		vz := &pixiev1alpha1.Vizier{}
 		err := m.vzGet(context.Background(), m.namespacedName, vz)
-		
-                err = deployCerts(context.Background(), m.namespace, vz, m.clientset, m.restConfig, true)
-                if err != nil {
-                        log.WithError(err).Error("Failed to update certs")
-                }
-                m.certState = okState()
 
-                log.Info("Bouncing Vizier pods to get certs update")
-                err = k8s.DeletePods(m.clientset, m.namespace, "")
-                if err != nil {
-                        return err
-                }
+		err = deployCerts(context.Background(), m.namespace, vz, m.clientset, m.restConfig, true)
+		if err != nil {
+			log.WithError(err).Error("Failed to update certs")
+		}
+		m.certState = okState()
+
+		log.Info("Bouncing Vizier pods to get certs update")
+		err = k8s.DeletePods(m.clientset, m.namespace, "")
+		if err != nil {
+			return err
+		}
 	} else if state.Reason == status.EtcdPodsCrashing {
 		log.Info("etcd detected to be crashing, attempting to restart etcd")
 		// Delete etcd, deploy will trigger a new statefulset to startup.

--- a/src/shared/status/vzstatus.go
+++ b/src/shared/status/vzstatus.go
@@ -47,6 +47,8 @@ var reasonToMessageMap = map[VizierReason]string{
 	NATSPodPending:               "NATS message bus pods are still pending. If this status persists, investigate failures on the Pending NATS pods in the Vizier namespace (default `pl`).",
 	NATSPodMissing:               "NATS message bus pods are missing. If this status persists, clobber and redeploy this Pixie instance.",
 	NATSPodFailed:                "NATS message bus pods have failed. Investigate failures on the Pending NATS pods in the Vizier namespace (default `pl`).",
+	EtcdPodsMissing:              "etcd pods are missing. If this status persists, clobber and redeploy this Pixie instance.",
+	EtcdPodsCrashing:             "etcd pods are in CrashLoopBackOff, likely due to loss of quorum. If this status persists, clobber and redeploy this Pixie instance.",
 	UnableToConnectToCloud:       "Failed to connect to Pixie Cloud. Please check the cloud address (and optional dev cloud namespace) in the Vizier object to ensure it is correct and accessible within your firewall and network configurations.",
 	PEMsSomeInsufficientMemory: "Some PEMs are failing to schedule due to insufficient memory available on the nodes. You will not be able to receive data from those failing nodes. " +
 		"Free up memory on those nodes to start scraping Pixie data from those nodes.",
@@ -118,6 +120,11 @@ const (
 	NATSPodMissing VizierReason = "NATSPodMissing"
 	// NATSPodFailed occurs when the nats pod failed to start up.
 	NATSPodFailed VizierReason = "NATSPodFailed"
+
+	// EtcdPodsMissing when the etcd pods are missing.
+	EtcdPodsMissing VizierReason = "EtcdPodsMissing"
+	// EtcdPodsCrashing when the etcd pods are crashing.
+	EtcdPodsCrashing VizierReason = "EtcdPodsCrashing"
 
 	// UnableToConnectToCloud occurs when the Operator cannot make requests to the Pixie Cloud instance.
 	UnableToConnectToCloud VizierReason = "UnableToConnectToCloud"


### PR DESCRIPTION
Summary: We've noticed that a lot of clusters running etcd are in a state where etcd is crashing. This is very likely to happen if etcd loses quorum. This PR updates the operator to detect that state and attempt to fix it by restarting etcd.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Skaffold deploy operator
