### PR TITLE
Update bpf build machines to have 32 cpus

### DIFF
--- a/ci/bpf/00_create_instance.sh
+++ b/ci/bpf/00_create_instance.sh
@@ -54,7 +54,7 @@ gcloud beta compute instances create \
   --quiet \
   --project="${GCP_PROJECT}" \
   --zone=us-west1-b \
-  --machine-type=c2-standard-16 \
+  --machine-type=c2-standard-32 \
   --service-account="jenkins-worker@${GCP_PROJECT}.iam.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/cloud-platform \
   --network-interface=network-tier=PREMIUM,subnet=us-west1-0 \

--- a/ci/jenkins.bazelrc
+++ b/ci/jenkins.bazelrc
@@ -40,6 +40,6 @@ build --jobs 16
 test --jobs 16
 
 # BPF machines are bit bigger.
-build:bpf --local_cpu_resources=48
-build:bpf --jobs 48
+build:bpf --local_cpu_resources=32
+build:bpf --jobs 32
 test:bpf --jobs 16


### PR DESCRIPTION
Summary: We should have enough quota to support 32cpu machines.
Will keep an eye out and bump to 48 if possible.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: N/A
