### PR TITLE
Add k8s tolerations for aarch64 and x86

### DIFF
--- a/k8s/vizier/base/arch_tolerations/deployment.yaml
+++ b/k8s/vizier/base/arch_tolerations/deployment.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/base/arch_tolerations/job.yaml
+++ b/k8s/vizier/base/arch_tolerations/job.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/base/arch_tolerations/statefulset.yaml
+++ b/k8s/vizier/base/arch_tolerations/statefulset.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/base/kustomization.yaml
+++ b/k8s/vizier/base/kustomization.yaml
@@ -10,6 +10,15 @@ patches:
   target:
     kind: Deployment
     labelSelector: vizier-bootstrap!=true
+- path: arch_tolerations/deployment.yaml
+  target:
+    kind: Deployment
+- path: arch_tolerations/job.yaml
+  target:
+    kind: Job
+- path: arch_tolerations/statefulset.yaml
+  target:
+    kind: StatefulSet
 resources:
 - ../bootstrap
 - kelvin_deployment.yaml

--- a/k8s/vizier/pem/base/arch_tolerations/daemonset.yaml
+++ b/k8s/vizier/pem/base/arch_tolerations/daemonset.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/pem/base/kustomization.yaml
+++ b/k8s/vizier/pem/base/kustomization.yaml
@@ -7,3 +7,7 @@ kind: Kustomization
 namespace: pl
 resources:
 - pem_daemonset.yaml
+patches:
+- path: arch_tolerations/daemonset.yaml
+  target:
+    kind: DaemonSet

--- a/k8s/vizier/persistent_metadata/aarch64/daemonset.yaml
+++ b/k8s/vizier/persistent_metadata/aarch64/daemonset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/aarch64/deployment.yaml
+++ b/k8s/vizier/persistent_metadata/aarch64/deployment.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/aarch64/job.yaml
+++ b/k8s/vizier/persistent_metadata/aarch64/job.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/aarch64/kustomization.yaml
+++ b/k8s/vizier/persistent_metadata/aarch64/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../pem
+patches:
+- path: deployment.yaml
+  target:
+    kind: Deployment
+- path: job.yaml
+  target:
+    kind: Job
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet

--- a/k8s/vizier/persistent_metadata/aarch64/statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/aarch64/statefulset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/x86/daemonset.yaml
+++ b/k8s/vizier/persistent_metadata/x86/daemonset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/x86/deployment.yaml
+++ b/k8s/vizier/persistent_metadata/x86/deployment.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/x86/job.yaml
+++ b/k8s/vizier/persistent_metadata/x86/job.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/k8s/vizier/persistent_metadata/x86/kustomization.yaml
+++ b/k8s/vizier/persistent_metadata/x86/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../pem
+patches:
+- path: deployment.yaml
+  target:
+    kind: Deployment
+- path: job.yaml
+  target:
+    kind: Job
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet

--- a/k8s/vizier/persistent_metadata/x86/statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/x86/statefulset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/skaffold/skaffold_vizier.yaml
+++ b/skaffold/skaffold_vizier.yaml
@@ -46,7 +46,7 @@ build:
 manifests:
   kustomize:
     paths:
-    - k8s/vizier/persistent_metadata
+    - k8s/vizier/persistent_metadata/x86
 profiles:
 - name: minikube
   activation:
@@ -114,6 +114,10 @@ profiles:
     path: /build/artifacts/context=./bazel/args
     value:
     - --config=aarch64_sysroot
+  - op: replace
+    path: /manifests/kustomize/paths
+    value:
+    - k8s/vizier/persistent_metadata/aarch64
 - name: x86_64_sysroot
   patches:
   - op: add


### PR DESCRIPTION
Summary: Adds k8s tolerations for aarch64 and x86.
The base has patches for multiarch.
For skaffold deploys we use single arch versions of the patches.

Relevant Issues: #147

Type of change: /kind cleanup

Test Plan: Tested that I can build the yamls, and skaffold deploy. Will cut an RC to test that the yamls look good there.
