### PR TITLE
Convert go_cross rules to use list comprehension

### DIFF
--- a/bazel/pl_build_system.bzl
+++ b/bazel/pl_build_system.bzl
@@ -22,6 +22,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_library", 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:defs.bzl", "py_test")
 
+pl_supported_go_sdk_versions = ["1.16", "1.17", "1.18", "1.19", "1.20"]
+
 def pl_copts():
     posix_options = [
         # Warnings setup.

--- a/src/stirling/obj_tools/testdata/go/BUILD.bazel
+++ b/src/stirling/obj_tools/testdata/go/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -37,33 +37,15 @@ pl_go_binary(
     }),
 )
 
-go_cross_binary(
-    name = "test_go_1_16_binary",
-    sdk_version = "1.16",
-    tags = ["manual"],
-    target = ":test_go_binary",
-)
-
-go_cross_binary(
-    name = "test_go_1_17_binary",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":test_go_binary",
-)
-
-go_cross_binary(
-    name = "test_go_1_18_binary",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":test_go_binary",
-)
-
-go_cross_binary(
-    name = "test_go_1_19_binary",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":test_go_binary",
-)
+[
+    go_cross_binary(
+        name = "test_go_%s_binary" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":test_go_binary",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]
 
 filegroup(
     name = "test_binaries",

--- a/src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -37,30 +37,12 @@ pl_go_binary(
     embed = [":grpc_client_lib"],
 )
 
-go_cross_binary(
-    name = "golang_1_16_grpc_client",
-    sdk_version = "1.16",
-    tags = ["manual"],
-    target = ":client",
-)
-
-go_cross_binary(
-    name = "golang_1_17_grpc_client",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":client",
-)
-
-go_cross_binary(
-    name = "golang_1_18_grpc_client",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":client",
-)
-
-go_cross_binary(
-    name = "golang_1_19_grpc_client",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":client",
-)
+[
+    go_cross_binary(
+        name = "golang_%s_grpc_client" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":client",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]

--- a/src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -36,70 +36,25 @@ pl_go_binary(
     embed = [":grpc_server_lib"],
 )
 
-go_cross_binary(
-    name = "golang_1_16_grpc_server",
-    sdk_version = "1.16",
-    tags = ["manual"],
-    target = ":server",
-)
+[
+    go_cross_binary(
+        name = "golang_%s_grpc_server" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":server",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]
 
-go_cross_binary(
-    name = "golang_1_17_grpc_server",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":server",
-)
-
-go_cross_binary(
-    name = "golang_1_18_grpc_server",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":server",
-)
-
-go_cross_binary(
-    name = "golang_1_19_grpc_server",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":server",
-)
-
-filegroup(
-    name = "golang_1_16_grpc_server_with_certs",
-    srcs = [":golang_1_16_grpc_server"],
-    data = [
-        "https-server.crt",
-        "https-server.key",
-    ],
-    visibility = ["//src/stirling:__subpackages__"],
-)
-
-filegroup(
-    name = "golang_1_17_grpc_server_with_certs",
-    srcs = [":golang_1_17_grpc_server"],
-    data = [
-        "https-server.crt",
-        "https-server.key",
-    ],
-    visibility = ["//src/stirling:__subpackages__"],
-)
-
-filegroup(
-    name = "golang_1_18_grpc_server_with_certs",
-    srcs = [":golang_1_18_grpc_server"],
-    data = [
-        "https-server.crt",
-        "https-server.key",
-    ],
-    visibility = ["//src/stirling:__subpackages__"],
-)
-
-filegroup(
-    name = "golang_1_19_grpc_server_with_certs",
-    srcs = [":golang_1_19_grpc_server"],
-    data = [
-        "https-server.crt",
-        "https-server.key",
-    ],
-    visibility = ["//src/stirling:__subpackages__"],
-)
+[
+    filegroup(
+        name = "golang_%s_grpc_server_with_certs" % sdk_version.replace(".", "_"),
+        srcs = [":golang_%s_grpc_server" % sdk_version.replace(".", "_")],
+        data = [
+            "https-server.crt",
+            "https-server.key",
+        ],
+        visibility = ["//src/stirling:__subpackages__"],
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/client/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/client/BUILD.bazel
@@ -16,7 +16,7 @@
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -45,71 +45,31 @@ pl_go_binary(
     embed = [":client_lib"],
 )
 
-go_cross_binary(
-    name = "golang_1_17_grpc_tls_client_binary",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":client",
-)
+[
+    go_cross_binary(
+        name = "golang_%s_grpc_tls_client_binary" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":client",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]
 
-go_cross_binary(
-    name = "golang_1_18_grpc_tls_client_binary",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":client",
-)
-
-go_cross_binary(
-    name = "golang_1_19_grpc_tls_client_binary",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":client",
-)
-
-container_image(
-    name = "golang_1_17_grpc_tls_client",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_17_grpc_tls_client_binary",
-        "--client_tls_cert=/certs/client.crt",
-        "--client_tls_key=/certs/client.key",
-        "--tls_ca_cert=/certs/ca.crt",
-        "--count=1",
-    ],
-    files = [
-        ":golang_1_17_grpc_tls_client_binary",
-    ],
-    layers = [":certs_layer"],
-)
-
-container_image(
-    name = "golang_1_18_grpc_tls_client",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_18_grpc_tls_client_binary",
-        "--client_tls_cert=/certs/client.crt",
-        "--client_tls_key=/certs/client.key",
-        "--tls_ca_cert=/certs/ca.crt",
-        "--count=1",
-    ],
-    files = [
-        ":golang_1_18_grpc_tls_client_binary",
-    ],
-    layers = [":certs_layer"],
-)
-
-container_image(
-    name = "golang_1_19_grpc_tls_client",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_19_grpc_tls_client_binary",
-        "--client_tls_cert=/certs/client.crt",
-        "--client_tls_key=/certs/client.key",
-        "--tls_ca_cert=/certs/ca.crt",
-        "--count=1",
-    ],
-    files = [
-        ":golang_1_19_grpc_tls_client_binary",
-    ],
-    layers = [":certs_layer"],
-)
+[
+    container_image(
+        name = "golang_%s_grpc_tls_client" % sdk_version.replace(".", "_"),
+        base = "//:pl_go_base_image",
+        entrypoint = [
+            "./golang_%s_grpc_tls_client_binary" % sdk_version.replace(".", "_"),
+            "--client_tls_cert=/certs/client.crt",
+            "--client_tls_key=/certs/client.key",
+            "--tls_ca_cert=/certs/ca.crt",
+            "--count=1",
+        ],
+        files = [
+            ":golang_%s_grpc_tls_client_binary" % sdk_version.replace(".", "_"),
+        ],
+        layers = [":certs_layer"],
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/BUILD.bazel
@@ -16,7 +16,7 @@
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -46,68 +46,30 @@ pl_go_binary(
     embed = [":server_lib"],
 )
 
-go_cross_binary(
-    name = "golang_1_17_grpc_tls_server_binary",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":server",
-)
+[
+    go_cross_binary(
+        name = "golang_%s_grpc_tls_server_binary" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":server",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]
 
-go_cross_binary(
-    name = "golang_1_18_grpc_tls_server_binary",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":server",
-)
-
-go_cross_binary(
-    name = "golang_1_19_grpc_tls_server_binary",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":server",
-)
-
-container_image(
-    name = "golang_1_17_grpc_tls_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_17_grpc_tls_server_binary",
-        "--server_tls_cert=/certs/server.crt",
-        "--server_tls_key=/certs/server.key",
-        "--tls_ca_cert=/certs/ca.crt",
-    ],
-    files = [
-        ":golang_1_17_grpc_tls_server_binary",
-    ],
-    layers = [":certs_layer"],
-)
-
-container_image(
-    name = "golang_1_18_grpc_tls_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_18_grpc_tls_server_binary",
-        "--server_tls_cert=/certs/server.crt",
-        "--server_tls_key=/certs/server.key",
-        "--tls_ca_cert=/certs/ca.crt",
-    ],
-    files = [
-        ":golang_1_18_grpc_tls_server_binary",
-    ],
-    layers = [":certs_layer"],
-)
-
-container_image(
-    name = "golang_1_19_grpc_tls_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_19_grpc_tls_server_binary",
-        "--server_tls_cert=/certs/server.crt",
-        "--server_tls_key=/certs/server.key",
-        "--tls_ca_cert=/certs/ca.crt",
-    ],
-    files = [
-        ":golang_1_19_grpc_tls_server_binary",
-    ],
-    layers = [":certs_layer"],
-)
+[
+    container_image(
+        name = "golang_%s_grpc_tls_server" % sdk_version.replace(".", "_"),
+        base = "//:pl_go_base_image",
+        entrypoint = [
+            "./golang_%s_grpc_tls_server_binary" % sdk_version.replace(".", "_"),
+            "--server_tls_cert=/certs/server.crt",
+            "--server_tls_key=/certs/server.key",
+            "--tls_ca_cert=/certs/ca.crt",
+        ],
+        files = [
+            ":golang_%s_grpc_tls_server_binary" % sdk_version.replace(".", "_"),
+        ],
+        layers = [":certs_layer"],
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]

--- a/src/stirling/testing/demo_apps/go_https/client/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_https/client/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -35,38 +35,20 @@ pl_go_binary(
     embed = [":client_lib"],
 )
 
-go_cross_binary(
-    name = "golang_1_17_client_binary",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":client",
-)
+[
+    go_cross_binary(
+        name = "golang_%s_client_binary" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":client",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]
 
-go_cross_binary(
-    name = "golang_1_18_client_binary",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":client",
-)
-
-go_cross_binary(
-    name = "golang_1_19_client_binary",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":client",
-)
-
-pl_go_image(
-    name = "golang_1_17_https_client",
-    binary = ":golang_1_17_client_binary",
-)
-
-pl_go_image(
-    name = "golang_1_18_https_client",
-    binary = ":golang_1_18_client_binary",
-)
-
-pl_go_image(
-    name = "golang_1_19_https_client",
-    binary = ":golang_1_19_client_binary",
-)
+[
+    pl_go_image(
+        name = "golang_%s_https_client" % sdk_version.replace(".", "_"),
+        binary = ":golang_%s_client_binary" % sdk_version.replace(".", "_"),
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]

--- a/src/stirling/testing/demo_apps/go_https/server/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_https/server/BUILD.bazel
@@ -16,7 +16,7 @@
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_cross_binary", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_supported_go_sdk_versions")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -55,65 +55,29 @@ pl_go_binary(
     embed = [":server_lib"],
 )
 
-go_cross_binary(
-    name = "golang_1_17_server_binary",
-    sdk_version = "1.17",
-    tags = ["manual"],
-    target = ":server",
-)
+[
+    go_cross_binary(
+        name = "golang_%s_server_binary" % sdk_version.replace(".", "_"),
+        sdk_version = sdk_version,
+        tags = ["manual"],
+        target = ":server",
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]
 
-go_cross_binary(
-    name = "golang_1_18_server_binary",
-    sdk_version = "1.18",
-    tags = ["manual"],
-    target = ":server",
-)
-
-go_cross_binary(
-    name = "golang_1_19_server_binary",
-    sdk_version = "1.19",
-    tags = ["manual"],
-    target = ":server",
-)
-
-container_image(
-    name = "golang_1_17_https_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_17_server_binary",
-        "--cert=server.crt",
-        "--key=server.key",
-    ],
-    files = [
-        ":golang_1_17_server_binary",
-        ":server_certs",
-    ],
-)
-
-container_image(
-    name = "golang_1_18_https_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_18_server_binary",
-        "--cert=server.crt",
-        "--key=server.key",
-    ],
-    files = [
-        ":golang_1_18_server_binary",
-        ":server_certs",
-    ],
-)
-
-container_image(
-    name = "golang_1_19_https_server",
-    base = "//:pl_go_base_image",
-    entrypoint = [
-        "./golang_1_19_server_binary",
-        "--cert=server.crt",
-        "--key=server.key",
-    ],
-    files = [
-        ":golang_1_19_server_binary",
-        ":server_certs",
-    ],
-)
+[
+    container_image(
+        name = "golang_%s_https_server" % sdk_version.replace(".", "_"),
+        base = "//:pl_go_base_image",
+        entrypoint = [
+            "./golang_%s_server_binary" % sdk_version.replace(".", "_"),
+            "--cert=server.crt",
+            "--key=server.key",
+        ],
+        files = [
+            ":golang_%s_server_binary" % sdk_version.replace(".", "_"),
+            ":server_certs",
+        ],
+    )
+    for sdk_version in pl_supported_go_sdk_versions
+]


### PR DESCRIPTION
Summary: Maintaining all the various `go_cross_binary` rules and
their corresponding images is a lot of manual work.
Instead we can use list comprehension to generate the rules
for all the supported SDK versions and then use them for any
tests as needed. This should make it easier to add/remove
support for go sdks.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: All existing build and test rules work.
