### PR TITLE
Relax podman loaded image check

### DIFF
--- a/src/common/testing/test_utils/container_runner.cc
+++ b/src/common/testing/test_utils/container_runner.cc
@@ -46,7 +46,7 @@ ContainerRunner::ContainerRunner(std::filesystem::path image_tar,
   std::vector<std::string_view> lines = absl::StrSplit(out, "\n", absl::SkipWhitespace());
   CHECK(!lines.empty());
   std::string_view image_line = lines.back();
-  constexpr std::string_view kLoadedImagePrefix = "Loaded image(s): ";
+  constexpr std::string_view kLoadedImagePrefix = "Loaded image";
   CHECK(absl::StartsWith(image_line, kLoadedImagePrefix));
   image_line.remove_prefix(kLoadedImagePrefix.length());
   image_ = image_line;

--- a/src/common/testing/test_utils/container_runner.cc
+++ b/src/common/testing/test_utils/container_runner.cc
@@ -47,9 +47,10 @@ ContainerRunner::ContainerRunner(std::filesystem::path image_tar,
   CHECK(!lines.empty());
   std::string_view image_line = lines.back();
   constexpr std::string_view kLoadedImagePrefix = "Loaded image";
-  CHECK(absl::StartsWith(image_line, kLoadedImagePrefix));
-  image_line.remove_prefix(kLoadedImagePrefix.length());
-  image_ = image_line;
+  std::vector<std::string> splits = absl::StrSplit(image_line, absl::ByString(": "));
+  CHECK_EQ(splits.size(), 2);
+  CHECK(absl::StartsWith(splits[0], kLoadedImagePrefix));
+  image_ = splits[1];
 }
 
 ContainerRunner::~ContainerRunner() {


### PR DESCRIPTION
Summary: Podman seems to print both  "Loaded image:" and "Loaded image(s):". This relaxes the check to make it less flaky.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: Tested locally on qemu.
