### PR TITLE
[perf_tool/runner] Prepare workloads

### DIFF
--- a/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
         "//src/e2e_test/perf_tool/pkg/bq",
         "//src/e2e_test/perf_tool/pkg/cluster",
+        "//src/e2e_test/perf_tool/pkg/deploy",
         "//src/e2e_test/perf_tool/pkg/pixie",
         "@com_github_gofrs_uuid//:uuid",
         "@com_github_sirupsen_logrus//:logrus",


### PR DESCRIPTION
Summary: Another PR that adds to the implementation of the experiment runner. This PR adds preparation of workloads in parallel to getting a cluster. The workloads aren't yet deployed that will be in a future PR.

Type of change: /kind test-infra

Test Plan: Tested all of the runner implementation as a whole.
