### PR TITLE
Allow fetching stdout from container_runner

### DIFF
--- a/src/common/testing/test_utils/container_runner.cc
+++ b/src/common/testing/test_utils/container_runner.cc
@@ -233,6 +233,8 @@ StatusOr<std::string> ContainerRunner::Run(const std::chrono::seconds& timeout,
   return container_out;
 }
 
+Status ContainerRunner::Stdout(std::string* out) { return podman_.Stdout(out); }
+
 void ContainerRunner::Stop() {
   // Clean-up the container.
   if (podman_.IsRunning()) {
@@ -241,6 +243,6 @@ void ContainerRunner::Stop() {
   podman_.Wait();
 }
 
-void ContainerRunner::Wait() { podman_.Wait(); }
+void ContainerRunner::Wait(bool close_pipe) { podman_.Wait(close_pipe); }
 
 }  // namespace px

--- a/src/common/testing/test_utils/container_runner.h
+++ b/src/common/testing/test_utils/container_runner.h
@@ -75,7 +75,13 @@ class ContainerRunner {
   /**
    * Wait for container to terminate.
    */
-  void Wait();
+  void Wait(bool close_pipe = true);
+
+  /**
+   * Returns the stdout of the container. Needs to be combined with the full output from Run
+   * to ensure the entire result is present.
+   */
+  Status Stdout(std::string* out);
 
   /**
    * The PID of the process within the container.


### PR DESCRIPTION
Summary: Currently we can only read stdout from containers until the ready message. This allows
us to read the rest of the stdout, even for containers that have exited.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: Test infrastrcture. Tested on QEMU environment on various tests.