### PR TITLE
[perf_tool/runner] Push spec to bigquery on success

### DIFF
--- a/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//src/e2e_test/perf_tool/pkg/metrics",
         "//src/e2e_test/perf_tool/pkg/pixie",
         "@com_github_gofrs_uuid//:uuid",
+        "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//types",
         "@com_github_sirupsen_logrus//:logrus",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
Summary: After a successful experiment run, the `Runner` now pushes a row to the bigquery `specs` table with the spec and experiment ID of the successful experiment.

Type of change: /kind test-infra

Test Plan: Tested that the spec shows up in bigquery after a successful experiment.
