### PR TITLE
Add cloud release build to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,14 +62,14 @@ isNightlyTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regressio
 isNightlyBPFTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regression-bpf')
 
 isOSSMainRun = (env.JOB_NAME == 'pixie-oss/build-and-test-all')
-isOSSCloudBuildRun = env.JOB_NAME.startsWith('pixie-release/oss-cloud/')
+isOSSCloudBuildRun = env.JOB_NAME.startsWith('pixie-release/cloud/')
 isOSSCodeReviewRun = env.JOB_NAME == 'pixie-oss/build-and-test-pr'
 isOSSRun = isOSSMainRun || isOSSCloudBuildRun || isOSSCodeReviewRun || isReleaseRun
 
 isCLIBuildRun =  env.JOB_NAME.startsWith('pixie-release/cli/')
 isOperatorBuildRun = env.JOB_NAME.startsWith('pixie-release/operator/')
 isVizierBuildRun = env.JOB_NAME.startsWith('pixie-release/vizier/')
-isCloudProdBuildRun = env.JOB_NAME.startsWith('pixie-release/cloud/')
+isCloudProdBuildRun = env.JOB_NAME.startsWith('pixie-release/cloud-prod/')
 isCloudStagingBuildRun = env.JOB_NAME.startsWith('pixie-release/cloud-staging/')
 isStirlingPerfEval = (env.JOB_NAME == 'pixie-main/stirling-perf-eval')
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ isNightlyTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regressio
 isNightlyBPFTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regression-bpf')
 
 isOSSMainRun = (env.JOB_NAME == 'pixie-oss/build-and-test-all')
-isOSSCloudBuildRun = env.JOB_NAME.startsWith('release/oss-cloud/')
+isOSSCloudBuildRun = env.JOB_NAME.startsWith('pixie-release/oss-cloud/')
 isOSSCodeReviewRun = env.JOB_NAME == 'pixie-oss/build-and-test-pr'
 isOSSRun = isOSSMainRun || isOSSCloudBuildRun || isOSSCodeReviewRun || isReleaseRun
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ isNightlyTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regressio
 isNightlyBPFTestRegressionRun = (env.JOB_NAME == 'pixie-main/nightly-test-regression-bpf')
 
 isOSSMainRun = (env.JOB_NAME == 'pixie-oss/build-and-test-all')
-isOSSCloudBuildRun = env.JOB_NAME.startsWith('pixie-oss/cloud/')
+isOSSCloudBuildRun = env.JOB_NAME.startsWith('release/oss-cloud/')
 isOSSCodeReviewRun = env.JOB_NAME == 'pixie-oss/build-and-test-pr'
 isOSSRun = isOSSMainRun || isOSSCloudBuildRun || isOSSCodeReviewRun || isReleaseRun
 

--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -538,6 +538,38 @@ controller:
                   }
                 }
               }
+          - script: >
+              multibranchPipelineJob("pixie-release/oss-cloud") {
+                branchSources {
+                  branchSource {
+                    source {
+                      git {
+                        id('pixie-cloud')
+                        remote('https://github.com/pixie-io/pixie.git')
+                        credentialsId('buildbot-ssh')
+                        traits {
+                          gitTagDiscovery()
+                          headWildcardFilter {
+                            includes("release/cloud/staging/*")
+                            excludes('')
+                          }
+                        }
+                      }
+                    }
+                    buildStrategies {
+                      buildTags {
+                        atMostDays('1')
+                        atLeastDays('0')
+                      }
+                    }
+                  }
+                }
+                triggers {
+                  periodicFolderTrigger {
+                    interval('1m')
+                  }
+                }
+              }
         # yamllint enable rule:indentation
     # Allows adding to the top-level security JCasC section. For legacy,  default the chart includes
     # apiToken configurations

--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -539,7 +539,7 @@ controller:
                 }
               }
           - script: >
-              multibranchPipelineJob("pixie-release/oss-cloud") {
+              multibranchPipelineJob("pixie-release/cloud") {
                 branchSources {
                   branchSource {
                     source {
@@ -550,7 +550,7 @@ controller:
                         traits {
                           gitTagDiscovery()
                           headWildcardFilter {
-                            includes("release/cloud/staging/*")
+                            includes("release/cloud/prod/*")
                             excludes('')
                           }
                         }


### PR DESCRIPTION
Summary: We are in the process of adding our release builds to the new OSS Jenkins. This adds our cloud release build to the new Jenkins via jcasc. This also required some renaming in the Jenkinsfile to make sure our cloud builds don't conflict.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Create a tag in staging, push it, and ensure that the build runs properly. (This tag has now been deleted)

