### PR TITLE
draft - Profiler cleanup: remove dependency on full stirling lib.

### DIFF
--- a/src/stirling/binaries/BUILD.bazel
+++ b/src/stirling/binaries/BUILD.bazel
@@ -96,7 +96,7 @@ pl_cc_binary(
     name = "stirling_profiler",
     srcs = ["stirling_profiler.cc"],
     deps = [
-        "//src/stirling:cc_library",
+        "//src/stirling/source_connectors/perf_profiler:cc_library",
     ],
 )
 

--- a/src/stirling/binaries/stirling_profiler.cc
+++ b/src/stirling/binaries/stirling_profiler.cc
@@ -114,13 +114,6 @@ class Profiler {
       }
     }
 
-    // This may be paranoid, but it is possible for StopTransferDataThread() to get
-    // called from the signal handler too. In any case, by the time we are here and from
-    // any entry point, transfer_data_thread_ should have been joined already.
-    if (transfer_data_thread_.joinable()) {
-      return error::Internal("transfer_data_thread_ failed to join.");
-    }
-
     return Status::OK();
   }
 


### PR DESCRIPTION
Summary: We remove the dependency on the full Stirling cc-lib for the stand alone perf profiler binary. This requires some re-writing of the program logic. We follow the pattern established in the perf profiler test case (e.g. use of the transfer data thread).

In the next diff, we will introduce a library function to create pprof proto output and replace the text printout with a pprof proto file output.

Type of change: /kind feature

Test Plan: Tested this locally both all processes and for a specific pid.
