### PR TITLE
[perf_tool] Add interface for recording metrics

### DIFF
--- a/src/e2e_test/perf_tool/pkg/metrics/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/metrics/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "metrics",
+    srcs = [
+        "recorder.go",
+        "results.go",
+    ],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
+        "//src/e2e_test/perf_tool/pkg/pixie",
+    ],
+)

--- a/src/e2e_test/perf_tool/pkg/metrics/recorder.go
+++ b/src/e2e_test/perf_tool/pkg/metrics/recorder.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package metrics
+
+import (
+	"px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/pixie"
+)
+
+// Recorder is an interface for all metric recorders.
+type Recorder interface {
+	Start() error
+	Close() error
+}
+
+// NewMetricsRecorder creates a new Recorder for the given MetricSpec.
+// Currently, no recorders are implemented.
+func NewMetricsRecorder(pxCtx *pixie.Context, spec *experimentpb.MetricSpec, resultCh chan<- *ResultRow) Recorder {
+	return nil
+}

--- a/src/e2e_test/perf_tool/pkg/metrics/results.go
+++ b/src/e2e_test/perf_tool/pkg/metrics/results.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package metrics
+
+import "time"
+
+// ResultRow stores a single recorded metric.
+type ResultRow struct {
+	Timestamp time.Time
+	Name      string
+	Value     float64
+	Tags      map[string]string
+}
+
+// Unused will be removed once newResultRow is used elsewhere in the package.
+func Unused() {
+	_ = newResultRow()
+}
+
+func newResultRow() *ResultRow {
+	return &ResultRow{
+		Tags: make(map[string]string),
+	}
+}


### PR DESCRIPTION
Summary: Adds the interface for creating a `metric.Recorder` based on a `MetricSpec`. Currently, there are no implementations of `metric.Recorder` so this is just a stub.

Type of change: /kind test-infra

Test Plan: No functional changes here, just adding an interface that will be implemented in future PRs.
