### PR TITLE
Add cacher workflow to main to generate caches for PRs

### DIFF
--- a/.github/workflows/cacher.yaml
+++ b/.github/workflows/cacher.yaml
@@ -1,0 +1,48 @@
+---
+name: main-cacher
+on:
+  push:
+    branches:
+    - 'main'
+permissions:
+  contents: read
+jobs:
+  get-dev-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image-with-tag: ${{ steps.get-version.outputs.image }}
+    steps:
+    - uses: actions/checkout@v3
+    - id: get-version
+      run: >-
+        IMAGE_NAME="gcr.io/pixie-oss/pixie-dev-public/dev_image";
+        IMAGE_TAG="$(cat docker.properties | cut -d'=' -f2)";
+        echo "image=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+  populate-caches:
+    runs-on: ubuntu-latest-8-cores
+    needs: get-dev-image
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      options: --cpus 7
+    steps:
+    - uses: actions/checkout@v3
+    - name: go cache
+      uses: actions/cache@v3
+      with:
+        path: /px/pkg/mod
+        key: go-cache-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-cache-
+    - name: yarn cache
+      uses: actions/cache@v3
+      with:
+        path: ./src/ui/.yarn/cache
+        key: yarn-cache-${{ hashFiles('src/ui/yarn.lock', 'src/ui/.yarnrc.yml') }}
+        restore-keys: |
+          yarn-cache-
+    - shell: bash
+      run: |
+        go mod download;
+        pushd src/ui > /dev/null;
+        yarn install;
+        popd > /dev/null;

--- a/.github/workflows/pr_genfiles.yml
+++ b/.github/workflows/pr_genfiles.yml
@@ -24,21 +24,20 @@ jobs:
       options: --cpus 7
     steps:
     - uses: actions/checkout@v3
-    - name: Go cache
+    - name: go cache
       uses: actions/cache@v3
       with:
         path: /px/pkg/mod
-        key: build-cache-${{hashFiles('go.sum')}}
-    - name: Yarn cache
+        key: go-cache-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-cache-
+    - name: yarn cache
       uses: actions/cache@v3
       with:
-        path: ./src/ui/.yarn
-        key: build-cache-${{hashFiles('src/ui/yarn.lock')}}
-    - name: Bazel cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/bazel
-        key: genfile-checker-${{hashFiles('WORKSPACE')}}
+        path: ./src/ui/.yarn/cache
+        key: yarn-cache-${{ hashFiles('src/ui/yarn.lock', 'src/ui/.yarnrc.yml') }}
+        restore-keys: |
+          yarn-cache-
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - uses: dorny/paths-filter@v2.11.1

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -26,11 +26,13 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 100
-    - name: Yarn cache
+    - name: yarn cache
       uses: actions/cache@v3
       with:
-        path: ./src/ui/.yarn
-        key: build-cache-${{hashFiles('src/ui/yarn.lock')}}
+        path: ./src/ui/.yarn/cache
+        key: yarn-cache-${{ hashFiles('src/ui/yarn.lock', 'src/ui/.yarnrc.yml') }}
+        restore-keys: |
+          yarn-cache-
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - name: Fetch main


### PR DESCRIPTION
Summary: After reading the [docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), I realized that github caches are local to PRs/branches.
This sets up a workflow on main pushes solely to populate the cache since other runs can restore from a cache on the main branch.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Test this to see if cache hits on PRs go up.
