### PR TITLE
Improve Command Palette and Breadcrumb sorting

### DIFF
--- a/src/ui/src/containers/live/breadcrumbs.tsx
+++ b/src/ui/src/containers/live/breadcrumbs.tsx
@@ -144,11 +144,11 @@ export const LiveViewBreadcrumbs: React.FC = React.memo(() => {
 
         const ids = scriptIds.filter(s => !input || s === SCRATCH_SCRIPT.id || matches.get(s)?.isMatch);
 
-        // First, sort by quality of the match
-        ids.sort((a, b) => (matches.get(a)?.distance ?? Infinity) - (matches.get(b)?.distance ?? Infinity));
-
         // The `px` namespace should appear before all others
         ids.sort((a, b) => Number(b.startsWith('px/')) - Number(a.startsWith('px/')));
+
+        // Higher quality matches appear before lower ones (with the `px/` namespace winning on a tie)
+        ids.sort((a, b) => (matches.get(a)?.distance ?? Infinity) - (matches.get(b)?.distance ?? Infinity));
 
         // The scratch script should always appear at the top of the list for visibility. It doesn't get auto-selected
         // unless it's the only thing in the list.

--- a/src/ui/src/utils/string-search-test.ts
+++ b/src/ui/src/utils/string-search-test.ts
@@ -100,8 +100,6 @@ describe('String search utils', () => {
   });
 
   it('Scoring of multiple types of matches results in a reasonable ordering', () => {
-    // TODO: This ordering is still not ideal... substring preference should probably be even stronger to fix it?
-
     // Each of these searches should end up with the following order of lowest distance to highest.
     // The balancing on how to score different scenarios is delicate, but should result in something that makes the
     // most sense to a user. We're aiming for relevance, not similarity: find what the user _meant_.

--- a/src/ui/src/utils/string-search-test.ts
+++ b/src/ui/src/utils/string-search-test.ts
@@ -27,11 +27,15 @@ describe('String search utils', () => {
   it('Highlights simple substring matches of normalized strings', () => {
     // Substring matches are treated as cheaper than typo matches (since it's all contiguos inserts), thus lower scores.
     expect(highlightScoredMatch('pod', 'px/pod'))
-      .toEqual({ isMatch: true, distance: 1, highlights: [3, 4, 5] });
+      .toEqual({ isMatch: true, distance: 0.75, highlights: [3, 4, 5] });
     expect(highlightScoredMatch('oba', 'foobar'))
-      .toEqual({ isMatch: true, distance: 1, highlights: [2, 3, 4] });
+      .toEqual({ isMatch: true, distance: 0.75, highlights: [2, 3, 4] });
     expect(highlightScoredMatch('o!Ba', '  F.o*O!bar__ '))
-      .toEqual({ isMatch: true, distance: 1, highlights: [6, 8, 9] });
+      .toEqual({ isMatch: true, distance: 0.75, highlights: [6, 8, 9] });
+    expect(highlightScoredMatch('ace', 'namespace'))
+      .toEqual({ isMatch: true, distance: 1.5, highlights: [6, 7, 8] });
+    expect(highlightScoredMatch('ace', 'namespaces'))
+      .toEqual({ isMatch: true, distance: 1.75, highlights: [6, 7, 8] });
   });
 
   it('Does not highlight strings that are too different to be reasonable matches', () => {
@@ -88,6 +92,34 @@ describe('String search utils', () => {
 
   it('Splits namespaced searches', () => {
     expect(highlightNamespacedScoredMatch('pod', 'px/pod', '/'))
-      .toEqual({ isMatch: true, distance: 0, highlights: [3, 4, 5] });
+      .toEqual({ isMatch: true, distance: 0.5, highlights: [3, 4, 5] });
+    expect(highlightNamespacedScoredMatch('px/ace', 'px/namespace', '/'))
+      .toEqual({ isMatch: true, distance: 1.5, highlights: [0, 1, 9, 10, 11] });
+    expect(highlightNamespacedScoredMatch('px/ace', 'px/namespaces', '/'))
+      .toEqual({ isMatch: true, distance: 1.75, highlights: [0, 1, 9, 10, 11] });
+  });
+
+  it('Scoring of multiple types of matches results in a reasonable ordering', () => {
+    // TODO: This ordering is still not ideal... substring preference should probably be even stronger to fix it?
+
+    // Each of these searches should end up with the following order of lowest distance to highest.
+    // The balancing on how to score different scenarios is delicate, but should result in something that makes the
+    // most sense to a user. We're aiming for relevance, not similarity: find what the user _meant_.
+    const searches = {
+      // Perfect matches are much stronger than anything else
+      'pod': ['px/POD', 'px/PODs', 'Px/nODe', 'nonsense'],
+      // Changing a character (d to s) is a slightly stronger match than deleting the extra d
+      'px/podd': ['PX/PODs', 'PX/POD'],
+      // An unbroken substring is a stronger match than one with edits, even if the latter is a much shorter string.
+      'px/ace': ['PX/namespACE', 'PX/namespACEs', 'PX/nodE'],
+      'px/stat': ['PX/cql_STATs', 'PX/agent_STATus', 'PX/service_edge_STATs', 'PX/dnS_dATa', 'PXbeTA/service_endpoint'],
+    };
+
+    for (const search in searches) {
+      const sources = searches[search];
+      const results = sources.map(source => highlightNamespacedScoredMatch(search, source, '/'));
+      const sorted = [...results].sort((a, b) => a.distance - b.distance);
+      expect(results).toEqual(sorted);
+    }
   });
 });

--- a/src/ui/src/utils/string-search.ts
+++ b/src/ui/src/utils/string-search.ts
@@ -18,6 +18,18 @@
 
 const ALLOWED_CHARS = new Set('abcdefghijklmnopqrstuvwxyz01234567890/'.split(''));
 
+// Scoring by relevance involves a bit of math based on what properties a match has.
+// These numbers were determined experimentally, by trying a variety of search strings against
+// the full list of PxL script names until the ordering consistently got desirable results.
+const PREFIX_DISTANCE_FACTOR = 0.2;
+const SUBSTRING_DISTANCE_FACTOR = 0.25;
+const MAX_DISTANCE_RATIO = 0.8;
+const INSERT_COST = 1;
+const DELETE_COST = 1;
+const SUBSTITUTE_COST = 0.75;
+const NEAR_SWAP_COST = 0.50;
+const FAR_SWAP_COST = 0.70;
+
 interface ScoredStringMatch {
   /** Whether the search string is a reasonably confident match for the source string */
   isMatch: boolean;
@@ -58,7 +70,7 @@ function isMatchGoodEnough(searchLen: number, sourceLen: number, distance: numbe
   // Must highlight at least half of the smaller string
   if (highlights.length <= Math.ceil(min / 2)) return false;
   // Edit distance should be within reason (too high, and we probably have a totally unrelated string)
-  if (distance >= (Math.max(searchLen, sourceLen) * 0.8)) return false;
+  if (distance >= (Math.max(searchLen, sourceLen) * MAX_DISTANCE_RATIO)) return false;
   return true;
 }
 
@@ -98,12 +110,12 @@ function optimalStringAlignmentAndHighlight(
 
       // Insert and delete "cost" more than substitution, which costs more than swapping.
       // This means we're not tracking "how many edits does it take"; we're preferring edits that look better to humans.
-      const deleteDist = d[k - 1][l] + 1;
-      const insertDist = d[k][l - 1] + 1;
-      const substituteDist = canSubstitute ? d[k - 1][l - 1] + 0.75 : Infinity;
+      const deleteDist = d[k - 1][l] + DELETE_COST;
+      const insertDist = d[k][l - 1] + INSERT_COST;
+      const substituteDist = canSubstitute ? d[k - 1][l - 1] + SUBSTITUTE_COST : Infinity;
       const noopDist = canSubstitute ? Infinity : d[k - 1][l - 1];
-      const swapDist = canSwap ? d[k - 2][l - 2] + 0.50 : Infinity;
-      const farSwapDist = canSwapFar ? d[k - 3][l - 3] + 0.70 : Infinity;
+      const swapDist = canSwap ? d[k - 2][l - 2] + NEAR_SWAP_COST : Infinity;
+      const farSwapDist = canSwapFar ? d[k - 3][l - 3] + FAR_SWAP_COST : Infinity;
       d[k][l] = Math.min(deleteDist, insertDist, substituteDist, noopDist, swapDist, farSwapDist);
 
       // Keep track of the path we took, so we can trace it back for highlights later
@@ -183,13 +195,13 @@ export function highlightScoredMatch(search: string, source: string): ScoredStri
     // Exact prefix is even better than exact substring, but not as good as a perfect match
     return {
       isMatch: true,
-      distance: Math.abs(searchNorm.length - sourceNorm.length) / 5,
+      distance: Math.abs(searchNorm.length - sourceNorm.length) * PREFIX_DISTANCE_FACTOR,
       highlights: Array(searchNorm.length).fill(0).map((_, i) => i),
     };
   } else if (exactSubstringIndex >= 0) {
     const start = sourceChars[exactSubstringIndex].i;
     // The edit distance for a substring is quite high, but substring matches are often better than typo matches.
-    const distance = Math.abs(sourceChars.length - searchChars.length) / 4;
+    const distance = Math.abs(sourceChars.length - searchChars.length) * SUBSTRING_DISTANCE_FACTOR;
     const highlights = Array(searchChars.length);
     for (let j = 0; j < searchChars.length; j++) {
       highlights[j] = start + searchChars[j].i;
@@ -264,7 +276,8 @@ export function highlightNamespacedScoredMatch(
     const match = highlightScoredMatch(search, parts[i]);
     for (let j = 0; j < match.highlights.length; j++) match.highlights[j] += sumLen;
     sumLen += 1 + parts[i].length;
-    match.distance += splitCost + parts.filter((_, k) => k !== i).reduce((a, c) => a + c.length / 4, 0);
+    match.distance += splitCost + parts.filter((_, k) => k !== i).reduce(
+      (a, c) => a + c.length * SUBSTRING_DISTANCE_FACTOR, 0);
     matches.push(match);
   }
   matches.sort((a, b) => a.distance - b.distance);


### PR DESCRIPTION
Summary: There were still a few scenarios where the filtering was a bit too aggressive, or the sorting of results didn't make much sense. This should fix quite a few of them.

Test Plan: Try all of the following searches in the `script` breadcrumb, and a few of them in the Command Palette as well.
They should both get similar results...

- The search `exec` should now find `bpftrace/EXEC_snoop` before it finds weaker matches
- The search `pod` should now greatly prefer scripts that have the string `pod` in them, even over shorter-named scripts that have vaguely similar spelling.
- The search `px/ace` should now do the same: `PX/namespACEs` should now be a stronger match than `PX/nodE`.
- And the same for `px/stat`.
- Finally, most searches should keep more results than before (further past "definitely relevant" into "eh, it might be what you meant" territory), but the most relevant ones should still come up first.

Type of change: /kind bug

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
