### PR TITLE
Add pprof proto output as command line arg. to perf profiler test.

### DIFF
--- a/bazel/external/pprof.BUILD
+++ b/bazel/external/pprof.BUILD
@@ -1,0 +1,31 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "pprof_proto",
+    srcs = [
+        "proto/profile.proto",
+    ],
+)
+
+cc_proto_library(
+    name = "pprof_proto_cc",
+    deps = [":pprof_proto"],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -176,6 +176,7 @@ def _cc_deps():
 
     # TODO(jps): For jattach, consider using a patch and directly pulling from upstream (vs. fork).
     _git_repo("com_github_apangin_jattach", build_file = "//bazel/external:jattach.BUILD")
+    _git_repo("com_github_google_pprof", build_file = "//bazel/external:pprof.BUILD")
 
     # Dependencies used in foreign cc rules (e.g. cmake-based builds)
     _include_all_repo("com_github_gperftools_gperftools")

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -176,6 +176,8 @@ def _cc_deps():
 
     # TODO(jps): For jattach, consider using a patch and directly pulling from upstream (vs. fork).
     _git_repo("com_github_apangin_jattach", build_file = "//bazel/external:jattach.BUILD")
+
+    # Using "git repo" because the pprof repo does not have any release tags.
     _git_repo("com_github_google_pprof", build_file = "//bazel/external:pprof.BUILD")
 
     # Dependencies used in foreign cc rules (e.g. cmake-based builds)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -459,6 +459,8 @@ GIT_REPOSITORY_LOCATIONS = dict(
         commit = "fa36a4fa141b4e9486b9126640d54a94c1d36fce",
         shallow_since = "1638898188 -0800",
     ),
+
+    # Used by the perf profiler to create pprof proto output.
     com_github_google_pprof = dict(
         remote = "https://github.com/google/pprof.git",
         commit = "5a9e8f65f08f77f42ab2a02f18561033f44da75e",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -459,6 +459,11 @@ GIT_REPOSITORY_LOCATIONS = dict(
         commit = "fa36a4fa141b4e9486b9126640d54a94c1d36fce",
         shallow_since = "1638898188 -0800",
     ),
+    com_github_google_pprof = dict(
+        remote = "https://github.com/google/pprof.git",
+        commit = "5a9e8f65f08f77f42ab2a02f18561033f44da75e",
+        shallow_since = "1675207505 -0800",
+    ),
 )
 
 # To use a local repo for local development, update the path to point to your local repo.

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -53,19 +53,20 @@ pl_cc_test(
         "//src/stirling/source_connectors/perf_profiler/testing/java:graal-vm-aot-fib",
     ],
     defines = ['JDK_IMAGE_NAMES=\\"%s\\"' % ",".join(jdk_image_names)],
-    shard_count = 3,
+    # shard_count = 3,
     tags = [
         "cpu:16",
         "exclusive",
         "requires_bpf",
-        # Disabling this test because it has a 25% pass rate on main at the moment.
-        "disabled_flaky_test",
     ],
     deps = [
         ":cc_library",
         "//src/common/exec:cc_library",
         "//src/common/testing/test_utils:cc_library",
         "//src/stirling/source_connectors/perf_profiler/testing:cc_library",
+        # "//src/stirling/source_connectors/perf_profiler/testing:profile_pl_cc_proto",
+        # "#include "opentelemetry/proto/trace/v1/trace.pb.h""
+        "@com_github_google_pprof//:pprof_proto_cc",
         "//src/stirling/testing:cc_library",
     ],
 )

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -53,21 +53,21 @@ pl_cc_test(
         "//src/stirling/source_connectors/perf_profiler/testing/java:graal-vm-aot-fib",
     ],
     defines = ['JDK_IMAGE_NAMES=\\"%s\\"' % ",".join(jdk_image_names)],
-    # shard_count = 3,
+    shard_count = 3,
     tags = [
         "cpu:16",
         "exclusive",
         "requires_bpf",
+        # Disabling this test because it has a 25% pass rate on main at the moment.
+        "disabled_flaky_test",
     ],
     deps = [
         ":cc_library",
         "//src/common/exec:cc_library",
         "//src/common/testing/test_utils:cc_library",
         "//src/stirling/source_connectors/perf_profiler/testing:cc_library",
-        # "//src/stirling/source_connectors/perf_profiler/testing:profile_pl_cc_proto",
-        # "#include "opentelemetry/proto/trace/v1/trace.pb.h""
-        "@com_github_google_pprof//:pprof_proto_cc",
         "//src/stirling/testing:cc_library",
+        "@com_github_google_pprof//:pprof_proto_cc",
     ],
 )
 

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -37,9 +37,12 @@
 #include "src/stirling/source_connectors/perf_profiler/testing/testing.h"
 #include "src/stirling/testing/common.h"
 
+#include "proto/profile.pb.h"
+
 DEFINE_uint32(test_run_time, 30, "Number of seconds to run the test.");
 DEFINE_string(test_java_image_names, JDK_IMAGE_NAMES,
               "Java docker images to use as Java test cases.");
+DEFINE_string(pprof_pb_file, "", "Location to create pprof pb file.");
 DECLARE_bool(stirling_profiler_java_symbols);
 DECLARE_string(stirling_profiler_java_agent_libs);
 DECLARE_uint32(stirling_profiler_table_update_period_seconds);
@@ -239,6 +242,11 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
       histo_[stack_trace_str] += count;
     }
 
+    if (FLAGS_pprof_pb_file != "") {
+      const auto pprof_pb_status = WritePProfProtoFile();
+      LOG_IF(WARNING, !pprof_pb_status.ok()) << pprof_pb_status.msg();
+    }
+
     // TODO(jps): bring in a 3rd party library for colorization. e.g., one of the following:
     // https://github.com/agauniyal/rang
     // https://github.com/ikalnytskyi/termcolor
@@ -249,6 +257,143 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
       VLOG(1) << makecolor(220) << absl::StrFormat("%5d: ", val) << key << reset() << std::endl;
     }
     VLOG(1) << std::endl;
+  }
+
+  Status WritePProfProtoFile() {
+    // See:
+    // https://github.com/google/pprof/blob/main/proto/profile.proto
+
+    // period_ns will be used when populating the nanos count.
+    const uint64_t period_ms = FLAGS_stirling_profiler_stack_trace_sample_period_ms;
+    const uint64_t period_ns = period_ms * 1000 * 1000;
+
+    // strings tracks which strings have been inserted into the profile.
+    absl::flat_hash_map<std::string, uint64_t> strings;
+
+    // This is the pprof profile, it will be populated next, and later, serialized to a file.
+    ::perftools::profiles::Profile profile;
+
+    // The pprof profiles start by describing their sample types. For CPU profiling,
+    // the convention is to describe to different metrics:
+    // "samples" with units of "count", and
+    // "cpu" with units of "nanoseconds".
+    // Note, the first entry in the strings table is required to be an empty string.
+    auto sample_type = profile.add_sample_type();
+    sample_type->set_type(1);
+    sample_type->set_unit(2);
+    profile.add_string_table("");
+    profile.add_string_table("samples");
+    profile.add_string_table("count");
+    sample_type = profile.add_sample_type();
+    sample_type->set_type(3);
+    sample_type->set_unit(4);
+    profile.add_string_table("cpu");
+    profile.add_string_table("nanoseconds");
+
+    // State variables useful as we build the pprof profile message.
+    // No locations messages exist (yet); next_location_id starts at 1.
+    // We already added some strings; next_string_id starts at 5.
+    uint64_t next_location_id = 1;
+    uint64_t next_string_id = 5;
+
+    // To build the profile, we iterate over the stack traces  histogram.
+    for (const auto& [stack_trace_str, count] : histo_) {
+      // Each histo entry will be recorded as a new sample.
+      auto sample = profile.add_sample();
+
+      // That sample will record its count and time in nanos.
+      const uint64_t nanos = count * period_ns / kNumSubProcs;
+      sample->add_value(count);
+      sample->add_value(nanos);
+
+      // Our stack traces are symbolized like so: main;foo;bar
+      // thus, we split on ';' to iterate over the individual symbols.
+      const std::vector<std::string_view> symbols = absl::StrSplit(stack_trace_str, ";");
+
+      // Iterate over the symbols in this stack trace.
+      // Each symbol will be added to the sample as a "location" message, which in turn refers to a
+      // string in the strings table (tracked in map "strings") (more details below).
+      // Note, because of how we built the stack trace string and how the pprof profile is
+      // organized, we iterate in reverse order.
+      for (auto symbols_iter = symbols.rbegin(); symbols_iter != symbols.rend(); ++symbols_iter) {
+        // For convenience.
+        const auto& symbol = *symbols_iter;
+
+        // try_emplace() looks up an existing entry in the strings table, or creates a new entry
+        // with the key provided. Here a new entry maps from symbol to next_location_id.
+        const auto [strings_iter, inserted] = strings.try_emplace(symbol, next_location_id);
+
+        if (inserted) {
+          // New symbol: create a new location, add it to the sample, and create a new symbol.
+
+          // For convenience & clarity, store the ids in locals, then compute their next values.
+          const uint64_t location_id = next_location_id;
+          const uint64_t string_id = next_string_id;
+          ++next_location_id;
+          ++next_string_id;
+
+          // Add a new "location" to the profile.
+          // Each sample is a sequence of locations. The locations, in their sequence, represent a
+          // stack trace. Each location may include an address and a reference to a mapping (useful
+          // if symbols are not included in the profile, enables post-hoc symbolization).
+          // Lacking both address and mapping here, we skip those.
+          auto location = profile.add_location();
+          location->set_id(location_id);
+
+          // To connect a location to a symbol, we need to go through a "line" and a "function".
+
+          // Add a "line" message to the location message.
+          // In our usage, this is essentially a pointer to a function message that points to a
+          // symbol. The function message may contain more information (e.g. starting line number).
+          auto line = location->add_line();
+          line->set_function_id(location_id);
+
+          // Add a "function" to the profile (to point to the string table).
+          auto function = profile.add_function();
+          function->set_id(location_id);
+
+          // Add a reference to the string table entry in the function message.
+          function->set_name(string_id);
+
+          // Add the string to the string table in the profile.
+          profile.add_string_table(std::string(symbol));
+
+          // Add the new location-id into the sample in the profile.
+          sample->add_location_id(location_id);
+
+          // Record the fact that we have written this string into the profile. Save the
+          // location-id because it is used if we find this symbol again.
+          strings[symbol] = location_id;
+        } else {
+          // Existing symbol.
+          // Just place the pre-existing location id into the sample.
+          const uint64_t location_id = strings_iter->second;
+          sample->add_location_id(location_id);
+        }
+      }
+    }
+
+    // Create a file.
+    std::ofstream ofs(FLAGS_pprof_pb_file, std::ios_base::out | std::ios_base::binary);
+
+    if (!ofs.is_open()) {
+      return error::ResourceUnavailable("Could not create or open file: $0.", FLAGS_pprof_pb_file);
+    }
+
+    // Serialize the pprof proto to that file.
+    if (!profile.SerializeToOstream(&ofs)) {
+      return error::Internal("Failed to serialize to file: $0.", FLAGS_pprof_pb_file);
+    }
+
+    // In the somewhat likely scenario that:
+    // 1. the user did not provide an abs path for the command line arg., and
+    // 2. the test was invoked through bazel,
+    // here, we dig up the resulting abs path because finding the file under bazel is painful.
+    auto abs_path_or_status = fs::Absolute(FLAGS_pprof_pb_file);
+    const auto abs_path = abs_path_or_status.ValueOr("none");
+    LOG(INFO) << absl::Substitute("Created pprof proto file: $0.", abs_path.string());
+
+    return Status::OK();
   }
 
   void PopulateCumulativeSum(const std::vector<size_t>& target_row_idxs) {

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -267,10 +267,10 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     const uint64_t period_ms = FLAGS_stirling_profiler_stack_trace_sample_period_ms;
     const uint64_t period_ns = period_ms * 1000 * 1000;
 
-    // strings tracks which strings have been inserted into the profile.
+    // Tracks which strings have been inserted into the profile.
     absl::flat_hash_map<std::string, uint64_t> strings;
 
-    // This is the pprof profile, it will be populated next, and later, serialized to a file.
+    // This is the pprof profile.
     ::perftools::profiles::Profile profile;
 
     // The pprof profiles start by describing their sample types. For CPU profiling,

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -274,7 +274,7 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     ::perftools::profiles::Profile profile;
 
     // The pprof profiles start by describing their sample types. For CPU profiling,
-    // the convention is to describe to different metrics:
+    // the convention is to describe two different metrics:
     // "samples" with units of "count", and
     // "cpu" with units of "nanoseconds".
     // Note, the first entry in the strings table is required to be an empty string.


### PR DESCRIPTION
Summary: Adds pprof proto output to profiler test via a command line arg.
```
scripts/sudo_bazel_run.sh //src/stirling/source_connectors/perf_profiler:perf_profiler_bpf_test -- -pprof_pb_file cpp-test.pprof.pb --gtest_filter=PerfProfileBPFTest.PerfProfilerCppTest
```

Currently, we are using this to investigate flaky tests. We plan to (in a subsequent PR) refactor the pprof export code into a library function that enables pprof export from pixel scripts or from a standalone pem.

Relevant Issues: https://github.com/pixie-io/pixie/issues/719

Type of change: /kind feature

Test Plan: Created a pprof proto file for each profiler test.