### PR TITLE
Add truncation to process cmdline in agent heartbeats

### DIFF
--- a/src/vizier/services/agent/shared/manager/heartbeat.cc
+++ b/src/vizier/services/agent/shared/manager/heartbeat.cc
@@ -201,7 +201,7 @@ void HeartbeatMessageHandler::ProcessPIDStartedEvent(const px::md::PIDStartedEve
     cmdline.resize(kCmdlineTruncationLimit);
     cmdline.append(kTruncatedMsg);
   }
-  process_info->set_cmdline(ev.pid_info.cmdline());
+  process_info->set_cmdline(cmdline);
   process_info->set_cid(ev.pid_info.cid());
 }
 

--- a/src/vizier/services/agent/shared/manager/heartbeat.cc
+++ b/src/vizier/services/agent/shared/manager/heartbeat.cc
@@ -198,8 +198,7 @@ void HeartbeatMessageHandler::ProcessPIDStartedEvent(const px::md::PIDStartedEve
   // Truncate cmdline to fit in the NATS message.
   auto cmdline = ev.pid_info.cmdline();
   if (cmdline.length() > kCmdlineTruncationLimit) {
-    cmdline.resize(kCmdlineTruncationLimit);
-    cmdline.append(kTruncatedMsg);
+    cmdline.replace(cmdline.begin() + kCmdlineTruncationLimit, cmdline.end(), kTruncatedMsg);
   }
   process_info->set_cmdline(cmdline);
   process_info->set_cid(ev.pid_info.cid());

--- a/src/vizier/services/agent/shared/manager/heartbeat.cc
+++ b/src/vizier/services/agent/shared/manager/heartbeat.cc
@@ -31,6 +31,9 @@ namespace agent {
 using ::px::event::Dispatcher;
 using ::px::shared::k8s::metadatapb::ResourceUpdate;
 
+const int64_t kCmdlineTruncationLimit = 4096;
+static constexpr char kTruncatedMsg[] = "... [TRUNCATED]";
+
 HeartbeatMessageHandler::HeartbeatMessageHandler(Dispatcher* d,
                                                  px::md::AgentMetadataStateManager* mds_manager,
                                                  RelationInfoManager* relation_info_manager,
@@ -192,6 +195,12 @@ void HeartbeatMessageHandler::ProcessPIDStartedEvent(const px::md::PIDStartedEve
   mu_upid->set_low(absl::Uint128Low64(upid.value()));
 
   process_info->set_start_timestamp_ns(ev.pid_info.start_time_ns());
+  // Truncate cmdline to fit in the NATS message.
+  auto cmdline = ev.pid_info.cmdline();
+  if (cmdline.length() > kCmdlineTruncationLimit) {
+    cmdline.resize(kCmdlineTruncationLimit);
+    cmdline.append(kTruncatedMsg);
+  }
   process_info->set_cmdline(ev.pid_info.cmdline());
   process_info->set_cid(ev.pid_info.cid());
 }


### PR DESCRIPTION
Summary: We've had user reports of PEMs failing to heartbeat to metadata because their heartbeat messages are too large for NATS. Upon closer inspection, it looks like the cmdline for some processes were very large (in one particular case, 20k+ characters--which can occur in Java processes).
This PR truncates the cmdline before we add it to the heartbeat update info. 4096 was chosen since that the maximum cmdline character limit in Linux. However, no further analyses were done to find the distribution of cmdline lengths.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Unit test

