### PR TITLE
Add skaffold deploy for go_grpc_tls_pl demo app

### DIFF
--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/client/client.go
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/client/client.go
@@ -35,12 +35,11 @@ import (
 	"px.dev/pixie/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/greetpb"
 )
 
-const serverAddr = "localhost:50400"
-
 func main() {
 	pflag.String("client_tls_cert", "", "Path to client.crt")
 	pflag.String("client_tls_key", "", "Path to client.key")
 	pflag.String("tls_ca_cert", "", "Path to ca.crt")
+	pflag.String("address", "localhost:50400", "Server address")
 	pflag.Int("count", 1000, "Number of requests sent.")
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
@@ -67,7 +66,7 @@ func main() {
 		InsecureSkipVerify: true,
 	}
 
-	conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(credentials.NewTLS(config)), grpc.WithBlock())
+	conn, err := grpc.Dial(viper.GetString("address"), grpc.WithTransportCredentials(credentials.NewTLS(config)), grpc.WithBlock())
 	if err != nil {
 		log.WithError(err).Fatal("Failed to connect to Server.")
 	}

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/client_deployment.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/client_deployment.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc-client
+  namespace: px-grpc-test
+  labels:
+    name: grpc-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: grpc-client
+  template:
+    metadata:
+      labels:
+        name: grpc-client
+    spec:
+      containers:
+      - name: grpc-client
+        image: gcr.io/pixie-oss/pixie-dev/src/stirling/testing/demo_apps/go_grpc_tls_pl/client:latest
+        args:
+        - --address=grpc-server:50400
+        - --count=100000
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 512Mi

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/kustomization.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: px-grpc-test
+resources:
+- server_deployment.yaml
+- server_service.yaml
+- client_deployment.yaml

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_deployment.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_deployment.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc-server
+  namespace: px-grpc-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: grpc-server
+  template:
+    metadata:
+      labels:
+        name: grpc-server
+    spec:
+      containers:
+      - name: grpc-server
+        image: gcr.io/pixie-oss/pixie-dev/src/stirling/testing/demo_apps/go_grpc_tls_pl/server:latest
+        ports:
+        - containerPort: 50400
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 512Mi

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_service.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-server
+  namespace: px-grpc-test
+spec:
+  type: ClusterIP
+  ports:
+  - protocol: "TCP"
+    port: 50400
+    targetPort: 50400
+  selector:
+    name: grpc-server

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/skaffold.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/skaffold.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: skaffold/v4beta1
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/pixie-oss/pixie-dev/src/stirling/testing/demo_apps/go_grpc_tls_pl/server
+    context: .
+    bazel:
+      target: //src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_20_grpc_tls_server.tar
+  - image: gcr.io/pixie-oss/pixie-dev/src/stirling/testing/demo_apps/go_grpc_tls_pl/client
+    context: .
+    bazel:
+      target: //src/stirling/testing/demo_apps/go_grpc_tls_pl/client:golang_1_20_grpc_tls_client.tar
+  tagPolicy:
+    dateTime: {}
+  local:
+    push: true
+manifests:
+  kustomize:
+    paths:
+    - src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s
+profiles:
+- name: aarch64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=aarch64_sysroot


### PR DESCRIPTION
Summary: Adds a skaffold deploy mechanism for the `go_grpc_tls_pl` demo app which we currently use in bpf tests.

Type of change: /kind test-infra

Test Plan: Tested the skaffold deploy on both x86 and ARM.
