### PR TITLE
Add NATSErrorCounter for tracking NATS errors

### DIFF
--- a/src/cloud/metrics/BUILD.bazel
+++ b/src/cloud/metrics/BUILD.bazel
@@ -56,6 +56,8 @@ go_library(
         "//src/shared/services/healthz",
         "//src/shared/services/msgbus",
         "//src/shared/services/server",
+        "@com_github_nats_io_nats_go//:nats_go",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",

--- a/src/cloud/metrics/BUILD.bazel
+++ b/src/cloud/metrics/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//src/shared/services/healthz",
         "//src/shared/services/msgbus",
         "//src/shared/services/server",
-        "@com_github_nats_io_nats_go//:nats_go",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_pflag//:pflag",

--- a/src/cloud/metrics/BUILD.bazel
+++ b/src/cloud/metrics/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
     importpath = "px.dev/pixie/src/cloud/metrics",
     deps = [
         "//src/cloud/metrics/controllers",
+        "//src/cloud/shared/messages",
         "//src/cloud/shared/vzshard",
         "//src/shared/services",
         "//src/shared/services/env",

--- a/src/cloud/metrics/BUILD.bazel
+++ b/src/cloud/metrics/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//src/shared/services/healthz",
         "//src/shared/services/msgbus",
         "//src/shared/services/server",
-        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",

--- a/src/cloud/metrics/metrics_server.go
+++ b/src/cloud/metrics/metrics_server.go
@@ -24,7 +24,6 @@ import (
 	_ "net/http/pprof"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -67,9 +66,7 @@ func main() {
 	// Connect to NATS.
 	nc := msgbus.MustConnectNATS()
 
-	nc.SetErrorHandler(func(conn *nats.Conn, subscription *nats.Subscription, err error) {
-		messages.HandleNatsError(subscription, err)
-	})
+	nc.SetErrorHandler(messages.HandleNatsError)
 
 	// Connect to BigQuery.
 	var client *bigquery.Client

--- a/src/cloud/shared/messages/BUILD.bazel
+++ b/src/cloud/shared/messages/BUILD.bazel
@@ -18,7 +18,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "messages",
-    srcs = ["messages.go"],
+    srcs = [
+        "messages.go",
+        "nats_metrics.go",
+    ],
     importpath = "px.dev/pixie/src/cloud/shared/messages",
     visibility = ["//src/cloud:__subpackages__"],
+    deps = [
+        "@com_github_nats_io_nats_go//:nats_go",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_sirupsen_logrus//:logrus",
+    ],
 )

--- a/src/cloud/shared/messages/nats_metrics.go
+++ b/src/cloud/shared/messages/nats_metrics.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package messages
+
+import (
+	"strings"
+
+	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// NatsErrorCount counts the number of errors that occurs over NATs.
+var (
+	NatsErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "nats_error_count",
+		Help: "NATS message bus error",
+	}, []string{"shardID", "vizierID", "messageKind", "errorKind"})
+)
+
+func extractShardMessageInfo(subject string) (string, string, string) {
+	vals := strings.Split(subject, ".")
+	if len(vals) >= 4 {
+		return vals[1], vals[2], vals[3]
+	}
+	return "", "", ""
+}
+
+// HandleNatsError handles the Nats error by logging and tracking metrics.
+func HandleNatsError(conn *nats.Conn, sub *nats.Subscription, err error) {
+	if err != nil {
+		log.WithError(err).
+			WithField("Subject", sub.Subject).
+			Error("Got NATS error")
+	}
+	shard, vizierID, messageType := extractShardMessageInfo(sub.Subject)
+	switch err {
+	case nats.ErrSlowConsumer:
+		NatsErrorCount.WithLabelValues(shard, vizierID, messageType, "ErrSlowConsumer").Inc()
+	default:
+		NatsErrorCount.WithLabelValues(shard, vizierID, messageType, "ErrUnknown").Inc()
+	}
+}

--- a/src/cloud/vzconn/BUILD.bazel
+++ b/src/cloud/vzconn/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     importpath = "px.dev/pixie/src/cloud/vzconn",
     visibility = ["//visibility:private"],
     deps = [
+        "//src/cloud/shared/messages",
         "//src/cloud/vzconn/bridge",
         "//src/cloud/vzconn/vzconnpb:service_pl_go_proto",
         "//src/cloud/vzmgr/vzmgrpb:service_pl_go_proto",

--- a/src/cloud/vzconn/BUILD.bazel
+++ b/src/cloud/vzconn/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//src/shared/services/msgbus",
         "//src/shared/services/server",
         "@com_github_nats_io_nats_go//:nats_go",
-        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",

--- a/src/cloud/vzconn/vzconn_server.go
+++ b/src/cloud/vzconn/vzconn_server.go
@@ -21,7 +21,6 @@ package main
 import (
 	"net/http"
 	_ "net/http/pprof"
-	"strings"
 
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,6 +29,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	"px.dev/pixie/src/cloud/shared/messages"
 	"px.dev/pixie/src/cloud/vzconn/bridge"
 	"px.dev/pixie/src/cloud/vzconn/vzconnpb"
 	"px.dev/pixie/src/cloud/vzmgr/vzmgrpb"
@@ -41,18 +41,11 @@ import (
 	"px.dev/pixie/src/shared/services/server"
 )
 
-var (
-	natsErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "nats_error_count",
-		Help: "NATS message bus error",
-	}, []string{"shardID", "vizierID", "messageKind", "errorKind"})
-)
-
 func init() {
 	pflag.String("vzmgr_service", "kubernetes:///vzmgr-service.plc:51800", "The profile service url (load balancer/list is ok)")
 	pflag.String("domain_name", "dev.withpixie.dev", "The domain name of Pixie Cloud")
 
-	prometheus.MustRegister(natsErrorCount)
+	prometheus.MustRegister(messages.NatsErrorCount)
 }
 
 func newVZMgrClients() (vzmgrpb.VZMgrServiceClient, vzmgrpb.VZDeploymentServiceClient, error) {
@@ -69,18 +62,6 @@ func newVZMgrClients() (vzmgrpb.VZMgrServiceClient, vzmgrpb.VZDeploymentServiceC
 	return vzmgrpb.NewVZMgrServiceClient(vzmgrChannel), vzmgrpb.NewVZDeploymentServiceClient(vzmgrChannel), nil
 }
 
-// Extracts information from the subject and return shard, vizierID, messageType.
-func extractMessageInfo(subject string) (string, string, string) {
-	vals := strings.Split(subject, ":")
-	if len(vals) > 0 {
-		strings.Split(vals[0], ".")
-		if len(vals) >= 4 {
-			return vals[1], vals[2], vals[3]
-		}
-	}
-	return "", "", ""
-}
-
 func mustSetupNATSAndJetStream() (*nats.Conn, msgbus.Streamer) {
 	nc := msgbus.MustConnectNATS()
 	js := msgbus.MustConnectJetStream(nc)
@@ -90,18 +71,7 @@ func mustSetupNATSAndJetStream() (*nats.Conn, msgbus.Streamer) {
 	}
 
 	nc.SetErrorHandler(func(conn *nats.Conn, subscription *nats.Subscription, err error) {
-		if err != nil {
-			log.WithError(err).
-				WithField("Subject", subscription.Subject).
-				Error("Got NATS error")
-		}
-		shard, vizierID, messageType := extractMessageInfo(subscription.Subject)
-		switch err {
-		case nats.ErrSlowConsumer:
-			natsErrorCount.WithLabelValues(shard, vizierID, messageType, "ErrSlowConsumer").Inc()
-		default:
-			natsErrorCount.WithLabelValues(shard, vizierID, messageType, "ErrUnknown").Inc()
-		}
+		messages.HandleNatsError(subscription, err)
 	})
 	return nc, strmr
 }

--- a/src/cloud/vzconn/vzconn_server.go
+++ b/src/cloud/vzconn/vzconn_server.go
@@ -70,9 +70,7 @@ func mustSetupNATSAndJetStream() (*nats.Conn, msgbus.Streamer) {
 		log.WithError(err).Fatal("Could not start JetStream streamer")
 	}
 
-	nc.SetErrorHandler(func(conn *nats.Conn, subscription *nats.Subscription, err error) {
-		messages.HandleNatsError(subscription, err)
-	})
+	nc.SetErrorHandler(messages.HandleNatsError)
 	return nc, strmr
 }
 

--- a/src/cloud/vzmgr/BUILD.bazel
+++ b/src/cloud/vzmgr/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//src/cloud/artifact_tracker/artifacttrackerpb:artifact_tracker_pl_go_proto",
+        "//src/cloud/shared/messages",
         "//src/cloud/shared/pgmigrate",
         "//src/cloud/shared/vzshard",
         "//src/cloud/vzmgr/controllers",

--- a/src/cloud/vzmgr/BUILD.bazel
+++ b/src/cloud/vzmgr/BUILD.bazel
@@ -44,7 +44,6 @@ go_library(
         "//src/shared/services/server",
         "@com_github_golang_migrate_migrate//source/go_bindata",
         "@com_github_nats_io_nats_go//:nats_go",
-        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",

--- a/src/cloud/vzmgr/vzmgr_server.go
+++ b/src/cloud/vzmgr/vzmgr_server.go
@@ -92,9 +92,7 @@ func mustSetupNATSAndJetStream() (*nats.Conn, msgbus.Streamer) {
 		log.WithError(err).Fatal("Could not start JetStream streamer")
 	}
 
-	nc.SetErrorHandler(func(conn *nats.Conn, subscription *nats.Subscription, err error) {
-		messages.HandleNatsError(subscription, err)
-	})
+	nc.SetErrorHandler(messages.HandleNatsError)
 	return nc, strmr
 }
 


### PR DESCRIPTION
Summary: The metrics server is known to heavily drop NATs messages due to a `slow consumer` error. We track the count of dropped messages for both vzconn and vzmgr, but don't track it for the metrics server yet. This PR adds the NATSErrorCounter so we can easily track nats errors in our cloud services.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deploy to a testing cloud, ensure metrics server doesn't crash.
