### PR TITLE
Use multiarch version of NATS

### DIFF
--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -111,7 +111,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: pl-nats
-        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:2.8.4-alpine3.15
+        image: gcr.io/pixie-oss/pixie-dev-public/nats:multiarch-2.8.4-alpine3.15
         ports:
         - containerPort: 4222
           name: client
@@ -175,3 +175,20 @@ spec:
               # the NATS Server to gracefully terminate the client connections.
               #
               command: ["/bin/sh", "-c", "/nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"


### PR DESCRIPTION

Summary: Use multi-arch manifest list version of NATS.

Relevant Issues: #147

Type of change: /kind cleanup

Test Plan: Tested that if I manually deploy this version of NATS to an x86 cluster the cluster still works. Also tested that this version of NATS works on an ARM cluster.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>
