### PR TITLE
Add -q to podman commands to reduce output

### DIFF
--- a/src/common/testing/test_utils/container_runner.cc
+++ b/src/common/testing/test_utils/container_runner.cc
@@ -104,7 +104,7 @@ StatusOr<std::string> ContainerRunner::Run(const std::chrono::seconds& timeout,
   podman_run_cmd.push_back("podman");
   podman_run_cmd.push_back("run");
   podman_run_cmd.push_back("--rm");
-  podman_run_cmd.push_back("--q");
+  podman_run_cmd.push_back("-q");
   if (use_host_pid_namespace) {
     podman_run_cmd.push_back("--pid=host");
   }


### PR DESCRIPTION
Summary: Reduces noise in test output.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: existing tests should pass
