### PR TITLE
Use hermetic sandbox for sysroot builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -79,6 +79,7 @@ build:clang-base --//bazel/cc_toolchains:libc_version=glibc_host
 
 # We build our own chroot for the sysroot tests, which doesn't work well under bazel's sandbox.
 build:sysroot-base --//bazel/test_runners:test_runner=sysroot_chroot
+import %workspace%/bazel/cc_toolchains/sysroots/sandbox.bazelrc
 test:sysroot-base --strategy TestRunner=standalone
 test:sysroot-base --run_under="bazel/test_runners/sysroot_chroot/test_runner.sh"
 

--- a/bazel/cc_toolchains/sysroots/sandbox.bazelrc
+++ b/bazel/cc_toolchains/sysroots/sandbox.bazelrc
@@ -1,0 +1,18 @@
+build:sysroot-base --experimental_use_hermetic_linux_sandbox
+build:sysroot-base --sandbox_add_mount_pair="/proc"
+build:sysroot-base --sandbox_add_mount_pair="/sys"
+build:sysroot-base --sandbox_add_mount_pair="/bin"
+build:sysroot-base --sandbox_add_mount_pair="/usr/bin"
+build:sysroot-base --sandbox_add_mount_pair="/lib"
+build:sysroot-base --sandbox_add_mount_pair="/lib64"
+build:sysroot-base --sandbox_add_mount_pair="/etc"
+# We need /opt for the UI build
+build:sysroot-base --sandbox_add_mount_pair="/opt"
+# Some java programs have issues without locale in the sandbox.
+build:sysroot-base --sandbox_add_mount_pair="/usr/lib/locale"
+# We currently require openssl in the build for building certs for a demo app.
+build:sysroot-base --sandbox_add_mount_pair="/usr/lib/ssl/openssl.cnf"
+# Bison/flex need things in /usr/share
+build:sysroot-base --sandbox_add_mount_pair="/usr/share"
+# We still use host GCC for building the java agent.
+build:sysroot-base --sandbox_add_mount_pair="/usr/lib/gcc"

--- a/bazel/external/rules_python.patch
+++ b/bazel/external/rules_python.patch
@@ -1,0 +1,20 @@
+diff --git a/python/repositories.bzl b/python/repositories.bzl
+index 395ef0e..c1093e3 100644
+--- a/python/repositories.bzl
++++ b/python/repositories.bzl
+@@ -151,6 +151,7 @@ py_runtime(
+     name = "py3_runtime",
+     files = [":files"],
+     interpreter = "{python_path}",
++    stub_shebang="#!/usr/bin/env -S /bin/bash -c '$0.runfiles/{interpreter_name}/bin/python3 $0 \\"$@\\"'",
+     python_version = "PY3",
+ )
+ 
+@@ -162,6 +163,7 @@ py_runtime_pair(
+ """.format(
+         python_path = python_bin,
+         python_version = python_short_version,
++        interpreter_name = rctx.attr.name,
+     )
+     rctx.file("BUILD.bazel", build_content)
+ 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -243,7 +243,7 @@ def _pl_deps():
     _bazel_repo("io_bazel_rules_k8s")
     _bazel_repo("io_bazel_rules_closure")
     _bazel_repo("io_bazel_rules_docker", patches = ["//bazel/external:rules_docker.patch", "//bazel/external:rules_docker_arch.patch"], patch_args = ["-p1"])
-    _bazel_repo("rules_python")
+    _bazel_repo("rules_python", patches = ["//bazel/external:rules_python.patch"], patch_args = ["-p1"])
     _bazel_repo("rules_pkg")
     _bazel_repo("com_github_bazelbuild_buildtools")
     _bazel_repo("com_github_fmeum_rules_meta")

--- a/tools/licenses/BUILD.bazel
+++ b/tools/licenses/BUILD.bazel
@@ -18,6 +18,7 @@
 # This includes the C API, Java API, and protocol buffer files.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:licenses.bzl", "fetch_licenses")
 load("//bazel:pl_build_system.bzl", "pl_go_binary")
 
@@ -69,6 +70,11 @@ fetch_licenses(
     out_missing = "deps_licenses_missing.json",
 )
 
+py_binary(
+    name = "combine_licenses",
+    srcs = ["combine_licenses.py"],
+)
+
 genrule(
     name = "all_licenses",
     srcs = [
@@ -80,14 +86,14 @@ genrule(
         "all_licenses.json",
     ],
     cmd = """
-        python3 $(location combine_licenses.py) \
+        $(location combine_licenses) \
             $(location go_licenses.json) \
             $(location deps_licenses.json) \
             $(location //src/ui:npm_licenses) \
             --output $(location all_licenses.json)
     """,
     tools = [
-        "combine_licenses.py",
+        ":combine_licenses",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Summary: We were seeing issues with building libarchive because it found `libxml2` on the host on some machines, and tried to include the host version in the aarch64 build.
This PR makes the sandbox for sysroot builds hermetic. However, we still have to include a variety of host paths to get our build to function. Importantly, we don't include all of `/usr/lib` in the sandbox, so that we don't run into issues with the build trying to use host libraries. The patch to `rules_docker` is necessary in order to avoid using the system python3 and instead use the python version from bazel.

Type of change: /kind cleanup

Test Plan: Tested that `bazel build --config={x86_64,aarch64}_sysroot` both work.
