### PR TITLE
Fix segfault in GetOwnerReferenceInfosFromMetadataObject

### DIFF
--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -811,11 +811,17 @@ inline std::vector<const px::md::K8sMetadataObject*> GetOwnerReferenceInfosFromM
     if (owner_reference.kind == owner_ref_kind) {
       const px::md::K8sMetadataObject* obj_info;
       if (owner_ref_kind == "ReplicaSet") {
-        obj_info = static_cast<const px::md::K8sMetadataObject*>(
-            md->k8s_metadata_state().ReplicaSetInfoByID(owner_reference.uid));
+        auto rs_info = md->k8s_metadata_state().ReplicaSetInfoByID(owner_reference.uid);
+        if (rs_info == nullptr) {
+          continue;
+        }
+        obj_info = static_cast<const px::md::K8sMetadataObject*>(rs_info);
       } else if (owner_ref_kind == "Deployment") {
-        obj_info = static_cast<const px::md::K8sMetadataObject*>(
-            md->k8s_metadata_state().DeploymentInfoByID(owner_reference.uid));
+        auto dep_info = md->k8s_metadata_state().DeploymentInfoByID(owner_reference.uid);
+        if (dep_info == nullptr) {
+          continue;
+        }
+        obj_info = static_cast<const px::md::K8sMetadataObject*>(dep_info);
       } else {
         continue;
       }

--- a/src/shared/k8s/metadatapb/test_proto.h
+++ b/src/shared/k8s/metadatapb/test_proto.h
@@ -112,6 +112,30 @@ owner_references: {
 }
 )";
 
+const char* kPodMissingOwnerPbTxt = R"(
+uid: "missing_owner_3_uid"
+name: "missing_owner_pod"
+namespace: "pl"
+start_timestamp_ns: 5
+container_ids: "pod2_container_1"
+qos_class: QOS_CLASS_GUARANTEED
+node_name: "test_node"
+hostname: "test_host"
+pod_ip: "4.4.4.4"
+phase: RUNNING
+message: "Running message"
+reason: "Running reason"
+conditions {
+  type: 2
+  status: 1
+}
+owner_references: {
+  uid: "rs_missing_uid"
+  name: "rs0"
+  kind: "ReplicaSet"
+}
+)";
+
 /*
  * Templates for container updates.
  */
@@ -322,6 +346,14 @@ conditions: {
 std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateRunningPodUpdatePB() {
   auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
   auto update_proto = absl::Substitute(kResourceUpdateTmpl, "pod_update", kRunningPodUpdatePbTxt);
+  CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
+      << "Failed to parse proto";
+  return update;
+}
+
+std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateMissingOwnerPodUpdatePB() {
+  auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
+  auto update_proto = absl::Substitute(kResourceUpdateTmpl, "pod_update", kPodMissingOwnerPbTxt);
   CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
       << "Failed to parse proto";
   return update;


### PR DESCRIPTION
Summary: There are some missing nullptr checks in
GetOwnerReferenceInfosFromMetadataObject causing segfaults.
The func should be rewritten but this is a quick fix to
unblock the release before I rewrite the func.

The first of two commits is a testcase that exhibits the
behavior, the latter fixes the issue.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Added a test case that exhibits the segfault without
the accompanying fix.
