### PR TITLE
Remove more uses of go 1.16 binaries

### DIFF
--- a/src/stirling/obj_tools/BUILD.bazel
+++ b/src/stirling/obj_tools/BUILD.bazel
@@ -74,7 +74,7 @@ pl_cc_test(
     data = [
         "//src/stirling/obj_tools/testdata/cc:test_exe_fixture",
         "//src/stirling/obj_tools/testdata/go:test_binaries",
-        "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_16_grpc_tls_server_binary",
+        "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_19_grpc_tls_server_binary",
     ],
     deps = [
         ":cc_library",
@@ -156,8 +156,9 @@ pl_cc_binary(
 
 pl_cc_binary(
     name = "dwarf_reader_benchmark",
+    testonly = 1,
     srcs = ["dwarf_reader_benchmark.cc"],
-    data = ["//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_16_grpc_tls_server_binary"],
+    data = ["//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_19_grpc_tls_server_binary"],
     deps = [
         ":cc_library",
         "//src/common/testing:cc_library",

--- a/src/stirling/obj_tools/dwarf_reader_benchmark.cc
+++ b/src/stirling/obj_tools/dwarf_reader_benchmark.cc
@@ -26,8 +26,8 @@ using px::stirling::obj_tools::DwarfReader;
 using px::testing::BazelRunfilePath;
 
 constexpr std::string_view kBinary =
-    "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_16_grpc_tls_server_binary_/"
-    "golang_1_16_grpc_tls_server_binary";
+    "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_19_grpc_tls_server_binary_/"
+    "golang_1_19_grpc_tls_server_binary";
 
 struct SymAddrs {
   // Members of net/http.http2serverConn.

--- a/src/stirling/obj_tools/dwarf_reader_test.cc
+++ b/src/stirling/obj_tools/dwarf_reader_test.cc
@@ -33,7 +33,7 @@ constexpr std::string_view kTestGo1_18Binary =
 constexpr std::string_view kTestGo1_19Binary =
     "src/stirling/obj_tools/testdata/go/test_go_1_19_binary";
 constexpr std::string_view kGoGRPCServer =
-    "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_16_grpc_tls_server_binary";
+    "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_19_grpc_tls_server_binary";
 constexpr std::string_view kCppBinary = "src/stirling/obj_tools/testdata/cc/test_exe_/test_exe";
 constexpr std::string_view kGoBinaryUnconventional =
     "src/stirling/obj_tools/testdata/go/sockshop_payments_service";
@@ -511,18 +511,24 @@ TEST_P(GolangDwarfReaderTest, FunctionArgInfo) {
         dwarf_reader->GetFunctionArgInfo("net/http.(*http2Framer).WriteDataPadded"),
         UnorderedElementsAre(
             Pair("f", ArgInfo{TypeInfo{VarType::kPointer, "*net/http.http2Framer"},
-                              {LocationType::kStack, 0}}),
-            Pair("streamID",
-                 ArgInfo{TypeInfo{VarType::kBaseType, "uint32"}, {LocationType::kStack, 8}}),
-            Pair("endStream",
-                 ArgInfo{TypeInfo{VarType::kBaseType, "bool"}, {LocationType::kStack, 12}}),
-            Pair("data",
-                 ArgInfo{TypeInfo{VarType::kStruct, "[]uint8"}, {LocationType::kStack, 16}}),
-            Pair("pad", ArgInfo{TypeInfo{VarType::kStruct, "[]uint8"}, {LocationType::kStack, 40}}),
+                              {LocationType::kRegister, 0, {RegisterName::kRAX}}}),
+            Pair("streamID", ArgInfo{TypeInfo{VarType::kBaseType, "uint32"},
+                                     {LocationType::kRegister, 8, {RegisterName::kRBX}}}),
+            Pair("endStream", ArgInfo{TypeInfo{VarType::kBaseType, "bool"},
+                                      {LocationType::kRegister, 16, {RegisterName::kRCX}}}),
+            Pair("data", ArgInfo{TypeInfo{VarType::kStruct, "[]uint8"},
+                                 {LocationType::kRegister,
+                                  24,
+                                  {RegisterName::kRDI, RegisterName::kRSI, RegisterName::kR8}}}),
+            Pair("pad", ArgInfo{TypeInfo{VarType::kStruct, "[]uint8"},
+                                {LocationType::kRegister,
+                                 48,
+                                 {RegisterName::kR9, RegisterName::kR10, RegisterName::kR11}}}),
             // The returned "error" variable has a different decl_type than the type_name.
-            Pair("~r4", ArgInfo{TypeInfo{VarType::kStruct, "runtime.iface", "error"},
-                                {LocationType::kStack, 64},
-                                true})));
+            Pair("~r0",
+                 ArgInfo{TypeInfo{VarType::kStruct, "runtime.iface", "error"},
+                         {LocationType::kRegister, 0, {RegisterName::kRAX, RegisterName::kRBX}},
+                         true})));
   }
 }
 

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -69,7 +69,7 @@ pl_cc_test(
     name = "uprobe_symaddrs_test",
     srcs = ["uprobe_symaddrs_test.cc"],
     data = [
-        "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_16_grpc_tls_server_binary",
+        "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_19_grpc_tls_server_binary",
         "//src/stirling/testing/demo_apps/node:node_debug",
     ],
     deps = [

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc
@@ -44,7 +44,7 @@ class UprobeSymaddrsTest : public ::testing::Test {
   }
 
   static inline constexpr std::string_view kGoGRPCServer =
-      "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_16_grpc_tls_server_binary";
+      "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_19_grpc_tls_server_binary";
 
   std::unique_ptr<DwarfReader> dwarf_reader_;
   std::unique_ptr<ElfReader> elf_reader_;
@@ -78,9 +78,9 @@ TEST_F(UprobeSymaddrsTest, GoHTTP2SymAddrs) {
   // The values may change when golang version is updated.
   // If the test breaks because of that, just update the numbers here.
   EXPECT_EQ(symaddrs.http2Framer_WriteDataPadded_f_loc,
-            (location_t{.type = kLocationTypeStack, .offset = 8}));
+            (location_t{.type = kLocationTypeRegisters, .offset = 0}));
   EXPECT_EQ(symaddrs.writeHeader_hf_ptr_loc,
-            (location_t{.type = kLocationTypeStack, .offset = 24}));
+            (location_t{.type = kLocationTypeRegisters, .offset = 24}));
 }
 
 TEST_F(UprobeSymaddrsTest, GoTLSSymAddrs) {
@@ -90,10 +90,10 @@ TEST_F(UprobeSymaddrsTest, GoTLSSymAddrs) {
   // Check some member offsets.
   // The values may change when golang version is updated.
   // If the test breaks because of that, just update the numbers here.
-  EXPECT_EQ(symaddrs.Write_c_loc, (location_t{.type = kLocationTypeStack, .offset = 8}));
-  EXPECT_EQ(symaddrs.Write_b_loc, (location_t{.type = kLocationTypeStack, .offset = 16}));
-  EXPECT_EQ(symaddrs.Read_c_loc, (location_t{.type = kLocationTypeStack, .offset = 8}));
-  EXPECT_EQ(symaddrs.Read_b_loc, (location_t{.type = kLocationTypeStack, .offset = 16}));
+  EXPECT_EQ(symaddrs.Write_c_loc, (location_t{.type = kLocationTypeRegisters, .offset = 0}));
+  EXPECT_EQ(symaddrs.Write_b_loc, (location_t{.type = kLocationTypeRegisters, .offset = 8}));
+  EXPECT_EQ(symaddrs.Read_c_loc, (location_t{.type = kLocationTypeRegisters, .offset = 0}));
+  EXPECT_EQ(symaddrs.Read_b_loc, (location_t{.type = kLocationTypeRegisters, .offset = 8}));
 }
 
 // Note that DwarfReader cannot be created if there is no dwarf info.

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/client/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/client/BUILD.bazel
@@ -46,13 +46,6 @@ pl_go_binary(
 )
 
 go_cross_binary(
-    name = "golang_1_16_grpc_tls_client_binary",
-    sdk_version = "1.16",
-    tags = ["manual"],
-    target = ":client",
-)
-
-go_cross_binary(
     name = "golang_1_17_grpc_tls_client_binary",
     sdk_version = "1.17",
     tags = ["manual"],
@@ -71,22 +64,6 @@ go_cross_binary(
     sdk_version = "1.19",
     tags = ["manual"],
     target = ":client",
-)
-
-container_image(
-    name = "golang_1_16_grpc_tls_client",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_16_grpc_tls_client_binary",
-        "--client_tls_cert=/certs/client.crt",
-        "--client_tls_key=/certs/client.key",
-        "--tls_ca_cert=/certs/ca.crt",
-        "--count=1",
-    ],
-    files = [
-        ":golang_1_16_grpc_tls_client_binary",
-    ],
-    layers = [":certs_layer"],
 )
 
 container_image(

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/BUILD.bazel
@@ -47,13 +47,6 @@ pl_go_binary(
 )
 
 go_cross_binary(
-    name = "golang_1_16_grpc_tls_server_binary",
-    sdk_version = "1.16",
-    tags = ["manual"],
-    target = ":server",
-)
-
-go_cross_binary(
     name = "golang_1_17_grpc_tls_server_binary",
     sdk_version = "1.17",
     tags = ["manual"],
@@ -72,21 +65,6 @@ go_cross_binary(
     sdk_version = "1.19",
     tags = ["manual"],
     target = ":server",
-)
-
-container_image(
-    name = "golang_1_16_grpc_tls_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_16_grpc_tls_server_binary",
-        "--server_tls_cert=/certs/server.crt",
-        "--server_tls_key=/certs/server.key",
-        "--tls_ca_cert=/certs/ca.crt",
-    ],
-    files = [
-        ":golang_1_16_grpc_tls_server_binary",
-    ],
-    layers = [":certs_layer"],
 )
 
 container_image(


### PR DESCRIPTION
Summary: Building with go 1.16 blocks us from upgrading some go libs
that depends on features introduced in go 1.17
go 1.16 has been EOL since 15 Mar 2022 and we don't see too many
folks running it in the wild so it should be fine to remove these
tests.

Relevant Issues: #846

Type of change: /kind cleanup

Test Plan: All test pass locally. Check Jenkins for BPF tests.
