### PR TITLE
Fix failing Cypress tests

### DIFF
--- a/src/ui/cypress/integration/live/keyboard-shortcuts.spec.ts
+++ b/src/ui/cypress/integration/live/keyboard-shortcuts.spec.ts
@@ -61,10 +61,11 @@ describe('Live view keyboard shortcuts', () => {
     cy.get('body').type('{shift}?');
     // Note: the way :nth-child works is weird; n+2 means "everything after the first child"
     cy.contains(modalTitle).parent().find('> div:nth-child(n+2)').as('rows');
-    cy.get('@rows').should('have.length', 4);
+    cy.get('@rows').should('have.length', 5);
     cy.get('@rows').within(() => {
       cy.contains('Show/hide script editor').should('exist');
       cy.contains('Show/hide data drawer').should('exist');
+      cy.contains('Show/hide command palette').should('exist');
       cy.contains('Execute current Live View script').should('exist');
       cy.contains('Show all keyboard shortcuts').should('exist');
     });
@@ -90,6 +91,16 @@ describe('Live view keyboard shortcuts', () => {
     cy.get(selector).should('be.visible');
     cy.get('body').type(hotkey);
     cy.get(selector).should('not.be.visible');
+  });
+
+  it('Shows and hides the command palette', () => {
+    const hotkey = `${useCmdKey ? '{cmd}' : '{ctrl}'}k`;
+    const selector = 'input#command-palette-autocomplete';
+    cy.get(selector).should('not.exist');
+    cy.get('body').type(hotkey);
+    cy.get(selector).should('exist');
+    cy.get('body').type(hotkey);
+    cy.get(selector).should('not.exist');
   });
 
   it('Re-runs the current script', () => {

--- a/src/ui/cypress/integration/live/navbars.spec.ts
+++ b/src/ui/cypress/integration/live/navbars.spec.ts
@@ -45,13 +45,14 @@ describe('Live View navbars', () => {
         cy.contains('Cluster:').find('+span').should(($span) => expect($span.text()).not.to.be.empty);
         // Items that have tooltips: the share/edit/move/run buttons.
         // The sidebar expander also has an aria-label but isn't a Material tooltip.
-        cy.get('[aria-label]').should('have.length', 5);
+        // The trigger for the Command Palette sets aria-label in the same way.
+        cy.get('[aria-label]').should('have.length', 6);
         cy.get('.MuiAvatar-root').should('exist');
       });
     });
 
     it('Has tooltips', () => {
-      cy.get('@topbar').find('[aria-label]:not([aria-label~="menu"])').as('hoverables');
+      cy.get('@topbar').find('[aria-label]:not([aria-label~="menu"]):not([aria-label~="command"])').as('hoverables');
       cy.get('@hoverables').should('have.length', 4);
       cy.get('@topbar').find('[aria-label="Execute script"]').should('exist'); // Wait for script to finish running.
       cy.get('@hoverables').each((el) => {

--- a/src/ui/src/components/command-palette/command-palette-trigger.tsx
+++ b/src/ui/src/components/command-palette/command-palette-trigger.tsx
@@ -110,7 +110,7 @@ const TriggerWrapper = React.memo(() => {
       className={classes.root}
       type='button'
       onClick={onClick}
-      aria-label={`Open command palette (shortcut: ${[displaySequence].flat().join('+')}`}
+      aria-label={`Open command palette (shortcut: ${[displaySequence].flat().join('+')})`}
     >
       <SearchIcon className={classes.leftIcon} />
       <span className={classes.info}>Run a command...</span>

--- a/src/ui/src/containers/App/sidebar.tsx
+++ b/src/ui/src/containers/App/sidebar.tsx
@@ -235,20 +235,20 @@ export const SideBar: React.FC<{ open: boolean }> = React.memo(({ open }) => {
         </List>
         <div className={classes.spacer} />
         <List>
-          <Tooltip title='Announcements' disableInteractive>
-            <div className={classes.announcekit}>
-              {
-                ANNOUNCEMENT_ENABLED && (
-                <AnnounceKit widget={ANNOUNCE_WIDGET_URL} user={announceUser} data={announceData}>
-                  <ListItem button key='announcements' className={classes.listIcon}>
-                    <ListItemIcon><CampaignIcon /></ListItemIcon>
-                    <ListItemText primary='Announcements' />
-                  </ListItem>
-                </AnnounceKit>
-                )
-              }
-            </div>
-          </Tooltip>
+          {
+            ANNOUNCEMENT_ENABLED && (
+              <Tooltip title='Announcements' disableInteractive>
+                <div className={classes.announcekit}>
+                    <AnnounceKit widget={ANNOUNCE_WIDGET_URL} user={announceUser} data={announceData}>
+                      <ListItem button key='announcements' className={classes.listIcon}>
+                        <ListItemIcon><CampaignIcon /></ListItemIcon>
+                        <ListItemText primary='Announcements' />
+                      </ListItem>
+                    </AnnounceKit>
+                </div>
+              </Tooltip>
+            )
+          }
           <SideBarExternalLinkItem
             key='Docs'
             icon={React.useMemo(() => <DocsIcon />, [])}


### PR DESCRIPTION
Summary: A handful of Cypress tests weren't correctly specified or weren't updated for the existence of the Command Palette.
Fixing these also found a couple of minor typos elsewhere, which this change also fixes.

Relevant Issues: N/A

Test Plan: Run Cypress tests.

Type of change: /kind failing-test

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
