### PR TITLE
Add logging for pluginService getRetentionScripts error

### DIFF
--- a/src/cloud/plugin/controllers/server.go
+++ b/src/cloud/plugin/controllers/server.go
@@ -745,6 +745,7 @@ func (s *Server) GetRetentionScripts(ctx context.Context, req *pluginpb.GetReten
 	}
 	cronScriptsResp, err := s.cronScriptClient.GetScripts(ctx, &cronscriptpb.GetScriptsRequest{IDs: scriptIDs, OrgID: utils.ProtoFromUUID(orgID)})
 	if err != nil {
+		log.WithField("orgID", orgID.String()).WithError(err).Error("Failed to fetch cron scripts for retention scripts for org")
 		return nil, status.Errorf(codes.Internal, "Failed to fetch cron scripts")
 	}
 


### PR DESCRIPTION
Summary: We have seen cases where the `GetRetentionScripts` call errors. Unfortunately, the current logging/error doesn't give us enough information as to what is actually going wrong. This PR adds some additional logging so we can track more details about the error and see why some plugins get into this error state. Although very uncommon, it can prevent users from loading the Data Export page.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: This just adds additional logging and has no functionality change.

