### PR TITLE
[2 of 2] Fix & re-enable perf profiler test: accomodate leaf node aliasing in histogram.

### DIFF
--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -58,8 +58,6 @@ pl_cc_test(
         "cpu:16",
         "exclusive",
         "requires_bpf",
-        # Disabling this test because it has a 25% pass rate on main at the moment.
-        "disabled_flaky_test",
     ],
     deps = [
         ":cc_library",

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -98,7 +98,7 @@ absl::flat_hash_map<std::string, uint64_t> KeepNLeafSyms(
     const auto end_iter = symbols.end();
 
     const auto leaf_syms = absl::StrJoin(begin_iter, end_iter, ";");
-    leaf_histo[leaf_syms] = count;
+    leaf_histo[leaf_syms] += count;
   }
   return leaf_histo;
 }
@@ -309,8 +309,7 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     LOG(INFO) << absl::StrFormat("ratio: %.2fx.", ratio);
 
     EXPECT_GT(ratio, 2.0 - kRatioMargin);
-    // TODO(jps): This is extremely flaky on Jenkins. Please fix and re-enable.
-    // EXPECT_LT(ratio, 2.0 + kRatioMargin);
+    EXPECT_LT(ratio, 2.0 + kRatioMargin);
 
     EXPECT_EQ(source_->stats().Get(PerfProfileConnector::StatKey::kLossHistoEvent), 0);
   }
@@ -452,8 +451,7 @@ TEST_F(PerfProfileBPFTest, PerfProfilerCppTest) {
       CheckExpectedCounts(KeepNLeafSyms(3, histo_), kNumSubProcs, t_elapsed, key1x, key2x));
 }
 
-// TODO(jps/oazizi): This test is flaky.
-TEST_F(PerfProfileBPFTest, DISABLED_GraalVM_AOT_Test) {
+TEST_F(PerfProfileBPFTest, GraalVM_AOT_Test) {
   const std::string app_path = "ProfilerTest";
   const std::filesystem::path bazel_app_path = BazelJavaTestAppPath(app_path);
   ASSERT_TRUE(fs::Exists(bazel_app_path)) << absl::StrFormat("Missing: %s.", bazel_app_path);

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -228,8 +228,7 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
   void TearDown() override { ASSERT_OK(source_->Stop()); }
 
   void PopulateObservedStackTraces(const std::vector<size_t>& target_row_idxs) {
-    // Just check that the test author populated the necessary,
-    // and did not corrupt the cumulative sum already.
+    // Sanity check; column pointers should be populated already.
     ASSERT_TRUE(column_ptrs_populated_);
 
     for (const auto row_idx : target_row_idxs) {

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -178,12 +178,11 @@ class ContainerSubProcesses final : public PerfProfilerTestSubProcesses {
   void StartAll() override {
     const system::ProcParser proc_parser;
     const auto timeout = std::chrono::seconds{2 * FLAGS_test_run_time};
+    const std::vector<std::string> options;
     const std::vector<std::string> args;
     static constexpr bool kUseHostPidNamespace = false;
 
     for (size_t i = 0; i < kNumSubProcs; ++i) {
-      const std::string cpu_set = absl::Substitute("--cpuset-cpus=$0", i);
-      const std::vector<std::string> options = {cpu_set};
       sub_processes_[i]->Run(timeout, options, args, kUseHostPidNamespace);
 
       // Grab the PID and generate a UPID.

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -178,11 +178,12 @@ class ContainerSubProcesses final : public PerfProfilerTestSubProcesses {
   void StartAll() override {
     const system::ProcParser proc_parser;
     const auto timeout = std::chrono::seconds{2 * FLAGS_test_run_time};
-    const std::vector<std::string> options;
     const std::vector<std::string> args;
     static constexpr bool kUseHostPidNamespace = false;
 
     for (size_t i = 0; i < kNumSubProcs; ++i) {
+      const std::string cpu_set = absl::Substitute("--cpuset-cpus=$0", i);
+      const std::vector<std::string> options = {cpu_set};
       sub_processes_[i]->Run(timeout, options, args, kUseHostPidNamespace);
 
       // Grab the PID and generate a UPID.


### PR DESCRIPTION
Summary: We fix and re-enable the flaky perf profiler test. The underlying issue was stack trace aliasing due to missing stack frames. We document this issue in https://github.com/pixie-io/pixie/pull/896. In brief, because the stack trace walker sometimes skips a stack frame, the test logic could find two different stack traces that matched by leaf symbol. We previously did not realize this, and hence we used assign (vs. accumulate) when building the leaf symbol histogram. In this patch, we accommodate the missing stack frames by accumulating when building the leaf symbol histogram.

After the switch to `podman`, the Java tests started failing, on Jenkins, based on expected sample rate. It is hard to predict the actual number of samples that will occur for a Java process because we do not have direct control over the number of processes and threads. Since we still have coverage for sample rate in cpp and go, we split the expectations into two parts and check sample rate only for cpp and go.

Relevant Issues: https://github.com/pixie-io/pixie/issues/719

Type of change: /kind bug fix.

Test Plan: Tested locally using `--runs_per_test=32`. All tests passed. Verified with local testing that we did see test failures and flakiness without the change.