### PR TITLE
[actions] Refactor actions to reuse common `get-image` action

### DIFF
--- a/.github/workflows/cacher.yaml
+++ b/.github/workflows/cacher.yaml
@@ -8,16 +8,9 @@ permissions:
   contents: read
 jobs:
   get-dev-image:
-    runs-on: ubuntu-latest
-    outputs:
-      image-with-tag: ${{ steps.get-version.outputs.image }}
-    steps:
-    - uses: actions/checkout@v3
-    - id: get-version
-      run: >-
-        IMAGE_NAME="gcr.io/pixie-oss/pixie-dev-public/dev_image";
-        IMAGE_TAG="$(cat docker.properties | cut -d'=' -f2)";
-        echo "image=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "dev_image"
   populate-caches:
     runs-on: ubuntu-latest-8-cores
     needs: get-dev-image

--- a/.github/workflows/get_image.yaml
+++ b/.github/workflows/get_image.yaml
@@ -1,0 +1,23 @@
+---
+on:
+  workflow_call:
+    inputs:
+      image-base-name:
+        required: true
+        type: string
+    outputs:
+      image-with-tag:
+        description: "A image with tag (from docker.properties) for the requested image"
+        value: ${{ jobs.get-image.outputs.image-with-tag }}
+jobs:
+  get-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image-with-tag: ${{ steps.get-version.outputs.image }}
+    steps:
+    - uses: actions/checkout@v3
+    - id: get-version
+      run: >-
+        IMAGE_NAME="gcr.io/pixie-oss/pixie-dev-public/${{ inputs.image-base-name }}";
+        IMAGE_TAG="$(cat docker.properties | cut -d'=' -f2)";
+        echo "image=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr_genfiles.yml
+++ b/.github/workflows/pr_genfiles.yml
@@ -6,16 +6,9 @@ permissions:
   contents: read
 jobs:
   get-dev-image:
-    runs-on: ubuntu-latest
-    outputs:
-      image-with-tag: ${{ steps.get-version.outputs.image }}
-    steps:
-    - uses: actions/checkout@v3
-    - id: get-version
-      run: >-
-        IMAGE_NAME="gcr.io/pixie-oss/pixie-dev-public/dev_image";
-        IMAGE_TAG="$(cat docker.properties | cut -d'=' -f2)";
-        echo "image=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "dev_image"
   run-genfiles:
     runs-on: ubuntu-latest-8-cores
     needs: get-dev-image

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -6,16 +6,9 @@ permissions:
   contents: read
 jobs:
   get-linter-image:
-    runs-on: ubuntu-latest
-    outputs:
-      image-with-tag: ${{ steps.get-version.outputs.image }}
-    steps:
-    - uses: actions/checkout@v3
-    - id: get-version
-      run: >-
-        IMAGE_NAME="gcr.io/pixie-oss/pixie-dev-public/linter_image";
-        IMAGE_TAG="$(cat docker.properties | cut -d'=' -f2)";
-        echo "image=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "linter_image"
   run-container-lint:
     runs-on: ubuntu-latest-8-cores
     needs: get-linter-image


### PR DESCRIPTION
Summary: Adds a `get_image.yaml` github action that can be reused by the various actions that need to look at `docker.properties` to get the image name for their subsequent job.
This reduces the need to repeat code for all the different actions that require our custom dev image.

Type of change: /kind test-infra

Test Plan: Testing the actions with this PR.
