### PR TITLE
Move test container using product catalog service to bazel

### DIFF
--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -273,6 +273,14 @@ def stirling_test_images():
         "pixie-oss/demo-apps/rabbitmq/rabbitmq:3-management",
     )
 
+    # Tag: productcatalogservice:v0.2.0
+    # Arch: linux/amd64
+    _gcr_io_image(
+        "productcatalogservice_v0_2_0",
+        "sha256:1726e4dd813190ad1eae7f3c42483a3a83dd1676832bb7b04256455c8968d82a",
+        "google-samples/microservices-demo/productcatalogservice:v0.2.0",
+    )
+
     # Built and pushed by src/stirling/testing/demo_apps/py_grpc/update_gcr.sh
     _gcr_io_image(
         "py_grpc_helloworld_image",

--- a/src/stirling/source_connectors/socket_tracer/testing/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/BUILD.bazel
@@ -56,6 +56,7 @@ pl_cc_test_library(
         "//src/stirling/source_connectors/socket_tracer/testing/containers:node_12_3_1_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:node_14_18_1_alpine_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:postgres_image.tar",
+        "//src/stirling/source_connectors/socket_tracer/testing/containers:productcatalogservice_v0_2_0.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:py_grpc_helloworld_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:redis_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:ruby_image.tar",

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images.h
@@ -610,11 +610,14 @@ class NATSClientContainer : public ContainerRunner {
 
 class ProductCatalogService : public ContainerRunner {
  public:
-  ProductCatalogService() : ContainerRunner(kImage, kContainerNamePrefix, kReadyMessage) {}
+  ProductCatalogService()
+      : ContainerRunner(::px::testing::BazelRunfilePath(kBazelImageTar), kContainerNamePrefix,
+                        kReadyMessage) {}
 
  private:
-  static constexpr std::string_view kImage =
-      "gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.0";
+  static constexpr std::string_view kBazelImageTar =
+      "src/stirling/source_connectors/socket_tracer/testing/containers/"
+      "productcatalogservice_v0_2_0.tar";
   static constexpr std::string_view kContainerNamePrefix = "pcs";
   static constexpr std::string_view kReadyMessage = "starting grpc server";
 };

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
@@ -121,3 +121,8 @@ container_image(
     name = "py_grpc_helloworld_image",
     base = "@py_grpc_helloworld_image//image",
 )
+
+container_image(
+    name = "productcatalogservice_v0_2_0",
+    base = "@productcatalogservice_v0_2_0//image",
+)


### PR DESCRIPTION
Summary: Remove the docker container fetch and replaces it with the bazel version. This should help us with a more hermetic
build and allow running tests where we don't have internet access.

Relevant Issues: #709

Type of change: /kind cleanup

Test Plan: Existing tests should pass.
