### PR TITLE
Remove duplicate flag in create_instance script

### DIFF
--- a/ci/bpf/00_create_instance.sh
+++ b/ci/bpf/00_create_instance.sh
@@ -58,7 +58,7 @@ gcloud beta compute instances create \
   --service-account="jenkins-worker@${GCP_PROJECT}.iam.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/cloud-platform \
   --network-interface=network-tier=PREMIUM,subnet=us-west1-0 \
-  --maintenance-policy=MIGRATE --provisioning-model=STANDARD --instance-termination-action=DELETE \
+  --maintenance-policy=MIGRATE --provisioning-model=STANDARD \
   --instance-termination-action=DELETE --max-run-duration=10800s \
   --service-account="jenkins-worker@${GCP_PROJECT}.iam.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/cloud-platform \


### PR DESCRIPTION
Summary: This flag was accidentally duplicated. Cleanup.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: The BPF test runners continue to work.