### PR TITLE
Add target_rps parameter to protocol_loadtest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
+	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
 	gonum.org/v1/gonum v0.11.0
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
@@ -276,7 +277,6 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/text v0.3.8 // indirect
-	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af // indirect
 	golang.org/x/tools v0.1.9 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect

--- a/src/e2e_test/protocol_loadtest/client/client.go
+++ b/src/e2e_test/protocol_loadtest/client/client.go
@@ -34,8 +34,9 @@ func init() {
 	pflag.Int("http_port", 0, "Port of the http server")
 
 	pflag.Int("num_connections", 0, "Number of simulataneous connections for the seq load generator")
-	pflag.Int("req_size", 16, "Size of the request in bytes")
-	pflag.Int("resp_size", 16, "Size of the response in bytes")
+	pflag.Int("target_rps", 0, "Target requests per second across all connections")
+	pflag.Int("req_size", 1024, "Size of the request in bytes")
+	pflag.Int("resp_size", 1024, "Size of the response in bytes")
 	pflag.Int("num_messages", 1000, "Num messages per conn per loop")
 }
 
@@ -49,6 +50,7 @@ func main() {
 	addr := fmt.Sprintf("http://%s:%d%s", host, port, path)
 
 	numConns := viper.GetInt("num_connections")
+	targetRPS := viper.GetInt("target_rps")
 	numMessagesPerConn := viper.GetInt("num_messages")
 	reqSize := viper.GetInt("req_size")
 	respSize := viper.GetInt("resp_size")
@@ -57,8 +59,8 @@ func main() {
 
 	seqNum := 0
 	for {
-		log.Infof("Started loadtest with %d conns, %d messages, %d req_size, %d resp_size", numConns, numMessages, reqSize, respSize)
-		c := httpclient.New(addr, seqNum, numMessages, numConns, reqSize, respSize)
+		log.Infof("Started loadtest with %d conns, %d messages, %d req_size, %d resp_size, %d target_rps", numConns, numMessages, reqSize, respSize, targetRPS)
+		c := httpclient.New(addr, seqNum, numMessages, numConns, reqSize, respSize, targetRPS)
 		err := c.Run()
 		if err != nil {
 			log.WithError(err).Error("failed to run seq client")

--- a/src/e2e_test/protocol_loadtest/k8s/client/loadtest_config.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/loadtest_config.yaml
@@ -5,3 +5,4 @@ metadata:
   name: px-protocol-loadtest-config
 data:
   NUM_CONNECTIONS: "99"
+  TARGET_RPS: "3000"

--- a/src/e2e_test/vizier/seq_tests/client/cmd/seq_http.go
+++ b/src/e2e_test/vizier/seq_tests/client/cmd/seq_http.go
@@ -31,6 +31,7 @@ func init() {
 	HTTPSeqCmd.PersistentFlags().IntP("num_conns", "c", 10, "Number of concurrent connections")
 	HTTPSeqCmd.PersistentFlags().IntP("req_size", "r", 16, "The size of the request body")
 	HTTPSeqCmd.PersistentFlags().IntP("resp_size", "z", 16, "The size of the response body")
+	HTTPSeqCmd.PersistentFlags().Int("target_rps", 5000, "The requests per second to aim for")
 }
 
 // HTTPSeqCmd is the generates HTTP sequence messages.
@@ -45,6 +46,7 @@ var HTTPSeqCmd = &cobra.Command{
 		numConns, _ := cmd.Flags().GetInt("num_conns")
 		reqSize, _ := cmd.Flags().GetInt("req_size")
 		respSize, _ := cmd.Flags().GetInt("resp_size")
+		targetRPS, _ := cmd.Flags().GetInt("target_rps")
 		log.
 			WithField("addr", addr).
 			WithField("start_sequence", startSequence).
@@ -52,9 +54,10 @@ var HTTPSeqCmd = &cobra.Command{
 			WithField("num_conns", numConns).
 			WithField("req_size", reqSize).
 			WithField("resp_size", respSize).
+			WithField("target_rps", targetRPS).
 			Info("Running HTTP sequence tests")
 
-		c := httpclient.New(addr, startSequence, numMessages, numConns, reqSize, respSize)
+		c := httpclient.New(addr, startSequence, numMessages, numConns, reqSize, respSize, targetRPS)
 		_ = c.Run()
 		_ = c.PrintStats()
 	},

--- a/src/e2e_test/vizier/seq_tests/client/pkg/httpclient/BUILD.bazel
+++ b/src/e2e_test/vizier/seq_tests/client/pkg/httpclient/BUILD.bazel
@@ -24,5 +24,6 @@ go_library(
     deps = [
         "//src/e2e_test/util",
         "@com_github_sirupsen_logrus//:logrus",
+        "@org_golang_x_time//rate",
     ],
 )


### PR DESCRIPTION
Summary: Add `target_rps` parameter to `protocol_loadtest`. This parameter sets a target for requests per second for the loadtest. It is only a limit on the RPS, so if the target RPS can't be achieved given the CPU/network of the cluster, the RPS will end up lower than the target.
This is useful to ensure consistency of the `protocol_loadtest` across different CPU loads. For example, without this change running the `protocol_loadtest` on an empty cluster would reach significantly higher RPS than running on a loaded cluster.
Also fixes a misnaming of one of the return values in the httpclient (`resp_size` -> `body_size`).

Type of change: /kind cleanup

Test Plan: Tested a skaffold deployment of the `protocol_loadtest`, saw that it reached the target RPS (with roughly 10% margin).
