### PR TITLE
[perf_tool/run_cmd] Gracefully exit after second interrrupt

### DIFF
--- a/src/e2e_test/perf_tool/cmd/run.go
+++ b/src/e2e_test/perf_tool/cmd/run.go
@@ -56,7 +56,7 @@ var RunCmd = &cobra.Command{
 		viper.BindPFlags(cmd.Flags())
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runCmd(context.Background(), cmd)
+		return runCmdWithInterrruptableContext(runCmd, cmd)
 	},
 }
 


### PR DESCRIPTION
Summary: Adds a wrapper around the `run` command, which ignores the first interrupt, starts to gracefully exit (cleaning up the cluster and other resources) on the second interrupt, and then ungracefully exits on the third interrupt.

Type of change: /kind test-infra

Test Plan: Tested that two interrupts cause a graceful exit.
