### PR TITLE
Fix ParseKernelVersion for large minor revisions.

### DIFF
--- a/src/stirling/utils/linux_headers.cc
+++ b/src/stirling/utils/linux_headers.cc
@@ -74,7 +74,7 @@ StatusOr<KernelVersion> ParseKernelVersionString(const std::string& linux_releas
   kernel_version.major_rev = tmp;
 
   ECHECK(absl::SimpleAtoi(match[3].str(), &tmp));
-  if (tmp > std::numeric_limits<uint8_t>::max()) {
+  if (tmp > std::numeric_limits<uint16_t>::max()) {
     return error::Internal("Kernel minor_rev does not appear valid %d", tmp);
   }
   kernel_version.minor_rev = tmp;


### PR DESCRIPTION
Summary: Previously, we checked that the kernel version's minor revision was less than 255. However, the kernel has no such restriction, and the headers we currently ship include kernel revisions: 4.19.271, and 4.14.304. This led to us ignoring these prepackaged headers with messages like:
```
W20230217 00:21:11.571775 1105042 linux_headers.cc:596] Ignoring /px/linux-headers-arm64-4.14.304.tar.gz since it does not conform to the naming convention
W20230217 00:21:11.571825 1105042 linux_headers.cc:596] Ignoring /px/linux-headers-arm64-4.19.271.tar.gz since it does not conform to the naming convention
```

Type of change: /kind bug

Test Plan: Relying on existing tests. Deployed on skaffold and no longer saw the warnings.
