### PR TITLE
Add securityContext to nats and postgres

### DIFF
--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -225,3 +225,18 @@ spec:
               # the NATS Server to gracefully terminate the client connections.
               #
               command: ["/bin/sh", "-c", "/nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 10100
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10100
+        fsGroup: 10100
+        seccompProfile:
+          type: RuntimeDefault

--- a/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
@@ -7,11 +7,16 @@ spec:
   selector:
     matchLabels:
       name: postgres
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         name: postgres
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgres
         image: postgres:14-alpine
@@ -34,6 +39,46 @@ spec:
         - mountPath: /var/lib/postgresql/data
           subPath: data
           name: postgres-pv-claim
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 10100
+          seccompProfile:
+            type: RuntimeDefault
+      initContainers:
+      - name: init-chown-data
+        image: busybox
+        command: ["chown", "-R", "10100:10100", "/var/lib/postgresql/data"]
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-pv-claim
+          subPath: data
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - CHOWN
+            - DAC_OVERRIDE
+            - FSETID
+            - FOWNER
+            - MKNOD
+            - SETFCAP
+            - SETGID
+            - SETUID
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: postgres-pv-claim
         persistentVolumeClaim:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/pixie-io/pixie/blob/main/CONTRIBUTING.md and https://github.com/pixie-io/pixie/blob/main/DEVELOPMENT.md.

Also, please delete all the comment blocks to make it easier for the maintainers to compose the final error message from this doc.

All the fields need to be filled out inline. For example:
Summary: Here is a description of this change, and
it's allowed to span multiple lines.

Leave an empty line between each block.
-->
Summary: Introduced securityContext to nats and postgres workloads to limit access the containers has on the Kubernetes cluster. This will help to minimize some of the security risks these containers may impose on the cluster.
<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Relevant Issues: N/A
<!--
Please list all the relevant issues (#<issue number>): eg. #1, #2. If the PR fixes an issue use `Fixes #<issue number>`
-->

Type of change: /kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Each type must include the entire "/kind {type}" text and not just the label.

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

Test Plan:
<!--
For stylistic change that don't require tests or enhancements write: N/A.
-->
1. Checkout the current branch.
2. Deploy Self hosted Pixie.

