### PR TITLE
Allow custom component underneath breadcrumbs

### DIFF
--- a/src/ui/src/configurables/base/breadcrumb-extras.tsx
+++ b/src/ui/src/configurables/base/breadcrumb-extras.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as React from 'react';
+
+/**
+ * Use this component to add something extra to the live view just underneath the breadcrumbs.
+ * It's a right-aligned block by default.
+ */
+export const BreadcrumbExtras = React.memo(() => {
+  return null;
+});
+BreadcrumbExtras.displayName = 'BreadcrumbExtras';

--- a/src/ui/src/containers/live/breadcrumbs.tsx
+++ b/src/ui/src/containers/live/breadcrumbs.tsx
@@ -100,6 +100,9 @@ const useStyles = makeStyles(({ spacing }: Theme) => createStyles({
   extras: {
     textAlign: 'right',
     marginRight: spacing(2.5),
+    marginTop: spacing(0.5),
+    marginBottom: spacing(-2),
+    zIndex: 1, // So it's clickable above the padding of the widgets
   },
 }), { name: 'LiveViewBreadcrumbs' });
 

--- a/src/ui/src/containers/live/breadcrumbs.tsx
+++ b/src/ui/src/containers/live/breadcrumbs.tsx
@@ -35,6 +35,7 @@ import { ScriptContext } from 'app/context/script-context';
 import { GQLAutocompleteEntityKind, GQLAutocompleteFieldResult } from 'app/types/schema';
 import { argVariableMap, argTypesForVis } from 'app/utils/args-utils';
 import { highlightNamespacedScoredMatch, highlightScoredMatch } from 'app/utils/string-search';
+import { BreadcrumbExtras } from 'configurable/breadcrumb-extras';
 import { TimeArgDetail } from 'configurable/time-arg-detail';
 
 import { Variable } from './vis';
@@ -94,6 +95,11 @@ const useStyles = makeStyles(({ spacing }: Theme) => createStyles({
     margin: `${spacing(-0.5)} ${spacing(2.5)}`,
     padding: spacing(0.5),
     overflow: 'auto hidden',
+    position: 'relative',
+  },
+  extras: {
+    textAlign: 'right',
+    marginRight: spacing(2.5),
   },
 }), { name: 'LiveViewBreadcrumbs' });
 
@@ -251,6 +257,8 @@ export const LiveViewBreadcrumbs: React.FC = React.memo(() => {
     return <></>;
   }
 
+  const extras = <BreadcrumbExtras />;
+
   return (
     <>
       <div className={classes.breadcrumbs}>
@@ -262,6 +270,7 @@ export const LiveViewBreadcrumbs: React.FC = React.memo(() => {
           breadcrumbs={argBreadcrumbs}
         />
       </div>
+      { extras && <div className={classes.extras}><BreadcrumbExtras /></div> }
     </>
   );
 });


### PR DESCRIPTION
Summary: Just a stub for now.

Relevant Issues: N/A

Test Plan: Try returning something, even just plain text, from 'breadcrumb-extras.tsx`. It should appear under the breadcrumbs on the right.

Type of change: /kind feature

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
