### PR TITLE
Upload testresults to stash even when some tests fail

### DIFF
--- a/ci/bpf/03_run_tests.sh
+++ b/ci/bpf/03_run_tests.sh
@@ -18,11 +18,11 @@
 
 printenv
 
+# 3 means that some tests failed.
 # 4 means that tests not present.
 # 38 means that bes update failed.
-# Both are not fatal.
 check_retval() {
-  if [[ $1 -eq 0 || $1 -eq 4 || $1 -eq 38 ]]; then
+  if [[ $1 -eq 0 || $1 -eq 3 || $1 -eq 4 || $1 -eq 38 ]]; then
     echo "Bazel returned ${1}, ignoring..."
   else
     echo "Bazel failed with ${1}"
@@ -37,11 +37,13 @@ IFS=' '
 # us to use an array access as args.
 read -ra BAZEL_ARGS <<< "${BAZEL_ARGS}"
 
-bazel build "${BAZEL_ARGS[@]}" --target_pattern_file "${BUILDABLE_FILE}"
-check_retval $?
+retval=0
+bazel build "${BAZEL_ARGS[@]}" --target_pattern_file "${BUILDABLE_FILE}" || retval=$?
+check_retval $retval
 
-bazel test "${BAZEL_ARGS[@]}" --target_pattern_file "${TEST_FILE}"
-check_retval $?
+retval=0
+bazel test "${BAZEL_ARGS[@]}" --target_pattern_file "${TEST_FILE}" || retval=$?
+check_retval $retval
 
 rm -rf bazel-testlogs-archive
 mkdir -p bazel-testlogs-archive
@@ -50,3 +52,10 @@ cp -a bazel-testlogs/ bazel-testlogs-archive || true
 STASH_FILE="${STASH_NAME}.tar.gz"
 mkdir -p .archive && tar --exclude=.archive  -czf ".archive/${STASH_FILE}" bazel-testlogs-archive/**
 gsutil -o GSUtil:parallel_composite_upload_threshold=150M cp ".archive/${STASH_FILE}" "gs://${GCS_STASH_BUCKET}/${BUILD_TAG}/${STASH_FILE}"
+
+# With failed tests, we want to upload the testlogs,
+# but then still fatal so that if there's issues parsing the testlog,
+# the build still fails.
+if [[ $retval -eq 3 ]]; then
+  exit 3
+fi


### PR DESCRIPTION
Summary: The Jenkins test reporter reports stats on test that
were run and failed. However we don't upload to test stashes
when the tests fail, which means we lose this data.
Instead capture retval 3 from bazel and ensure that stash
uploads happen when retval is 3. This will ensure that we
get aggredate test reports from jenkins.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Broke some tests to try this out.
