### PR TITLE
Add deterministic mtime for hermetic sysroots

### DIFF
--- a/tools/docker/sysroot_creator/build_tar_for_packages.sh
+++ b/tools/docker/sysroot_creator/build_tar_for_packages.sh
@@ -113,7 +113,8 @@ inside_tmpdir() {
 
   relativize_symlinks "${root_dir}"
 
-  tar -C "${root_dir}" -czf "${output_tar_path}" .
+  # Pick a deterministic mtime so that the sha sums only change if there are actual changes to the sysroot.
+  tar --mtime="2023-01-01 00:00:00 UTC" -C "${root_dir}" -czf "${output_tar_path}" .
 }
 
 tmpdir="$(mktemp -d)"


### PR DESCRIPTION
Summary: Add deterministic mtime to sysroot tars, so that the sha256sum doesn't change unless there's actual changes to the sysroot.

Type of change: /kind cleanup

Test Plan: Tested that building the sysroots twice gives the same shas.
