### PR TITLE
Disable tests for aarch64_sysroot config that don't work without full kernel emulation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,6 +93,7 @@ build:aarch64_sysroot --config=sysroot-base
 # Increase test timeouts for qemu (don't increase the slowest ones because those are already very long).
 test:aarch64_sysroot --test_timeout=180,600,1800,3600
 test:aarch64_sysroot --test_env=QEMU_STRACE
+test:aarch64_sysroot --test_tag_filters=-no_libcpp,-requires_root,-requires_bpf,-disabled,-requires_full_qemu_emulation
 
 
 # Build for Clang using Libc++.

--- a/src/common/system/BUILD.bazel
+++ b/src/common/system/BUILD.bazel
@@ -85,7 +85,11 @@ pl_cc_test(
     flaky = 1,
     # TODO(oazizi/yzhao): Make this test safe to run with other tests. Right now it relies on global
     # network state making it flaky.
-    tags = ["exclusive"],
+    tags = [
+        "exclusive",
+        # The NETLINK_SOCK_DIAG protocol we use is not supported by userspace QEMU.
+        "requires_full_qemu_emulation",
+    ],
     deps = [
         ":cc_library",
     ],

--- a/src/stirling/source_connectors/jvm_stats/BUILD.bazel
+++ b/src/stirling/source_connectors/jvm_stats/BUILD.bazel
@@ -42,6 +42,10 @@ pl_cc_test(
     tags = [
         "exclusive",
         "no_coverage",
+        # Currently we detect java processes by checking the name of the command run.
+        # This fails when run under userspace qemu, because the name of the command run is qemu-aarch64-static.
+        # We should probably fix this, but for now we require full qemu emulation.
+        "requires_full_qemu_emulation",
     ],
     deps = [
         ":cc_library",

--- a/src/stirling/utils/BUILD.bazel
+++ b/src/stirling/utils/BUILD.bazel
@@ -74,6 +74,11 @@ pl_cc_test(
         "testdata/sample_host_ubuntu/**",
         "testdata/sample_host_debian/**",
     ]),
+    tags = [
+        # Getting kernel version from VDSO fails because the system VDSO will be used with userspace qemu,
+        # so we need full qemu emulation to test that for ARM.
+        "requires_full_qemu_emulation",
+    ],
     deps = [
         ":cc_library",
         "//src/common/system:cc_library",


### PR DESCRIPTION
Summary: Some tests use features that aren't supported by userspace qemu emulation, and will require full qemu kernel emulation to work.
This adds a tag that is filtered out by the aarch64_sysroot config, so that these tests never run in userspace qemu emulation.

Type of change: /kind test-infra

Test Plan: Tested that the tests in question no longer get run by the `aarch64_sysroot` config.
