### PR TITLE
Operator: Fetch and send K8s cluster version to ConfigManager

### DIFF
--- a/src/operator/BUILD.bazel
+++ b/src/operator/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//src/utils/shared/k8s",
         "@com_github_sirupsen_logrus//:logrus",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_client_go//discovery",
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_client_go//rest",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",

--- a/src/operator/controllers/vizier_controller.go
+++ b/src/operator/controllers/vizier_controller.go
@@ -78,6 +78,7 @@ type VizierReconciler struct {
 
 	monitor      *VizierMonitor
 	lastChecksum []byte
+	K8sVersion   string
 
 	sentryFlush func()
 }
@@ -395,7 +396,7 @@ func (r *VizierReconciler) deployVizier(ctx context.Context, req ctrl.Request, v
 		return err
 	}
 
-	configForVizierResp, err := generateVizierYAMLsConfig(ctx, req.Namespace, vz, cloudClient)
+	configForVizierResp, err := generateVizierYAMLsConfig(ctx, req.Namespace, r.K8sVersion, vz, cloudClient)
 	if err != nil {
 		log.WithError(err).Error("Failed to generate configs for Vizier YAMLs")
 		return err
@@ -718,12 +719,13 @@ func convertResourceType(originalLst v1.ResourceList) *vizierconfigpb.ResourceLi
 
 // generateVizierYAMLsConfig is responsible retrieving a yaml map of configurations from
 // Pixie Cloud.
-func generateVizierYAMLsConfig(ctx context.Context, ns string, vz *v1alpha1.Vizier, conn *grpc.ClientConn) (*cloudpb.ConfigForVizierResponse,
+func generateVizierYAMLsConfig(ctx context.Context, ns string, k8sVersion string, vz *v1alpha1.Vizier, conn *grpc.ClientConn) (*cloudpb.ConfigForVizierResponse,
 	error) {
 	client := cloudpb.NewConfigServiceClient(conn)
 
 	req := &cloudpb.ConfigForVizierRequest{
-		Namespace: ns,
+		Namespace:  ns,
+		K8sVersion: k8sVersion,
 		VzSpec: &vizierconfigpb.VizierSpec{
 			Version:               vz.Spec.Version,
 			DeployKey:             vz.Spec.DeployKey,

--- a/src/operator/manager.go
+++ b/src/operator/manager.go
@@ -21,7 +21,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +88,7 @@ func main() {
 		if err != nil {
 			log.WithError(err).Error("Failed to get server version from discovery client")
 		} else {
-			k8sVersion = strings.TrimPrefix(version.GitVersion, "v")
+			k8sVersion = version.GitVersion
 		}
 	}
 

--- a/src/operator/manager.go
+++ b/src/operator/manager.go
@@ -21,6 +21,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +89,7 @@ func main() {
 		if err != nil {
 			log.WithError(err).Error("Failed to get server version from discovery client")
 		} else {
-			k8sVersion = version.GitVersion
+			k8sVersion = strings.TrimPrefix(version.GitVersion, "v")
 		}
 	}
 


### PR DESCRIPTION
Summary: You can now send your K8s cluster version to the config manager service, which allows the config manager service to modify the Vizier YAMLs accordingly based on your cluster version.
This PR updates the operator to fetch the K8s cluster version and pass it to the configmanager service when deploying a Vizier.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Skaffold deploy operator and verify that K8s version is fetched properly

