### PR TITLE
Fix off by one error in `amqp/parse.cc`.

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
@@ -90,7 +90,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* packet)
   packet->frame_type = frame_type;
   packet->channel = channel;
   packet->payload_size = payload_size;
-  if (decoder.BufSize() < payload_size) {
+  if (decoder.BufSize() <= payload_size) {
     return ParseState::kInvalid;
   }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
@@ -91,7 +91,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* packet)
   packet->channel = channel;
   packet->payload_size = payload_size;
   if (decoder.BufSize() <= payload_size) {
-    return ParseState::kInvalid;
+    return ParseState::kNeedsMoreData;
   }
 
   // Check end byte is valid


### PR DESCRIPTION
Summary: We fix an off-by-one error in `amqp/parse.cc` that was causing segfaults when parsing traffic for the same.

We also change the parse state to `kNeedsMoreData` (vs. `kInvalid` its previous state update) if the parser returns early when the buffer does not have enough data to read the entire payload.

Closes #942.

We opened #945 to track test coverage.

Type of change: /kind bug fix

Test Plan: Ran `stirling_wrapper` both with and without the fix on a node with `px-sock-shop` deployed (with load testing up). Without the off-by-one fix, we wbserved segfaults matching the original issue reported. With the fix, observed no segfaults.
