### PR TITLE
[perf_tool/runner] Send ResultRow with timestamp of when workloads are deployed

### DIFF
--- a/src/e2e_test/perf_tool/pkg/run/run.go
+++ b/src/e2e_test/perf_tool/pkg/run/run.go
@@ -152,6 +152,17 @@ func (r *Runner) RunExperiment(ctx context.Context, expID uuid.UUID, spec *exper
 		return err
 	}
 
+	// Add a row to the results with the time when workloads were deployed.
+	row := &metrics.ResultRow{
+		Timestamp: time.Now(),
+		Name:      "workloads_deployed",
+		Value:     0.0,
+	}
+	select {
+	case <-ctx.Done():
+	case metricsResultCh <- row:
+	}
+
 	// Wait for the experiment duration specified in the RunSpec.
 	// During this time, Vizier and workloads are deployed and metrics are recording.
 	dur, err := types.DurationFromProto(spec.RunSpec.Duration)


### PR DESCRIPTION
Summary: Send a metric row with the timestamp that workloads finish deploying and pass their healthchecks. This will be used to ignore results before this point in the datastudio views.

Type of change: /kind test-infra

Test Plan: Tested that the workloads_deployed row shows up in bigquery.
