### PR TITLE
Use curl image for sock shop load test init.

### DIFF
--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -28,10 +28,10 @@ spec:
 
       initContainers:
       - name: wait-sock-shop
-        image: alpine:3.6
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
         # yamllint disable rule:indentation
-        command: ['sh', '-c', 'set -x;  apk add --no-cache curl;
-          until timeout -t 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do
+        command: ['sh', '-c', 'set -x;
+          until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do
             echo "waiting for ${SOCK_SHOP_HEALTH_ADDR}";
             sleep 2;
           done;']

--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -28,7 +28,7 @@ spec:
 
       initContainers:
       - name: wait-sock-shop
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:1.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do


### PR DESCRIPTION
Summary: We change the container image for sock shop load test init from `alpine:3.6` to `gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0`. The new image comes with curl baked in. This avoids a potential problem where (for unknown reasons) the init pod fails because apk fails to install curl. Our curl image is created from `tools/docker/curl_image/Dockerfile`.

Type of change: /kind bug fix

Test Plan: Tested locally by applying the sock shop demo yamls on my dev cluster. The new load test yaml worked (as expected).