### PR TITLE
Remove uses of bazel info in scripts and tests

### DIFF
--- a/src/stirling/e2e_tests/probe_cleaner_bpf_test.sh
+++ b/src/stirling/e2e_tests/probe_cleaner_bpf_test.sh
@@ -22,13 +22,14 @@
 # It runs an instance of stirling_wrapper, and then does a SIGKILL to ensure it leaks probes.
 # Then it runs the cleaner to clean those probes up.
 
-if [ -z "$1" ]; then
-    stirling_wrapper_bin=$(bazel info bazel-bin)/src/stirling/binaries/stirling_wrapper
-    probe_cleaner_bin=$(bazel info bazel-bin)/src/stirling/bpf_tools/probe_cleaner_standalone
-else
-    stirling_wrapper_bin=$1
-    probe_cleaner_bin=$2
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <stirling_wrapper> <probe_cleaner_bin>"
+  echo "Example: probe_cleaner_bpf_test.sh bazel-bin/src/stirling/binaries/stirling_wrapper bazel-bin/src/stirling/bpf_tools/probe_cleaner_standalone"
+  exit 1
 fi
+
+stirling_wrapper_bin=$1
+probe_cleaner_bin=$2
 
 # Switch to root user.
 if [[ $EUID -ne 0 ]]; then

--- a/src/stirling/scripts/kprobe_leak_test.sh
+++ b/src/stirling/scripts/kprobe_leak_test.sh
@@ -33,9 +33,9 @@
 # Amount of time after start, after which we kill the executable.
 Tkill=3
 
-if [ $# -eq 0 ]; then
+if [ $# -ne 1 ]; then
   echo "Usage: $0 <command to test for leaks>"
-  echo "Example: ./kprobe_leak_test.sh \$(bazel info bazel-bin)/src/stirling/binaries/stirling_wrapper"
+  echo "Example: kprobe_leak_test.sh bazel-bin/src/stirling/binaries/stirling_wrapper"
   exit 1
 fi
 

--- a/src/stirling/scripts/profile_stirling_wrapper.sh
+++ b/src/stirling/scripts/profile_stirling_wrapper.sh
@@ -72,13 +72,10 @@ shift $((OPTIND -1))
 # Build Stirling
 ###############################################################################
 
-bazel_flags="-c opt"
+bazel_flags=(-c opt)
 
-# shellcheck disable=SC2086
-bazel build $bazel_flags //src/stirling/binaries:stirling_wrapper
-
-# shellcheck disable=SC2086
-cmd=$(bazel info $bazel_flags bazel-bin)/src/stirling/binaries/stirling_wrapper
+bazel build "${bazel_flags[@]}" //src/stirling/binaries:stirling_wrapper
+cmd=$(bazel cquery "${bazel_flags[@]}" //src/stirling/binaries:stirling_wrapper --output starlark --starlark:expr "target.files.to_list()[0].path" 2> /dev/null)
 
 ###############################################################################
 # Run Stirling

--- a/src/stirling/scripts/stirling_wrapper.sh
+++ b/src/stirling/scripts/stirling_wrapper.sh
@@ -29,5 +29,5 @@ flags=""
 
 bazel build $flags //src/stirling/binaries:stirling_wrapper
 
-cmd=$(bazel info $flags bazel-bin)/src/stirling/binaries/stirling_wrapper
+cmd=$(bazel cquery $flags //src/stirling/binaries:stirling_wrapper --output starlark --starlark:expr "target.files.to_list()[0].path" 2> /dev/null)
 run_prompt_sudo "$cmd" "$@"


### PR DESCRIPTION
Summary: The uses of `bazel info` to find built binaries were
inaccurate in some places. Additionally calling out to bazel
in a test causes issues when running under qemu. This cleans up
`bazel info` calls in non-test helpers and updates the tests
to not invoke bazel and expect the relevant args to always be
supplied.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: All the updated scripts and tests should continue to work.
