### PR TITLE
Support pushing multi-arch images in vizier_build_release.sh

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -75,12 +75,22 @@ build:linux --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:clang-base --//bazel/cc_toolchains:compiler=clang
 build:clang-base --//bazel/cc_toolchains:libc_version=glibc_host
 
+# We build our own chroot for the sysroot tests, which doesn't work well under bazel's sandbox.
+build:sysroot_common --//bazel/test_runners:test_runner=sysroot_chroot
+test:sysroot_common --strategy TestRunner=standalone
+test:sysroot_common --run_under="bazel/test_runners/sysroot_chroot/test_runner.sh"
+
 build:x86_64_sysroot --config=clang
 build:x86_64_sysroot --//bazel/cc_toolchains:libc_version=glibc2_36
+build:x86_64_sysroot --config=sysroot_common
 
 build:aarch64_sysroot --config=clang
 build:aarch64_sysroot --//bazel/cc_toolchains:libc_version=glibc2_36
 build:aarch64_sysroot --platforms=//bazel/cc_toolchains:linux-aarch64
+build:aarch64_sysroot --config=sysroot_common
+# Increase test timeouts for qemu (don't increase the slowest ones because those are already very long).
+test:aarch64_sysroot --test_timeout=180,600,1800,3600
+test:aarch64_sysroot --test_env=QEMU_STRACE
 
 
 # Build for Clang using Libc++.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("//bazel:repositories.bzl", "list_pl_deps")
 load("//bazel/cc_toolchains:llvm_libs.bzl", "llvm_variant_repo_name", "llvm_variant_setting_label", "llvm_variants")
+load("//bazel/cc_toolchains/sysroots:images.bzl", "sysroot_runtime_image")
 load("//bazel/external/ubuntu_packages:packages.bzl", "packages")
 
 licenses(["restricted"])
@@ -142,16 +143,32 @@ filegroup(
 )
 
 container_image(
-    name = "pl_go_base_image",
+    name = "pl_go_base_image_default",
+    base = "@base_image//image",
+    debs = pl_cc_base_packages,
+)
+
+container_image(
+    name = "pl_cc_base_image_default",
     base = "@base_image//image",
     debs = pl_cc_base_packages,
     visibility = ["//visibility:public"],
 )
 
+sysroot_runtime_image(
+    name = "pl_go_base_image",
+    default_image = ":pl_go_base_image_default",
+    visibility = ["//visibility:public"],
+)
+
+sysroot_runtime_image(
+    name = "pl_cc_base_image_no_extra_files",
+    default_image = ":pl_cc_base_image_default",
+)
+
 container_image(
     name = "pl_cc_base_image",
-    base = "@base_image//image",
-    debs = pl_cc_base_packages,
+    base = ":pl_cc_base_image_no_extra_files",
     files = [
         "//:embedding.proto",
         "//:sentencepiece.proto",

--- a/bazel/cc_toolchains/sysroots/BUILD.bazel
+++ b/bazel/cc_toolchains/sysroots/BUILD.bazel
@@ -13,3 +13,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+load("//bazel/cc_toolchains/sysroots:sysroots.bzl", "pl_sysroot_settings")
+
+pl_sysroot_settings()

--- a/bazel/cc_toolchains/sysroots/build/sysroot.BUILD
+++ b/bazel/cc_toolchains/sysroots/build/sysroot.BUILD
@@ -51,11 +51,18 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "tar",
+    srcs = ["{tar_path}"],
+    visibility = ["//visibility:public"],
+)
+
 sysroot_toolchain(
     name = "sysroot_toolchain",
     architecture = "{target_arch}",
     files = ":all_files",
     path = "{path_to_this_repo}",
+    tar = ":tar",
 )
 
 toolchain(

--- a/bazel/cc_toolchains/sysroots/images.bzl
+++ b/bazel/cc_toolchains/sysroots/images.bzl
@@ -1,0 +1,83 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@io_bazel_rules_docker//container:container.bzl", _container = "container")
+load("@io_bazel_rules_docker//container:providers.bzl", "ImageInfo")
+
+def _forward_default_image(ctx):
+    target = ctx.attr.default_image
+    providers = [target[p] for p in [ImageInfo, InstrumentedFilesInfo] if p in target]
+
+    for name in _container.image.outputs:
+        # We are required to produce the predefined outputs,
+        # but they're only used for the sysroot version, not for this forwarding.
+        ctx.actions.write(getattr(ctx.outputs, name), "")
+
+    default_info = target[DefaultInfo]
+
+    orig_exe = default_info.files_to_run.executable
+    new_executable_path = "{name}_/{basename}".format(
+        name = ctx.attr.name,
+        basename = orig_exe.basename,
+    )
+    new_executable = ctx.actions.declare_file(new_executable_path)
+    ctx.actions.symlink(
+        output = new_executable,
+        target_file = orig_exe,
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles()
+    runfiles = runfiles.merge(default_info.default_runfiles)
+    runfiles = runfiles.merge(default_info.data_runfiles)
+    providers.append(
+        DefaultInfo(
+            files = default_info.files,
+            runfiles = runfiles,
+            executable = new_executable,
+        ),
+    )
+    return providers
+
+def _image_from_sysroot_info(ctx, sysroot_info):
+    tars = sysroot_info.tar.to_list()
+    architecture = sysroot_info.architecture
+    return _container.image.implementation(ctx, tars = tars, architecture = architecture)
+
+def _sysroot_variant_image_factory(variant):
+    def _impl(ctx):
+        sysroot_toolchain = ctx.toolchains["//bazel/cc_toolchains/sysroots/{variant}:toolchain_type".format(variant = variant)]
+        if sysroot_toolchain == None:
+            return _forward_default_image(ctx)
+        return _image_from_sysroot_info(ctx, sysroot_toolchain.sysroot)
+
+    return rule(
+        name = "sysroot_{variant}_image".format(variant = variant),
+        implementation = _impl,
+        attrs = dicts.add(_container.image.attrs, {
+            "default_image": attr.label(mandatory = True, doc = "Default container_image to use if no sysroot toolchain is found"),
+        }),
+        outputs = _container.image.outputs,
+        cfg = _container.image.cfg,
+        executable = True,
+        toolchains = [
+            "@io_bazel_rules_docker//toolchains/docker:toolchain_type",
+            config_common.toolchain_type("//bazel/cc_toolchains/sysroots/{variant}:toolchain_type".format(variant = variant), mandatory = False),
+        ],
+    )
+
+sysroot_runtime_image = _sysroot_variant_image_factory("runtime")
+sysroot_test_image = _sysroot_variant_image_factory("test")

--- a/bazel/cc_toolchains/sysroots/runtime/sysroot.BUILD
+++ b/bazel/cc_toolchains/sysroots/runtime/sysroot.BUILD
@@ -18,9 +18,18 @@ load("@px//bazel/cc_toolchains/sysroots:sysroots.bzl", "sysroot_toolchain")
 
 filegroup(
     name = "all_files",
-    srcs = glob([
-        "**",
-    ]),
+    srcs = glob(
+        [
+            "**",
+        ],
+        exclude = ["{tar_path}"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "tar",
+    srcs = ["{tar_path}"],
     visibility = ["//visibility:public"],
 )
 
@@ -29,6 +38,7 @@ sysroot_toolchain(
     architecture = "{target_arch}",
     files = ":all_files",
     path = "{path_to_this_repo}",
+    tar = ":tar",
 )
 
 toolchain(

--- a/bazel/cc_toolchains/sysroots/test/sysroot.BUILD
+++ b/bazel/cc_toolchains/sysroots/test/sysroot.BUILD
@@ -18,9 +18,18 @@ load("@px//bazel/cc_toolchains/sysroots:sysroots.bzl", "sysroot_toolchain")
 
 filegroup(
     name = "all_files",
-    srcs = glob([
-        "**",
-    ]),
+    srcs = glob(
+        [
+            "**",
+        ],
+        exclude = ["{tar_path}"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "tar",
+    srcs = ["{tar_path}"],
     visibility = ["//visibility:public"],
 )
 
@@ -29,6 +38,7 @@ sysroot_toolchain(
     architecture = "{target_arch}",
     files = ":all_files",
     path = "{path_to_this_repo}",
+    tar = ":tar",
 )
 
 toolchain(

--- a/bazel/images.bzl
+++ b/bazel/images.bzl
@@ -56,3 +56,25 @@ image_prefix_provider = rule(
         "image_prefix": attr.string(mandatory = True),
     },
 )
+
+def _list_image_bundle(ctx):
+    exe = ctx.actions.declare_file(ctx.attr.name)
+    exe_content = ""
+    for image_tag in ctx.attr.images:
+        image_tag = image_tag.replace("$(IMAGE_PREFIX)", ctx.var["IMAGE_PREFIX"])
+        image_tag = image_tag.replace("$(BUNDLE_VERSION)", ctx.var["BUNDLE_VERSION"])
+        exe_content += "echo '{}'\n".format(image_tag)
+    ctx.actions.write(exe, exe_content)
+
+    return DefaultInfo(
+        files = depset([exe]),
+        executable = exe,
+    )
+
+list_image_bundle = rule(
+    implementation = _list_image_bundle,
+    executable = True,
+    attrs = dict(
+        images = attr.string_dict(),
+    ),
+)

--- a/bazel/test_runners/BUILD.bazel
+++ b/bazel/test_runners/BUILD.bazel
@@ -1,0 +1,47 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "test_runner",
+    build_setting_default = "none",
+    values = [
+        "none",
+        "sysroot_chroot",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "test_runner_sysroot_chroot",
+    flag_values = {
+        ":test_runner": "sysroot_chroot",
+    },
+)
+
+filegroup(
+    name = "empty",
+)
+
+alias(
+    name = "test_runner_dep",
+    actual = select({
+        "test_runner_sysroot_chroot": "//bazel/test_runners/sysroot_chroot:runner",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/bazel/test_runners/sysroot_chroot/BUILD.bazel
+++ b/bazel/test_runners/sysroot_chroot/BUILD.bazel
@@ -1,0 +1,22 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel/test_runners/sysroot_chroot:runner.bzl", "sysroot_test_runner")
+
+sysroot_test_runner(
+    name = "runner",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/test_runners/sysroot_chroot/chroot.sh
+++ b/bazel/test_runners/sysroot_chroot/chroot.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+trap exit INT
+
+PWD="$(pwd)"
+pwd_resolved="$(readlink -f "${PWD}")"
+
+# TODO(james): find a more reliable way to find execroot, for now we use pwd and look for an execroot directory.
+# This approach is somewhat fragile, since if someone creates a directory called execroot, it will break.
+execroot="${pwd_resolved%/${pwd_resolved##*/execroot/}}"
+output_base="$(realpath "${execroot}/..")"
+
+top_of_repo=""
+for dir in "${output_base}"/execroot/px/*/; do
+  if [ -L "${dir%/}" ]
+  then
+    resolved_dir=$(readlink -f "${dir%/}")
+    top_of_repo="$(dirname "${resolved_dir}")"
+    break
+  fi
+done
+
+# Bazel sets up symlinks only on the files themselves, so find the real sysroot directory using files we know will exist.
+sysroot_path="$(realpath "$(dirname "$(readlink -f "${PWD}/%sysroot%/usr/include/stdio.h")")/../..")"
+
+chroot_dir="$TEST_TMPDIR/chroot";
+
+chroot_script_internal_name="/scripts/inside_chroot.sh"
+chroot_script="$(mktemp -p "${TEST_TMPDIR}")"
+cat > "${chroot_script}" <<EOF
+  cd ${PWD}
+  $@
+EOF
+
+chroot_bash_args=()
+if [ "${DEBUG_CHROOT}" = true ]; then
+  # Instead of running the test, print the way to invoke the test.
+  # If we run the test and the test segfaults the user will not get a shell in the chroot,
+  # which defeats the purpose of DEBUG_CHROOT.
+  sed -i '$ d' "${chroot_script}"
+  {
+    echo "echo '---------------------------------------'";
+    echo "echo '- Command to run test: $*'";
+    echo "echo '---------------------------------------'";
+  } >> "${chroot_script}"
+  chroot_bash_args+=("--init-file")
+fi
+chroot_bash_args+=("${chroot_script_internal_name}")
+
+unshare_script="$(mktemp -p "${TEST_TMPDIR}")"
+cat > "${unshare_script}" <<EOF
+  bazel/test_runners/sysroot_chroot/setup_unshare.sh "${chroot_dir}" "${sysroot_path}" "${output_base}" "${top_of_repo}"
+
+  # Copy the chroot script into the chroot directory.
+  mkdir -p "${chroot_dir}/scripts"
+  cp "${chroot_script}" "${chroot_dir}${chroot_script_internal_name}"
+
+  # TODO(james): maybe don't rely on system chroot (although it should be present on most systems).
+  /usr/sbin/chroot "${chroot_dir}" /bin/bash ${chroot_bash_args[@]}
+EOF
+
+unshare_bash_args=()
+if [ "${DEBUG_UNSHARE}" = true ]; then
+  unshare_bash_args+=("--init-file")
+fi
+unshare_bash_args+=("${unshare_script}")
+
+echo "Running test in chroot with sysroot: ${sysroot_path}"
+
+set +e
+# -m creates a new mount namespace
+# -r runs the script as a fake root
+# -p creates a new PID namespace
+# -f runs the script in a fork instead of directly through unshare (this seems to be necessary for the PID namespace to work properly)
+# We currently don't create a network namespace for the unshare environment. Once we use podman, we should be able to use an isolated network namespace.
+unshare -mrpf bash "${unshare_bash_args[@]}"
+exit_code="$?"
+set -e
+
+if [[ "${exit_code}" != 0 ]] && [[ "${DEBUG_CHROOT}" != true ]] && [[ "${DEBUG_UNSHARE}" != true ]]; then
+  echo "---------------------------------------------------------------"
+  echo "  To drop into a shell in the chroot, run: "
+  echo "    (pushd ${PWD}; \\"
+  echo "    export TEST_TMPDIR=\`mktemp -d\`; \\"
+  echo "    export TEST_SRCDIR=$TEST_SRCDIR; \\"
+  echo "    DEBUG_CHROOT=true  bazel/test_runners/sysroot_chroot/test_runner.sh $*; \\"
+  echo "    popd; rm -rf \"\$TEST_TMPDIR\"; unset TEST_TMPDIR; unset TEST_SRCDIR)"
+  echo "---------------------------------------------------------------"
+fi
+
+rm "${unshare_script}"
+rm "${chroot_script}"
+
+exit "${exit_code}"

--- a/bazel/test_runners/sysroot_chroot/runner.bzl
+++ b/bazel/test_runners/sysroot_chroot/runner.bzl
@@ -1,0 +1,68 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+HOST_ARCH = "x86_64"
+
+def _file(target):
+    return target[DefaultInfo].files.to_list()[0]
+
+def _test_runner_impl(ctx):
+    output_script = ctx.actions.declare_file("test_runner.sh")
+
+    sysroot_toolchain = ctx.toolchains["//bazel/cc_toolchains/sysroots/test:toolchain_type"]
+    if sysroot_toolchain == None:
+        # Since all branches of the test_runner_dep alias are evaluated, this rule has to return something, even if there's no sysroot toolchain.
+        ctx.actions.write(output_script, "", is_executable = True)
+        return DefaultInfo(executable = output_script)
+    sysroot_info = sysroot_toolchain.sysroot
+
+    ctx.actions.expand_template(
+        template = _file(ctx.attr._chroot_tpl),
+        output = output_script,
+        substitutions = {
+            "%arch%": sysroot_info.architecture,
+            "%sysroot%": sysroot_info.path,
+        },
+        is_executable = True,
+    )
+    return DefaultInfo(
+        files = depset(
+            [output_script],
+            transitive = [
+                sysroot_info.files,
+                ctx.attr._setup_unshare_script.files,
+            ],
+        ),
+        executable = output_script,
+    )
+
+sysroot_test_runner = rule(
+    implementation = _test_runner_impl,
+    attrs = {
+        "_chroot_tpl": attr.label(
+            default = Label("//bazel/test_runners/sysroot_chroot:chroot.sh"),
+            allow_single_file = True,
+        ),
+        "_setup_unshare_script": attr.label(
+            default = Label("//bazel/test_runners/sysroot_chroot:setup_unshare.sh"),
+            allow_single_file = True,
+        ),
+    },
+    toolchains = [
+        config_common.toolchain_type("//bazel/cc_toolchains/sysroots/test:toolchain_type", mandatory = False),
+    ],
+    executable = True,
+)

--- a/bazel/test_runners/sysroot_chroot/setup_unshare.sh
+++ b/bazel/test_runners/sysroot_chroot/setup_unshare.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+chroot_dir="$1"
+sysroot_path="$2"
+output_base="$3"
+top_of_repo="$4"
+
+bind_mount() {
+  src="$1"
+  dst="$2"
+  if [ -d "${src}" ]; then
+    mkdir -p "${dst}"
+  else
+    mkdir -p "$(dirname "${dst}")"
+    touch "${dst}"
+  fi
+  mount --bind "${src}" "${dst}"
+}
+
+overlay_mount() {
+  src="$1"
+  dst="$2"
+  overlay_dir="$3"
+  upper="${overlay_dir}/upper"
+  workdir="${overlay_dir}/workdir"
+
+  mkdir -p "${overlay_dir}"
+  mount -t tmpfs tmpfs "${overlay_dir}"
+  mkdir -p "${upper}"
+  mkdir -p "${workdir}"
+  mkdir -p "${dst}"
+  mount -t overlay overlay -o "xino=off,lowerdir=${src},upperdir=${upper},workdir=${workdir}" "${dst}"
+}
+
+
+sysroot_dirs=("lib" "usr" "bin" "etc" "var" "sbin" "run")
+if [ -d "${sysroot_path}/lib64" ]; then
+  sysroot_dirs+=("lib64")
+fi
+
+# Mount all the sysroot dirs.
+for dir in "${sysroot_dirs[@]}"
+do
+  bind_mount "${sysroot_path}/${dir}" "${chroot_dir}/${dir}"
+done
+
+# Mount docker socket.
+bind_mount /var/run/docker.sock "${chroot_dir}/var/run/docker.sock"
+
+# Mount repo, bazel output base as overlays, so that the actual repo and output_base are not modified.
+output_base_overlay="$TEST_TMPDIR/output_base_overlay";
+overlay_mount "${output_base}" "${chroot_dir}/${output_base}" "${output_base_overlay}"
+
+if [ -n "${top_of_repo}" ]
+then
+  repo_overlay="$TEST_TMPDIR/repo_overlay";
+  overlay_mount "${top_of_repo}" "${chroot_dir}/${top_of_repo}" "${repo_overlay}"
+fi
+
+# Mount a new tmpfs for the test tmpdir.
+mkdir -p "${chroot_dir}/tmp"
+mount -t tmpfs tmpfs "${chroot_dir}/tmp"
+export TEST_TMPDIR=/tmp
+
+# Mount system dirs
+mkdir -p "${chroot_dir}/dev"
+mount --rbind /dev "${chroot_dir}/dev"
+mkdir -p "${chroot_dir}/sys"
+mount --rbind /sys "${chroot_dir}/sys"
+mkdir -p "${chroot_dir}/proc"
+mount -t proc /proc "${chroot_dir}/proc"
+
+
+# Miscellaneous setup tasks
+echo "127.0.0.1 localhost" > "${chroot_dir}/etc/hosts"
+echo "root:x:0:0:root:/root:/bin/bash" > "${chroot_dir}/etc/passwd"
+export SHELL=/bin/bash
+ln -snf /usr/bin/gawk "${chroot_dir}/usr/bin/awk"

--- a/k8s/vizier/BUILD.bazel
+++ b/k8s/vizier/BUILD.bazel
@@ -17,7 +17,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//bazel:images.bzl", "DEV_PREFIX", "image_replacements")
+load("//bazel:images.bzl", "DEV_PREFIX", "image_replacements", "list_image_bundle")
 load("//bazel:kustomize.bzl", "kustomize_build")
 
 package(default_visibility = ["//visibility:public"])
@@ -140,6 +140,15 @@ kustomize_build(
 
 container_bundle(
     name = "image_bundle",
+    images = VIZIER_IMAGE_TO_LABEL,
+    toolchains = [
+        "//k8s:image_prefix",
+        "//k8s:bundle_version",
+    ],
+)
+
+list_image_bundle(
+    name = "list_image_bundle",
     images = VIZIER_IMAGE_TO_LABEL,
     toolchains = [
         "//k8s:image_prefix",

--- a/src/carnot/carnot_test.cc
+++ b/src/carnot/carnot_test.cc
@@ -1184,7 +1184,7 @@ class TransferResultChunkTests : public CarnotTest,
 };
 TEST_P(TransferResultChunkTests, send_and_forward_messages) {
   grpc::ServerBuilder builder;
-  builder.AddListeningPort("localhost:0", grpc::InsecureServerCredentials());
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials());
   builder.RegisterService(router_);
   auto grpc_server = builder.BuildAndStart();
 

--- a/src/carnot/exec/grpc_router_test.cc
+++ b/src/carnot/exec/grpc_router_test.cc
@@ -66,7 +66,7 @@ class GRPCRouterTest : public ::testing::Test {
   void SetUp() override {
     // Setup server.
     ServerBuilder builder;
-    builder.AddListeningPort("localhost:0", InsecureServerCredentials());
+    builder.AddListeningPort("127.0.0.1:0", InsecureServerCredentials());
     builder.RegisterService(service_.get());
     server_ = builder.BuildAndStart();
 

--- a/src/carnot/exec/local_grpc_result_server.h
+++ b/src/carnot/exec/local_grpc_result_server.h
@@ -78,7 +78,7 @@ class LocalGRPCResultSinkServer {
   LocalGRPCResultSinkServer() {
     grpc::ServerBuilder builder;
 
-    builder.AddListeningPort("localhost:0", grpc::InsecureServerCredentials());
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials());
     builder.RegisterService(&result_sink_server_);
     grpc_server_ = builder.BuildAndStart();
     CHECK(grpc_server_ != nullptr);

--- a/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
@@ -80,7 +80,10 @@ cc_static_musl_binary(
 
 filegroup(
     name = "agent",
-    srcs = ["px-java-agent"],
+    srcs = select({
+        "@platforms//cpu:aarch64": [],
+        "//conditions:default": ["px-java-agent"],
+    }),
     visibility = [
         # Add visibility at top-level so that we can include
         # the lib in the pem image.


### PR DESCRIPTION
Summary: Adds pushing multi-arch images in the vizier release process.
Builds each architecture's images separately and pushes those individually. Then pushes a manifest list pointing to each architecture for each vizier image.

Relevant Issues: #147

Type of change: /kind cleanup

Test Plan: Changed the image prefix to a gcr I have access to, ran the script with a fake tag, saw that multi-arch manifest lists are correctly pushed.
