### PR TITLE
Fix config=aarch64_sysroot build

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/exit_qemu_with_status/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/exit_qemu_with_status/BUILD.bazel
@@ -26,4 +26,5 @@ cc_binary(
         "-msan",
     ],
     linkstatic = True,
+    target_compatible_with = ["@platforms//cpu:x86_64"],
 )

--- a/src/stirling/BUILD.bazel
+++ b/src/stirling/BUILD.bazel
@@ -82,8 +82,10 @@ gen_timeconst(name = "stirling_linux_timeconst_files")
 # Used by stirling runtime to provide symbolization for Java application profiling.
 stirling_java_profiling_tools = [
     "//src/stirling/source_connectors/perf_profiler/java/px_jattach:px_jattach",
-    "//src/stirling/source_connectors/perf_profiler/java/agent:agent",
-]
+] + select({
+    "@platforms//cpu:x86_64": ["//src/stirling/source_connectors/perf_profiler/java/agent:agent"],
+    "//conditions:default": [],
+})
 
 # Use this binary to dynamically turn on/off Stirling runtime's debug logging.
 # See src/stirling/e2e_tests/stirling_signal_test.sh for its usage.

--- a/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
@@ -80,10 +80,7 @@ cc_static_musl_binary(
 
 filegroup(
     name = "agent",
-    srcs = select({
-        "@platforms//cpu:aarch64": [],
-        "//conditions:default": ["px-java-agent"],
-    }),
+    srcs = ["px-java-agent"],
     visibility = [
         # Add visibility at top-level so that we can include
         # the lib in the pem image.


### PR DESCRIPTION
Summary: To get aarch64 images to work I added a select on cpu:x86_64 for the java agent. I put this select in the wrong place, because it causes test builds to fail.
This PR moves the select to where its only used for the image and not for the tests.

Type of change: /kind cleanup

Test Plan: Ran `bazel test --config=aarch64_sysroot //...` and saw only 7 failed tests as expected.
