### PR TITLE
Enforce stricter checks on mux's TDispatch and RDispatch frames during protocol inference

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
@@ -111,6 +111,9 @@ inline StatusOr<Type> GetMatchingRespType(Type req_type) {
  * ----------------------------------------------
  *
  * Rdispatch / Tdispatch (Tdispatch does not have reply status)
+ *
+ * reply status is one of ok (0), error (1) or nack (2)
+ * https://github.com/twitter/finagle/blob/2e4d56d93a2bdfb63e293d84727d5266d2969f01/finagle-mux/src/main/scala/com/twitter/finagle/mux/transport/Message.scala#L549-L552
  * ----------------------------------------------
  * | uint32 header size | int8 type | int24 tag |
  * ----------------------------------------------


### PR DESCRIPTION
Summary: Enforce stricter checks on mux's TDispatch and RDispatch frames during protocol inference

This change addresses a large portion of the mux protocol misclassification identified in #913. As verified in #981, mux protocol traffic is very likely to be matched against tls traffic. This change addresses the 0.6% of traffic mislabelled in our test dataset.

Relevant Issues: #913

Type of change: /kind bug

Test Plan: Performed the following tests outlined below
- [x] Verified the protocol inference scripts no longer mislabel the 0.6% of tls traffic identified in #981
- [x] Deployed this change to my testing cluster and verified that mux data loss metric is no longer increasing by ~100 trillion every hour. The second graph decreases the y axis max so the "missing" data points can be seen.
<p float="left">

<img width="453" alt="Screen Shot 2023-03-08 at 2 33 03 PM" src="https://user-images.githubusercontent.com/5855593/223866632-a2bd359a-3d39-4be1-94a8-805b2aedcc57.png">
<img width="360" alt="Screen Shot 2023-03-08 at 8 07 17 AM" src="https://user-images.githubusercontent.com/5855593/223864500-09dc1216-4fb1-4e63-be97-1342deeab51e.png">
</p>
