### PR TITLE
[perf_tool] Add `suites` package for defining experiment specs

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/suites/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "suites",
+    srcs = ["suites.go"],
+    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/suites",
+    visibility = ["//visibility:public"],
+    deps = ["//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto"],
+)

--- a/src/e2e_test/perf_tool/pkg/suites/suites.go
+++ b/src/e2e_test/perf_tool/pkg/suites/suites.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package suites
+
+import (
+	pb "px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+)
+
+// ExperimentSuite is a group of experiments, represented as a function that returns multiple named experiment specs.
+type ExperimentSuite func() map[string]*pb.ExperimentSpec
+
+// ExperimentSuiteRegistry contains all the ExperimentSuite, keyed by name.
+var ExperimentSuiteRegistry = map[string]ExperimentSuite{}


### PR DESCRIPTION
Summary: Adds the interface for the `suites` package. This package defines a set of experiment "suites" which are essentially just a named set of `ExperimentSpecs`. For example, one of the suites will be the `main` suite which we'll run on each commit to `main`.

Type of change: /kind test-infra

Test Plan: This is just an interface, will be tested along with the implementation.
