### PR TITLE
[perf_tool/suites] Add specs for cpu, heap, and data loss metrics

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/suites/BUILD.bazel
@@ -20,17 +20,22 @@ go_library(
     name = "suites",
     srcs = [
         "clusters.go",
+        "metrics.go",
         "suites.go",
         "workloads.go",
     ],
     embedsrcs = [
         "scripts/healthcheck/http_data_in_namespace.pxl",
         "scripts/healthcheck/vizier.pxl",
+        "scripts/heap_size.pxl",
+        "scripts/http_data_loss.pxl",
+        "scripts/process_stats.pxl",
     ],
     importpath = "px.dev/pixie/src/e2e_test/perf_tool/pkg/suites",
     visibility = ["//visibility:public"],
     deps = [
         "//src/e2e_test/perf_tool/experimentpb:experiment_pl_go_proto",
+        "@com_github_gogo_protobuf//types",
         "@com_github_sirupsen_logrus//:logrus",
     ],
 )

--- a/src/e2e_test/perf_tool/pkg/suites/metrics.go
+++ b/src/e2e_test/perf_tool/pkg/suites/metrics.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package suites
+
+import (
+	// Necessary to use go:embed directive.
+	_ "embed"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
+	pb "px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
+)
+
+//go:embed scripts/process_stats.pxl
+var processStatsScript string
+
+//go:embed scripts/heap_size.pxl
+var heapSizeScript string
+
+//go:embed scripts/http_data_loss.pxl
+var httpDataLossScript string
+
+// ProcessStatsMetrics adds a metric spec that collects process stats such as rss,vsize, and cpu_usage.
+func ProcessStatsMetrics(period time.Duration) *pb.MetricSpec {
+	return &pb.MetricSpec{
+		MetricType: &pb.MetricSpec_PxL{
+			PxL: &pb.PxLScriptSpec{
+				Script:           processStatsScript,
+				Streaming:        false,
+				CollectionPeriod: types.DurationProto(period),
+				TableOutputs: map[string]*pb.PxLScriptOutputList{
+					"*": {
+						Outputs: []*pb.PxLScriptOutputSpec{
+							singleMetricOutputWithPodNodeName("rss"),
+							singleMetricOutputWithPodNodeName("vsize"),
+							singleMetricOutputWithPodNodeName("cpu_usage"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// HeapMetrics collects metrics around heap usage and amount of data stored in the table store.
+func HeapMetrics(period time.Duration) *pb.MetricSpec {
+	return &pb.MetricSpec{
+		MetricType: &pb.MetricSpec_PxL{
+			PxL: &pb.PxLScriptSpec{
+				Script:           heapSizeScript,
+				Streaming:        false,
+				CollectionPeriod: types.DurationProto(period),
+				TableOutputs: map[string]*pb.PxLScriptOutputList{
+					"*": {
+						Outputs: []*pb.PxLScriptOutputSpec{
+							singleMetricOutputWithPodNodeName("table_size"),
+							singleMetricOutputWithPodNodeName("current_allocated_bytes", "heap_allocated_bytes"),
+							singleMetricOutputWithPodNodeName("heap_size_bytes"),
+							singleMetricOutputWithPodNodeName("free_bytes", "heap_free_bytes"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// HTTPDataLossMetric adds a metric that tracks HTTP data loss based on the `X-Px-Seq-Id` header.
+func HTTPDataLossMetric(outputPeriod time.Duration) *pb.MetricSpec {
+	return &pb.MetricSpec{
+		MetricType: &pb.MetricSpec_PxL{
+			PxL: &pb.PxLScriptSpec{
+				Script:    httpDataLossScript,
+				Streaming: true,
+				TemplateValues: map[string]string{
+					"header_name": "X-Px-Seq-Id",
+				},
+				TableOutputs: map[string]*pb.PxLScriptOutputList{
+					"*": {
+						Outputs: []*pb.PxLScriptOutputSpec{
+							{
+								OutputSpec: &pb.PxLScriptOutputSpec_DataLossCounter{
+									DataLossCounter: &pb.DataLossCounterOutput{
+										TimestampCol: "timestamp",
+										MetricName:   "http_data_loss",
+										SeqIDCol:     "seq_id",
+										OutputPeriod: types.DurationProto(outputPeriod),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func singleMetricOutputWithPodNodeName(col string, newName ...string) *pb.PxLScriptOutputSpec {
+	metricName := col
+	if len(newName) > 0 {
+		metricName = newName[0]
+	}
+	return &pb.PxLScriptOutputSpec{
+		OutputSpec: &pb.PxLScriptOutputSpec_SingleMetric{
+			SingleMetric: &pb.SingleMetricPxLOutput{
+				TimestampCol: "timestamp",
+				MetricName:   metricName,
+				ValueCol:     col,
+				TagCols: []string{
+					"node_name",
+					"pod",
+				},
+			},
+		},
+	}
+}

--- a/src/e2e_test/perf_tool/pkg/suites/scripts/heap_size.pxl
+++ b/src/e2e_test/perf_tool/pkg/suites/scripts/heap_size.pxl
@@ -1,0 +1,60 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import px
+
+heap_df = px._HeapStatsNumeric()
+heap_df.node_name = px._exec_hostname()
+heap_df.timestamp = px.now()
+heap_df.free_bytes = (
+    heap_df.central_cache_free_bytes
+    + heap_df.transfer_cache_free_bytes
+    + heap_df.thread_cache_free_bytes
+    + heap_df.pageheap_free_bytes
+)
+
+table_df = px._DebugTableInfo()
+table_df = table_df.groupby("asid").agg(table_size=("size", px.sum))
+table_df.table_size = px.Bytes(table_df.table_size)
+
+pod_df = px.DataFrame("process_stats", start_time="-1m1s")
+pod_df = pod_df[pod_df.ctx["namespace"] == "pl"]
+pod_df.pod = pod_df.ctx["pod"]
+pod_df = pod_df[px.contains(pod_df.pod, "pem")]
+pod_df.asid = px.upid_to_asid(pod_df.upid)
+pod_df = pod_df.groupby(["asid", "pod"]).agg()
+
+df = heap_df.merge(
+    table_df, how="left", left_on=["asid"], right_on=["asid"], suffixes=["", "_y"]
+)
+df = df.merge(
+    pod_df, how="left", left_on=["asid"], right_on=["asid"], suffixes=["", "_z"]
+)
+df.pod = px.select(df.pod == "", "pl/" + df.node_name, df.pod)
+px.display(
+    df[
+        [
+            "timestamp",
+            "node_name",
+            "pod",
+            "table_size",
+            "current_allocated_bytes",
+            "heap_size_bytes",
+            "free_bytes",
+            "pageheap_unmapped_bytes",
+        ]
+    ]
+)

--- a/src/e2e_test/perf_tool/pkg/suites/scripts/http_data_loss.pxl
+++ b/src/e2e_test/perf_tool/pkg/suites/scripts/http_data_loss.pxl
@@ -1,0 +1,28 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import px
+
+df = px.DataFrame("http_events", start_time="-1s")
+
+df.seq_id = px.atoi(px.pluck(df.req_headers, "{{.TemplateValues.header_name}}"), -1)
+df = df[df.seq_id != -1]
+df.timestamp = df.time_
+df = df[["timestamp", "seq_id"]]
+
+df = df.stream()
+
+px.display(df)

--- a/src/e2e_test/perf_tool/pkg/suites/scripts/process_stats.pxl
+++ b/src/e2e_test/perf_tool/pkg/suites/scripts/process_stats.pxl
@@ -1,0 +1,57 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import px
+
+df = px.DataFrame("process_stats", start_time="-{{.CollectionPeriod.String}}")
+df = df[df.ctx["namespace"] == "pl"]
+df.pod = df.ctx["pod"]
+df.container = df.ctx["container_name"]
+df.node_name = df.ctx["node"]
+
+df = df.groupby(["node_name", "pod", "container", "upid"]).agg(
+    rss=("rss_bytes", px.mean),
+    vsize=("vsize_bytes", px.mean),
+    cpu_utime_ns_max=("cpu_utime_ns", px.max),
+    cpu_utime_ns_min=("cpu_utime_ns", px.min),
+    cpu_ktime_ns_max=("cpu_ktime_ns", px.max),
+    cpu_ktime_ns_min=("cpu_ktime_ns", px.min),
+    time_min=("time_", px.min),
+    time_max=("time_", px.max),
+)
+
+df.cpu_utime_ns = df.cpu_utime_ns_max - df.cpu_utime_ns_min
+df.cpu_ktime_ns = df.cpu_ktime_ns_max - df.cpu_ktime_ns_min
+
+df = df.groupby(["node_name", "pod"]).agg(
+    cpu_utime_ns=("cpu_utime_ns", px.sum),
+    cpu_ktime_ns=("cpu_ktime_ns", px.sum),
+    rss=("rss", px.sum),
+    vsize=("vsize", px.sum),
+    time_min=("time_min", px.min),
+    time_max=("time_max", px.max),
+)
+
+df.window = df.time_max - df.time_min
+# Avoid NaNs in the case of an empty window.
+# The numerator will be 0 in this case so we can set the denominator to an arbitrary non-zero value.
+df.window = px.select(df.window > 0, df.window, 1)
+
+df.cpu_usage = (df.cpu_utime_ns + df.cpu_ktime_ns) / df.window
+
+df.timestamp = px.now()
+df = df[["timestamp", "node_name", "pod", "cpu_usage", "rss", "vsize"]]
+px.display(df)


### PR DESCRIPTION
Summary: Add specs for metric recorders to record cpu usage, heap size (including how much of the heap is used for table store), and data loss.

Type of change: /kind test-infra

Test Plan: Tested that these metrics show up in bigquery and look reasonable.
