### PR TITLE
Fix mux protocol inference bug which causes certain frames to be labeled as 'unknown'

### DIFF
--- a/src/stirling/protocol_inference/model/ruleset_basic.py
+++ b/src/stirling/protocol_inference/model/ruleset_basic.py
@@ -429,11 +429,11 @@ def infer_mux_message(buf, count):
         return MessageType.kUnknown
 
     if mux_type == kRerr or mux_type == kRerrOld:
-        if buf[length - 5: length] != 'check':
+        if buf[length - 5: length] != b'check':
             return MessageType.kUnknown
 
     if mux_type == kRinit or mux_type == kTinit:
-        if buf[mux_framer_pos:mux_framer_pos + 10] != 'mux-framer':
+        if buf[mux_framer_pos:mux_framer_pos + 10] != b'mux-framer':
             return MessageType.kUnknown
 
     if tag < 1 or tag > ((1 << 23) - 1):


### PR DESCRIPTION
Summary: Fix mux protocol inference bug which causes certain frames to be labeled as 'unknown'

Our protocol inference will indefinitely attempt to identify a connection's protocol until it matches something other than `unknown`. Once the protocol is determined, its classification will not change for the lifetime of the connection. What this means is that it's possible for earlier payloads to be labeled as unknown as long as it doesn't match an incorrect protocol. Mux is a session layer protocol and therefore has a handshake process that occurs before the core frames are sent (TDispatch, RDispatch).

This change fixes a bug that prevented Tinit, Rinit, Rerr and RerrOld frames from being identified (initial frames in the [handshake process](https://github.com/pixie-io/pixie/blob/dd6545240ae39fc8b34f6286eb0d482d4f96af79/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc#L161-L162)). This wasn't an issue prior to because the TDispatch and RDispatch frames were matched before mux was labeled as another protocol.

While working to fix the mislabelling of tls packets as mux protocol data (#981), I broke the classification of TDispatch and RDispatch frames and noticed that all of mux's protocol data was labeled as unknown. This allowed me to realize there was a bug in these conditions preventing mux from being identified as early as possible.

Note: this code is duplicated amongst our [BPF program](https://github.com/pixie-io/pixie/blob/dd6545240ae39fc8b34f6286eb0d482d4f96af79/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference.h#L585-L598) and these adhoc scripts. I believe the BPF program's protocol inference is working as expected.

Relevant Issues: #913

Type of change: /kind test-infra

Test Plan: Performed the following tests below to verify that mux protocol traffic is identified by earlier mux frames
- [x] Removed TDispatch and RDispatch from protocol inference which resulted in mux labled as `unknown` ([P328](https://phab.corp.pixielabs.ai/P328))

<img width="1179" alt="confusion-matrix-when-TDispatch-and-RDispatch-exluded" src="https://user-images.githubusercontent.com/5855593/223556278-2551abac-2606-4137-8492-e7f4692efb0f.png">

- [x] Removed TDispatch and RDispatch from protocol inference with the bug fix which resulted in mux being labeled properly ([P329](https://phab.corp.pixielabs.ai/P329))
<img width="1170" alt="confusion-matrix-with-byte-comparison-fix" src="https://user-images.githubusercontent.com/5855593/223556321-58b8adfa-6e7c-4bbe-9606-7e072a164886.png">
