### PR TITLE
[perf_tool] Add perf_tool root command

### DIFF
--- a/src/e2e_test/perf_tool/BUILD.bazel
+++ b/src/e2e_test/perf_tool/BUILD.bazel
@@ -1,0 +1,35 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel:pl_build_system.bzl", "pl_go_binary")
+
+go_library(
+    name = "perf_tool_lib",
+    srcs = ["main.go"],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/e2e_test/perf_tool/cmd",
+        "@com_github_sirupsen_logrus//:logrus",
+    ],
+)
+
+pl_go_binary(
+    name = "perf_tool",
+    embed = [":perf_tool_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/src/e2e_test/perf_tool/cmd/BUILD.bazel
+++ b/src/e2e_test/perf_tool/cmd/BUILD.bazel
@@ -1,0 +1,29 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cmd",
+    srcs = ["root.go"],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_sirupsen_logrus//:logrus",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_github_spf13_viper//:viper",
+    ],
+)

--- a/src/e2e_test/perf_tool/cmd/root.go
+++ b/src/e2e_test/perf_tool/cmd/root.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package cmd
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	levelStr := os.Getenv("LOG_LEVEL")
+	level, err := log.ParseLevel(levelStr)
+	if err != nil {
+		level = log.InfoLevel
+	}
+	log.SetLevel(level)
+
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("PX")
+}
+
+// RootCmd is the base command used to add other commands.
+var RootCmd = &cobra.Command{
+	Use:   "root",
+	Short: "root command used by other commands",
+}

--- a/src/e2e_test/perf_tool/main.go
+++ b/src/e2e_test/perf_tool/main.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"px.dev/pixie/src/e2e_test/perf_tool/cmd"
+)
+
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		log.WithError(err).Fatal("failed to run perf_tool")
+	}
+}


### PR DESCRIPTION
Summary: Add root command for `perf_tool` that other commands will be a subcommand of.
This doesn't currently do anything and will only be used once other commands are added.

Type of change: /kind cleanup.

Test Plan: No functional changes, just boilerplate for future changes.
