### PR TITLE
Fix linux headers upload

### DIFF
--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -203,9 +203,9 @@ $(LINUX_HEADERS_ARM64_MERGED_FILE): $(LINUX_HEADER_ARM64_TARGETS)
 	tar -czf $@ -C $(LINUX_HEADER_ASSETS_BUILD_DIR) $(^F)
 
 .PHONY: upload_linux_headers
-upload_linux_headers:  $(LINUX_HEADERS_X86_64_MERGED_FILE) $(LINUX_HEADER_X86_64_TARGETS) $(LINUX_HEADERS_ARM64_MERGED_FILE) $(LINUX_HEADER_ARM64_TARGETS) ## Target to build and upload linux headers image
-	gsutil cp $< $(LINUX_HEADERS_GS_PATH)/$(<F)
-	sha256sum $<
+upload_linux_headers:  $(LINUX_HEADERS_X86_64_MERGED_FILE) $(LINUX_HEADERS_ARM64_MERGED_FILE) ## Target to build and upload linux headers image
+	gsutil cp $^ $(LINUX_HEADERS_GS_PATH)
+	sha256sum $^
 
 
 ##############################################


### PR DESCRIPTION
Summary: When I added building of ARM headers, I didn't test the gsutil cp command part of the upload process. This fix is necessary so that both architectures' header tars get uploaded, instead of just the first one.

Type of change: /kind cleanup.

Test Plan: Tested by uploading to a bucket I have access to.
