### PR TITLE
Change taskset usage to improve compatibility

### DIFF
--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -112,7 +112,7 @@ class PerfProfilerTestSubProcesses {
   const std::vector<int>& pids() const { return pids_; }
   const std::vector<struct upid_t>& struct_upids() const { return struct_upids_; }
   const absl::flat_hash_set<md::UPID>& upids() const { return upids_; }
-  static constexpr size_t kNumSubProcs = 4;
+  static constexpr size_t kNumSubProcs = 1;
   virtual ~PerfProfilerTestSubProcesses() = default;
 
  protected:
@@ -130,21 +130,27 @@ class CPUPinnedSubProcesses final : public PerfProfilerTestSubProcesses {
   void StartAll() override {
     ASSERT_TRUE(fs::Exists(binary_path_));
     ASSERT_TRUE(fs::Exists(kTasksetBinPath));
+    const auto processor_count = std::thread::hardware_concurrency();
+    if (processor_count > 0) {
+      ASSERT_GE(processor_count, kNumSubProcs);
+    }
+
     const system::ProcParser proc_parser;
 
     for (size_t i = 0; i < kNumSubProcs; ++i) {
-      sub_processes_.push_back(std::make_unique<SubProcess>());
+      auto sub_process = std::make_unique<SubProcess>();
 
       // Run the sub-process & pin it to a CPU.
-      const std::string kTasksetBinPath = "/usr/bin/taskset";
-      ASSERT_OK(sub_processes_[i]->Start({kTasksetBinPath, "-c", std::to_string(i), binary_path_}));
+      std::string mask = absl::StrFormat("%#x", 1 << i);
+      ASSERT_OK(sub_process->Start({std::string(kTasksetBinPath), mask, binary_path_}));
 
       // Grab the PID and generate a UPID.
-      const int pid = sub_processes_[i]->child_pid();
+      const int pid = sub_process->child_pid();
       ASSERT_OK_AND_ASSIGN(const uint64_t ts, proc_parser.GetPIDStartTimeTicks(pid));
       pids_.push_back(pid);
       struct_upids_.push_back({{static_cast<uint32_t>(pid)}, ts});
       upids_.emplace(0, pid, ts);
+      sub_processes_.emplace_back(std::move(sub_process));
     }
   }
 
@@ -158,7 +164,7 @@ class CPUPinnedSubProcesses final : public PerfProfilerTestSubProcesses {
   }
 
  private:
-  static constexpr std::string_view kTasksetBinPath = "/usr/bin/taskset";
+  static constexpr std::string_view kTasksetBinPath = "/bin/taskset";
   std::vector<std::unique_ptr<SubProcess>> sub_processes_;
   const std::string binary_path_;
 };

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -112,7 +112,7 @@ class PerfProfilerTestSubProcesses {
   const std::vector<int>& pids() const { return pids_; }
   const std::vector<struct upid_t>& struct_upids() const { return struct_upids_; }
   const absl::flat_hash_set<md::UPID>& upids() const { return upids_; }
-  static constexpr size_t kNumSubProcs = 1;
+  static constexpr size_t kNumSubProcs = 4;
   virtual ~PerfProfilerTestSubProcesses() = default;
 
  protected:


### PR DESCRIPTION
Summary: Updates our use of taskset to improve compatibility with smaller versions from Busyboy.
In addition, we change the path to where it's found on more systems.

Relevant Issues: #709

Type of change: /kind cleanup

Test Plan: Existing tests should pass.

