### PR TITLE
Fix artifact_db_updater image

### DIFF
--- a/src/utils/artifacts/artifact_db_updater/BUILD.bazel
+++ b/src/utils/artifacts/artifact_db_updater/BUILD.bazel
@@ -18,7 +18,7 @@ load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
 go_library(
     name = "artifact_db_updater_lib",
@@ -48,13 +48,6 @@ pl_go_binary(
 )
 
 container_layer(
-    name = "artifact_db_updater_go_layer",
-    directory = "/artifact_db_updater",
-    files = [":artifact_db_updater"],
-    visibility = ["//src:__subpackages__"],
-)
-
-container_layer(
     name = "changelogs",
     directory = "/changelogs",
     files = [
@@ -63,12 +56,16 @@ container_layer(
 )
 
 container_image(
+    name = "changelogs_image",
+    # We need a debug image because the artifact_db_updater_job calls busybox to set a TRAP.
+    base = "//:pl_cc_base_debug_image",
+    layers = [":changelogs"],
+)
+
+pl_go_image(
     name = "artifact_db_updater_image",
-    base = "@base_image_debug//image",
-    layers = [
-        ":artifact_db_updater_go_layer",
-        ":changelogs",
-    ],
+    base = ":changelogs_image",
+    binary = ":artifact_db_updater",
 )
 
 k8s_object(

--- a/src/utils/artifacts/artifact_db_updater/artifact_db_updater_job.yaml
+++ b/src/utils/artifacts/artifact_db_updater/artifact_db_updater_job.yaml
@@ -20,7 +20,7 @@ spec:
         args:
         - |
             trap "touch /tmp/pod/terminated" EXIT
-            /artifact_db_updater/artifact_db_updater
+            src/utils/artifacts/artifact_db_updater/artifact_db_updater_/artifact_db_updater
         volumeMounts:
         - mountPath: /tmp/pod
           name: tmp-pod

--- a/src/utils/artifacts/artifact_db_updater/main.go
+++ b/src/utils/artifacts/artifact_db_updater/main.go
@@ -40,7 +40,7 @@ import (
 )
 
 func init() {
-	pflag.String("versions_file", "VERSIONS.json", "Path to the versions file")
+	pflag.String("versions_file", "/changelogs/VERSIONS.json", "Path to the versions file")
 	pflag.Bool("check_only", false, "Only run check")
 }
 


### PR DESCRIPTION
Summary: Updates the artifact_db_updater_image to use a `pl_go_image` instead of a `container_image`.
This ensures that our version of glibc is pulled in, instead of the default in the `base_image_debug` distroless image.
Ideally, we wouldn't need a debug image here, but I don't want to mess with the artifact_db_updater_job too much.

Type of change: /kind cleanup

Test Plan: @aimichelle is testing it on staging.

