### PR TITLE
Add clusterID to requestproxyer error

### DIFF
--- a/src/cloud/api/ptproxy/request_proxyer.go
+++ b/src/cloud/api/ptproxy/request_proxyer.go
@@ -230,7 +230,7 @@ func (p *requestProxyer) run() error {
 
 				// These errors happen frequently, for example, if a Kelvin isn't ready for a cluster yet, or there is slight clock skew on the Vizier. Do not log an error in these situations.
 				if !strings.Contains(err.Error(), "InvalidArgument") && !strings.Contains(err.Error(), "Unauthenticated") {
-					log.WithError(err).Error("Failed to process nats message")
+					log.WithField("vizier", p.clusterID).WithError(err).Error("Failed to process nats message")
 				}
 				// Try to cancel stream.
 				if cancelErr := p.sendCancelMessageToVizier(); cancelErr != nil {


### PR DESCRIPTION
Summary: The request proxyer is very sensitive to the state of downstream clusters. It is possible for this error to get triggered due to a single unhealthy cluster. We can add some of the cluster information to the error so we can determine if this error is occurring across many viziers, or just a single one.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: This is just a log change and affects no functionality

