### PR TITLE
Pass through kwargs on pl_cc_test rule

### DIFF
--- a/bazel/pl_build_system.bzl
+++ b/bazel/pl_build_system.bzl
@@ -228,7 +228,8 @@ def pl_cc_test(
         defines = [],
         coverage = True,
         local = False,
-        flaky = False):
+        flaky = False,
+        **kwargs):
     test_lib_tags = list(tags)
     if coverage:
         test_lib_tags.append("coverage_test_lib")
@@ -261,6 +262,7 @@ def pl_cc_test(
         local = local,
         flaky = flaky,
         features = pl_default_features(),
+        **kwargs
     )
 
 # PL C++ test related libraries (that want gtest, gmock) should be specified


### PR DESCRIPTION
Summary: If kwargs are present then we pass them through. Allows us to access cc_test parameters without                                                                                                                                                                                  hardcoding the entire list.

Relevant Issues: #709

Type of change: /kind test-inra

Test Plan: Jenkins, no functional change.

