### PR TITLE
[perf_tool/suites] Add workload specs for HTTP loadtest, Vizier, and sock shop workloads

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/scripts/healthcheck/http_data_in_namespace.pxl
+++ b/src/e2e_test/perf_tool/pkg/suites/scripts/healthcheck/http_data_in_namespace.pxl
@@ -14,23 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+import px
 
-go_library(
-    name = "suites",
-    srcs = [
-        "clusters.go",
-        "suites.go",
-        "workloads.go",
-    ],
-    embedsrcs = [
-        "scripts/healthcheck/http_data_in_namespace.pxl",
-        "scripts/healthcheck/vizier.pxl",
-    ],
-    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/suites",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
-        "@com_github_sirupsen_logrus//:logrus",
-    ],
-)
+df = px.DataFrame('http_events', start_time='-30s')
+df.namespace = df.ctx['namespace']
+df = df[df.namespace == '{{.Namespace}}']
+
+df = df.agg(count=('time_', px.count))
+df.success = (df.count > 0)
+px.display(df[['success']])

--- a/src/e2e_test/perf_tool/pkg/suites/scripts/healthcheck/vizier.pxl
+++ b/src/e2e_test/perf_tool/pkg/suites/scripts/healthcheck/vizier.pxl
@@ -14,23 +14,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+import px
 
-go_library(
-    name = "suites",
-    srcs = [
-        "clusters.go",
-        "suites.go",
-        "workloads.go",
-    ],
-    embedsrcs = [
-        "scripts/healthcheck/http_data_in_namespace.pxl",
-        "scripts/healthcheck/vizier.pxl",
-    ],
-    importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/suites",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
-        "@com_github_sirupsen_logrus//:logrus",
-    ],
-)
+df = px.DataFrame('process_stats', start_time='-1m')
+df.hostname = px._exec_hostname()
+df = df[['hostname']]
+
+df = df[not px.contains(df.hostname, 'kelvin')]
+df = df.groupby(['hostname']).agg()
+df = df.agg(num_pems=('hostname', px.count))
+df.success = (df.num_pems == {{.NumNodes}})
+px.display(df[['success']])

--- a/src/e2e_test/perf_tool/pkg/suites/workloads.go
+++ b/src/e2e_test/perf_tool/pkg/suites/workloads.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package suites
+
+import (
+	// Embed import is required to use go:embed directive.
+	_ "embed"
+	"fmt"
+	"strings"
+	"text/template"
+
+	log "github.com/sirupsen/logrus"
+
+	pb "px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+)
+
+// VizierWorkload returns the workload spec to deploy Vizier.
+func VizierWorkload() *pb.WorkloadSpec {
+	return &pb.WorkloadSpec{
+		Name: "vizier",
+		DeploySteps: []*pb.DeployStep{
+			{
+				DeployType: &pb.DeployStep_Px{
+					Px: &pb.PxCLIDeploy{
+						Args: []string{
+							"deploy",
+						},
+						SetClusterID: true,
+						Namespaces: []string{
+							"pl",
+							"px-operator",
+							"olm",
+						},
+					},
+				},
+			},
+			{
+				DeployType: &pb.DeployStep_Px{
+					Px: &pb.PxCLIDeploy{
+						Args: []string{
+							"delete",
+							"--clobber=false",
+						},
+					},
+				},
+			},
+			{
+				DeployType: &pb.DeployStep_Skaffold{
+					Skaffold: &pb.SkaffoldDeploy{
+						SkaffoldPath: "skaffold/skaffold_vizier.yaml",
+						SkaffoldArgs: []string{
+							"-p", "opt",
+						},
+					},
+				},
+			},
+		},
+		Healthchecks: VizierHealthChecks(),
+	}
+}
+
+const protocolLoadtestConfigMapPatch = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: px-protocol-loadtest-config
+data:
+  NUM_CONNECTIONS: "%d"
+  TARGET_RPS: "%d"
+`
+
+// HTTPLoadTestWorkload returns the WorkloadSpec to deploy a simple client/server http loadtest (see src/e2e_test/protocol_loadtest)
+func HTTPLoadTestWorkload(numConns int, targetRPS int) *pb.WorkloadSpec {
+	return &pb.WorkloadSpec{
+		Name: "http_loadtest",
+		DeploySteps: []*pb.DeployStep{
+			{
+				DeployType: &pb.DeployStep_Skaffold{
+					Skaffold: &pb.SkaffoldDeploy{
+						SkaffoldPath: "src/e2e_test/protocol_loadtest/skaffold_loadtest.yaml",
+					},
+				},
+			},
+			{
+				DeployType: &pb.DeployStep_Skaffold{
+					Skaffold: &pb.SkaffoldDeploy{
+						SkaffoldPath: "src/e2e_test/protocol_loadtest/skaffold_client.yaml",
+						Patches: []*pb.PatchSpec{
+							{
+								YAML: fmt.Sprintf(protocolLoadtestConfigMapPatch, numConns, targetRPS),
+								Target: &pb.PatchTarget{
+									Kind: "ConfigMap",
+									Name: "px-protocol-loadtest-config",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Healthchecks: HTTPHealthChecks("px-protocol-loadtest"),
+	}
+}
+
+// SockShopWorkload returns the WorkloadSpec to deploy sock shop.
+func SockShopWorkload() *pb.WorkloadSpec {
+	return &pb.WorkloadSpec{
+		Name: "px-sock-shop",
+		DeploySteps: []*pb.DeployStep{
+			{
+				DeployType: &pb.DeployStep_Px{
+					Px: &pb.PxCLIDeploy{
+						Args: []string{
+							"demo",
+							"deploy",
+							"px-sock-shop",
+						},
+						Namespaces: []string{
+							"px-sock-shop",
+						},
+					},
+				},
+			},
+		},
+		Healthchecks: HTTPHealthChecks("px-sock-shop"),
+	}
+}
+
+//go:embed scripts/healthcheck/vizier.pxl
+var vizierHealthCheckScript string
+
+//go:embed scripts/healthcheck/http_data_in_namespace.pxl
+var httpHealthCheckScript string
+
+// VizierHealthChecks returns the healthchecks for a vizier workload.
+func VizierHealthChecks() []*pb.HealthCheck {
+	return []*pb.HealthCheck{
+		{
+			CheckType: &pb.HealthCheck_K8S{
+				K8S: &pb.K8SPodsReadyCheck{
+					Namespace: "pl",
+				},
+			},
+		},
+		{
+			CheckType: &pb.HealthCheck_PxL{
+				PxL: &pb.PxLHealthCheck{
+					Script:        vizierHealthCheckScript,
+					SuccessColumn: "success",
+				},
+			},
+		},
+	}
+}
+
+// HTTPHealthChecks returns a healthcheck based on the existence of http_events in Pixie for a given namespace.
+func HTTPHealthChecks(namespace string) []*pb.HealthCheck {
+	t, err := template.New("").Parse(httpHealthCheckScript)
+	if err != nil {
+		log.WithError(err).Fatal("failed to parse HTTP healthcheck script")
+	}
+	buf := &strings.Builder{}
+	err = t.Execute(buf, &struct {
+		Namespace string
+	}{
+		Namespace: namespace,
+	})
+	if err != nil {
+		log.WithError(err).Fatal("failed to execute HTTP healthcheck template")
+	}
+
+	return []*pb.HealthCheck{
+		{
+			CheckType: &pb.HealthCheck_K8S{
+				K8S: &pb.K8SPodsReadyCheck{
+					Namespace: namespace,
+				},
+			},
+		},
+		{
+			CheckType: &pb.HealthCheck_PxL{
+				PxL: &pb.PxLHealthCheck{
+					Script:        buf.String(),
+					SuccessColumn: "success",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Summary: Add funcs for creating workload specs for common workloads such as Vizier, sock shop, and `protocol_loadtest`. Also adds pxl scripts to healthcheck those workloads.
The vizier healthcheck script, makes sure it sees as many nodes as there are in the cluster, and the http healthcheck script makes sure there is some http data being traced in the given namespace.

Type of change: /kind test-infra

Test Plan: Tested that all of these workloads deploy successfully during experiments.
