### PR TITLE
[perf_tool/runner] Get cluster in runner

### DIFF
--- a/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
@@ -27,5 +27,7 @@ go_library(
         "//src/e2e_test/perf_tool/pkg/cluster",
         "//src/e2e_test/perf_tool/pkg/pixie",
         "@com_github_gofrs_uuid//:uuid",
+        "@com_github_sirupsen_logrus//:logrus",
+        "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
Summary: I've split the experiment `Runner` implementation into many small diffs. This first one just calls `cluster.Provider` to get a cluster.

Type of change: /kind test-infra

Test Plan: Tested along with all `Runner` implementation PRs to make sure the runner works as expected.
