### PR TITLE
Enable `grpc_trace_bpf_test` since switch to podman stabilized the test

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -314,8 +314,6 @@ pl_cc_test(
     flaky = True,
     shard_count = 3,
     tags = [
-        # TODO: This test has a <90% pass rate in CI, please fix and re-enable.
-        "disabled_flaky_test",
         "requires_bpf",
         "cpu:16",
         # This test runs Go gRPC client & server, which causes other tests to attach & detach


### PR DESCRIPTION
Summary: Enable the `grpc_trace_bpf_test` since the switch to podman stabilized the test

Before switching to `podman`, `grpc_trace_bpf_test` was failing with the [following error](https://phab.corp.pixielabs.ai/P323). Although the test has stabilized, we may still have a bug. We created #290 to track this because the switch to `podman` may have merely papered over the issue.

The test failures originate from the py grpc test case (see output below), which use docker unlike the other go grpc test cases. I tested a variety of commits and confirmed that 5fa450de3e6f8304f45eb018feb33f4a4bca5338 was the commit that fixes the flakiness.

Relevant Issues: #698

Type of change: /kind cleanup

Test Plan: Ran the `grpc_trace_bpf` tests and bisected the failures until it passed on the podman commit
- [x] Ran tests before 5fa450de3e6f8304f45eb018feb33f4a4bca5338 and verified they failed ([P321](https://phab.corp.pixielabs.ai/P321))
- [x] Ran tests on main and on 5fa450de3e6f8304f45eb018feb33f4a4bca5338 to verify they succeed with `--runs_per_test=50` ([P322](https://phab.corp.pixielabs.ai/P322))