### PR TITLE
[perf_tool/deploy] Implement `Workload` interface

### DIFF
--- a/src/e2e_test/perf_tool/experimentpb/experiment.pb.go
+++ b/src/e2e_test/perf_tool/experimentpb/experiment.pb.go
@@ -101,6 +101,9 @@ func (m *ExperimentSpec) GetCommitSHA() string {
 }
 
 type WorkloadSpec struct {
+	Name         string         `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	DeploySteps  []*DeployStep  `protobuf:"bytes,2,rep,name=deploy_steps,json=deploySteps,proto3" json:"deploy_steps,omitempty"`
+	Healthchecks []*HealthCheck `protobuf:"bytes,3,rep,name=healthchecks,proto3" json:"healthchecks,omitempty"`
 }
 
 func (m *WorkloadSpec) Reset()      { *m = WorkloadSpec{} }
@@ -135,13 +138,104 @@ func (m *WorkloadSpec) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_WorkloadSpec proto.InternalMessageInfo
 
+func (m *WorkloadSpec) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *WorkloadSpec) GetDeploySteps() []*DeployStep {
+	if m != nil {
+		return m.DeploySteps
+	}
+	return nil
+}
+
+func (m *WorkloadSpec) GetHealthchecks() []*HealthCheck {
+	if m != nil {
+		return m.Healthchecks
+	}
+	return nil
+}
+
+type DeployStep struct {
+}
+
+func (m *DeployStep) Reset()      { *m = DeployStep{} }
+func (*DeployStep) ProtoMessage() {}
+func (*DeployStep) Descriptor() ([]byte, []int) {
+	return fileDescriptor_96d7e52dda1e6fe3, []int{2}
+}
+func (m *DeployStep) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *DeployStep) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_DeployStep.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *DeployStep) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeployStep.Merge(m, src)
+}
+func (m *DeployStep) XXX_Size() int {
+	return m.Size()
+}
+func (m *DeployStep) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeployStep.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeployStep proto.InternalMessageInfo
+
+type HealthCheck struct {
+}
+
+func (m *HealthCheck) Reset()      { *m = HealthCheck{} }
+func (*HealthCheck) ProtoMessage() {}
+func (*HealthCheck) Descriptor() ([]byte, []int) {
+	return fileDescriptor_96d7e52dda1e6fe3, []int{3}
+}
+func (m *HealthCheck) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *HealthCheck) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_HealthCheck.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *HealthCheck) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_HealthCheck.Merge(m, src)
+}
+func (m *HealthCheck) XXX_Size() int {
+	return m.Size()
+}
+func (m *HealthCheck) XXX_DiscardUnknown() {
+	xxx_messageInfo_HealthCheck.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_HealthCheck proto.InternalMessageInfo
+
 type MetricSpec struct {
 }
 
 func (m *MetricSpec) Reset()      { *m = MetricSpec{} }
 func (*MetricSpec) ProtoMessage() {}
 func (*MetricSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{2}
+	return fileDescriptor_96d7e52dda1e6fe3, []int{4}
 }
 func (m *MetricSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -178,7 +272,7 @@ type ClusterSpec struct {
 func (m *ClusterSpec) Reset()      { *m = ClusterSpec{} }
 func (*ClusterSpec) ProtoMessage() {}
 func (*ClusterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{3}
+	return fileDescriptor_96d7e52dda1e6fe3, []int{5}
 }
 func (m *ClusterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -228,7 +322,7 @@ type NodeSpec struct {
 func (m *NodeSpec) Reset()      { *m = NodeSpec{} }
 func (*NodeSpec) ProtoMessage() {}
 func (*NodeSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_96d7e52dda1e6fe3, []int{4}
+	return fileDescriptor_96d7e52dda1e6fe3, []int{6}
 }
 func (m *NodeSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -267,6 +361,8 @@ func (m *NodeSpec) GetMachineType() string {
 func init() {
 	proto.RegisterType((*ExperimentSpec)(nil), "px.perf_tool.ExperimentSpec")
 	proto.RegisterType((*WorkloadSpec)(nil), "px.perf_tool.WorkloadSpec")
+	proto.RegisterType((*DeployStep)(nil), "px.perf_tool.DeployStep")
+	proto.RegisterType((*HealthCheck)(nil), "px.perf_tool.HealthCheck")
 	proto.RegisterType((*MetricSpec)(nil), "px.perf_tool.MetricSpec")
 	proto.RegisterType((*ClusterSpec)(nil), "px.perf_tool.ClusterSpec")
 	proto.RegisterType((*NodeSpec)(nil), "px.perf_tool.NodeSpec")
@@ -277,34 +373,39 @@ func init() {
 }
 
 var fileDescriptor_96d7e52dda1e6fe3 = []byte{
-	// 431 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0x31, 0x6f, 0xd3, 0x40,
-	0x18, 0x86, 0x7d, 0x69, 0x1a, 0xc5, 0x9f, 0xdd, 0x08, 0x79, 0x40, 0xa6, 0x48, 0x47, 0xf0, 0x54,
-	0x21, 0x6a, 0x4b, 0x85, 0xad, 0x2c, 0x4d, 0x85, 0x84, 0x90, 0x60, 0x48, 0x10, 0x48, 0x2c, 0x56,
-	0x72, 0xbd, 0x26, 0x16, 0x39, 0xdf, 0xc9, 0x77, 0xa6, 0x2d, 0x13, 0x3f, 0x81, 0x9f, 0xc1, 0xbf,
-	0x60, 0x65, 0xcc, 0xd8, 0x09, 0x91, 0xcb, 0xc2, 0xd8, 0x9f, 0x80, 0xfc, 0x39, 0x4d, 0x9d, 0xa9,
-	0xdb, 0xbd, 0xdf, 0xbd, 0xcf, 0x7b, 0xaf, 0xad, 0x0f, 0x5e, 0xea, 0x82, 0x25, 0xfc, 0x88, 0xa7,
-	0x86, 0x6b, 0x93, 0x28, 0x5e, 0x9c, 0xa7, 0x46, 0xca, 0x79, 0xc2, 0x2f, 0x15, 0x2f, 0x32, 0xc1,
-	0x73, 0xa3, 0x26, 0x0d, 0x11, 0xab, 0x42, 0x1a, 0x19, 0xf8, 0xea, 0x32, 0xde, 0x78, 0xf7, 0x0f,
-	0xa7, 0x99, 0x99, 0x95, 0x93, 0x98, 0x49, 0x91, 0x4c, 0xe5, 0x54, 0x26, 0x68, 0x9a, 0x94, 0xe7,
-	0xa8, 0x50, 0xe0, 0xa9, 0x86, 0xa3, 0x5f, 0x2d, 0xe8, 0xbd, 0xde, 0x24, 0x8e, 0x14, 0x67, 0xc1,
-	0x31, 0x78, 0x5f, 0xb3, 0x6f, 0x19, 0x2f, 0x52, 0xad, 0x38, 0x0b, 0x49, 0x9f, 0x1c, 0x78, 0x47,
-	0xfb, 0x71, 0xf3, 0x95, 0xf8, 0x93, 0x2c, 0xbe, 0xcc, 0xe5, 0xf8, 0xac, 0x02, 0x86, 0x50, 0xdb,
-	0x11, 0x3e, 0x81, 0xde, 0xc5, 0xfa, 0x0e, 0x71, 0x1d, 0xb6, 0xfa, 0x3b, 0xf7, 0xf0, 0x7b, 0x17,
-	0x0d, 0xa5, 0x83, 0x63, 0xf0, 0x05, 0x37, 0x45, 0xc6, 0xd6, 0x01, 0x3b, 0x18, 0x10, 0x6e, 0x07,
-	0xbc, 0x43, 0x07, 0xe2, 0x9e, 0xd8, 0x9c, 0x75, 0xf0, 0x0a, 0x7c, 0x36, 0x2f, 0xb5, 0xb9, 0x6d,
-	0xdf, 0xc6, 0xf6, 0x8f, 0xb6, 0xe1, 0xd3, 0xda, 0x51, 0xd3, 0xec, 0x4e, 0x04, 0xcf, 0x01, 0x98,
-	0x14, 0x22, 0x33, 0xa9, 0x9e, 0x8d, 0xc3, 0x4e, 0x9f, 0x1c, 0xb8, 0x83, 0x3d, 0xfb, 0xe7, 0x89,
-	0x7b, 0x8a, 0xd3, 0xd1, 0x9b, 0x93, 0xa1, 0x5b, 0x1b, 0x46, 0xb3, 0xf1, 0xdb, 0x76, 0x77, 0xf7,
-	0x41, 0x27, 0xea, 0x81, 0xdf, 0xfc, 0x9a, 0xc8, 0x07, 0xb8, 0x2b, 0x17, 0x7d, 0x04, 0xaf, 0xf1,
-	0x5a, 0xf0, 0x18, 0xdc, 0xbc, 0x14, 0x69, 0x2e, 0xcf, 0xb8, 0xc6, 0x3f, 0xbb, 0x3b, 0xec, 0xe6,
-	0xa5, 0x78, 0x5f, 0xe9, 0xe0, 0x19, 0xb4, 0xab, 0x8b, 0xb0, 0x85, 0x9d, 0x1f, 0x6e, 0x77, 0xae,
-	0x2c, 0x58, 0x18, 0x3d, 0xd1, 0x21, 0x74, 0x6f, 0x27, 0xc1, 0x53, 0xf0, 0xc5, 0x98, 0xcd, 0xb2,
-	0x9c, 0xa7, 0xe6, 0x4a, 0x71, 0xcc, 0x75, 0x87, 0xde, 0x7a, 0xf6, 0xe1, 0x4a, 0xf1, 0xc1, 0x60,
-	0xb1, 0xa4, 0xce, 0xf5, 0x92, 0x3a, 0x37, 0x4b, 0x4a, 0xbe, 0x5b, 0x4a, 0x7e, 0x5a, 0x4a, 0x7e,
-	0x5b, 0x4a, 0x16, 0x96, 0x92, 0xbf, 0x96, 0x92, 0x7f, 0x96, 0x3a, 0x37, 0x96, 0x92, 0x1f, 0x2b,
-	0xea, 0x2c, 0x56, 0xd4, 0xb9, 0x5e, 0x51, 0xe7, 0xb3, 0xdf, 0x5c, 0xbc, 0x49, 0x07, 0x37, 0xe6,
-	0xc5, 0xff, 0x00, 0x00, 0x00, 0xff, 0xff, 0x62, 0xc2, 0x0d, 0x79, 0xa6, 0x02, 0x00, 0x00,
+	// 500 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x93, 0x31, 0x6f, 0xd3, 0x40,
+	0x14, 0xc7, 0x7d, 0x69, 0x1a, 0x25, 0x67, 0xa7, 0x42, 0x37, 0xa0, 0x50, 0xa4, 0x23, 0x78, 0xaa,
+	0x10, 0x4d, 0xa4, 0xc2, 0x56, 0x18, 0x9a, 0x80, 0x54, 0x21, 0xc1, 0xe0, 0x20, 0x90, 0x58, 0x2c,
+	0xe7, 0xf2, 0x1a, 0x5b, 0x8d, 0x7d, 0x27, 0xdf, 0x85, 0x36, 0x4c, 0x7c, 0x04, 0x3e, 0x01, 0x33,
+	0xdf, 0x82, 0x95, 0x31, 0x63, 0x27, 0x44, 0x9c, 0x85, 0xb1, 0x1f, 0x01, 0xf9, 0x25, 0x4e, 0x9c,
+	0x2e, 0x6c, 0xef, 0x7f, 0xef, 0xf7, 0x7f, 0x79, 0xef, 0xaf, 0x98, 0x3e, 0xd7, 0xa9, 0xe8, 0xc2,
+	0x09, 0xf8, 0x06, 0xb4, 0xe9, 0x2a, 0x48, 0x2f, 0x7c, 0x23, 0xe5, 0xa4, 0x0b, 0xd7, 0x0a, 0xd2,
+	0x28, 0x86, 0xc4, 0xa8, 0x61, 0x49, 0x74, 0x54, 0x2a, 0x8d, 0x64, 0x8e, 0xba, 0xee, 0x6c, 0xd8,
+	0xc3, 0xe3, 0x71, 0x64, 0xc2, 0xe9, 0xb0, 0x23, 0x64, 0xdc, 0x1d, 0xcb, 0xb1, 0xec, 0x22, 0x34,
+	0x9c, 0x5e, 0xa0, 0x42, 0x81, 0xd5, 0xca, 0xec, 0xfe, 0xac, 0xd0, 0x83, 0xd7, 0x9b, 0x89, 0x03,
+	0x05, 0x82, 0x9d, 0x52, 0xfb, 0x73, 0xf4, 0x25, 0x82, 0xd4, 0xd7, 0x0a, 0x44, 0x8b, 0xb4, 0xc9,
+	0x91, 0x7d, 0x72, 0xd8, 0x29, 0xff, 0x4a, 0xe7, 0xa3, 0x4c, 0x2f, 0x27, 0x32, 0x18, 0xe5, 0x06,
+	0x8f, 0xae, 0x70, 0x34, 0x9f, 0xd1, 0x83, 0xab, 0x75, 0x0f, 0xed, 0xba, 0x55, 0x69, 0xef, 0xfd,
+	0xc7, 0xdf, 0xbc, 0x2a, 0x29, 0xcd, 0x4e, 0xa9, 0x13, 0x83, 0x49, 0x23, 0xb1, 0x1e, 0xb0, 0x87,
+	0x03, 0x5a, 0xbb, 0x03, 0xde, 0x22, 0x81, 0x76, 0x3b, 0xde, 0xd4, 0x9a, 0xbd, 0xa0, 0x8e, 0x98,
+	0x4c, 0xb5, 0x29, 0xb6, 0xaf, 0xe2, 0xf6, 0x0f, 0x76, 0xcd, 0xfd, 0x15, 0xb1, 0x72, 0x8b, 0xad,
+	0x60, 0x4f, 0x29, 0x15, 0x32, 0x8e, 0x23, 0xe3, 0xeb, 0x30, 0x68, 0xd5, 0xda, 0xe4, 0xa8, 0xd1,
+	0x6b, 0x66, 0xbf, 0x1f, 0x35, 0xfa, 0xf8, 0x3a, 0x38, 0x3f, 0xf3, 0x1a, 0x2b, 0x60, 0x10, 0x06,
+	0x6f, 0xaa, 0xf5, 0xfd, 0x7b, 0x35, 0xf7, 0x3b, 0xa1, 0x4e, 0xf9, 0x1c, 0xc6, 0x68, 0x35, 0x09,
+	0x62, 0xc0, 0xe0, 0x1a, 0x1e, 0xd6, 0xf9, 0x4d, 0x23, 0x50, 0x13, 0x39, 0xf3, 0xb5, 0x01, 0x55,
+	0x84, 0x72, 0xe7, 0xa6, 0x57, 0x48, 0x0c, 0x0c, 0x28, 0xcf, 0x1e, 0x6d, 0x6a, 0xcd, 0x5e, 0x52,
+	0x27, 0x84, 0x60, 0x62, 0x42, 0x11, 0x82, 0xb8, 0x2c, 0x02, 0xb9, 0x73, 0xd3, 0x39, 0x12, 0xfd,
+	0x9c, 0xf0, 0x76, 0x70, 0xd7, 0xa1, 0x74, 0x3b, 0xd9, 0x6d, 0x52, 0xbb, 0x84, 0xe6, 0xcd, 0x6d,
+	0x94, 0xee, 0x07, 0x6a, 0x97, 0xb2, 0x61, 0x0f, 0x69, 0x23, 0x99, 0xc6, 0x7e, 0x22, 0x47, 0xa0,
+	0xf1, 0x9c, 0x7d, 0xaf, 0x9e, 0x4c, 0xe3, 0x77, 0xb9, 0x66, 0x4f, 0x68, 0x35, 0x6f, 0xb4, 0x2a,
+	0x98, 0xf0, 0xfd, 0xdd, 0x6d, 0x72, 0x04, 0xe3, 0x45, 0xc6, 0x3d, 0xa6, 0xf5, 0xe2, 0x85, 0x3d,
+	0xa6, 0x4e, 0x1c, 0x88, 0x30, 0x4a, 0xc0, 0x37, 0x33, 0x55, 0xc4, 0x64, 0xaf, 0xdf, 0xde, 0xcf,
+	0x14, 0xf4, 0x7a, 0xf3, 0x05, 0xb7, 0x6e, 0x16, 0xdc, 0xba, 0x5d, 0x70, 0xf2, 0x35, 0xe3, 0xe4,
+	0x47, 0xc6, 0xc9, 0xaf, 0x8c, 0x93, 0x79, 0xc6, 0xc9, 0x9f, 0x8c, 0x93, 0xbf, 0x19, 0xb7, 0x6e,
+	0x33, 0x4e, 0xbe, 0x2d, 0xb9, 0x35, 0x5f, 0x72, 0xeb, 0x66, 0xc9, 0xad, 0x4f, 0x4e, 0xf9, 0x33,
+	0x19, 0xd6, 0xf0, 0xff, 0xfd, 0xec, 0x5f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x16, 0x40, 0x96, 0x77,
+	0x54, 0x03, 0x00, 0x00,
 }
 
 func (this *ExperimentSpec) Equal(that interface{}) bool {
@@ -361,6 +462,67 @@ func (this *WorkloadSpec) Equal(that interface{}) bool {
 	that1, ok := that.(*WorkloadSpec)
 	if !ok {
 		that2, ok := that.(WorkloadSpec)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if len(this.DeploySteps) != len(that1.DeploySteps) {
+		return false
+	}
+	for i := range this.DeploySteps {
+		if !this.DeploySteps[i].Equal(that1.DeploySteps[i]) {
+			return false
+		}
+	}
+	if len(this.Healthchecks) != len(that1.Healthchecks) {
+		return false
+	}
+	for i := range this.Healthchecks {
+		if !this.Healthchecks[i].Equal(that1.Healthchecks[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (this *DeployStep) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*DeployStep)
+	if !ok {
+		that2, ok := that.(DeployStep)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	return true
+}
+func (this *HealthCheck) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*HealthCheck)
+	if !ok {
+		that2, ok := that.(HealthCheck)
 		if ok {
 			that1 = &that2
 		} else {
@@ -472,8 +634,33 @@ func (this *WorkloadSpec) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 4)
+	s := make([]string, 0, 7)
 	s = append(s, "&experimentpb.WorkloadSpec{")
+	s = append(s, "Name: "+fmt.Sprintf("%#v", this.Name)+",\n")
+	if this.DeploySteps != nil {
+		s = append(s, "DeploySteps: "+fmt.Sprintf("%#v", this.DeploySteps)+",\n")
+	}
+	if this.Healthchecks != nil {
+		s = append(s, "Healthchecks: "+fmt.Sprintf("%#v", this.Healthchecks)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *DeployStep) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 4)
+	s = append(s, "&experimentpb.DeployStep{")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *HealthCheck) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 4)
+	s = append(s, "&experimentpb.HealthCheck{")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -615,6 +802,87 @@ func (m *WorkloadSpec) MarshalTo(dAtA []byte) (int, error) {
 }
 
 func (m *WorkloadSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Healthchecks) > 0 {
+		for iNdEx := len(m.Healthchecks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Healthchecks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintExperiment(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.DeploySteps) > 0 {
+		for iNdEx := len(m.DeploySteps) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.DeploySteps[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintExperiment(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintExperiment(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DeployStep) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DeployStep) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DeployStep) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *HealthCheck) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HealthCheck) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *HealthCheck) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -765,6 +1033,40 @@ func (m *WorkloadSpec) Size() (n int) {
 	}
 	var l int
 	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovExperiment(uint64(l))
+	}
+	if len(m.DeploySteps) > 0 {
+		for _, e := range m.DeploySteps {
+			l = e.Size()
+			n += 1 + l + sovExperiment(uint64(l))
+		}
+	}
+	if len(m.Healthchecks) > 0 {
+		for _, e := range m.Healthchecks {
+			l = e.Size()
+			n += 1 + l + sovExperiment(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *DeployStep) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *HealthCheck) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	return n
 }
 
@@ -840,7 +1142,38 @@ func (this *WorkloadSpec) String() string {
 	if this == nil {
 		return "nil"
 	}
+	repeatedStringForDeploySteps := "[]*DeployStep{"
+	for _, f := range this.DeploySteps {
+		repeatedStringForDeploySteps += strings.Replace(f.String(), "DeployStep", "DeployStep", 1) + ","
+	}
+	repeatedStringForDeploySteps += "}"
+	repeatedStringForHealthchecks := "[]*HealthCheck{"
+	for _, f := range this.Healthchecks {
+		repeatedStringForHealthchecks += strings.Replace(f.String(), "HealthCheck", "HealthCheck", 1) + ","
+	}
+	repeatedStringForHealthchecks += "}"
 	s := strings.Join([]string{`&WorkloadSpec{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`DeploySteps:` + repeatedStringForDeploySteps + `,`,
+		`Healthchecks:` + repeatedStringForHealthchecks + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *DeployStep) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DeployStep{`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HealthCheck) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HealthCheck{`,
 		`}`,
 	}, "")
 	return s
@@ -1132,6 +1465,206 @@ func (m *WorkloadSpec) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: WorkloadSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExperiment
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploySteps", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExperiment
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DeploySteps = append(m.DeploySteps, &DeployStep{})
+			if err := m.DeploySteps[len(m.DeploySteps)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Healthchecks", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExperiment
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Healthchecks = append(m.Healthchecks, &HealthCheck{})
+			if err := m.Healthchecks[len(m.Healthchecks)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipExperiment(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeployStep) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowExperiment
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeployStep: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeployStep: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipExperiment(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthExperiment
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HealthCheck) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowExperiment
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HealthCheck: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HealthCheck: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/src/e2e_test/perf_tool/experimentpb/experiment.proto
+++ b/src/e2e_test/perf_tool/experimentpb/experiment.proto
@@ -52,7 +52,17 @@ message ExperimentSpec {
 // WorkloadSpec specifies how to run a particular workload.
 // Example workloads include: Vizier, Sock shop, or an HTTP protocol loadtest (see
 // src/e2e_test/protocol_loadtest).
-message WorkloadSpec {}
+message WorkloadSpec {
+  string name = 1;
+  repeated DeployStep deploy_steps = 2;
+  repeated HealthCheck healthchecks = 3;
+}
+
+// DeployStep specifies a single step in the process of deploying a workload.
+message DeployStep {}
+
+// HealthCheck specifies how to run a single check on a workload.
+message HealthCheck {}
 
 // MetricSpec specifies how to record a set of metrics for an experiment.
 // Currently, PxL scripts are the only supported way of recording metrics.

--- a/src/e2e_test/perf_tool/pkg/deploy/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/deploy/BUILD.bazel
@@ -24,5 +24,11 @@ go_library(
     deps = [
         "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
         "//src/e2e_test/perf_tool/pkg/cluster",
+        "//src/e2e_test/perf_tool/pkg/deploy/checks",
+        "//src/e2e_test/perf_tool/pkg/deploy/steps",
+        "//src/e2e_test/perf_tool/pkg/pixie",
+        "//src/utils/shared/k8s",
+        "@com_github_sirupsen_logrus//:logrus",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/src/e2e_test/perf_tool/pkg/deploy/workload.go
+++ b/src/e2e_test/perf_tool/pkg/deploy/workload.go
@@ -20,9 +20,17 @@ package deploy
 
 import (
 	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
 	"px.dev/pixie/src/e2e_test/perf_tool/pkg/cluster"
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/deploy/checks"
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/deploy/steps"
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/pixie"
+	"px.dev/pixie/src/utils/shared/k8s"
 )
 
 // Workload is the interface for workloads that get deployed to the experiment cluster.
@@ -31,4 +39,97 @@ type Workload interface {
 	Start(*cluster.Context) error
 	WaitForHealthCheck(context.Context, *cluster.Context, *experimentpb.ClusterSpec) error
 	Close() error
+}
+
+type workloadImpl struct {
+	name         string
+	spec         *experimentpb.WorkloadSpec
+	clusterCtx   *cluster.Context
+	pxCtx        *pixie.Context
+	deploySteps  []steps.DeployStep
+	healthChecks []checks.HealthCheck
+
+	namespacesToDelete map[string]bool
+}
+
+// NewWorkload creates a new Workload capable of deploying according to the spec given.
+func NewWorkload(pxCtx *pixie.Context, containerRegistryRepo string, spec *experimentpb.WorkloadSpec) (Workload, error) {
+	// Add deploy steps and healthchecks from spec once those are implemented.
+	deploySteps := make([]steps.DeployStep, len(spec.DeploySteps))
+	healthchecks := make([]checks.HealthCheck, len(spec.Healthchecks))
+	return &workloadImpl{
+		name:               spec.Name,
+		spec:               spec,
+		pxCtx:              pxCtx,
+		deploySteps:        deploySteps,
+		healthChecks:       healthchecks,
+		namespacesToDelete: make(map[string]bool),
+	}, nil
+}
+
+// Prepare the workload by building necessary images and rendering yamls.
+func (w *workloadImpl) Prepare() error {
+	log.WithField("workload", w.name).Trace("Preparing workload for deployment")
+	for _, s := range w.deploySteps {
+		log.WithField("workload", w.name).WithField("step", s.Name()).Trace("preparing deploy step")
+		if err := s.Prepare(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Start starts the workload.
+func (w *workloadImpl) Start(clusterCtx *cluster.Context) error {
+	w.clusterCtx = clusterCtx
+	log.WithField("workload", w.name).Trace("Starting workload deployment")
+	for _, s := range w.deploySteps {
+		log.WithField("workload", w.name).WithField("step", s.Name()).Trace("running deploy step")
+		namespaces, err := s.Deploy(clusterCtx)
+		if err != nil {
+			return err
+		}
+		for _, ns := range namespaces {
+			w.namespacesToDelete[ns] = true
+		}
+	}
+	return nil
+}
+
+// WaitForHealthCheck waits for all of the workload's healthchecks to pass.
+// The ClusterSpec is provided so that the healthcheck can use the number of nodes if necessary.
+func (w *workloadImpl) WaitForHealthCheck(ctx context.Context, clusterCtx *cluster.Context, clusterSpec *experimentpb.ClusterSpec) error {
+	var eg errgroup.Group
+	for _, c := range w.healthChecks {
+		check := c
+		eg.Go(func() error {
+			log.WithField("workload", w.name).WithField("check", check.Name()).Trace("waiting for healthcheck")
+			err := check.Wait(ctx, clusterCtx, clusterSpec)
+			if err != nil {
+				return err
+			}
+			log.WithField("workload", w.name).WithField("check", check.Name()).Trace("healthcheck passed")
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close stops the workload.
+func (w *workloadImpl) Close() error {
+	for ns := range w.namespacesToDelete {
+		log.WithField("workload", w.name).WithField("namespace", ns).Trace("deleting workload namespace")
+		od := k8s.ObjectDeleter{
+			Namespace:  ns,
+			Clientset:  w.clusterCtx.Clientset(),
+			RestConfig: w.clusterCtx.RestConfig(),
+			Timeout:    5 * time.Minute,
+		}
+		return od.DeleteNamespace()
+	}
+	w.namespacesToDelete = make(map[string]bool)
+	return nil
 }


### PR DESCRIPTION
Summary: Adds an implementation of the `Workload` interface, which creates `DeploySteps` and `HealthChecks` based on the `WorkloadSpec`.
Currently, none of the deploy steps or healthchecks are implemented so this implementation won't do much yet, but all of the logic is there once those steps/checks can be added.

Type of change: /kind test-infra

Test Plan: Tested along with future changes. Made sure all steps in the spec are deployed and all checks run.
