### PR TITLE
Update the socket tracer metrics to differentiate between tls and plaintext metrics

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
@@ -542,6 +542,9 @@ bool ConnTracker::SetSSL(bool ssl, std::string_view reason) {
 
   bool old_ssl = ssl_;
   ssl_ = ssl;
+  send_data_.set_ssl(ssl);
+  recv_data_.set_ssl(ssl);
+
   CONN_TRACE(1) << absl::Substitute("SSL state changed: $0->$1, reason=[$2]", old_ssl, ssl, reason);
   return true;
 }

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
@@ -178,8 +178,8 @@ void ConnTracker::AddDataEvent(std::unique_ptr<SocketDataEvent> event) {
 
 namespace {
 void UpdateProtocolMetrics(traffic_protocol_t protocol, const conn_stats_event_t& event,
-                           const ConnTracker::ConnStatsTracker& conn_stats) {
-  auto& metrics = SocketTracerMetrics::GetProtocolMetrics(protocol);
+                           const ConnTracker::ConnStatsTracker& conn_stats, bool ssl) {
+  auto& metrics = SocketTracerMetrics::GetProtocolMetrics(protocol, ssl);
   if (event.rd_bytes > conn_stats.bytes_recv()) {
     metrics.conn_stats_bytes.Increment(event.rd_bytes - conn_stats.bytes_recv());
   }
@@ -204,7 +204,7 @@ void ConnTracker::AddConnStats(const conn_stats_event_t& event) {
     DCHECK_GE(event.rd_bytes, conn_stats_.bytes_recv());
     DCHECK_GE(event.wr_bytes, conn_stats_.bytes_sent());
 
-    UpdateProtocolMetrics(protocol_, event, conn_stats_);
+    UpdateProtocolMetrics(protocol_, event, conn_stats_, ssl_);
 
     conn_stats_.set_bytes_recv(event.rd_bytes);
     conn_stats_.set_bytes_sent(event.wr_bytes);

--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -168,7 +168,7 @@ void DataStream::ProcessBytesToFrames(message_type_t type, TStateType* state) {
   ssize_t num_bytes_advanced = data_buffer_.position() - last_processed_pos_;
   if (num_bytes_advanced > 0 && static_cast<size_t>(num_bytes_advanced) > frame_bytes) {
     size_t bytes_lost = num_bytes_advanced - frame_bytes;
-    SocketTracerMetrics::GetProtocolMetrics(protocol_).data_loss_bytes.Increment(bytes_lost);
+    SocketTracerMetrics::GetProtocolMetrics(protocol_, is_ssl_).data_loss_bytes.Increment(bytes_lost);
   }
   last_processed_pos_ = data_buffer_.position();
 

--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -168,7 +168,8 @@ void DataStream::ProcessBytesToFrames(message_type_t type, TStateType* state) {
   ssize_t num_bytes_advanced = data_buffer_.position() - last_processed_pos_;
   if (num_bytes_advanced > 0 && static_cast<size_t>(num_bytes_advanced) > frame_bytes) {
     size_t bytes_lost = num_bytes_advanced - frame_bytes;
-    SocketTracerMetrics::GetProtocolMetrics(protocol_, is_ssl_).data_loss_bytes.Increment(bytes_lost);
+    SocketTracerMetrics::GetProtocolMetrics(protocol_, is_ssl_)
+        .data_loss_bytes.Increment(bytes_lost);
   }
   last_processed_pos_ = data_buffer_.position();
 

--- a/src/stirling/source_connectors/socket_tracer/data_stream.h
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.h
@@ -198,6 +198,8 @@ class DataStream : NotCopyMoveable {
 
   void set_conn_closed() { conn_closed_ = true; }
 
+  void set_ssl(bool ssl) { is_ssl_ = ssl; }
+
   void set_current_time(std::chrono::time_point<std::chrono::steady_clock> time) {
     ECHECK(time >= current_time_);
     current_time_ = time;
@@ -301,6 +303,8 @@ class DataStream : NotCopyMoveable {
 
   // This is set to true when connection is closed.
   bool conn_closed_ = false;
+
+  bool is_ssl_ = false;
 
   // Keep some stats on ParseFrames() attempts.
   int stat_valid_frames_ = 0;

--- a/src/stirling/source_connectors/socket_tracer/data_stream_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream_test.cc
@@ -49,7 +49,8 @@ class DataStreamTest : public ::testing::Test {
 
   void TearDown() override {
     TestOnlyResetMetricsRegistry();
-    SocketTracerMetrics::TestOnlyResetProtocolMetrics(kProtocolHTTP);
+    SocketTracerMetrics::TestOnlyResetProtocolMetrics(kProtocolHTTP, false);
+    SocketTracerMetrics::TestOnlyResetProtocolMetrics(kProtocolHTTP, true);
   }
 
   std::chrono::steady_clock::time_point now() {
@@ -95,7 +96,8 @@ TEST_F(DataStreamTest, LostEvent) {
   EXPECT_THAT(stream.Frames<http::Message>(), SizeIs(4));
 
   EXPECT_EQ(req1->msg.size() + req4->msg.size(),
-            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, StuckTemporarily) {
@@ -126,7 +128,8 @@ TEST_F(DataStreamTest, StuckTemporarily) {
   EXPECT_EQ(requests[1].req_path, "/foo.html");
   EXPECT_EQ(requests[2].req_path, "/bar.html");
 
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, StuckTooLong) {
@@ -161,7 +164,8 @@ TEST_F(DataStreamTest, StuckTooLong) {
   EXPECT_EQ(requests[1].req_path, "/bar.html");
 
   EXPECT_EQ(kHTTPReq0.length(),
-            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, PartialMessageRecovery) {
@@ -187,7 +191,8 @@ TEST_F(DataStreamTest, PartialMessageRecovery) {
   EXPECT_EQ(requests[1].req_path, "/bar.html");
 
   EXPECT_EQ(kHTTPReq1.length(),
-            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, HeadAndMiddleMissing) {
@@ -221,7 +226,8 @@ TEST_F(DataStreamTest, HeadAndMiddleMissing) {
   EXPECT_EQ(requests[0].req_path, "/bar.html");
 
   EXPECT_EQ(req0b_size + kHTTPReq1.length(),
-            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, LateArrivalPlusMissingEvents) {
@@ -278,7 +284,8 @@ TEST_F(DataStreamTest, LateArrivalPlusMissingEvents) {
   EXPECT_EQ(requests[2].req_path, "/foo.html");
 
   EXPECT_EQ(kHTTPReq0.length() + kHTTPReq2.length(),
-            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 // This test checks that various stats updated on each call ProcessBytesToFrames()
@@ -422,7 +429,38 @@ TEST_F(DataStreamTest, SpikeCapacityWithLargeDataChunk) {
   // Run ProcessBytesToFrames again to propagate data loss stats.
   stream.ProcessBytesToFrames<http::Message>(message_type_t::kResponse, &state);
   EXPECT_EQ(kHTTPIncompleteResp.length() - retention_capacity_bytes,
-            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP).data_loss_bytes.Value());
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+}
+
+TEST_F(DataStreamTest, SpikeCapacityWithLargeDataChunkAndSSLEnabled) {
+  int spike_capacity_bytes = 1024;
+  int retention_capacity_bytes = 16;
+  auto buffer_expiry_timestamp = now() - std::chrono::seconds(10000);
+  DataStream stream(spike_capacity_bytes);
+  stream.set_ssl(true);
+  stream.set_protocol(kProtocolHTTP);
+
+  std::unique_ptr<SocketDataEvent> resp0 = event_gen_.InitRecvEvent<kProtocolHTTP>(kHTTPResp0);
+  std::unique_ptr<SocketDataEvent> resp1 = event_gen_.InitRecvEvent<kProtocolHTTP>(kHTTPResp0);
+  std::unique_ptr<SocketDataEvent> resp2 =
+      event_gen_.InitRecvEvent<kProtocolHTTP>(kHTTPIncompleteResp);
+
+  stream.AddData(std::move(resp0));
+  stream.AddData(std::move(resp1));
+  stream.AddData(std::move(resp2));
+
+  protocols::http::StateWrapper state{};
+  stream.ProcessBytesToFrames<http::Message>(message_type_t::kResponse, &state);
+  stream.CleanupEvents(retention_capacity_bytes, buffer_expiry_timestamp);
+  EXPECT_THAT(stream.Frames<http::Message>(), SizeIs(2));
+  EXPECT_EQ(stream.data_buffer().size(), 16);
+
+  // Run ProcessBytesToFrames again to propagate data loss stats.
+  stream.ProcessBytesToFrames<http::Message>(message_type_t::kResponse, &state);
+  EXPECT_EQ(kHTTPIncompleteResp.length() - retention_capacity_bytes,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, ResyncCausesDuplicateEventBug) {

--- a/src/stirling/source_connectors/socket_tracer/data_stream_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream_test.cc
@@ -97,7 +97,8 @@ TEST_F(DataStreamTest, LostEvent) {
 
   EXPECT_EQ(req1->msg.size() + req4->msg.size(),
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, StuckTemporarily) {
@@ -128,8 +129,10 @@ TEST_F(DataStreamTest, StuckTemporarily) {
   EXPECT_EQ(requests[1].req_path, "/foo.html");
   EXPECT_EQ(requests[2].req_path, "/bar.html");
 
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, StuckTooLong) {
@@ -165,7 +168,8 @@ TEST_F(DataStreamTest, StuckTooLong) {
 
   EXPECT_EQ(kHTTPReq0.length(),
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, PartialMessageRecovery) {
@@ -192,7 +196,8 @@ TEST_F(DataStreamTest, PartialMessageRecovery) {
 
   EXPECT_EQ(kHTTPReq1.length(),
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, HeadAndMiddleMissing) {
@@ -227,7 +232,8 @@ TEST_F(DataStreamTest, HeadAndMiddleMissing) {
 
   EXPECT_EQ(req0b_size + kHTTPReq1.length(),
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, LateArrivalPlusMissingEvents) {
@@ -285,7 +291,8 @@ TEST_F(DataStreamTest, LateArrivalPlusMissingEvents) {
 
   EXPECT_EQ(kHTTPReq0.length() + kHTTPReq2.length(),
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 // This test checks that various stats updated on each call ProcessBytesToFrames()
@@ -430,7 +437,8 @@ TEST_F(DataStreamTest, SpikeCapacityWithLargeDataChunk) {
   stream.ProcessBytesToFrames<http::Message>(message_type_t::kResponse, &state);
   EXPECT_EQ(kHTTPIncompleteResp.length() - retention_capacity_bytes,
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, SpikeCapacityWithLargeDataChunkAndSSLEnabled) {
@@ -460,7 +468,8 @@ TEST_F(DataStreamTest, SpikeCapacityWithLargeDataChunkAndSSLEnabled) {
   stream.ProcessBytesToFrames<http::Message>(message_type_t::kResponse, &state);
   EXPECT_EQ(kHTTPIncompleteResp.length() - retention_capacity_bytes,
             SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, true).data_loss_bytes.Value());
-  EXPECT_EQ(0, SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
+  EXPECT_EQ(0,
+            SocketTracerMetrics::GetProtocolMetrics(kProtocolHTTP, false).data_loss_bytes.Value());
 }
 
 TEST_F(DataStreamTest, ResyncCausesDuplicateEventBug) {

--- a/src/stirling/source_connectors/socket_tracer/metrics.cc
+++ b/src/stirling/source_connectors/socket_tracer/metrics.cc
@@ -28,8 +28,7 @@ namespace px {
 namespace stirling {
 
 SocketTracerMetrics::SocketTracerMetrics(prometheus::Registry* registry,
-                                         traffic_protocol_t protocol,
-                                         bool tls)
+                                         traffic_protocol_t protocol, bool tls)
     : data_loss_bytes(
           prometheus::BuildCounter()
               .Name("data_loss_bytes")
@@ -50,11 +49,14 @@ SocketTracerMetrics::SocketTracerMetrics(prometheus::Registry* registry,
                            })) {}
 
 namespace {
-std::unordered_map<traffic_protocol_t, std::unique_ptr<SocketTracerMetrics>> g_plaintext_protocol_metrics;
+std::unordered_map<traffic_protocol_t, std::unique_ptr<SocketTracerMetrics>>
+    g_plaintext_protocol_metrics;
 
-std::unordered_map<traffic_protocol_t, std::unique_ptr<SocketTracerMetrics>> g_encrypted_protocol_metrics;
+std::unordered_map<traffic_protocol_t, std::unique_ptr<SocketTracerMetrics>>
+    g_encrypted_protocol_metrics;
 
-std::unordered_map<traffic_protocol_t, std::unique_ptr<SocketTracerMetrics>>* GetUnderlyingProtocolMetrics(bool tls) {
+std::unordered_map<traffic_protocol_t, std::unique_ptr<SocketTracerMetrics>>*
+GetUnderlyingProtocolMetrics(bool tls) {
   if (tls) {
     return &g_encrypted_protocol_metrics;
   } else {
@@ -68,7 +70,8 @@ void ResetProtocolMetrics(traffic_protocol_t protocol, bool tls) {
 }
 }  // namespace
 
-SocketTracerMetrics& SocketTracerMetrics::GetProtocolMetrics(traffic_protocol_t protocol, bool tls) {
+SocketTracerMetrics& SocketTracerMetrics::GetProtocolMetrics(traffic_protocol_t protocol,
+                                                             bool tls) {
   auto metrics = GetUnderlyingProtocolMetrics(tls);
   if (metrics->find(protocol) == metrics->end()) {
     ResetProtocolMetrics(protocol, tls);

--- a/src/stirling/source_connectors/socket_tracer/metrics.h
+++ b/src/stirling/source_connectors/socket_tracer/metrics.h
@@ -28,13 +28,13 @@ namespace px {
 namespace stirling {
 
 struct SocketTracerMetrics {
-  SocketTracerMetrics(prometheus::Registry* registry, traffic_protocol_t protocol);
+  SocketTracerMetrics(prometheus::Registry* registry, traffic_protocol_t protocol, bool tls);
   prometheus::Counter& data_loss_bytes;
   prometheus::Counter& conn_stats_bytes;
 
-  static SocketTracerMetrics& GetProtocolMetrics(traffic_protocol_t protocol);
+  static SocketTracerMetrics& GetProtocolMetrics(traffic_protocol_t protocol, bool tls);
 
-  static void TestOnlyResetProtocolMetrics(traffic_protocol_t protocol);
+  static void TestOnlyResetProtocolMetrics(traffic_protocol_t protocol, bool tls);
 };
 
 }  // namespace stirling


### PR DESCRIPTION
Summary: This updates the `SocketTracerMetrics` class to differentiate between plaintext and tls metrics. Since we are working to instrument BoringSSL based applications more broadly (#692), this will allow us to experiment with the underlying tls tracing implementation and verify that there aren't protocol parsing issues introduced (indicated by more data loss).

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Updated the `mux_trace_bpf_test` and `netty_tls_trace_bpf_test` with the following diff to verify that they increment the correct counter ([P317](https://phab.corp.pixielabs.ai/P317))
- [x] Inspect the counters values and dimensions despite end to end test mentioned above
- [x] Verified that this data was not used for any previous purposes (new dimension would likely cause breakage)