### PR TITLE
[perf_tool] Add converter from `metrics.ResultRow` to `bq.ResultRow`

### DIFF
--- a/src/e2e_test/perf_tool/pkg/bq/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/bq/BUILD.bazel
@@ -26,6 +26,8 @@ go_library(
     importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/bq",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/e2e_test/perf_tool/pkg/metrics",
+        "@com_github_gofrs_uuid//:uuid",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_google_cloud_go_bigquery//:bigquery",
         "@org_golang_google_api//googleapi",

--- a/src/e2e_test/perf_tool/pkg/bq/row.go
+++ b/src/e2e_test/perf_tool/pkg/bq/row.go
@@ -19,7 +19,12 @@
 package bq
 
 import (
+	"encoding/json"
 	"time"
+
+	"github.com/gofrs/uuid"
+
+	"px.dev/pixie/src/e2e_test/perf_tool/pkg/metrics"
 )
 
 // ResultRow represents a single datapoint for a single metric, to be stored in bigquery.
@@ -44,4 +49,19 @@ type SpecRow struct {
 	// CommitTopoOrder is the number of commits since the beginning of history for the commit this experiment was run on.
 	// This is used to order experiments in datastudio views.
 	CommitTopoOrder int `bigquery:"commit_topo_order"`
+}
+
+// MetricsRowToResultRow converts a `metrics.ResultRow` into a `bq.ResultRow`.
+func MetricsRowToResultRow(expID uuid.UUID, row *metrics.ResultRow) (*ResultRow, error) {
+	encodedTags, err := json.Marshal(row.Tags)
+	if err != nil {
+		return nil, err
+	}
+	return &ResultRow{
+		ExperimentID: expID.String(),
+		Timestamp:    row.Timestamp,
+		Name:         row.Name,
+		Value:        row.Value,
+		Tags:         string(encodedTags),
+	}, nil
 }


### PR DESCRIPTION
Summary: This adds a conversion utility from the `ResultRow` format in `metrics` to the row format that is stored in bigquery. This is useful so that the `metrics` package doesn't have to know anything about experiment IDs, and also can store its tags in the more logical `map[string]string` format, rather than a json encoded string.

Type of change: /kind test-infra

Test Plan: Tested that the conversion works as part of broader changes.
