### PR TITLE
QEMU test runner for bpf tests.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -104,11 +104,18 @@ build:clang --build_tag_filters=-no_libcpp
 build:clang --test_tag_filters=-no_libcpp,-requires_root,-requires_bpf,-disabled
 
 
-
 # Build for Clang with libstdc++:
 build:clang-libstdc++ --config=clang-base
 build:clang-libstdc++ --//bazel/cc_toolchains:compiler=clang
 build:clang-libstdc++ --//bazel/cc_toolchains:libc_version=gnu
+
+build:qemu-bpf --config=clang
+build:qemu-bpf --sandbox_fake_username
+build:qemu-bpf --//bazel/cc_toolchains:libc_version=glibc2_36
+build:qemu-bpf --//bazel/test_runners:test_runner=qemu_with_kernel
+build:qemu-bpf --run_under="bazel/test_runners/qemu_with_kernel/test_runner.sh"
+build:qemu-bpf --build_tag_filters=requires_bpf,-no_qemu
+test:qemu-bpf --test_tag_filters=requires_bpf,-disabled,-no_qemu
 
 # Build for GCC.
 # These are copts because they apply to both c++ and c files.

--- a/bazel/test_runners/BUILD.bazel
+++ b/bazel/test_runners/BUILD.bazel
@@ -22,6 +22,7 @@ string_flag(
     values = [
         "none",
         "sysroot_chroot",
+        "qemu_with_kernel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -33,6 +34,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "test_runner_qemu_with_kernel",
+    flag_values = {
+        ":test_runner": "qemu_with_kernel",
+    },
+)
+
 filegroup(
     name = "empty",
 )
@@ -40,6 +48,7 @@ filegroup(
 alias(
     name = "test_runner_dep",
     actual = select({
+        "test_runner_qemu_with_kernel": "//bazel/test_runners/qemu_with_kernel:runner",
         "test_runner_sysroot_chroot": "//bazel/test_runners/sysroot_chroot:runner",
         "//conditions:default": ":empty",
     }),

--- a/bazel/test_runners/qemu_with_kernel/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/BUILD.bazel
@@ -14,18 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//bazel/test_runners/qemu_with_kernel:runner.bzl", "qemu_with_kernel_test_runner")
 
-cc_binary(
-    name = "exit_qemu_with_status",
-    srcs = ["exit_qemu_with_status.c"],
-    features = [
-        "fully_static_link",
-        "-asan",
-        "-tsan",
-        "-msan",
-    ],
-    linkstatic = True,
-    target_compatible_with = ["@platforms//cpu:x86_64"],
+qemu_with_kernel_test_runner(
+    name = "runner",
     visibility = ["//visibility:public"],
 )

--- a/bazel/test_runners/qemu_with_kernel/runner.bzl
+++ b/bazel/test_runners/qemu_with_kernel/runner.bzl
@@ -1,0 +1,124 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+HOST_ARCH = "x86_64"
+
+def _test_runner_impl(ctx):
+    output_script = ctx.actions.declare_file("test_runner.sh")
+
+    sysroot_toolchain = ctx.toolchains["//bazel/cc_toolchains/sysroots/test:toolchain_type"]
+    if sysroot_toolchain == None:
+        # Since all branches of the test_runner_dep alias are evaluated, this rule has to return something, even if there's no sysroot toolchain.
+        ctx.actions.write(output_script, "", is_executable = True)
+        return DefaultInfo(executable = output_script)
+    sysroot_info = sysroot_toolchain.sysroot
+
+    disk_image = ctx.actions.declare_file("disk_image.qcow2")
+    extra_files = []
+    for target, out_path in ctx.attr._extra_files.items():
+        extra_files.append("{}:{}".format(target.files.to_list()[0].path, out_path))
+
+    args = ctx.actions.args()
+    args.add("-o", disk_image)
+    args.add("-s", sysroot_info.tar.to_list()[0])
+    args.add("-k", ctx.files._kernel_image[0])
+    args.add("-b", ctx.files._busybox[0])
+    args.add("-e", ",".join(extra_files))
+
+    ctx.actions.run(
+        outputs = [disk_image],
+        inputs = ctx.files._extra_files + ctx.files._kernel_image + ctx.files._busybox + sysroot_info.tar.to_list(),
+        arguments = [args],
+        executable = ctx.files._create_sysroot_disk_script[0],
+    )
+
+    kernel_bzimage = ctx.actions.declare_file("bzImage")
+    ctx.actions.run_shell(
+        inputs = ctx.files._kernel_image,
+        outputs = [kernel_bzimage],
+        command = "tar -C $(dirname %s) -xf %s pkg/bzImage --strip-components=1" % (kernel_bzimage.path, ctx.files._kernel_image[0].path),
+    )
+
+    # Executable script.
+    ctx.actions.expand_template(
+        template = ctx.files._test_launcher_tpl[0],
+        output = output_script,
+        substitutions = {
+            "%diskimage%": "bazel/test_runners/qemu_with_kernel/disk_image.qcow2",
+            "%kernelimage%": "bazel/test_runners/qemu_with_kernel/bzImage",
+            "%runqemuscript%": "bazel/test_runners/qemu_with_kernel/run_qemu.sh",
+            "%testrunnerinsideqemu%": "bazel/test_runners/qemu_with_kernel/test_runner_inside_qemu.sh",
+        },
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [
+        disk_image,
+        kernel_bzimage,
+        ctx.files._test_runner_inside_qemu[0],
+        ctx.files._run_qemu_script[0],
+    ])
+
+    return DefaultInfo(
+        files = depset(
+            [output_script],
+        ),
+        runfiles = runfiles,
+        executable = output_script,
+    )
+
+qemu_with_kernel_test_runner = rule(
+    implementation = _test_runner_impl,
+    attrs = {
+        "_busybox": attr.label(
+            default = Label("@busybox//file:busybox"),
+            allow_single_file = True,
+        ),
+        "_create_sysroot_disk_script": attr.label(
+            default = Label("//bazel/test_runners/qemu_with_kernel:create_sysroot_disk.sh"),
+            allow_single_file = True,
+        ),
+        "_extra_files": attr.label_keyed_string_dict(
+            default = {
+                Label("//bazel/test_runners/qemu_with_kernel:hostname"): "/etc/hostname",
+                Label("//bazel/test_runners/qemu_with_kernel:passwd"): "/etc/passwd",
+                Label("//bazel/test_runners/qemu_with_kernel:init"): "/bin/init",
+                Label("//bazel/test_runners/qemu_with_kernel/exit_qemu_with_status:exit_qemu_with_status"): "/bin/exit_qemu_with_status",
+            },
+            allow_files = True,
+        ),
+        "_kernel_image": attr.label(
+            default = Label("@linux_build_5_18_19_x86_64//file:linux-build.tar.gz"),
+            allow_single_file = True,
+        ),
+        "_run_qemu_script": attr.label(
+            default = Label("//bazel/test_runners/qemu_with_kernel:run_qemu.sh"),
+            allow_single_file = True,
+        ),
+        "_test_launcher_tpl": attr.label(
+            default = Label("//bazel/test_runners/qemu_with_kernel:launcher.sh"),
+            allow_single_file = True,
+        ),
+        "_test_runner_inside_qemu": attr.label(
+            default = Label("//bazel/test_runners/qemu_with_kernel:test_runner_inside_qemu.sh"),
+            allow_single_file = True,
+        ),
+    },
+    toolchains = [
+        config_common.toolchain_type("//bazel/cc_toolchains/sysroots/test:toolchain_type", mandatory = False),
+    ],
+    executable = True,
+)

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -53,10 +53,12 @@ pl_cc_test(
         "//src/stirling/source_connectors/perf_profiler/testing/java:graal-vm-aot-test",
     ],
     defines = ['JDK_IMAGE_NAMES=\\"%s\\"' % ",".join(jdk_image_names)],
+    env = {"QEMU_CPU_COUNT": "4"},
     shard_count = 3,
     tags = [
         "cpu:16",
         "exclusive",
+        "no_qemu",
         "requires_bpf",
     ],
     deps = [


### PR DESCRIPTION
Summary: This adds the bazel test runner for BPF tests using qemu. After this change
test should work by adding in
`bazel test -c opt --config=qemu-bpf`

The next step is adding in the ability to debug within the launched qemu environments.

Relevant Issues: #709.

Type of change: /kind test-infra

Test Plan: Ran `bazel test -c opt --config=qemu-bpf //src/stirling/...`, There is one more change needed to fix tmpfs in some cases.
