### PR TITLE
[perf_tool/suites] Add default cluster spec

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/suites/BUILD.bazel
@@ -18,7 +18,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "suites",
-    srcs = ["suites.go"],
+    srcs = [
+        "clusters.go",
+        "suites.go",
+    ],
     importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/suites",
     visibility = ["//visibility:public"],
     deps = ["//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto"],

--- a/src/e2e_test/perf_tool/pkg/suites/clusters.go
+++ b/src/e2e_test/perf_tool/pkg/suites/clusters.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package suites
+
+import pb "px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+
+// DefaultCluster is the default ClusterSpec all experiments currently use.
+var DefaultCluster = &pb.ClusterSpec{
+	NumNodes: 1,
+	Node: &pb.NodeSpec{
+		MachineType: `n2-standard-4`,
+	},
+}


### PR DESCRIPTION
Summary: Add default `ClusterSpec` to use for default experiments. For now we use 1 `n2-standard-4` node.

Type of change: /kind test-infra

Test Plan: Tested along with other changes that the experiments work on a cluster of this spec.
