### PR TITLE
Fix Go TLS trace test by reducing number of iterations

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/go_tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/go_tls_trace_bpf_test.cc
@@ -94,7 +94,7 @@ TYPED_TEST(GoTLSTraceTest, BasicHTTP) {
   PX_CHECK_OK(this->client_.Run(
       std::chrono::seconds{10},
       {absl::Substitute("--network=container:$0", this->server_.container_name())},
-      {"--http2=false"}));
+      {"--http2=false", "--iters=2", "--sub_iters=5"}));
   this->client_.Wait();
 
   this->StopTransferDataThread();
@@ -131,7 +131,7 @@ TYPED_TEST(GoTLSTraceTest, BasicHTTP2) {
   PX_CHECK_OK(this->client_.Run(
       std::chrono::seconds{10},
       {absl::Substitute("--network=container:$0", this->server_.container_name())},
-      {"--http2=true"}));
+      {"--http2=true", "--iters=2", "--sub_iters=5"}));
   this->client_.Wait();
 
   this->StopTransferDataThread();


### PR DESCRIPTION
Summary: This test used to rely on implicit container termination to progress. This change reduces the number of iterations
to make sure the test progresses.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: Tested locally.

