### PR TITLE
Set build status on Github after Jenkins runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,6 +279,9 @@ def postBuildActions = {
   if (!isOSSRun) {
     sendSlackNotification()
   }
+  if (isOSSMainRun) {
+    step([$class: "GitHubCommitStatusSetter",]);
+  }
 }
 
 def initializeRepoState() {


### PR DESCRIPTION
Summary: This should set the actions style checkmark
status on github after jenkins runs on main.
Should help track broken main builds.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check status on main after this lands.
