### PR TITLE
Support pushing multi-arch images in vizier_build_release.sh

### DIFF
--- a/bazel/images.bzl
+++ b/bazel/images.bzl
@@ -56,3 +56,25 @@ image_prefix_provider = rule(
         "image_prefix": attr.string(mandatory = True),
     },
 )
+
+def _list_image_bundle(ctx):
+    exe = ctx.actions.declare_file(ctx.attr.name)
+    exe_content = ""
+    for image_tag in ctx.attr.images:
+        image_tag = image_tag.replace("$(IMAGE_PREFIX)", ctx.var["IMAGE_PREFIX"])
+        image_tag = image_tag.replace("$(BUNDLE_VERSION)", ctx.var["BUNDLE_VERSION"])
+        exe_content += "echo '{}'\n".format(image_tag)
+    ctx.actions.write(exe, exe_content)
+
+    return DefaultInfo(
+        files = depset([exe]),
+        executable = exe,
+    )
+
+list_image_bundle = rule(
+    implementation = _list_image_bundle,
+    executable = True,
+    attrs = dict(
+        images = attr.string_dict(),
+    ),
+)

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -41,8 +41,36 @@ fi
 output_path="gs://${bucket}/vizier/${release_tag}"
 latest_output_path="gs://${bucket}/vizier/latest"
 
-bazel run --stamp -c opt --//k8s:image_version="${release_tag}" \
-    --stamp "${build_type}" //k8s/vizier:vizier_images_push "${extra_bazel_args[@]}"
+push_images_for_arch() {
+  arch="$1"
+  bazel run --stamp -c opt --//k8s:image_version="${release_tag}-${arch}" \
+      --config="${arch}_sysroot" \
+      --stamp "${build_type}" //k8s/vizier:vizier_images_push "${extra_bazel_args[@]}" > /dev/null
+}
+
+push_images_for_arch "x86_64"
+push_images_for_arch "aarch64"
+
+push_multiarch_image() {
+  multiarch_image="$1"
+  x86_image="${multiarch_image}-x86_64"
+  aarch64_image="${multiarch_image}-aarch64"
+  echo "Building ${multiarch_image} manifest"
+  # If the multiarch manifest list already exists locally, remove it before building a new one.
+  # otherwise, the docker manifest create step will fail because it can't amend manifests to an existing image.
+  # We could use the --amend flag to `manifest create` but it doesn't seem to overwrite existing images with the same tag,
+  # instead it seems to just ignore images that already exist in the local manifest.
+  docker manifest rm "${multiarch_image}" || true
+  docker manifest create "${multiarch_image}" "${x86_image}" "${aarch64_image}"
+  docker manifest push "${multiarch_image}"
+}
+
+while read -r image;
+do
+  push_multiarch_image "${image}"
+done < <(bazel run --stamp -c opt --//k8s:image_version="${release_tag}" \
+         --stamp "${build_type}" //k8s/vizier:list_image_bundle "${extra_bazel_args[@]}")
+
 bazel build --stamp -c opt --//k8s:image_version="${release_tag}" \
     --stamp "${build_type}" //k8s/vizier:vizier_yamls "${extra_bazel_args[@]}"
 

--- a/k8s/vizier/BUILD.bazel
+++ b/k8s/vizier/BUILD.bazel
@@ -17,7 +17,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//bazel:images.bzl", "DEV_PREFIX", "image_replacements")
+load("//bazel:images.bzl", "DEV_PREFIX", "image_replacements", "list_image_bundle")
 load("//bazel:kustomize.bzl", "kustomize_build")
 
 package(default_visibility = ["//visibility:public"])
@@ -140,6 +140,15 @@ kustomize_build(
 
 container_bundle(
     name = "image_bundle",
+    images = VIZIER_IMAGE_TO_LABEL,
+    toolchains = [
+        "//k8s:image_prefix",
+        "//k8s:bundle_version",
+    ],
+)
+
+list_image_bundle(
+    name = "list_image_bundle",
     images = VIZIER_IMAGE_TO_LABEL,
     toolchains = [
         "//k8s:image_prefix",


### PR DESCRIPTION
Summary: Adds pushing multi-arch images in the vizier release process.
Builds each architecture's images separately and pushes those individually. Then pushes a manifest list pointing to each architecture for each vizier image.

Relevant Issues: #147.

Type of change: /kind cleanup

Test Plan: Created an RC with these changes, saw that it built multi-arch images.
Ran `px deploy --vizier_version=<RC>` and it successfully deployed Pixie.

Changelog Message:
```release-note
Our releases now build multi-arch docker images that support x86_64 and aarch64.
ARM support is now in an early alpha stage. We'd love for the community to help test out ARM support.
```
