### PR TITLE
ConfigManager service should determine which PodDisruptionBudget apiVersion to use based on K8s version

### DIFF
--- a/src/cloud/config_manager/controllers/BUILD.bazel
+++ b/src/cloud/config_manager/controllers/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//src/utils/shared/tar",
         "//src/utils/shared/yamls",
         "//src/utils/template_generator/vizier_yamls",
+        "@com_github_blang_semver//:semver",
         "@com_github_gofrs_uuid//:uuid",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_viper//:viper",

--- a/src/cloud/config_manager/controllers/server.go
+++ b/src/cloud/config_manager/controllers/server.go
@@ -169,7 +169,7 @@ func (s *Server) GetConfigForVizier(ctx context.Context,
 	// We make slight modifications to the YAMLs depending on K8s version, to maintain support for older versions.
 	useOldPDB := false
 	if in.K8sVersion != "" {
-		// policy/v1beta1 podDisruptionBudget was deprecated as of v1.21.
+		// podDisruptionBudget graduated from beta to stable as of v1.21.
 		minPDBVers, pdbErr := semver.ParseTolerant("1.21.0")
 		currentK8sVers, err := semver.ParseTolerant(in.K8sVersion)
 		if err == nil && pdbErr == nil {

--- a/src/cloud/config_manager/controllers/server.go
+++ b/src/cloud/config_manager/controllers/server.go
@@ -170,8 +170,8 @@ func (s *Server) GetConfigForVizier(ctx context.Context,
 	useOldPDB := false
 	if in.K8sVersion != "" {
 		// policy/v1beta1 podDisruptionBudget was deprecated as of v1.21.
-		minPDBVers, pdbErr := semver.Make("1.21.0")
-		currentK8sVers, err := semver.Make(in.K8sVersion)
+		minPDBVers, pdbErr := semver.ParseTolerant("1.21.0")
+		currentK8sVers, err := semver.ParseTolerant(in.K8sVersion)
 		if err == nil && pdbErr == nil {
 			if currentK8sVers.LT(minPDBVers) {
 				useOldPDB = true

--- a/src/cloud/config_manager/controllers/server.go
+++ b/src/cloud/config_manager/controllers/server.go
@@ -167,14 +167,14 @@ func (s *Server) GetConfigForVizier(ctx context.Context,
 	}
 
 	// We make slight modifications to the YAMLs depending on K8s version, to maintain support for older versions.
-	useOldPDB := false
+	useBetaPDB := false
 	if in.K8sVersion != "" {
 		// podDisruptionBudget graduated from beta to stable as of v1.21.
 		minPDBVers, pdbErr := semver.ParseTolerant("1.21.0")
 		currentK8sVers, err := semver.ParseTolerant(in.K8sVersion)
 		if err == nil && pdbErr == nil {
 			if currentK8sVers.LT(minPDBVers) {
-				useOldPDB = true
+				useBetaPDB = true
 			}
 		}
 	}
@@ -196,7 +196,7 @@ func (s *Server) GetConfigForVizier(ctx context.Context,
 		ClockConverter:        in.VzSpec.ClockConverter,
 		DataAccess:            in.VzSpec.DataAccess,
 		Registry:              in.VzSpec.Registry,
-		UseBetaPdbVersion:     useOldPDB,
+		UseBetaPdbVersion:     useBetaPDB,
 	}
 
 	if in.VzSpec.DataCollectorParams != nil && in.VzSpec.DataCollectorParams.DatastreamBufferSize != 0 {


### PR DESCRIPTION
Summary: We can now change the apiVersion of podDisruptionBudget in our Vizier YAMLs. The configmanager service can decide to do so based on the K8s version provided by the operator.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Skaffold deploy testing cloud
