### PR TITLE
Initialize both x86 and aarch64 for LLVM

### DIFF
--- a/src/stirling/obj_tools/init.cc
+++ b/src/stirling/obj_tools/init.cc
@@ -26,12 +26,21 @@ namespace px {
 namespace stirling {
 
 namespace {
+#define InitTarget(TargetName)                  \
+  do {                                          \
+    LLVMInitialize##TargetName##Target();       \
+    LLVMInitialize##TargetName##TargetInfo();   \
+    LLVMInitialize##TargetName##TargetMC();     \
+    LLVMInitialize##TargetName##AsmPrinter();   \
+    LLVMInitialize##TargetName##AsmParser();    \
+    LLVMInitialize##TargetName##Disassembler(); \
+  } while (0)
+
 void InitLLVMImpl() {
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
-  llvm::InitializeNativeTargetAsmParser();
-  llvm::InitializeNativeTargetDisassembler();
+  InitTarget(X86);
+  InitTarget(AArch64);
 }
+#undef InitTarget
 }  // namespace
 
 void InitLLVMOnce() {


### PR DESCRIPTION
Summary: Adds initialization of LLVM targets for x86 and aarch64. Previously, we only initialized the native target (x86).

Relevant Issues: necessary for #147

Type of change: /kind cleanup

Test Plan: No change in existing functionality. Only adds support for ARM targets to LLVM disassembler.
Will run #ci:bpf-build to make sure no changes in functionality of existing disassembler.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>
