### PR TITLE
Update build metadata repo

### DIFF
--- a/ci/jenkins.bazelrc
+++ b/ci/jenkins.bazelrc
@@ -7,7 +7,7 @@ common --keep_going
 
 build --build_metadata=HOST=jenkins-worker
 build --build_metadata=USER=jenkins
-build --build_metadata=REPO_URL=https://github.com/pixie-labs/pixielabs/
+build --build_metadata=REPO_URL=https://github.com/pixie-io/pixie
 build --verbose_failures
 
 test --verbose_failures


### PR DESCRIPTION
Summary: This metadata was set to a stale value. Update it.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check buildbuddy on the CI run for this PR.
