### PR TITLE
[perf_tool/run_cmd] Create bigquery tables

### DIFF
--- a/src/e2e_test/perf_tool/cmd/BUILD.bazel
+++ b/src/e2e_test/perf_tool/cmd/BUILD.bazel
@@ -35,5 +35,6 @@ go_library(
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_viper//:viper",
+        "@com_google_cloud_go_bigquery//:bigquery",
     ],
 )


### PR DESCRIPTION
Summary: Create bigquery tables in `run` subcommand. These tables are used by the runner to store experiment results and specs.

Type of change: /kind test-infra

Test Plan: Tested that results end up in bigquery with the full implementation of the `run` subcommand.
