### PR TITLE
Fix bpf machine type

### DIFF
--- a/ci/bpf/00_create_instance.sh
+++ b/ci/bpf/00_create_instance.sh
@@ -54,7 +54,7 @@ gcloud beta compute instances create \
   --quiet \
   --project="${GCP_PROJECT}" \
   --zone=us-west1-b \
-  --machine-type=c2-standard-32 \
+  --machine-type=n2d-standard-32 \
   --service-account="jenkins-worker@${GCP_PROJECT}.iam.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/cloud-platform \
   --network-interface=network-tier=PREMIUM,subnet=us-west1-0 \


### PR DESCRIPTION
Summary: GCE doesn't have a c2-standard-32 machine, only a c2-standard-30 machine. This updates the bpf workers to use `n2d-standard-32` instead.

Type of change: /kind cleanup

Test Plan: Run #ci:bpf-build

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>
