### PR TITLE
Use -P in pgrep to be compatible with more versions of pgrep

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/dyn_lib_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/dyn_lib_trace_bpf_test.cc
@@ -178,7 +178,7 @@ TEST_F(DynLibTraceTest, TraceDynLoadedOpenSSL) {
       // Nginx has a master process and a worker process. We need the PID of the worker process.
       int worker_pid;
       std::string pid_str =
-          px::Exec(absl::Substitute("pgrep --parent $0", server.process_pid())).ValueOrDie();
+          px::Exec(absl::Substitute("pgrep -P $0", server.process_pid())).ValueOrDie();
       ASSERT_TRUE(absl::SimpleAtoi(pid_str, &worker_pid));
       LOG(INFO) << absl::Substitute("Worker thread PID: $0", worker_pid);
 


### PR DESCRIPTION
Summary: Some versions of pgrep don't like --parent. Instead use -P which works more broadly.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: existing tests, on qemu sysroot
