### PR TITLE
Register metrics handler for metrics server

### DIFF
--- a/src/cloud/metrics/BUILD.bazel
+++ b/src/cloud/metrics/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//src/shared/services",
         "//src/shared/services/env",
         "//src/shared/services/healthz",
+        "//src/shared/services/metrics",
         "//src/shared/services/msgbus",
         "//src/shared/services/server",
         "@com_github_sirupsen_logrus//:logrus",

--- a/src/cloud/metrics/metrics_server.go
+++ b/src/cloud/metrics/metrics_server.go
@@ -36,6 +36,7 @@ import (
 	"px.dev/pixie/src/shared/services"
 	"px.dev/pixie/src/shared/services/env"
 	"px.dev/pixie/src/shared/services/healthz"
+	"px.dev/pixie/src/shared/services/metrics"
 	"px.dev/pixie/src/shared/services/msgbus"
 	"px.dev/pixie/src/shared/services/server"
 )
@@ -63,6 +64,7 @@ func main() {
 	// This handles all the pprof endpoints.
 	mux.Handle("/debug/", http.DefaultServeMux)
 	healthz.RegisterDefaultChecks(mux)
+	metrics.MustRegisterMetricsHandler(mux)
 
 	// Connect to NATS.
 	nc := msgbus.MustConnectNATS()


### PR DESCRIPTION
Summary: Previous changes added a counter for NATS error messages in the metrics server. After taking a look at the metrics, I didn't see any data from the metrics server despite the NATS errors showing up in the logs. Turns out I forgot to register the metrics handler. This is unfortunately a little harder to test, since our testing/staging instances don't generate enough traffic to actually trigger the error.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Skaffold deploy to testing cloud and ensure things continue running as expected.

