### PR TITLE
Add prometheus annotations to metrics-server YAML

### DIFF
--- a/k8s/cloud/base/metrics_deployment.yaml
+++ b/k8s/cloud/base/metrics_deployment.yaml
@@ -11,6 +11,11 @@ spec:
     metadata:
       labels:
         name: metrics-server
+        monitoring.gke.io/scrape: 'true'
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '50800'
+        prometheus.io/scheme: 'https'
     spec:
       containers:
       - name: metrics-server


### PR DESCRIPTION
Summary: Previous changes registered the metrics handler to the metrics server... But unfortunately we were still missing some annotations in the deployment YAML to make sure the prometheus metrics get propagated correctly.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deploy with skaffold

