### PR TITLE
[perf_tool/deploy] Implement rendered YAML deploy.

### DIFF
--- a/src/e2e_test/perf_tool/pkg/deploy/steps/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/deploy/steps/BUILD.bazel
@@ -21,5 +21,11 @@ go_library(
     srcs = ["common.go"],
     importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/deploy/steps",
     visibility = ["//visibility:public"],
-    deps = ["//src/e2e_test/perf_tool/pkg/cluster"],
+    deps = [
+        "//src/e2e_test/perf_tool/pkg/cluster",
+        "//src/utils/shared/k8s",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
 )


### PR DESCRIPTION
Summary: This PR implements deploying of a rendered YAML, using the `shared/k8s` package. This will be used by both the `skaffold` and `prerendered` `DeployStep`s.
It also implements a method to get the namespace the rendered yamls are deployed to.

Type of change: /kind test-infra

Test Plan: Tested along with future changes, that rendered yamls get deployed as expected.
