### PR TITLE
Bump versions for public cloud

### DIFF
--- a/k8s/cloud/public/artifact_tracker_versions.yaml
+++ b/k8s/cloud/public/artifact_tracker_versions.yaml
@@ -10,8 +10,8 @@ spec:
       - name: artifact-tracker-server
         env:
         - name: PL_VIZIER_VERSION
-          value: "0.12.9"
+          value: "0.12.12"
         - name: PL_CLI_VERSION
           value: "0.7.17"
         - name: PL_OPERATOR_VERSION
-          value: "0.0.34"
+          value: "0.0.37"


### PR DESCRIPTION
Summary: Public cloud users are missing CQL funcs since they
are running old viziers but new script bundles. This
should fix the same.

Relevant Issues: Addresses one of the issues found in #764

Type of change: /kind bug

Test Plan: Once a new cloud release is tagged, deploying a
public cloud shouldn't cause errors about missing `cql_opcode_name`
