### PR TITLE
[perf_tool/runner] Add sleeps

### DIFF
--- a/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//src/e2e_test/perf_tool/pkg/deploy",
         "//src/e2e_test/perf_tool/pkg/pixie",
         "@com_github_gofrs_uuid//:uuid",
+        "@com_github_gogo_protobuf//types",
         "@com_github_sirupsen_logrus//:logrus",
         "@org_golang_x_sync//errgroup",
     ],


### PR DESCRIPTION
Summary: Add sleeps based on the `RunSpec`. We sleep once after `vizier` is deployed and before the other workloads are deployed, as a burn-in period. We then sleep after the rest of the workloads are deployed for the duration of the rest of the experiment.

Type of change: /kind test-infra

Test Plan: Tested with the full `Runner` implementation.
