### PR TITLE
Add default root cert to sysroots

### DIFF
--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -49,7 +49,7 @@ GRAALVM_ARCHIVE_FNAME := graalvm-native-image-22.3.0.tar.gz
 GRAALVM_ARCHIVE_GS_PATH := gs://pixie-dev-public/graalvm-native-image-22.3.0-$(GRAALVM_IMAGE_VERSION).tar.gz
 
 ## Sysroot parameters
-SYSROOT_REV := pl3
+SYSROOT_REV := pl4
 SYSROOT_BUILD_DIR := $(BUILD_DIR)/sysroots
 SYSROOT_ARCHITECTURES := amd64 arm64
 SYSROOT_VARIANTS := runtime build test

--- a/tools/docker/sysroot_creator/build_tar_for_packages.sh
+++ b/tools/docker/sysroot_creator/build_tar_for_packages.sh
@@ -81,6 +81,15 @@ relativize_symlinks() {
   popd > /dev/null
 }
 
+create_root_cert() {
+  root_dir="$1"
+  combined_certs="$(find "${root_dir}/usr/share/ca-certificates" -type f -name '*.crt' -exec cat {} +)"
+  if [ -n "${combined_certs}" ]; then
+    # Only create the root cert file if there were certificates in the ca-certificates directory.
+    echo "${combined_certs}" > "${root_dir}/etc/ssl/certs/ca-certificates.crt"
+  fi
+}
+
 inside_tmpdir() {
   echo "${debs[@]}" | xargs curl -fLO --remote-name-all &> /dev/null
 
@@ -88,6 +97,8 @@ inside_tmpdir() {
   while read -r deb; do
     dpkg-deb -x "${deb}" "${root_dir}" &>/dev/null
   done < <(ls -- *.deb)
+
+  create_root_cert "${root_dir}"
 
   for dir in "${!extra_dirs[@]}"
   do

--- a/tools/docker/sysroot_creator/package_groups/runtime.yaml
+++ b/tools/docker/sysroot_creator/package_groups/runtime.yaml
@@ -1,5 +1,6 @@
 ---
 include:
+- ca-certificates
 - libtinfo6
 - libc6
 - libelf1


### PR DESCRIPTION
Summary: Adds `ca-certificates` package to runtime sysroots. Also creates a default cert chain by concatenating all of the `ca-certificates` certs. Debian usually creates this chain by running `update-ca-certificates`, which is a shell script that concatenates the certs based on a config file. However, it requires `sed` and other utilities. Instead of having to run this script inside the sysroot, we just manually concatenate the certs.

Type of change: /kind bug

Test Plan: Ran `skaffold run -f skaffold/skaffold_vizier.yaml -p x86_64_sysroot` with the new sysroots, no longer saw errors in OTEL export.
