### PR TITLE
[perf_tool/run] Avoid retrying when workload prepartion fails

### DIFF
--- a/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
+++ b/src/e2e_test/perf_tool/pkg/run/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//src/e2e_test/perf_tool/pkg/metrics",
         "//src/e2e_test/perf_tool/pkg/pixie",
         "//src/shared/bq",
+        "@com_github_cenkalti_backoff_v4//:backoff",
         "@com_github_gofrs_uuid//:uuid",
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//types",


### PR DESCRIPTION
Summary: When workloads fail to prepare theres most likely an issue in the experiment spec, or the state of the workloads in the repo, so retrying will not help. This avoids the retries if preparing workloads fails.

Type of change: /kind test-infra

Test Plan: Tested that the experiment is not retried if workload preparation fails.
