### PR TITLE
Add timeout to OTLP export

### DIFF
--- a/src/carnot/exec/exec_metrics.cc
+++ b/src/carnot/exec/exec_metrics.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/carnot/exec/exec_metrics.h"
+#include <prometheus/counter.h>
+#include <string>
+
+ExecMetrics::ExecMetrics(prometheus::Registry* registry)
+    : otlp_metrics_timeout_counter(
+          prometheus::BuildCounter()
+              .Name("otlp_timeouts")
+              .Help("Total number of timeouts which occurred when exporting data to an OTLP client")
+              .Register(*registry)
+              .Add({{"name", "metrics"}})),
+      otlp_spans_timeout_counter(
+          prometheus::BuildCounter()
+              .Name("otlp_timeouts")
+              .Help("Total number of timeouts which occurred when exporting data to an OTLP client")
+              .Register(*registry)
+              .Add({{"name", "spans"}})) {}

--- a/src/carnot/exec/exec_metrics.h
+++ b/src/carnot/exec/exec_metrics.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+#include <prometheus/registry.h>
+#include <string>
+
+#include "src/common/metrics/metrics.h"
+
+struct ExecMetrics {
+  explicit ExecMetrics(prometheus::Registry* registry);
+
+  prometheus::Counter& otlp_metrics_timeout_counter;
+  prometheus::Counter& otlp_spans_timeout_counter;
+};

--- a/src/carnot/exec/exec_state.h
+++ b/src/carnot/exec/exec_state.h
@@ -29,6 +29,7 @@
 #include <sole.hpp>
 
 #include "src/carnot/carnotpb/carnot.pb.h"
+#include "src/carnot/exec/exec_metrics.h"
 #include "src/carnot/exec/grpc_router.h"
 #include "src/carnot/udf/model_pool.h"
 #include "src/carnot/udf/registry.h"
@@ -70,7 +71,8 @@ class ExecState {
       const MetricsStubGenerator& metrics_stub_generator,
       const TraceStubGenerator& trace_stub_generator, const sole::uuid& query_id,
       udf::ModelPool* model_pool, GRPCRouter* grpc_router = nullptr,
-      std::function<void(grpc::ClientContext*)> add_auth_func = [](grpc::ClientContext*) {})
+      std::function<void(grpc::ClientContext*)> add_auth_func = [](grpc::ClientContext*) {},
+      ExecMetrics* exec_metrics = nullptr)
       : func_registry_(func_registry),
         table_store_(std::move(table_store)),
         stub_generator_(stub_generator),
@@ -79,7 +81,8 @@ class ExecState {
         query_id_(query_id),
         model_pool_(model_pool),
         grpc_router_(grpc_router),
-        add_auth_to_grpc_client_context_func_(add_auth_func) {}
+        add_auth_to_grpc_client_context_func_(add_auth_func),
+        exec_metrics_(exec_metrics) {}
 
   ~ExecState() {
     if (grpc_router_ != nullptr) {
@@ -197,6 +200,8 @@ class ExecState {
     add_auth_to_grpc_client_context_func_(ctx);
   }
 
+  ExecMetrics* exec_metrics() { return exec_metrics_; }
+
  private:
   udf::Registry* func_registry_;
   std::shared_ptr<table_store::TableStore> table_store_;
@@ -210,6 +215,7 @@ class ExecState {
   udf::ModelPool* model_pool_;
   GRPCRouter* grpc_router_ = nullptr;
   std::function<void(grpc::ClientContext*)> add_auth_to_grpc_client_context_func_;
+  ExecMetrics* exec_metrics_;
 
   int64_t current_source_ = 0;
   bool current_source_set_ = false;

--- a/src/carnot/exec/otel_export_sink_node.cc
+++ b/src/carnot/exec/otel_export_sink_node.cc
@@ -49,7 +49,7 @@ const int64_t kOTelTraceIDLength = 16;
 
 const int64_t kB3ShortTraceIDLength = 8;
 
-const int64_t otelClientTimeoutS = 5;
+constexpr auto otelClientTimeout = std::chrono::seconds{5};
 
 std::string OTelExportSinkNode::DebugStringImpl() {
   return absl::Substitute("Exec::OTelExportSinkNode: $0", plan_node_->DebugString());
@@ -285,7 +285,7 @@ Status OTelExportSinkNode::ConsumeMetrics(ExecState* exec_state, const RowBatch&
 
   // Set timeout, to avoid blocking on query.
   std::chrono::system_clock::time_point deadline =
-      std::chrono::system_clock::now() + std::chrono::seconds(otelClientTimeoutS);
+      std::chrono::system_clock::now() + otelClientTimeout;
   context.set_deadline(deadline);
 
   grpc::Status status = metrics_service_stub_->Export(&context, request, &metrics_response_);
@@ -413,7 +413,7 @@ Status OTelExportSinkNode::ConsumeSpans(ExecState* exec_state, const RowBatch& r
   }
   // Set timeout, to avoid blocking on query.
   std::chrono::system_clock::time_point deadline =
-      std::chrono::system_clock::now() + std::chrono::seconds(otelClientTimeoutS);
+      std::chrono::system_clock::now() + otelClientTimeout;
   context.set_deadline(deadline);
 
   grpc::Status status = trace_service_stub_->Export(&context, request, &trace_response_);

--- a/src/carnot/exec/otel_export_sink_node.cc
+++ b/src/carnot/exec/otel_export_sink_node.cc
@@ -284,7 +284,7 @@ Status OTelExportSinkNode::ConsumeMetrics(ExecState* exec_state, const RowBatch&
   // Set timeout, to avoid blocking on query.
   if (plan_node_->timeout() > 0) {
     std::chrono::system_clock::time_point deadline =
-      std::chrono::system_clock::now() + std::chrono::seconds{plan_node_->timeout()};
+        std::chrono::system_clock::now() + std::chrono::seconds{plan_node_->timeout()};
     context.set_deadline(deadline);
   }
 
@@ -414,7 +414,7 @@ Status OTelExportSinkNode::ConsumeSpans(ExecState* exec_state, const RowBatch& r
   // Set timeout, to avoid blocking on query.
   if (plan_node_->timeout() > 0) {
     std::chrono::system_clock::time_point deadline =
-      std::chrono::system_clock::now() + std::chrono::seconds{plan_node_->timeout()};
+        std::chrono::system_clock::now() + std::chrono::seconds{plan_node_->timeout()};
     context.set_deadline(deadline);
   }
 

--- a/src/carnot/exec/otel_export_sink_node.h
+++ b/src/carnot/exec/otel_export_sink_node.h
@@ -51,8 +51,8 @@ class OTelExportSinkNode : public SinkNode {
                          size_t parent_index) override;
 
  private:
-  Status ConsumeMetrics(const table_store::schema::RowBatch& rb);
-  Status ConsumeSpans(const table_store::schema::RowBatch& rb);
+  Status ConsumeMetrics(ExecState* exec_state, const table_store::schema::RowBatch& rb);
+  Status ConsumeSpans(ExecState* exec_state, const table_store::schema::RowBatch& rb);
 
   std::unique_ptr<table_store::schema::RowDescriptor> input_descriptor_;
   opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceResponse metrics_response_;


### PR DESCRIPTION
Summary: This PR adds a timeout to our OTLP span/metrics exports. It also adds a metrics counter for tracking how many OTLP timeouts have occurred, if any.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Skaffold deploy Vizier

