### PR TITLE
[perf_tool] Simplify ExperimentSpec by removing VersionSpec

### DIFF
--- a/src/e2e_test/perf_tool/experimentpb/experiment.pb.go
+++ b/src/e2e_test/perf_tool/experimentpb/experiment.pb.go
@@ -26,11 +26,11 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ExperimentSpec struct {
-	VersionSpec   *VersionSpec    `protobuf:"bytes,1,opt,name=version_spec,json=versionSpec,proto3" json:"version_spec,omitempty"`
-	VizierSpec    *WorkloadSpec   `protobuf:"bytes,2,opt,name=vizier_spec,json=vizierSpec,proto3" json:"vizier_spec,omitempty"`
-	WorkloadSpecs []*WorkloadSpec `protobuf:"bytes,3,rep,name=workload_specs,json=workloadSpecs,proto3" json:"workload_specs,omitempty"`
-	MetricSpecs   []*MetricSpec   `protobuf:"bytes,4,rep,name=metric_specs,json=metricSpecs,proto3" json:"metric_specs,omitempty"`
-	ClusterSpec   *ClusterSpec    `protobuf:"bytes,5,opt,name=cluster_spec,json=clusterSpec,proto3" json:"cluster_spec,omitempty"`
+	VizierSpec    *WorkloadSpec   `protobuf:"bytes,1,opt,name=vizier_spec,json=vizierSpec,proto3" json:"vizier_spec,omitempty"`
+	WorkloadSpecs []*WorkloadSpec `protobuf:"bytes,2,rep,name=workload_specs,json=workloadSpecs,proto3" json:"workload_specs,omitempty"`
+	MetricSpecs   []*MetricSpec   `protobuf:"bytes,3,rep,name=metric_specs,json=metricSpecs,proto3" json:"metric_specs,omitempty"`
+	ClusterSpec   *ClusterSpec    `protobuf:"bytes,4,opt,name=cluster_spec,json=clusterSpec,proto3" json:"cluster_spec,omitempty"`
+	CommitSHA     string          `protobuf:"bytes,6,opt,name=commit_sha,json=commitSha,proto3" json:"commit_sha,omitempty"`
 }
 
 func (m *ExperimentSpec) Reset()      { *m = ExperimentSpec{} }
@@ -65,13 +65,6 @@ func (m *ExperimentSpec) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ExperimentSpec proto.InternalMessageInfo
 
-func (m *ExperimentSpec) GetVersionSpec() *VersionSpec {
-	if m != nil {
-		return m.VersionSpec
-	}
-	return nil
-}
-
 func (m *ExperimentSpec) GetVizierSpec() *WorkloadSpec {
 	if m != nil {
 		return m.VizierSpec
@@ -100,40 +93,12 @@ func (m *ExperimentSpec) GetClusterSpec() *ClusterSpec {
 	return nil
 }
 
-type VersionSpec struct {
-}
-
-func (m *VersionSpec) Reset()      { *m = VersionSpec{} }
-func (*VersionSpec) ProtoMessage() {}
-func (*VersionSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{1}
-}
-func (m *VersionSpec) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *VersionSpec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_VersionSpec.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
+func (m *ExperimentSpec) GetCommitSHA() string {
+	if m != nil {
+		return m.CommitSHA
 	}
+	return ""
 }
-func (m *VersionSpec) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VersionSpec.Merge(m, src)
-}
-func (m *VersionSpec) XXX_Size() int {
-	return m.Size()
-}
-func (m *VersionSpec) XXX_DiscardUnknown() {
-	xxx_messageInfo_VersionSpec.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_VersionSpec proto.InternalMessageInfo
 
 type WorkloadSpec struct {
 }
@@ -141,7 +106,7 @@ type WorkloadSpec struct {
 func (m *WorkloadSpec) Reset()      { *m = WorkloadSpec{} }
 func (*WorkloadSpec) ProtoMessage() {}
 func (*WorkloadSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{2}
+	return fileDescriptor_96d7e52dda1e6fe3, []int{1}
 }
 func (m *WorkloadSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -176,7 +141,7 @@ type MetricSpec struct {
 func (m *MetricSpec) Reset()      { *m = MetricSpec{} }
 func (*MetricSpec) ProtoMessage() {}
 func (*MetricSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{3}
+	return fileDescriptor_96d7e52dda1e6fe3, []int{2}
 }
 func (m *MetricSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -211,7 +176,7 @@ type ClusterSpec struct {
 func (m *ClusterSpec) Reset()      { *m = ClusterSpec{} }
 func (*ClusterSpec) ProtoMessage() {}
 func (*ClusterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{4}
+	return fileDescriptor_96d7e52dda1e6fe3, []int{3}
 }
 func (m *ClusterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -240,48 +205,11 @@ func (m *ClusterSpec) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ClusterSpec proto.InternalMessageInfo
 
-type Empty struct {
-}
-
-func (m *Empty) Reset()      { *m = Empty{} }
-func (*Empty) ProtoMessage() {}
-func (*Empty) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{5}
-}
-func (m *Empty) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *Empty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_Empty.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *Empty) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Empty.Merge(m, src)
-}
-func (m *Empty) XXX_Size() int {
-	return m.Size()
-}
-func (m *Empty) XXX_DiscardUnknown() {
-	xxx_messageInfo_Empty.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Empty proto.InternalMessageInfo
-
 func init() {
 	proto.RegisterType((*ExperimentSpec)(nil), "px.perf_tool.ExperimentSpec")
-	proto.RegisterType((*VersionSpec)(nil), "px.perf_tool.VersionSpec")
 	proto.RegisterType((*WorkloadSpec)(nil), "px.perf_tool.WorkloadSpec")
 	proto.RegisterType((*MetricSpec)(nil), "px.perf_tool.MetricSpec")
 	proto.RegisterType((*ClusterSpec)(nil), "px.perf_tool.ClusterSpec")
-	proto.RegisterType((*Empty)(nil), "px.perf_tool.Empty")
 }
 
 func init() {
@@ -289,29 +217,30 @@ func init() {
 }
 
 var fileDescriptor_96d7e52dda1e6fe3 = []byte{
-	// 348 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0x3f, 0x4f, 0x02, 0x31,
-	0x18, 0xc6, 0xaf, 0x20, 0x9a, 0xf4, 0x0e, 0x86, 0x9b, 0x90, 0xe1, 0x0d, 0xb9, 0xc9, 0xc5, 0xbb,
-	0x04, 0xdd, 0x70, 0x11, 0xc3, 0xe8, 0xa2, 0x89, 0x26, 0x2e, 0xc4, 0xab, 0x05, 0x2f, 0x72, 0xb4,
-	0x69, 0xcb, 0x1f, 0x9d, 0xfc, 0x08, 0x7e, 0x0c, 0x3f, 0x8a, 0x6e, 0x8c, 0x8c, 0x52, 0x16, 0x47,
-	0x3e, 0x82, 0xa1, 0x45, 0x28, 0x89, 0x89, 0xdb, 0xfb, 0xa4, 0xcf, 0xef, 0x79, 0xdf, 0xb7, 0x2d,
-	0x3e, 0x95, 0x82, 0x24, 0xb4, 0x41, 0x3b, 0x8a, 0x4a, 0x95, 0x70, 0x2a, 0xba, 0x1d, 0xc5, 0x58,
-	0x3f, 0xa1, 0x13, 0x4e, 0x45, 0x96, 0xd3, 0x81, 0xe2, 0xa9, 0x23, 0x62, 0x2e, 0x98, 0x62, 0x61,
-	0xc0, 0x27, 0xf1, 0xc6, 0x5b, 0x3b, 0xee, 0x65, 0xea, 0x71, 0x98, 0xc6, 0x84, 0xe5, 0x49, 0x8f,
-	0xf5, 0x58, 0x62, 0x4c, 0xe9, 0xb0, 0x6b, 0x94, 0x11, 0xa6, 0xb2, 0x70, 0xf4, 0x59, 0xc0, 0x95,
-	0xf6, 0x26, 0xf1, 0x9a, 0x53, 0x12, 0x9e, 0xe1, 0x60, 0x44, 0x85, 0xcc, 0xd8, 0xa0, 0x23, 0x39,
-	0x25, 0x55, 0x54, 0x47, 0x47, 0x7e, 0xe3, 0x30, 0x76, 0xdb, 0xc4, 0x37, 0xd6, 0xb1, 0x02, 0xae,
-	0xfc, 0xd1, 0x56, 0x84, 0x4d, 0xec, 0x8f, 0xb2, 0x97, 0x8c, 0x0a, 0x0b, 0x17, 0x0c, 0x5c, 0xdb,
-	0x85, 0x6f, 0x99, 0x78, 0xea, 0xb3, 0xfb, 0x07, 0x43, 0x63, 0x6b, 0x37, 0xf0, 0x39, 0xae, 0x8c,
-	0xd7, 0x67, 0x06, 0x97, 0xd5, 0x62, 0xbd, 0xf8, 0x0f, 0x5f, 0x1e, 0x3b, 0x4a, 0x86, 0x4d, 0x1c,
-	0xe4, 0x54, 0x89, 0x8c, 0xac, 0x03, 0xf6, 0x4c, 0x40, 0x75, 0x37, 0xe0, 0xd2, 0x38, 0xec, 0xf0,
-	0xf9, 0xa6, 0x96, 0xab, 0xd5, 0x49, 0x7f, 0x28, 0xd5, 0xef, 0xf4, 0xa5, 0xbf, 0x56, 0xbf, 0xb0,
-	0x0e, 0x4b, 0x93, 0xad, 0x88, 0xca, 0xd8, 0x77, 0xae, 0x25, 0xaa, 0xe0, 0xc0, 0x1d, 0x34, 0x0a,
-	0x30, 0xde, 0xf6, 0x5d, 0x99, 0x9d, 0xa0, 0xe8, 0x00, 0x97, 0xda, 0x39, 0x57, 0xcf, 0xad, 0xd6,
-	0x74, 0x0e, 0xde, 0x6c, 0x0e, 0xde, 0x72, 0x0e, 0xe8, 0x55, 0x03, 0x7a, 0xd7, 0x80, 0x3e, 0x34,
-	0xa0, 0xa9, 0x06, 0xf4, 0xa5, 0x01, 0x7d, 0x6b, 0xf0, 0x96, 0x1a, 0xd0, 0xdb, 0x02, 0xbc, 0xe9,
-	0x02, 0xbc, 0xd9, 0x02, 0xbc, 0xbb, 0xc0, 0xfd, 0x22, 0xe9, 0xbe, 0x79, 0xdb, 0x93, 0x9f, 0x00,
-	0x00, 0x00, 0xff, 0xff, 0x8d, 0xf9, 0x3b, 0x40, 0x50, 0x02, 0x00, 0x00,
+	// 360 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0x31, 0x4f, 0xfa, 0x40,
+	0x18, 0xc6, 0x7b, 0xc0, 0x9f, 0xfc, 0xb9, 0x16, 0x62, 0x3a, 0x55, 0x86, 0x57, 0xd2, 0x89, 0x41,
+	0xdb, 0x04, 0xdd, 0x70, 0x01, 0x62, 0x62, 0x4c, 0x5c, 0x60, 0x30, 0x71, 0x69, 0xe8, 0x79, 0x40,
+	0x23, 0xf5, 0x9a, 0xbb, 0x43, 0x88, 0x93, 0x1f, 0xc1, 0x8f, 0xe1, 0xb7, 0x70, 0x75, 0x64, 0x64,
+	0x32, 0x72, 0x2c, 0x8e, 0x7c, 0x04, 0xe3, 0x15, 0xa1, 0x4c, 0x6e, 0xef, 0xd3, 0x3e, 0xbf, 0xe7,
+	0x7d, 0x2e, 0x77, 0xf8, 0x4c, 0x70, 0xe2, 0xd3, 0x06, 0x0d, 0x24, 0x15, 0xd2, 0x4f, 0x28, 0x1f,
+	0x04, 0x92, 0xb1, 0xb1, 0x4f, 0x67, 0x09, 0xe5, 0x51, 0x4c, 0x1f, 0x64, 0x12, 0x66, 0x84, 0x97,
+	0x70, 0x26, 0x99, 0x6d, 0x25, 0x33, 0x6f, 0xeb, 0xad, 0x9e, 0x0c, 0x23, 0x39, 0x9a, 0x84, 0x1e,
+	0x61, 0xb1, 0x3f, 0x64, 0x43, 0xe6, 0x6b, 0x53, 0x38, 0x19, 0x68, 0xa5, 0x85, 0x9e, 0x52, 0xd8,
+	0x7d, 0xcb, 0xe1, 0xca, 0xc5, 0x36, 0xb1, 0x97, 0x50, 0x62, 0x37, 0xb1, 0xf9, 0x18, 0x3d, 0x45,
+	0x94, 0x07, 0x22, 0xa1, 0xc4, 0x41, 0x35, 0x54, 0x37, 0x1b, 0x55, 0x2f, 0xbb, 0xc5, 0xbb, 0x61,
+	0xfc, 0x7e, 0xcc, 0xfa, 0x77, 0x3f, 0x40, 0x17, 0xa7, 0x76, 0x0d, 0xb7, 0x70, 0x65, 0xba, 0xf9,
+	0xa7, 0x71, 0xe1, 0xe4, 0x6a, 0xf9, 0x3f, 0xf8, 0xf2, 0x34, 0xa3, 0x84, 0xdd, 0xc4, 0x56, 0x4c,
+	0x25, 0x8f, 0xc8, 0x26, 0x20, 0xaf, 0x03, 0x9c, 0xfd, 0x80, 0x6b, 0xed, 0xd0, 0xb8, 0x19, 0x6f,
+	0x67, 0x61, 0x9f, 0x63, 0x8b, 0x8c, 0x27, 0x42, 0xfe, 0xb6, 0x2f, 0xe8, 0xf6, 0x87, 0xfb, 0x70,
+	0x27, 0x75, 0xa4, 0x34, 0xd9, 0x09, 0xfb, 0x18, 0x63, 0xc2, 0xe2, 0x38, 0x92, 0x81, 0x18, 0xf5,
+	0x9d, 0x62, 0x0d, 0xd5, 0x4b, 0xed, 0xb2, 0xfa, 0x38, 0x2a, 0x75, 0xf4, 0xd7, 0xde, 0x65, 0xab,
+	0x5b, 0x4a, 0x0d, 0xbd, 0x51, 0xff, 0xaa, 0xf0, 0xff, 0xdf, 0x41, 0xd1, 0xad, 0x60, 0x2b, 0x7b,
+	0x1a, 0xd7, 0xc2, 0x78, 0x57, 0xce, 0x2d, 0x63, 0x33, 0xb3, 0xad, 0xdd, 0x9e, 0x2f, 0xc1, 0x58,
+	0x2c, 0xc1, 0x58, 0x2f, 0x01, 0x3d, 0x2b, 0x40, 0xaf, 0x0a, 0xd0, 0xbb, 0x02, 0x34, 0x57, 0x80,
+	0x3e, 0x15, 0xa0, 0x2f, 0x05, 0xc6, 0x5a, 0x01, 0x7a, 0x59, 0x81, 0x31, 0x5f, 0x81, 0xb1, 0x58,
+	0x81, 0x71, 0x6b, 0x65, 0x1f, 0x40, 0x58, 0xd4, 0x37, 0x77, 0xfa, 0x1d, 0x00, 0x00, 0xff, 0xff,
+	0x63, 0xd5, 0x66, 0x28, 0x2e, 0x02, 0x00, 0x00,
 }
 
 func (this *ExperimentSpec) Equal(that interface{}) bool {
@@ -331,9 +260,6 @@ func (this *ExperimentSpec) Equal(that interface{}) bool {
 	if that1 == nil {
 		return this == nil
 	} else if this == nil {
-		return false
-	}
-	if !this.VersionSpec.Equal(that1.VersionSpec) {
 		return false
 	}
 	if !this.VizierSpec.Equal(that1.VizierSpec) {
@@ -358,25 +284,7 @@ func (this *ExperimentSpec) Equal(that interface{}) bool {
 	if !this.ClusterSpec.Equal(that1.ClusterSpec) {
 		return false
 	}
-	return true
-}
-func (this *VersionSpec) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*VersionSpec)
-	if !ok {
-		that2, ok := that.(VersionSpec)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
+	if this.CommitSHA != that1.CommitSHA {
 		return false
 	}
 	return true
@@ -444,36 +352,12 @@ func (this *ClusterSpec) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *Empty) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*Empty)
-	if !ok {
-		that2, ok := that.(Empty)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	return true
-}
 func (this *ExperimentSpec) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 9)
 	s = append(s, "&experimentpb.ExperimentSpec{")
-	if this.VersionSpec != nil {
-		s = append(s, "VersionSpec: "+fmt.Sprintf("%#v", this.VersionSpec)+",\n")
-	}
 	if this.VizierSpec != nil {
 		s = append(s, "VizierSpec: "+fmt.Sprintf("%#v", this.VizierSpec)+",\n")
 	}
@@ -486,15 +370,7 @@ func (this *ExperimentSpec) GoString() string {
 	if this.ClusterSpec != nil {
 		s = append(s, "ClusterSpec: "+fmt.Sprintf("%#v", this.ClusterSpec)+",\n")
 	}
-	s = append(s, "}")
-	return strings.Join(s, "")
-}
-func (this *VersionSpec) GoString() string {
-	if this == nil {
-		return "nil"
-	}
-	s := make([]string, 0, 4)
-	s = append(s, "&experimentpb.VersionSpec{")
+	s = append(s, "CommitSHA: "+fmt.Sprintf("%#v", this.CommitSHA)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -522,15 +398,6 @@ func (this *ClusterSpec) GoString() string {
 	}
 	s := make([]string, 0, 4)
 	s = append(s, "&experimentpb.ClusterSpec{")
-	s = append(s, "}")
-	return strings.Join(s, "")
-}
-func (this *Empty) GoString() string {
-	if this == nil {
-		return "nil"
-	}
-	s := make([]string, 0, 4)
-	s = append(s, "&experimentpb.Empty{")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -562,6 +429,13 @@ func (m *ExperimentSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.CommitSHA) > 0 {
+		i -= len(m.CommitSHA)
+		copy(dAtA[i:], m.CommitSHA)
+		i = encodeVarintExperiment(dAtA, i, uint64(len(m.CommitSHA)))
+		i--
+		dAtA[i] = 0x32
+	}
 	if m.ClusterSpec != nil {
 		{
 			size, err := m.ClusterSpec.MarshalToSizedBuffer(dAtA[:i])
@@ -572,7 +446,7 @@ func (m *ExperimentSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i = encodeVarintExperiment(dAtA, i, uint64(size))
 		}
 		i--
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x22
 	}
 	if len(m.MetricSpecs) > 0 {
 		for iNdEx := len(m.MetricSpecs) - 1; iNdEx >= 0; iNdEx-- {
@@ -585,7 +459,7 @@ func (m *ExperimentSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 				i = encodeVarintExperiment(dAtA, i, uint64(size))
 			}
 			i--
-			dAtA[i] = 0x22
+			dAtA[i] = 0x1a
 		}
 	}
 	if len(m.WorkloadSpecs) > 0 {
@@ -599,7 +473,7 @@ func (m *ExperimentSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 				i = encodeVarintExperiment(dAtA, i, uint64(size))
 			}
 			i--
-			dAtA[i] = 0x1a
+			dAtA[i] = 0x12
 		}
 	}
 	if m.VizierSpec != nil {
@@ -612,43 +486,8 @@ func (m *ExperimentSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i = encodeVarintExperiment(dAtA, i, uint64(size))
 		}
 		i--
-		dAtA[i] = 0x12
-	}
-	if m.VersionSpec != nil {
-		{
-			size, err := m.VersionSpec.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = encodeVarintExperiment(dAtA, i, uint64(size))
-		}
-		i--
 		dAtA[i] = 0xa
 	}
-	return len(dAtA) - i, nil
-}
-
-func (m *VersionSpec) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *VersionSpec) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *VersionSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
 	return len(dAtA) - i, nil
 }
 
@@ -721,29 +560,6 @@ func (m *ClusterSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *Empty) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Empty) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *Empty) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	return len(dAtA) - i, nil
-}
-
 func encodeVarintExperiment(dAtA []byte, offset int, v uint64) int {
 	offset -= sovExperiment(v)
 	base := offset
@@ -761,10 +577,6 @@ func (m *ExperimentSpec) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.VersionSpec != nil {
-		l = m.VersionSpec.Size()
-		n += 1 + l + sovExperiment(uint64(l))
-	}
 	if m.VizierSpec != nil {
 		l = m.VizierSpec.Size()
 		n += 1 + l + sovExperiment(uint64(l))
@@ -785,15 +597,10 @@ func (m *ExperimentSpec) Size() (n int) {
 		l = m.ClusterSpec.Size()
 		n += 1 + l + sovExperiment(uint64(l))
 	}
-	return n
-}
-
-func (m *VersionSpec) Size() (n int) {
-	if m == nil {
-		return 0
+	l = len(m.CommitSHA)
+	if l > 0 {
+		n += 1 + l + sovExperiment(uint64(l))
 	}
-	var l int
-	_ = l
 	return n
 }
 
@@ -824,15 +631,6 @@ func (m *ClusterSpec) Size() (n int) {
 	return n
 }
 
-func (m *Empty) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	return n
-}
-
 func sovExperiment(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -854,20 +652,11 @@ func (this *ExperimentSpec) String() string {
 	}
 	repeatedStringForMetricSpecs += "}"
 	s := strings.Join([]string{`&ExperimentSpec{`,
-		`VersionSpec:` + strings.Replace(this.VersionSpec.String(), "VersionSpec", "VersionSpec", 1) + `,`,
 		`VizierSpec:` + strings.Replace(this.VizierSpec.String(), "WorkloadSpec", "WorkloadSpec", 1) + `,`,
 		`WorkloadSpecs:` + repeatedStringForWorkloadSpecs + `,`,
 		`MetricSpecs:` + repeatedStringForMetricSpecs + `,`,
 		`ClusterSpec:` + strings.Replace(this.ClusterSpec.String(), "ClusterSpec", "ClusterSpec", 1) + `,`,
-		`}`,
-	}, "")
-	return s
-}
-func (this *VersionSpec) String() string {
-	if this == nil {
-		return "nil"
-	}
-	s := strings.Join([]string{`&VersionSpec{`,
+		`CommitSHA:` + fmt.Sprintf("%v", this.CommitSHA) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -895,15 +684,6 @@ func (this *ClusterSpec) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&ClusterSpec{`,
-		`}`,
-	}, "")
-	return s
-}
-func (this *Empty) String() string {
-	if this == nil {
-		return "nil"
-	}
-	s := strings.Join([]string{`&Empty{`,
 		`}`,
 	}, "")
 	return s
@@ -947,42 +727,6 @@ func (m *ExperimentSpec) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field VersionSpec", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExperiment
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthExperiment
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthExperiment
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.VersionSpec == nil {
-				m.VersionSpec = &VersionSpec{}
-			}
-			if err := m.VersionSpec.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field VizierSpec", wireType)
 			}
 			var msglen int
@@ -1017,7 +761,7 @@ func (m *ExperimentSpec) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 3:
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field WorkloadSpecs", wireType)
 			}
@@ -1051,7 +795,7 @@ func (m *ExperimentSpec) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MetricSpecs", wireType)
 			}
@@ -1085,7 +829,7 @@ func (m *ExperimentSpec) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ClusterSpec", wireType)
 			}
@@ -1121,56 +865,38 @@ func (m *ExperimentSpec) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipExperiment(dAtA[iNdEx:])
-			if err != nil {
-				return err
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CommitSHA", wireType)
 			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExperiment
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
 				return ErrInvalidLengthExperiment
 			}
-			if (iNdEx + skippy) > l {
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *VersionSpec) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowExperiment
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: VersionSpec: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: VersionSpec: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
+			m.CommitSHA = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipExperiment(dAtA[iNdEx:])
@@ -1319,56 +1045,6 @@ func (m *ClusterSpec) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: ClusterSpec: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		default:
-			iNdEx = preIndex
-			skippy, err := skipExperiment(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthExperiment
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *Empty) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowExperiment
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Empty: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Empty: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/src/e2e_test/perf_tool/experimentpb/experiment.proto
+++ b/src/e2e_test/perf_tool/experimentpb/experiment.proto
@@ -26,34 +26,28 @@ import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // ExperimentSpec fully specifies how to run a single perf experiment.
 // An Experiment is fully specified by specifying all of the following:
-//  - version of the Pixie repo (commit) to use to build the components of the experiment (see
-//  VizierSpec).
 //  - parameters to use when building/running Vizier.
 //  - specifications for other workloads to run on the same cluster during the experiment (see
 //  WorkloadSpec).
 //  - specifications for metrics to record during the experiment (see MetricSpec).
 //  - specifications for the cluster that the experiment runs on (see ClusterSpec).
+//  - the commit the experiment was run from.
 message ExperimentSpec {
-  // VersionSpec specifies what version of the pixie repo to use to build the various components of
-  // the experiment.
-  VersionSpec version_spec = 1;
   // vizier_spec specifies parameters around building and deploying the vizier workload for the
   // experiment.
-  WorkloadSpec vizier_spec = 2;
+  WorkloadSpec vizier_spec = 1;
   // Each workload spec specifies parameters for building and deploying a workload for the
   // experiment.
-  repeated WorkloadSpec workload_specs = 3;
+  repeated WorkloadSpec workload_specs = 2;
   // Each metric spec specifies parameters for building and recording a metric during the
   // experiment.
-  repeated MetricSpec metric_specs = 4;
+  repeated MetricSpec metric_specs = 3;
   // ClusterSpec specifies what type of cluster to run the experiment on.
-  ClusterSpec cluster_spec = 5;
+  ClusterSpec cluster_spec = 4;
+  reserved 5;
+  // commit_sha of the commit the experiment was run from.
+  string commit_sha = 6 [ (gogoproto.customname) = "CommitSHA" ];
 }
-
-// VersionSpec specifies the version of the Pixie repo to use for running the Experiment.
-// It specifies the base commit via a commit SHA, and allows specifying patches on top of that
-// commit.
-message VersionSpec {}
 
 // WorkloadSpec specifies how to build, deploy and teardown a particular workload.
 // Example workloads include: Vizier, Sock shop, or an HTTP protocol loadtest (see
@@ -70,5 +64,3 @@ message MetricSpec {}
 // Cluster parameters currently include things like machine type, and number of nodes in the
 // cluster.
 message ClusterSpec {}
-
-message Empty {}


### PR DESCRIPTION
Summary: Experiments can no longer be run on arbitrary versions, this simplifies a lot of the logic internally, and also simplifies the spec. Instead we rely on Jenkins/Github Actions to pick the version to run the experiments from.

Type of change: /kind test-infra

Test Plan: No functional changes yet. Tested as part of future diffs that consume this proto.
