### PR TITLE
Add sysroot profiles to vizier skaffold

### DIFF
--- a/skaffold/skaffold_vizier.yaml
+++ b/skaffold/skaffold_vizier.yaml
@@ -108,3 +108,15 @@ profiles:
     path: /manifests/kustomize/paths
     value:
     - k8s/vizier/etcd_metadata
+- name: aarch64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=aarch64_sysroot
+- name: x86_64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=x86_64_sysroot


### PR DESCRIPTION
Summary: Add profiles to skaffold deploy sysroot images.

Relevant Issues: #147

Type of change: /kind cleanup

Test Plan: Tested that skaffold works with both profiles.
