### PR TITLE
Add multiarch tolerations to metadata statefulset

### DIFF
--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -108,3 +108,20 @@ spec:
       - name: metadata-volume
         persistentVolumeClaim:
           claimName: metadata-pv-claim
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"


### PR DESCRIPTION
Summary: The metadata stateful set was missing the multiarch tolerations, because we previously only added them to base.

Type of change: /kind cleanup

Test Plan: Tested that kustomize build of `persistent_metadata` has the multiarch tolerations, and that kustomize build of `persistent_metadata/x86` only has x86 tolerations and `persistent_metadata/aarch64` only has arm64 tolerations.
