### PR TITLE
Cleanup owner references code

### DIFF
--- a/src/shared/metadata/metadata_state.cc
+++ b/src/shared/metadata/metadata_state.cc
@@ -118,6 +118,34 @@ UID K8sMetadataState::DeploymentIDByName(K8sNameIdentView deployment_name) const
   return (it == deployments_by_name_.end()) ? "" : it->second;
 }
 
+const ReplicaSetInfo* K8sMetadataState::OwnerReplicaSetInfo(
+    const K8sMetadataObject* obj_info) const {
+  for (const auto& owner_reference : obj_info->owner_references()) {
+    if (owner_reference.kind != "ReplicaSet") {
+      continue;
+    }
+    auto rs_info = ReplicaSetInfoByID(owner_reference.uid);
+    if (rs_info != nullptr) {
+      return rs_info;
+    }
+  }
+  return nullptr;
+}
+
+const DeploymentInfo* K8sMetadataState::OwnerDeploymentInfo(
+    const K8sMetadataObject* obj_info) const {
+  for (const auto& owner_reference : obj_info->owner_references()) {
+    if (owner_reference.kind != "Deployment") {
+      continue;
+    }
+    auto dep_info = DeploymentInfoByID(owner_reference.uid);
+    if (dep_info != nullptr) {
+      return dep_info;
+    }
+  }
+  return nullptr;
+}
+
 std::unique_ptr<K8sMetadataState> K8sMetadataState::Clone() const {
   auto other = std::make_unique<K8sMetadataState>();
 

--- a/src/shared/metadata/metadata_state.h
+++ b/src/shared/metadata/metadata_state.h
@@ -223,6 +223,24 @@ class K8sMetadataState : NotCopyable {
    */
   UID DeploymentIDByName(K8sNameIdentView deployment_name) const;
 
+  /**
+   * OwnerReplicaSetInfo gets an unowned pointer to the first replicaset that is the
+   * owner (if any) for the given k8s object. This pointer will remain active
+   * for the lifetime of this metadata state instance.
+   * @param obj_info pointer to the given k8s object.
+   * @return Pointer to the ReplicaSetInfo.
+   */
+  const ReplicaSetInfo* OwnerReplicaSetInfo(const K8sMetadataObject* obj_info) const;
+
+  /**
+   * OwnerDeploymentInfo gets an unowned pointer to the first deployment that is the
+   * owner (if any) for the given k8s object. This pointer will remain active
+   * for the lifetime of this metadata state instance.
+   * @param obj_info pointer to the given k8s object.
+   * @return Pointer to the DeploymentInfo.
+   */
+  const DeploymentInfo* OwnerDeploymentInfo(const K8sMetadataObject* obj_info) const;
+
   std::unique_ptr<K8sMetadataState> Clone() const;
 
   Status HandlePodUpdate(const PodUpdate& update);


### PR DESCRIPTION
Summary: The `GetOwnerReferenceInfosFromMetadataObject` method
was a bit complex and too abstract whereas our usecases for
it were very simple. Thie introduces `OwnerReplicaSetInfo` and
`OwnerDeploymentInfo` which effectively achieve the same end
goal but also make the code easier to follow.

Relevant Issues: This is a followup from #820 where we discovered and patched
a SegFault.

Type of change: /kind cleanup

Test Plan: All the metadata and metadata_ops tests pass.