### PR TITLE
Update data_collection protocol inference script to work with cri cli tool

### DIFF
--- a/src/stirling/protocol_inference/data_collection.py
+++ b/src/stirling/protocol_inference/data_collection.py
@@ -19,29 +19,39 @@ import subprocess
 import json
 import argparse
 
+def create_pod2pid(runtime):
+    """
+    Builds a mapping of running pod names to host pids.
+    """
 
-def create_pod2pid():
-    """
-    Build a mapping of running pod names to host pids.
-    """
-    # This cmd gets the host pid of each running container and its corresponding labels.
-    list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- bash -c "docker ps -q | \
-    xargs docker inspect --format '{{.State.Pid}}{{json .Config.Labels}}'"'''
+    # This command prints one line of output per container where each line is the pid of the container, a 
+    # single space and the name of the k8s pod determined by the io.kubernetes.pod.name container label.
+    # See the output below for example output:
+
+    # $ sudo crictl ps -q | sudo xargs crictl inspect --template '{{.info.pid}} {{index .info.config.labels "io.kubernetes.pod.name"}}' -o go-template
+    # 3635260 vizier-pem-sx7pr
+    # 3634678 kelvin-cdf78c57c-qlzlb
+
+    list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "crictl ps -q | \
+    xargs crictl inspect -o go-template --template '{{.info.pid}} {{index .info.config.labels \\"io.kubernetes.pod.name\\"}}'"'''
+    if runtime == 'docker':
+      list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "docker ps -q | \
+    xargs docker inspect --format '{{.State.Pid}} {{index .Config.Labels \\"io.kubernetes.pod.name\\"}}'"'''
 
     pod2pid = {}
     ps_out = subprocess.run(list_ps_cmd, shell=True, capture_output=True)
-    rows = str(ps_out.stdout).split('\\n')[1:-3]
+
+    rows = ps_out.stdout.decode('utf-8').splitlines()
     for row in rows:
-        # Example: '3217413{..., "io.kubernetes.pod.name": "vizier-query-broker", ...}'
-        pid_cutoff_idx = row.index("{")
-        pid = row[:pid_cutoff_idx]
-        try:
-            kube_info = json.loads(format(row[pid_cutoff_idx:]).replace("\\\\", "\\"))
-        except RuntimeError:
-            print(f"Failed to parse config for pid: {pid}. Skipping to the next pid.")
-            continue
-        pod_name = kube_info['io.kubernetes.pod.name']
+        split_row = row.split()
+
+        if len(split_row) != 2:
+          print(f"Failed to parse config for row: {row}. Skipping to new pid")
+          continue
+
+        pid, pod_name = split_row
         pod2pid[pod_name] = pid
+
     return pod2pid
 
 
@@ -74,6 +84,7 @@ def trace_pods(pod2pid, node, pods, duration):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Protocol Dataset Collection")
     parser.add_argument('--node', type=str, required=True)
+    parser.add_argument('--container-runtime', type=str, default='crio')
     parser.add_argument('--pods', '-p', type=str, default="pod_names.txt")
     parser.add_argument('--duration', type=int, default=30)
     args = parser.parse_args()
@@ -87,5 +98,5 @@ if __name__ == "__main__":
     node = args.node
     duration = args.duration
 
-    pod2pid = create_pod2pid()
+    pod2pid = create_pod2pid(args.container_runtime)
     trace_pods(pod2pid, node, pods, duration)

--- a/src/stirling/protocol_inference/data_collection.py
+++ b/src/stirling/protocol_inference/data_collection.py
@@ -19,10 +19,21 @@ import subprocess
 import argparse
 
 
-def create_pod2pid(runtime):
+def create_pod2pid(node, runtime_cli):
     """
     Builds a mapping of running pod names to host pids.
     """
+
+    binaries = {
+        'docker': 'docker',
+        'crictl': 'crictl',
+    }
+    ps_templates = {
+        'docker': '''--format   '{{.State.Pid}} {{index .Config.Labels \\"io.kubernetes.pod.name\\"}}' ''',
+        'crictl': '''--template '{{.info.pid}}  {{index .info.config.labels \\"io.kubernetes.pod.name\\"}}' ''',
+    }
+    binary = binaries[runtime_cli]
+    ps_template = ps_templates[runtime_cli]
 
     # This command prints one line of output per container where each line is the pid of the container, a
     # single space and the name of the k8s pod determined by the io.kubernetes.pod.name container label.
@@ -32,16 +43,13 @@ def create_pod2pid(runtime):
     #     '{{.info.pid}} {{index .info.config.labels "io.kubernetes.pod.name"}}' -o go-template
     # 3635260 vizier-pem-sx7pr
     # 3634678 kelvin-cdf78c57c-qlzlb
-
-    list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "crictl ps -q | \
-    xargs crictl inspect -o go-template \
-    --template '{{.info.pid}} {{index .info.config.labels \\"io.kubernetes.pod.name\\"}}'"'''
-    if runtime == 'docker':
-        list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "docker ps -q | \
-    xargs docker inspect --format '{{.State.Pid}} {{index .Config.Labels \\"io.kubernetes.pod.name\\"}}'"'''
+    cmd = (
+        f"kubectl node-shell {node} -- "
+        f"sudo bash -c \"{binary} ps -q | xargs {binary} inspect -o go-template {ps_template}\""
+    )
 
     pod2pid = {}
-    ps_out = subprocess.run(list_ps_cmd, shell=True, capture_output=True)
+    ps_out = subprocess.run(cmd, shell=True, capture_output=True)
 
     rows = ps_out.stdout.decode('utf-8').splitlines()
     for row in rows:
@@ -86,7 +94,8 @@ def trace_pods(pod2pid, node, pods, duration):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Protocol Dataset Collection")
     parser.add_argument('--node', type=str, required=True)
-    parser.add_argument('--container-runtime', type=str, default='crio')
+    parser.add_argument('--container-runtime-cli',
+                        type=str, default='crictl', help='The cli to use to find running containers, defaults to crictl')
     parser.add_argument('--pods', '-p', type=str, default="pod_names.txt")
     parser.add_argument('--duration', type=int, default=30)
     args = parser.parse_args()
@@ -100,5 +109,5 @@ if __name__ == "__main__":
     node = args.node
     duration = args.duration
 
-    pod2pid = create_pod2pid(args.container_runtime)
+    pod2pid = create_pod2pid(node, args.container_runtime_cli)
     trace_pods(pod2pid, node, pods, duration)

--- a/src/stirling/protocol_inference/data_collection.py
+++ b/src/stirling/protocol_inference/data_collection.py
@@ -16,26 +16,28 @@
 
 import os
 import subprocess
-import json
 import argparse
+
 
 def create_pod2pid(runtime):
     """
     Builds a mapping of running pod names to host pids.
     """
 
-    # This command prints one line of output per container where each line is the pid of the container, a 
+    # This command prints one line of output per container where each line is the pid of the container, a
     # single space and the name of the k8s pod determined by the io.kubernetes.pod.name container label.
     # See the output below for example output:
 
-    # $ sudo crictl ps -q | sudo xargs crictl inspect --template '{{.info.pid}} {{index .info.config.labels "io.kubernetes.pod.name"}}' -o go-template
+    # $ sudo crictl ps -q | sudo xargs crictl inspect --template \
+    #     '{{.info.pid}} {{index .info.config.labels "io.kubernetes.pod.name"}}' -o go-template
     # 3635260 vizier-pem-sx7pr
     # 3634678 kelvin-cdf78c57c-qlzlb
 
     list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "crictl ps -q | \
-    xargs crictl inspect -o go-template --template '{{.info.pid}} {{index .info.config.labels \\"io.kubernetes.pod.name\\"}}'"'''
+    xargs crictl inspect -o go-template \
+    --template '{{.info.pid}} {{index .info.config.labels \\"io.kubernetes.pod.name\\"}}'"'''
     if runtime == 'docker':
-      list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "docker ps -q | \
+        list_ps_cmd = '''kubectl node-shell ''' + node + ''' -- sudo bash -c "docker ps -q | \
     xargs docker inspect --format '{{.State.Pid}} {{index .Config.Labels \\"io.kubernetes.pod.name\\"}}'"'''
 
     pod2pid = {}
@@ -46,8 +48,8 @@ def create_pod2pid(runtime):
         split_row = row.split()
 
         if len(split_row) != 2:
-          print(f"Failed to parse config for row: {row}. Skipping to new pid")
-          continue
+            print(f"Failed to parse config for row: {row}. Skipping to new pid")
+            continue
 
         pid, pod_name = split_row
         pod2pid[pod_name] = pid

--- a/src/stirling/protocol_inference/data_collection.py
+++ b/src/stirling/protocol_inference/data_collection.py
@@ -95,7 +95,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Protocol Dataset Collection")
     parser.add_argument('--node', type=str, required=True)
     parser.add_argument('--container-runtime-cli',
-                        type=str, default='crictl', help='The cli to use to find running containers, defaults to crictl')
+                        type=str, default='crictl',
+                        help='The cli to use to find running containers, defaults to crictl')
     parser.add_argument('--pods', '-p', type=str, default="pod_names.txt")
     parser.add_argument('--duration', type=int, default=30)
     args = parser.parse_args()


### PR DESCRIPTION
Summary: Update data_collection protocol inference script to work with cri cli tool

The previous implementation for the protocol inference data collection script relied on the docker cli. GKE clusters running k8s 1.24 and later do not support docker anymore, so this prevents the script from working on newer clusters. This change adds support for clusters using CRI (`crictl`) in addition to keeping the existing docker interface. The docker implementation had complicated parsing logic that was also simplified in this change.

Relevant Issues: #913 (script was used as part of the investigation)

Type of change: /kind bug

Test Plan: Followed the instructions in the protocol inference [docs](src/stirling/protocol_inference/README.md) and verified pcaps were successfully captured
```
ddelnano@turing:~/code/pixie$ bazel run src/stirling/protocol_inference:data_collection -- --node gke-testing-node --pods $(pwd)/pod_names.txt --duration 120

# Verify that pcap files are present on the host
$ ls -alh /captures/*
/captures/metrics-server-v0.5.2-6bf845b67f-pkncq:
total 440K
drwxr-xr-x 2 root root 4.0K Mar  6 17:54 .
drwxr-xr-x 4 root root 4.0K Mar  6 17:54 ..
-rw------- 1 root root 430K Mar  6 17:55 5540.pcapng

/captures/vizier-query-broker-6d5cddb8c5-jcq6m:
total 748K
drwxr-xr-x 2 root root 4.0K Mar  6 17:54 .
drwxr-xr-x 4 root root 4.0K Mar  6 17:54 ..
-rw------- 1 root root 738K Mar  6 17:55 2361577.pcapng
```