### PR TITLE
Create hostname, init and passwd files for qemu test runner

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/hostname
+++ b/bazel/test_runners/qemu_with_kernel/hostname
@@ -1,0 +1,1 @@
+q-runner

--- a/bazel/test_runners/qemu_with_kernel/init
+++ b/bazel/test_runners/qemu_with_kernel/init
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# We need proc mounted, otherwise the future mounts commands will fail.
+mount -t proc none /proc
+
+# Remount the root filesystem, since it starts out read-only.
+mount -o rw,remount /
+
+mount -t sysfs none /sys
+mount -t debugfs none /sys/kernel/debug
+mount -t cgroup2 none /sys/fs/cgroup
+mount -t bpf none /sys/fs/bpf
+mount -t tracefs none /sys/kernel/tracing
+#mount -t devtmpfs udev /dev
+mount -t tmpfs tmpfs /run
+
+mkdir -p /dev/shm
+mount -t tmpfs tmpfs /dev/shm
+
+# Mount the test filesystem.
+mkdir -p /test_fs
+mount -t 9p -o trans=virtio test_fs /test_fs || true
+
+ip link set dev lo up
+
+if [[ -f "/etc/hostname" ]]; then
+    hostname -F /etc/hostname
+fi
+
+
+cat <<EOF
+
+Boot took $(cut -d' ' -f1 /proc/uptime) seconds
+
+Welcome to PX BPF Runner
+
+EOF
+
+test_runner="/test_fs/test_runner"
+if [[ -x "${test_runner}" ]]; then
+  exec "${test_runner}"
+else
+  exec /bin/bash
+fi

--- a/bazel/test_runners/qemu_with_kernel/passwd
+++ b/bazel/test_runners/qemu_with_kernel/passwd
@@ -1,0 +1,1 @@
+root:x:0:0:root:/root:/bin/bash


### PR DESCRIPTION
Summary: This some of the basic files needed to be added to the qemu disk image.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: Check and make this works:

```bash

./create_sysroot_disk.sh -s sysroot-amd64-test.tar.gz -o test.qcow2 \
  -e init:/bin/init,passwd:/etc/passwd,hostname:/etc/hostname -b busybox

qemu-img create -f qcow2 -F qcow2 -b test.qcow2 overlay.qcow2

qemu-system-x86_64 \
  -append "console=ttyS0 root=/dev/sda" \
  -device isa-debug-exit,iobase=0xf4,iosize=0x4 \
  -hda overlay.qcow2 \
  -kernel bzImage \
  -cpu host \
  -m 4096 \
  -cpu max \
  -nographic

```
