### PR TITLE
[perf_tool/cluster] Allow dynamic subnetwork creation

### DIFF
--- a/src/e2e_test/perf_tool/cmd/test_gke_cluster.go
+++ b/src/e2e_test/perf_tool/cmd/test_gke_cluster.go
@@ -50,7 +50,7 @@ func init() {
 	TestGKEClusterCmd.Flags().String("gke_project", "pl-pixies", "The gcloud project to use for GKE clusters")
 	TestGKEClusterCmd.Flags().String("gke_zone", "us-west1-a", "The gcloud zone to use for GKE clusters")
 	TestGKEClusterCmd.Flags().String("gke_network", "dev", "The gcloud network to use for GKE clusters")
-	TestGKEClusterCmd.Flags().String("gke_subnet", "us-west1-1", "The subnetwork to use for GKE clusters")
+	TestGKEClusterCmd.Flags().String("gke_subnet", "", "The subnetwork to use for GKE clusters, if empty a subnetwork will be created on demand")
 	TestGKEClusterCmd.Flags().String("gke_security_group", "gke-security-groups@pixielabs.ai", "The security group to use for GKE clusters")
 	RootCmd.AddCommand(TestGKEClusterCmd)
 }

--- a/src/e2e_test/perf_tool/pkg/cluster/gke/cluster_ops.go
+++ b/src/e2e_test/perf_tool/pkg/cluster/gke/cluster_ops.go
@@ -214,6 +214,7 @@ func (p *ClusterProvider) createCluster(ctx context.Context, spec *experimentpb.
 				MonitoringService: `none`,
 				IpAllocationPolicy: &containerpb.IPAllocationPolicy{
 					UseIpAliases:          true,
+					CreateSubnetwork:      p.clusterOpts.DynamicSubnet,
 					ClusterIpv4CidrBlock:  p.clusterOpts.CIDR,
 					ServicesIpv4CidrBlock: p.clusterOpts.ServicesCIDR,
 				},

--- a/src/e2e_test/perf_tool/pkg/cluster/gke/gke.go
+++ b/src/e2e_test/perf_tool/pkg/cluster/gke/gke.go
@@ -35,6 +35,7 @@ type ClusterOptions struct {
 	Zone          string
 	Network       string
 	Subnet        string
+	DynamicSubnet bool
 	CIDR          string
 	ServicesCIDR  string
 	SecurityGroup string
@@ -82,6 +83,9 @@ func addDefaults(clusterOpts *ClusterOptions) {
 	}
 	if clusterOpts.DiskSizeGB == 0 {
 		clusterOpts.DiskSizeGB = defaultDiskSizeGB
+	}
+	if clusterOpts.Subnet == "" {
+		clusterOpts.DynamicSubnet = true
 	}
 }
 


### PR DESCRIPTION
Summary: Add support to the `gke.ClusterProvider` for creating clusters with on demand subnetworks, rather than a preset subnetwork name.

Type of change: /kind test-infra

Test Plan: Tested with `test_gke_cluster` that the `gke.ClusterProvider` can create a cluster with a dynamic subnetwork.
