### PR TITLE
Fix client-side tracing in standalone PEM

### DIFF
--- a/src/shared/metadata/standalone_state_manager.cc
+++ b/src/shared/metadata/standalone_state_manager.cc
@@ -106,10 +106,8 @@ Status StandaloneAgentMetadataStateManager::PerformMetadataStateUpdate() {
   // disabled for any addresses that fall in the CIDR.
   px::CIDRBlock pod_cidr;
   std::string pod_cidr_str("0.0.0.1/32");
-  Status s = px::ParseCIDRBlock(pod_cidr_str, &pod_cidr);
-  if (s.ok()) {
-    shadow_state->k8s_metadata_state()->set_pod_cidrs({pod_cidr});
-  }
+  PX_RETURN_IF_ERROR(px::ParseCIDRBlock(pod_cidr_str, &pod_cidr));
+  shadow_state->k8s_metadata_state()->set_pod_cidrs({pod_cidr});
 
   {
     absl::base_internal::SpinLockHolder lock(&agent_metadata_state_lock_);

--- a/src/shared/metadata/standalone_state_manager.cc
+++ b/src/shared/metadata/standalone_state_manager.cc
@@ -102,6 +102,15 @@ Status StandaloneAgentMetadataStateManager::PerformMetadataStateUpdate() {
   shadow_state->set_epoch_id(epoch_id);
   shadow_state->set_last_update_ts_ns(ts);
 
+  // Set Pod CIDR to be as exclusive as possible, because client-side tracing will be
+  // disabled for any addresses that fall in the CIDR.
+  px::CIDRBlock pod_cidr;
+  std::string pod_cidr_str("0.0.0.1/32");
+  Status s = px::ParseCIDRBlock(pod_cidr_str, &pod_cidr);
+  if (s.ok()) {
+    shadow_state->k8s_metadata_state()->set_pod_cidrs({pod_cidr});
+  }
+
   {
     absl::base_internal::SpinLockHolder lock(&agent_metadata_state_lock_);
     agent_metadata_state_ = std::move(shadow_state);


### PR DESCRIPTION
Summary: Client-side tracing is currently broken in the standalone PEM. This is because we automatically disable client-side tracing for any addresses that fall within the cluster CIDR, or if no cluster CIDR is specified.
This updates the pod CIDR (which gets propagated to the context's cluster CIDR) so that client-side tracing works. Used the cluster CIDR that was specified in `StandaloneContext`.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Run standalone PEM and run go binary which makes outgoing HTTP calls with/without TLS.

