### PR TITLE
Add support for ARM in the datacollector.

### DIFF
--- a/src/common/base/arch.h
+++ b/src/common/base/arch.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#if defined(__x86_64__) || defined(_M_X64)
+#define X86_64 1
+#else
+#define X86_64 0
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define AARCH64 1
+#else
+#define AARCH64 0
+#endif

--- a/src/common/base/base.h
+++ b/src/common/base/base.h
@@ -22,6 +22,7 @@
  * importing them everywhere.
  */
 
+#include "src/common/base/arch.h"           // IWYU pragma: export
 #include "src/common/base/byte_utils.h"     // IWYU pragma: export
 #include "src/common/base/defer.h"          // IWYU pragma: export
 #include "src/common/base/enum_utils.h"     // IWYU pragma: export

--- a/src/stirling/obj_tools/elf_reader.cc
+++ b/src/stirling/obj_tools/elf_reader.cc
@@ -439,10 +439,17 @@ class LLVMDisasmContext {
   LLVMDisasmContext() {
     InitLLVMOnce();
 
+#if X86_64
+    constexpr char triple[] = "x86_64-pc-linux";
+#elif AARCH64
+    constexpr char triple[] = "aarch64-pc-linux";
+#else
+#error Architecture not supported.
+#endif
+
     // TripleName is ARCHITECTURE-VENDOR-OPERATING_SYSTEM.
     // See https://llvm.org/doxygen/Triple_8h_source.html
-    // TODO(yzhao): Change to get TripleName from the system, instead of hard coding.
-    ref_ = LLVMCreateDisasm(/*TripleName*/ "x86_64-pc-linux",
+    ref_ = LLVMCreateDisasm(triple,
                             /*DisInfo*/ nullptr, /*TagType*/ 0, /*LLVMOpInfoCallback*/ nullptr,
                             /*LLVMSymbolLookupCallback*/ nullptr);
   }

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/BUILD.bazel
@@ -51,12 +51,16 @@ cc_library(
 pl_bpf_cc_resource(
     name = "socket_trace",
     src = "socket_trace.c",
+    # Uncomment to enable debug printks.
+    # defines = ["BPF_DEBUG"],
+    defines = select({
+        "@platforms//cpu:aarch64": ["TARGET_ARCH_AARCH64"],
+        "@platforms//cpu:x86_64": ["TARGET_ARCH_X86_64"],
+    }),
     deps = [
         ":headers",
         "//src/stirling/bpf_tools/bcc_bpf/system-headers",
     ],
-    # Uncomment to enable debug printks.
-    # defines = ["BPF_DEBUG"],
 )
 
 pl_cc_test(

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/go_trace_common.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/go_trace_common.h
@@ -53,6 +53,7 @@ static __inline uint64_t* go_regabi_regs(const struct pt_regs* ctx) {
     return NULL;
   }
 
+#if defined(TARGET_ARCH_X86_64)
   regs_heap_var->regs[0] = ctx->ax;
   regs_heap_var->regs[1] = ctx->bx;
   regs_heap_var->regs[2] = ctx->cx;
@@ -62,6 +63,14 @@ static __inline uint64_t* go_regabi_regs(const struct pt_regs* ctx) {
   regs_heap_var->regs[6] = ctx->r9;
   regs_heap_var->regs[7] = ctx->r10;
   regs_heap_var->regs[8] = ctx->r11;
+#elif defined(TARGET_ARCH_AARCH64)
+#pragma unroll
+  for (uint32_t i = 0; i < 9; i++) {
+    regs_heap_var->regs[i] = ctx->regs[i];
+  }
+#else
+#error Target Architecture not supported
+#endif
 
   return regs_heap_var->regs;
 }
@@ -95,7 +104,14 @@ static inline uint64_t get_goid(struct pt_regs* ctx) {
   if (!task_ptr) {
     return 0;
   }
+
+#if defined(TARGET_ARCH_X86_64)
   const void* fs_base = (void*)task_ptr->thread.fsbase;
+#elif defined(TARGET_ARCH_AARCH64)
+  const void* fs_base = (void*)task_ptr->thread.uw.tp_value;
+#else
+#error Target architecture not supported
+#endif
 
   // Get ptr to `struct g` from 8 bytes before fsbase and then access the goID.
   uint64_t goid;


### PR DESCRIPTION
Summary: Adds support for ARM inside of stirling.
- Adds support to the bpf probes for targetting ARM. Specifically changes where we get the pointer to thread local storage, and how we access registers.
- Adds support in ELF reader for disassembling ARM binaries.
All of these changes are behind ifdefs based on the architecture being compiled for.

Relevant Issues: #147

Type of change: /kind feature

Test Plan: Tested that the deployed images work on an ARM cluster. Saw HTTP data, process data, flamegraph data and more.
More testing needs to be done to ensure that all the data being collected is still correct.
Additionally, once we have the infrastructure to run bpf tests through QEMU, we should make sure those tests work for ARM.
