### PR TITLE
Don't fail the main build if coverage drops

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,13 @@
 ---
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+
 ignore:
 - "src/ui/.yarn"
 - "src/ui/src/testing"


### PR DESCRIPTION
Summary: Small changes in the coverage are failing the main build. Make coverage infromation "informational"
until we add PR coverage.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: `cat codecov.yml |  curl --data-binary @- https://codecov.io/validate`

