### PR TITLE
No need to call init on podman command

### DIFF
--- a/src/stirling/e2e_tests/stirling_wrapper_container_bpf_test.sh
+++ b/src/stirling/e2e_tests/stirling_wrapper_container_bpf_test.sh
@@ -48,7 +48,7 @@ run_uprobe_target "$go_grpc_server" "$go_grpc_client"
 echo "Running stirling_wrapper container."
 
 flags="--timeout_secs=0"
-out=$(podman run --init --rm \
+out=$(podman run --rm \
  -v /:/host \
  -v /sys:/sys \
  --env PL_HOST_PATH=/host \


### PR DESCRIPTION
Summary: Init is not needed here and was making podman in qemu unhappy.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: Jenkins, no functional change.

