### PR TITLE
Unpin and upgrade vega-funtions

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -170,7 +170,6 @@
     "multicast-dns": "7.2.3",
     "resize-img": "^2.0.0",
     "sharp": "0.30.5",
-    "vega-functions": "5.13.0",
     "d3-interpolate": "3.0.1"
   }
 }

--- a/src/ui/yarn.lock
+++ b/src/ui/yarn.lock
@@ -3060,17 +3060,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^0.0.50":
-  version: 0.0.50
-  resolution: "@types/estree@npm:0.0.50"
-  checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^1.0.0":
+"@types/estree@npm:*, @types/estree@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/estree@npm:1.0.0"
   checksum: 910d97fb7092c6738d30a7430ae4786a38542023c6302b95d46f49420b797f21619cdde11fa92b338366268795884111c2eb10356e4bd2c8ad5b92941e9e6443
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^0.0.50":
+  version: 0.0.50
+  resolution: "@types/estree@npm:0.0.50"
+  checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
   languageName: node
   linkType: hard
 
@@ -6054,16 +6054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:1 - 3, d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:^3.1.1":
-  version: 3.2.1
-  resolution: "d3-array@npm:3.2.1"
-  dependencies:
-    internmap: 1 - 2
-  checksum: 0bed33cc33b70f9d48ccef3e7a5956e134862e09179bf14df0bf9c8fc0ec02b8f847d4f5e1d32729cd5e02032af1d0a32bcc968ff1333795028455a749994623
-  languageName: node
-  linkType: hard
-
-"d3-array@npm:^3.2.2":
+"d3-array@npm:1 - 3, d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3.2.2, d3-array@npm:^3.2.2":
   version: 3.2.2
   resolution: "d3-array@npm:3.2.2"
   dependencies:
@@ -6072,7 +6063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-color@npm:1 - 3, d3-color@npm:^3.0.1, d3-color@npm:^3.1.0":
+"d3-color@npm:1 - 3, d3-color@npm:^3.1.0":
   version: 3.1.0
   resolution: "d3-color@npm:3.1.0"
   checksum: 4931fbfda5d7c4b5cfa283a13c91a954f86e3b69d75ce588d06cde6c3628cebfc3af2069ccf225e982e8987c612aa7948b3932163ce15eb3c11cd7c003f3ee3b
@@ -6151,16 +6142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-geo@npm:1.12.0 - 3, d3-geo@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "d3-geo@npm:3.0.1"
-  dependencies:
-    d3-array: 2.5.0 - 3
-  checksum: e0f7e6a2f0d4c26efe08a7aa2c40b9a1a5a037220c6aaa51fb527035597e6e8841222b433e5681f9b5588b5b6f9a1c2d7f032a76ccbac3a17b0c1cbfffd05c1b
-  languageName: node
-  linkType: hard
-
-"d3-geo@npm:^3.1.0":
+"d3-geo@npm:1.12.0 - 3, d3-geo@npm:^3.1.0":
   version: 3.1.0
   resolution: "d3-geo@npm:3.1.0"
   dependencies:
@@ -6189,13 +6171,6 @@ __metadata:
   version: 2.0.0
   resolution: "d3-path@npm:2.0.0"
   checksum: e39e91dfb9abf9637962caede1f4ea4877f4b9e1c914868bdfc355688e9a637ba51bed0fb6180934eb596e50a4d0d1f001b5f2e98a4a3d23cc42558acfbd1f2c
-  languageName: node
-  linkType: hard
-
-"d3-path@npm:1 - 3, d3-path@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "d3-path@npm:3.0.1"
-  checksum: 6347c7055e0af330acadbe7f02144963eecabff560a791ecfeaffb45662e4d38eedabc6109dc481478f136b41d03707d3a43321ca9a115962888c99732ceb41a
   languageName: node
   linkType: hard
 
@@ -6235,15 +6210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-shape@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "d3-shape@npm:3.1.0"
-  dependencies:
-    d3-path: 1 - 3
-  checksum: 3dffe31b56feaf0817954748c9823c0e1fb6ab888b83775e9d568176ffa369546064ae49403963aac70108272988f632452634851f1c8a92805134d0c40e6dba
-  languageName: node
-  linkType: hard
-
 "d3-shape@npm:^3.2.0":
   version: 3.2.0
   resolution: "d3-shape@npm:3.2.0"
@@ -6262,7 +6228,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.0.0, d3-time@npm:^3.1.0":
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.1.0":
   version: 3.1.0
   resolution: "d3-time@npm:3.1.0"
   dependencies:
@@ -15476,14 +15442,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-canvas@npm:^1.2.5, vega-canvas@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "vega-canvas@npm:1.2.6"
-  checksum: d23f6f3367b5a302ef20c0e55fcc3e93c628ed15bd3b1b353c468130374de5d8551797ae7bc0075dd179e3bc1f4be2afa22b851b5813b31cba3184bb6986fbdd
-  languageName: node
-  linkType: hard
-
-"vega-canvas@npm:^1.2.7":
+"vega-canvas@npm:^1.2.5, vega-canvas@npm:^1.2.6, vega-canvas@npm:^1.2.7":
   version: 1.2.7
   resolution: "vega-canvas@npm:1.2.7"
   checksum: 6ff92fcdf0c359f2f662909c859a7f4cb4a502436136ab2f4c02373c47a621996ec0eea23e2108f11d62a618be301de86cd8528b5058c2e207a53ddd7ff58d1b
@@ -15501,18 +15460,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-dataflow@npm:^5.7.3":
-  version: 5.7.4
-  resolution: "vega-dataflow@npm:5.7.4"
-  dependencies:
-    vega-format: ^1.0.4
-    vega-loader: ^4.3.2
-    vega-util: ^1.16.1
-  checksum: ae0af6c9c4aeeab419819018f6b2c5b3ebcced721f1b446aefec54b8bcb6ea45460106fcbff4c64fbf064b93847b6d95b1caec100f9c0aabf5be5fb0843ffcf7
-  languageName: node
-  linkType: hard
-
-"vega-dataflow@npm:^5.7.5, vega-dataflow@npm:~5.7.5":
+"vega-dataflow@npm:^5.7.3, vega-dataflow@npm:^5.7.5, vega-dataflow@npm:~5.7.5":
   version: 5.7.5
   resolution: "vega-dataflow@npm:5.7.5"
   dependencies:
@@ -15567,16 +15515,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-expression@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "vega-expression@npm:5.0.0"
-  dependencies:
-    "@types/estree": ^0.0.50
-    vega-util: ^1.16.0
-  checksum: 0f53aeb133711bf365ae45e4eff8c233cfe421bdd70be6fed5fa59c48d42eb34b56ec6905569fc3cf96596aa28e0e7def398c99da6eacda2e61bff03f0e73b39
-  languageName: node
-  linkType: hard
-
 "vega-expression@npm:^5.0.1, vega-expression@npm:~5.0.1":
   version: 5.0.1
   resolution: "vega-expression@npm:5.0.1"
@@ -15607,19 +15545,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-format@npm:^1.0.4, vega-format@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "vega-format@npm:1.1.0"
-  dependencies:
-    d3-array: ^3.1.1
-    d3-format: ^3.1.0
-    d3-time-format: ^4.1.0
-    vega-time: ^2.0.3
-    vega-util: ^1.15.2
-  checksum: f8edd1b91faa99e8f4f28c85c16aec63a3ec263c90dcdd5dba245a0032cac6de90a901930cc1dad0f3716a587799a59ed8686d9aada3595c18e6177ae48d1919
-  languageName: node
-  linkType: hard
-
 "vega-format@npm:^1.1.1, vega-format@npm:~1.1.1":
   version: 1.1.1
   resolution: "vega-format@npm:1.1.1"
@@ -15633,22 +15558,22 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-functions@npm:5.13.0":
-  version: 5.13.0
-  resolution: "vega-functions@npm:5.13.0"
+"vega-functions@npm:^5.13.1, vega-functions@npm:~5.13.1":
+  version: 5.13.1
+  resolution: "vega-functions@npm:5.13.1"
   dependencies:
-    d3-array: ^3.1.1
-    d3-color: ^3.0.1
-    d3-geo: ^3.0.1
-    vega-dataflow: ^5.7.3
-    vega-expression: ^5.0.0
-    vega-scale: ^7.2.0
-    vega-scenegraph: ^4.9.3
-    vega-selections: ^5.3.1
-    vega-statistics: ^1.7.9
-    vega-time: ^2.1.0
-    vega-util: ^1.16.0
-  checksum: f4ff3571969b11af40f2928363b7e6e8c1f7e10c7099d65a56925d525331acb3e9f7f4e3488abffe9dc27be65c5dd3c94b179e25ff94533f6087e1f29c18119b
+    d3-array: ^3.2.2
+    d3-color: ^3.1.0
+    d3-geo: ^3.1.0
+    vega-dataflow: ^5.7.5
+    vega-expression: ^5.0.1
+    vega-scale: ^7.3.0
+    vega-scenegraph: ^4.10.2
+    vega-selections: ^5.4.1
+    vega-statistics: ^1.8.1
+    vega-time: ^2.1.1
+    vega-util: ^1.17.1
+  checksum: 05d154f29dec1742935bfe2852176e392e7c3a107ef76e2c0fe103c7f68812084218ee3c50ef13ba250fa6629d0f4e3a0997fac4b475a1f27be1e465e99b170b
   languageName: node
   linkType: hard
 
@@ -15718,20 +15643,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-loader@npm:^4.3.2, vega-loader@npm:^4.3.3, vega-loader@npm:^4.4.0":
-  version: 4.5.0
-  resolution: "vega-loader@npm:4.5.0"
-  dependencies:
-    d3-dsv: ^3.0.1
-    node-fetch: ^2.6.7
-    topojson-client: ^3.1.0
-    vega-format: ^1.1.0
-    vega-util: ^1.16.0
-  checksum: 02356dee454cd86e88c8badd50399cb5f8ee8ce13fe660d8e10272351801cc2fd03345b5524737dd5697cea81dae809f120e3a826765534cf3dbdf9cbcc05e25
-  languageName: node
-  linkType: hard
-
-"vega-loader@npm:^4.5.1, vega-loader@npm:~4.5.1":
+"vega-loader@npm:^4.3.3, vega-loader@npm:^4.5.1, vega-loader@npm:~4.5.1":
   version: 4.5.1
   resolution: "vega-loader@npm:4.5.1"
   dependencies:
@@ -15790,20 +15702,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-scale@npm:^7.0.0, vega-scale@npm:^7.1.1, vega-scale@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "vega-scale@npm:7.2.0"
-  dependencies:
-    d3-array: ^3.1.1
-    d3-interpolate: ^3.0.1
-    d3-scale: ^4.0.2
-    vega-time: ^2.1.0
-    vega-util: ^1.17.0
-  checksum: 1d345feceb42825f97770bdf83a71fb27a210ab8ae0a7af93eacaf11a785a7a23a7d70122c7de9e6324790b1c3988d9e3b3c378e8cea295f7bf57af5df10fa63
-  languageName: node
-  linkType: hard
-
-"vega-scale@npm:^7.3.0, vega-scale@npm:~7.3.0":
+"vega-scale@npm:^7.0.0, vega-scale@npm:^7.1.1, vega-scale@npm:^7.3.0, vega-scale@npm:~7.3.0":
   version: 7.3.0
   resolution: "vega-scale@npm:7.3.0"
   dependencies:
@@ -15830,7 +15729,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-scenegraph@npm:^4.10.2, vega-scenegraph@npm:~4.10.2":
+"vega-scenegraph@npm:^4.10.2, vega-scenegraph@npm:^4.9.2, vega-scenegraph@npm:~4.10.2":
   version: 4.10.2
   resolution: "vega-scenegraph@npm:4.10.2"
   dependencies:
@@ -15844,20 +15743,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-scenegraph@npm:^4.9.2, vega-scenegraph@npm:^4.9.3":
-  version: 4.10.1
-  resolution: "vega-scenegraph@npm:4.10.1"
-  dependencies:
-    d3-path: ^3.0.1
-    d3-shape: ^3.1.0
-    vega-canvas: ^1.2.5
-    vega-loader: ^4.4.0
-    vega-scale: ^7.2.0
-    vega-util: ^1.15.2
-  checksum: b897e9408d5fad25a1ebcbb468892f188c0713a1305fa739093d124a0787125b84a198ec0fb23b2c3f843c572e515f95240fba06457fbca7e19331a68e5b5be4
-  languageName: node
-  linkType: hard
-
 "vega-schema-url-parser@npm:^2.1.0":
   version: 2.1.0
   resolution: "vega-schema-url-parser@npm:2.1.0"
@@ -15865,26 +15750,18 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-selections@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "vega-selections@npm:5.3.1"
+"vega-selections@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "vega-selections@npm:5.4.1"
   dependencies:
-    vega-expression: ^5.0.0
-    vega-util: ^1.16.0
-  checksum: f607600b47b2adc15fcc81f85c4710abf306f0d48c5bea8cf08888548da1f9d0c7ad6106d1ec42ec04d1f4e947b7e4af7c56c9b6a693842b6a082c3eb95e2ae6
+    d3-array: 3.2.2
+    vega-expression: ^5.0.1
+    vega-util: ^1.17.1
+  checksum: c594d41ec3886af94976e4dc4e152bea9b3975a22d435aa38dac2aab105851cb83fd4aa0f1e81a47f8bc0bea1677af93816331e3ed084ab3ec2e51b3544c109f
   languageName: node
   linkType: hard
 
-"vega-statistics@npm:^1.7.9":
-  version: 1.8.0
-  resolution: "vega-statistics@npm:1.8.0"
-  dependencies:
-    d3-array: ^3.1.1
-  checksum: 36816bdb0d585da39c47b2a89a8ddb935f2a5537dfa6fbfdf6fa5d14cb96b30d48cf70f7b95b5cadb5b322041fb0e988d4229bc3443d840e6950d132e19111de
-  languageName: node
-  linkType: hard
-
-"vega-statistics@npm:^1.8.1, vega-statistics@npm:~1.8.1":
+"vega-statistics@npm:^1.7.9, vega-statistics@npm:^1.8.1, vega-statistics@npm:~1.8.1":
   version: 1.8.1
   resolution: "vega-statistics@npm:1.8.1"
   dependencies:
@@ -15900,17 +15777,6 @@ resolve@^2.0.0-next.3:
     vega: "*"
     vega-lite: "*"
   checksum: 92fb43cabc5d9085b4b986141ad5e90aadddc58d1db247b4fed9afa1d1ede5b492103e0a4387087a65d4b9de327d35522f62a16957f8c9ed918693d672ea8de1
-  languageName: node
-  linkType: hard
-
-"vega-time@npm:^2.0.3, vega-time@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "vega-time@npm:2.1.0"
-  dependencies:
-    d3-array: ^3.1.1
-    d3-time: ^3.0.0
-    vega-util: ^1.15.2
-  checksum: 4e57376bc36e1e9166b8ecfc52833ae5f7295b10754c6c509149661a9e2627d86dbd7fea0e2bb2472f008e4dc21633b3c2c4a50ace5c209262bcb98a5e373a53
   languageName: node
   linkType: hard
 
@@ -15959,14 +15825,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-util@npm:^1.15.2, vega-util@npm:^1.16.0, vega-util@npm:^1.16.1, vega-util@npm:^1.17.0":
-  version: 1.17.0
-  resolution: "vega-util@npm:1.17.0"
-  checksum: 9f54e4795d6b43aeced2249ab081c98ebe5bb7b1d911fdfbc59c831a611b51877a7792ad10cd11828c74eaaedf46d65f6b6661d860e59f151cc04376ec4ca82b
-  languageName: node
-  linkType: hard
-
-"vega-util@npm:^1.17.1, vega-util@npm:~1.17.1":
+"vega-util@npm:^1.15.2, vega-util@npm:^1.16.0, vega-util@npm:^1.17.1, vega-util@npm:~1.17.1":
   version: 1.17.1
   resolution: "vega-util@npm:1.17.1"
   checksum: aa8b6a43bd38f49aea6d97988cdc2bdae6e0adb59080287b87dc82b9b7246faa87a20d2c143e700ba5669adaa249dd27b88b3c74c4b4df9fa6a510381c575713


### PR DESCRIPTION
Summary: Unpin the forced resolution for vega-functions so that it can be
upgraded.

Relevant Issues: GHSA-4vq7-882g-wcg4 and GHSA-w5m3-xh75-mp55

Type of change: /kind cve

Test Plan: Existing unit tests should cover this.
