### PR TITLE
Add GetKubeconfigPath method to k8s auth

### DIFF
--- a/src/utils/shared/k8s/auth.go
+++ b/src/utils/shared/k8s/auth.go
@@ -115,6 +115,10 @@ func GetClientAPIConfig() *clientcmdapi.Config {
 	return clientcmd.GetConfigFromFileOrDie(*kubeconfig)
 }
 
+func GetKubeconfigPath() string {
+	return *kubeconfig
+}
+
 func homeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h


### PR DESCRIPTION
Summary: Adds `GetKubeconfigPath()` method to `k8s` package.
This method allows reusing the logic to find the kubeconfig that the `k8s` package uses.

Type of change: /kind cleanup

Test Plan: No effect on existing code. Will be used for the `perf_tool`.
