### PR TITLE
[perf_tool] Add interface for deploying workloads

### DIFF
--- a/src/e2e_test/perf_tool/experimentpb/experiment.proto
+++ b/src/e2e_test/perf_tool/experimentpb/experiment.proto
@@ -49,11 +49,9 @@ message ExperimentSpec {
   string commit_sha = 6 [ (gogoproto.customname) = "CommitSHA" ];
 }
 
-// WorkloadSpec specifies how to build, deploy and teardown a particular workload.
+// WorkloadSpec specifies how to run a particular workload.
 // Example workloads include: Vizier, Sock shop, or an HTTP protocol loadtest (see
-// src/e2e_test/protocol_loadtest). Workloads can be made up of multiple components (such as a
-// client and a server), or can be specified without splitting things into components (eg. sock
-// shop).
+// src/e2e_test/protocol_loadtest).
 message WorkloadSpec {}
 
 // MetricSpec specifies how to record a set of metrics for an experiment.

--- a/src/e2e_test/perf_tool/pkg/deploy/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/deploy/BUILD.bazel
@@ -1,0 +1,28 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "deploy",
+    srcs = ["workload.go"],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/deploy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
+        "//src/e2e_test/perf_tool/pkg/cluster",
+    ],
+)

--- a/src/e2e_test/perf_tool/pkg/deploy/checks/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/deploy/checks/BUILD.bazel
@@ -1,0 +1,28 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "checks",
+    srcs = ["common.go"],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/deploy/checks",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
+        "//src/e2e_test/perf_tool/pkg/cluster",
+    ],
+)

--- a/src/e2e_test/perf_tool/pkg/deploy/checks/common.go
+++ b/src/e2e_test/perf_tool/pkg/deploy/checks/common.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package checks
+
+import (
+	"context"
+
+	"px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/cluster"
+)
+
+// HealthCheck is the interface for checking an arbitrary health condition on a workload.
+type HealthCheck interface {
+	// Wait for this healthchecks condition to be true.
+	Wait(context.Context, *cluster.Context, *experimentpb.ClusterSpec) error
+	// Name returns a printable name for the healthcheck.
+	Name() string
+}

--- a/src/e2e_test/perf_tool/pkg/deploy/steps/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/deploy/steps/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "steps",
+    srcs = ["common.go"],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/deploy/steps",
+    visibility = ["//visibility:public"],
+    deps = ["//src/e2e_test/perf_tool/pkg/cluster"],
+)

--- a/src/e2e_test/perf_tool/pkg/deploy/steps/common.go
+++ b/src/e2e_test/perf_tool/pkg/deploy/steps/common.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package steps
+
+import (
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/cluster"
+)
+
+// DeployStep is the interface for running a stage in a given workloads deploy process.
+type DeployStep interface {
+	// Prepare runs any preparation steps that don't require an assigned cluster.
+	Prepare() error
+	// Deploy runs the deploy step, and returns any namespaces that should be deleted on Close.
+	Deploy(*cluster.Context) ([]string, error)
+	// Name returns a printable name for the deploy step.
+	Name() string
+}

--- a/src/e2e_test/perf_tool/pkg/deploy/workload.go
+++ b/src/e2e_test/perf_tool/pkg/deploy/workload.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package deploy
+
+import (
+	"context"
+
+	"px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/cluster"
+)
+
+// Workload is the interface for workloads that get deployed to the experiment cluster.
+type Workload interface {
+	Prepare() error
+	Start(*cluster.Context) error
+	WaitForHealthCheck(context.Context, *cluster.Context, *experimentpb.ClusterSpec) error
+	Close() error
+}


### PR DESCRIPTION
Summary: Adds interface to use `WorkloadSpec` to deploy a workload. Currently, there are no implementations of this interface.

Type of change: /kind test-infra

Test Plan: No functional changes, just declaring an interface without any implementations of that interface.
