### PR TITLE
[actions] Add buildbuddy action to copy buildbuddy config

### DIFF
--- a/.github/actions/buildbuddy/action.yaml
+++ b/.github/actions/buildbuddy/action.yaml
@@ -1,0 +1,16 @@
+---
+name: Use buildbuddy bazel config
+description: Adds BES support to the bazelrc for connecting to bb.px.dev
+inputs:
+  bb_api_key:
+    required: true
+    type: string
+runs:
+  using: "composite"
+  steps:
+  - name: Copy BES bazel config
+    run: |
+      cp ci/bes-oss-gce.bazelrc bes.bazelrc
+      echo "build --remote_header=x-buildbuddy-api-key=${{ inputs.bb_api_key }}" >> bes.bazelrc
+      echo "build --build_metadata=USER=github-actions" >> bes.bazelrc
+    shell: bash


### PR DESCRIPTION
Summary: Adds a custom github action that copies the correct `bes.bazelrc` and adds the buildbuddy api key to it. 
To use this action, add a step to a job like so (make sure there's a previous step that checkouts the code)
```
uses: ./.github/actions/buildbuddy
with:
  bb_api_key: ${{ secrets.BB_API_KEY }}
```

Type of change: /kind test-infra

Test Plan: Tested that this works along with my perf_tool github actions.
