### PR TITLE
[perf_tool] Add bigquery storage format definitions

### DIFF
--- a/src/e2e_test/perf_tool/pkg/bq/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/bq/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     name = "bq",
     srcs = [
         "batch_inserter.go",
+        "row.go",
         "table.go",
     ],
     importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/bq",

--- a/src/e2e_test/perf_tool/pkg/bq/row.go
+++ b/src/e2e_test/perf_tool/pkg/bq/row.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package bq
+
+import (
+	"time"
+)
+
+// ResultRow represents a single datapoint for a single metric, to be stored in bigquery.
+// Each result row is associated to a particular run of an experiment (via ExperimentID).
+type ResultRow struct {
+	// ExperimentID is a string representation of a UUID.
+	ExperimentID string    `bigquery:"experiment_id"`
+	Timestamp    time.Time `bigquery:"timestamp"`
+	Name         string    `bigquery:"name"`
+	Value        float64   `bigquery:"value"`
+	// JSON encoded map[string]string of tags.
+	Tags string `bigquery:"tags"`
+}
+
+// SpecRow stores an experiments ExperimentSpec in bigquery, encoded as JSON.
+// SpecRows are only written to bigquery on experiment success, so all results from failed attempts can be ignored by joining on the ExperimentID
+type SpecRow struct {
+	// ExperimentID is a string representation of a experiment UUID.
+	ExperimentID string `bigquery:"experiment_id"`
+	// Spec is a json encoded `experimentpb.ExperimentSpec`
+	Spec string `bigquery:"spec"`
+	// CommitTopoOrder is the number of commits since the beginning of history for the commit this experiment was run on.
+	// This is used to order experiments in datastudio views.
+	CommitTopoOrder int `bigquery:"commit_topo_order"`
+}


### PR DESCRIPTION
Summary: Add definitions for how both results and specs will be stored in bigquery. Specs and results will be stored in separate tables. The spec table is only written to on experiment success, so joining the spec and result tables on the ExperimentID will remove all result rows from failed experiments.

Type of change: /kind test-infra

Test Plan: Tested that bigquery tables get created correctly based on the implicit schemas of these structs.
