### PR TITLE
Add /tmp to runtime sysroot

### DIFF
--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -49,7 +49,7 @@ GRAALVM_ARCHIVE_FNAME := graalvm-native-image-22.3.0.tar.gz
 GRAALVM_ARCHIVE_GS_PATH := gs://pixie-dev-public/graalvm-native-image-22.3.0-$(GRAALVM_IMAGE_VERSION).tar.gz
 
 ## Sysroot parameters
-SYSROOT_REV := pl2
+SYSROOT_REV := pl3
 SYSROOT_BUILD_DIR := $(BUILD_DIR)/sysroots
 SYSROOT_ARCHITECTURES := amd64 arm64
 SYSROOT_VARIANTS := runtime build test

--- a/tools/docker/sysroot_creator/build_tar_for_packages.sh
+++ b/tools/docker/sysroot_creator/build_tar_for_packages.sh
@@ -56,6 +56,13 @@ while read -r path; do
   fi
 done < <(yq eval -N '.path_excludes[]' "${@:4}")
 
+declare -A extra_dirs
+while read -r dir; do
+  if [ -n "${dir}" ]; then
+    extra_dirs["${dir}"]=true
+  fi
+done < <(yq eval -N '.extra_dirs[]' "${@:4}")
+
 relativize_symlinks() {
   dir="$1"
   libdirs=("lib" "lib64" "usr/lib")
@@ -81,6 +88,11 @@ inside_tmpdir() {
   while read -r deb; do
     dpkg-deb -x "${deb}" "${root_dir}" &>/dev/null
   done < <(ls -- *.deb)
+
+  for dir in "${!extra_dirs[@]}"
+  do
+    mkdir -p "${root_dir}/${dir}"
+  done
 
   for path in "${!paths_to_exclude[@]}"
   do

--- a/tools/docker/sysroot_creator/package_groups/runtime.yaml
+++ b/tools/docker/sysroot_creator/package_groups/runtime.yaml
@@ -8,3 +8,5 @@ include:
 - libunwind8
 path_excludes:
 - usr/share/
+extra_dirs:
+- tmp/


### PR DESCRIPTION
Summary: Adds support in sysroot creator for adding arbitrary empty directories in the sysroot.
Then uses this support to add `/tmp` to the runtime sysroot.
Without `/tmp` `std::tmpfile` fails on some systems, which was leading to segfaults when I deployed on nodes without installed kernel headers.

Type of change: /kind cleanup

Test Plan: Tested that the created sysroots have an empty `/tmp`. Also tested that if you put `/tmp` in the image `std::tmpfile` no longer fails.
