### PR TITLE
Fixup genfiles workflow

### DIFF
--- a/.github/workflows/pr_genfiles.yml
+++ b/.github/workflows/pr_genfiles.yml
@@ -72,6 +72,6 @@ jobs:
           echo "Please update generated files by running the appropriate script."
           echo "Changed files:"
           git diff --name-only
-          exit $retval
+          exit 1
         fi
       # yamllint enable rule:indentation


### PR DESCRIPTION
Summary: The script in the workflow had a stale retval reference.
Fix it and exit with 1 instead.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: The workflow should exit with a non-zero code when
genfiles need to be updated.