### PR TITLE
Fix linux headers for x86

### DIFF
--- a/tools/docker/linux_headers_image/Dockerfile
+++ b/tools/docker/linux_headers_image/Dockerfile
@@ -71,7 +71,7 @@ RUN find usr/src/linux-headers-${KERN_VERSION}-pl -xtype l -exec rm {} +
 RUN rm -rf usr/share
 RUN find usr/src/linux-headers-${KERN_VERSION}-pl -maxdepth 1 -mindepth 1 ! -name include ! -name arch -type d \
     -exec rm -rf {} +
-RUN find usr/src/linux-headers-${KERN_VERSION}-pl/arch -maxdepth 1 -mindepth 1 ! -name ${ARCH} -type d -exec rm -rf {} +
+RUN find usr/src/linux-headers-${KERN_VERSION}-pl/arch -maxdepth 1 -mindepth 1 ! -name $(echo ${ARCH} | sed 's/x86_64/x86/g') -type d -exec rm -rf {} +
 RUN tar zcf linux-headers-${ARCH}-${KERN_VERSION}.tar.gz usr
 
 VOLUME /output


### PR DESCRIPTION
Summary: The linux kernel has a confusing naming system for x86_64 which includes x86_64,x86, and amd64 as names for the same architecture in different parts of the code base. When I added support for ARM headers, I accidentally removed the arch/x86 folder. This diff ensures that folder remains.

Type of change: /kind cleanup.

Test Plan: Tested a skaffold deploy on both aarch64 and x86_64.
