### PR TITLE
Update protocol inference scripts to take into account tls packets

### DIFF
--- a/src/stirling/protocol_inference/dataset_generation.py
+++ b/src/stirling/protocol_inference/dataset_generation.py
@@ -134,7 +134,7 @@ def parse_protocol(frame_protocol):
     """
     # Putting http after http2/grpc since it can overlap with http2 and grpc.
     protocols = ["http2", "mysql", "pgsql", "cql", "amqp", "redis", "dns", "mongo", "http", "ssh",
-                 "kafka", "mux"]
+                 "kafka", "mux", "tls"]
     for protocol in protocols:
         if protocol in frame_protocol:
             return protocol

--- a/src/stirling/protocol_inference/model/metadata.py
+++ b/src/stirling/protocol_inference/model/metadata.py
@@ -29,4 +29,5 @@ kTargetProtocols = [
     "kafka",
     "nats",
     "mux",
+    "tls",
 ]


### PR DESCRIPTION
Summary: Update protocol inference scripts to take into account tls packets

While investigating #913, I deployed stirling with verbose logging to identify which processes are contributors to the mux protocol confusion: kubelet, metrics-server, query broker, cloud connector ([P325](https://phab.corp.pixielabs.ai/P325)). After fixing the data collection script (#968) and using it on these pods, I realized that it didn't change the output of the protocol confusion matrix. This is because the dataset generation script ignores anything that is encrypted ([source](https://github.com/pixie-io/pixie/blob/9d16ad1f218beb2b01e879192859b4a0e99adfce/src/stirling/protocol_inference/dataset_generation.py#L179)). Essentially if `tshark` doesn't recognize the protocol as one of [these](https://github.com/pixie-io/pixie/blob/9d16ad1f218beb2b01e879192859b4a0e99adfce/src/stirling/protocol_inference/dataset_generation.py#L136-L137) it is labeled as unknown and skipped.

Our ideal confusion matrix would label tls as `unknown` 100% of the time and should not be labeled as any other protocol. With this change, we can evaluate modifications to the protocol inference and work to get mux's `tls` classification down to 0%.

Relevant Issues: #913

Type of change: /kind test-infra

Test Plan: Generated the confusion matrix (seen below) and saw the mux's mislabelling of tls traffic with our existing data set

<img width="1117" alt="conn_dataset_with_tls" src="https://user-images.githubusercontent.com/5855593/223548100-cefacd11-37c9-485d-a842-12bc4a6115ae.png">

While 0.6% doesn't seem like a large amount of traffic, this amounts to 126 packets from our data set some of which are quite large.
