### PR TITLE
[perf_tool/run_cmd] Get specs from `suites` package

### DIFF
--- a/src/e2e_test/perf_tool/cmd/BUILD.bazel
+++ b/src/e2e_test/perf_tool/cmd/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//src/e2e_test/perf_tool/pkg/cluster/local",
         "//src/e2e_test/perf_tool/pkg/pixie",
         "//src/e2e_test/perf_tool/pkg/run",
+        "//src/e2e_test/perf_tool/pkg/suites",
         "//src/pixie_cli/pkg/components",
         "@com_github_cenkalti_backoff_v4//:backoff",
         "@com_github_gofrs_uuid//:uuid",


### PR DESCRIPTION
Summary: Use the `suites` package to get experiment specs for the `run` command. Optionally, select just one experiment from the suite, or run all of the experiments in the suite.

Type of change: /kind test-infra

Test Plan: Tested along with the `suites` package PRs that I can specify a `--suite` and it will run the corresponding experiments.
