### PR TITLE
[perf_tool/run_cmd] Add experiment retries

### DIFF
--- a/src/e2e_test/perf_tool/cmd/BUILD.bazel
+++ b/src/e2e_test/perf_tool/cmd/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//src/e2e_test/perf_tool/pkg/pixie",
         "//src/e2e_test/perf_tool/pkg/run",
         "//src/pixie_cli/pkg/components",
+        "@com_github_cenkalti_backoff_v4//:backoff",
         "@com_github_gofrs_uuid//:uuid",
         "@com_github_gogo_protobuf//proto",
         "@com_github_sirupsen_logrus//:logrus",


### PR DESCRIPTION
Summary: Experiments sometimes fail because pixie becomes unhealthy during the course of the experiment or for other transient reasons. This adds a retry mechanism to the `run` command so that each experiment is retried multiple times if it fails.

Type of change: /kind test-infra

Test Plan: Tested that failed experiments get retried.
