### PR TITLE
Make http_body_limit_bytes able to be set by environment variable

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/http/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/parse.cc
@@ -25,7 +25,8 @@
 #include <string>
 #include <utility>
 
-DEFINE_uint32(http_body_limit_bytes, 1024,
+DEFINE_uint32(http_body_limit_bytes,
+              gflags::Uint32FromEnv("PX_STIRLING_HTTP_BODY_LIMIT_BYTES", 1024),
               "The amount of an HTTP body that will be returned on a parse");
 
 namespace px {


### PR DESCRIPTION
Summary: Changing the value of `max_body_bytes` by setting the `PL_STIRLING_MAX_BODY_BYTES` does not allow for sizes over `http_body_limit_bytes` for the body of ebpf traffic captured in the http setting. I've added an environment variable for setting `http_body_limit_bytes` using `PX_STIRLING_MAX_BODY_BYTES`.

Test Plan: Deployed Stirling in a self-hosted environment with a variety of values.

Type of change: /kind cleanup

Signed-off-as: AdityaAtulTewari <adityaatewari@gmail.com>