### PR TITLE
[perf_tool] Add github action to run perf_tool

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -1,0 +1,113 @@
+---
+name: perf-eval
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+  # Run at 23:49 PST (07:49 UTC) every day. Github suggests not running actions on the hour.
+  - cron: '49 7 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or commit'
+        required: true
+        type: string
+      suite:
+        description: 'Experiment suite'
+        type: string
+        required: true
+      tags:
+        description: 'Tags (comma separated)'
+        type: string
+        required: false
+
+jobs:
+  nightly-perf-eval:
+    name: Nightly Performance Evaluation
+    if: github.event.schedule
+    uses: ./.github/workflows/perf_common.yaml
+    with:
+      suites: "nightly"
+      tags: "main"
+    secrets: inherit
+
+  manual-perf-eval:
+    name: Manual Performance Evaluation
+    if: inputs.ref && inputs.suite
+    uses: ./.github/workflows/perf_common.yaml
+    with:
+      ref: ${{ inputs.ref }}
+      suites: ${{ inputs.suite }}
+      tags: ${{ inputs.tags }}
+    secrets: inherit
+
+  pr-perf-setup:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request
+    outputs:
+      suites: ${{ steps.parse.outputs.suites }}
+      tags: ${{ steps.default-tags.outputs.tags }}
+    steps:
+    - name: Check for /perf command
+      uses: xt0rted/slash-command-action@8a7e10c4cf69ee4126bf815c3d2a07455de5233a
+      id: command
+      with:
+        command: perf
+        reaction: true
+        reaction-type: rocket
+        allow-edits: false
+        permission-level: admin
+    - name: Parse /perf command
+      id: parse
+      run: |
+        args="${{ steps.command.outputs.command-arguments }}"
+        suites="$(echo ${args} | cut -d" " -f1)"
+        tags="$(echo "${args}" | cut -s -d" " -f2)"
+        echo "suites=${suites}" >> $GITHUB_OUTPUT
+        echo "tags=${tags}" >> $GITHUB_OUTPUT
+    - name: Add default tags
+      id: default-tags
+      # yamllint disable rule:indentation
+      run: |
+        default_tags="PR#${{ github.event.issue.number }}"
+        tags="${{ steps.parse.outputs.tags }}"
+        if [[ -n "${tags}" ]]; then
+          tags="${tags},"
+        fi
+        tags="${tags}${default_tags}"
+        echo "tags=${tags}" >> $GITHUB_OUTPUT
+      # yamllint enable rule:indentation
+  pr-perf-eval:
+    name: PR Performance Evaluation
+    needs: pr-perf-setup
+    uses: ./.github/workflows/perf_common.yaml
+    with:
+      suites: ${{ needs.pr-perf-setup.outputs.suites }}
+      tags: ${{ needs.pr-perf-setup.outputs.tags }}
+      ref: refs/pull/${{ github.event.issue.number }}/head
+    secrets: inherit
+  pr-perf-comment:
+    name: Comment results on PR
+    needs: pr-perf-eval
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        # yamllint disable rule:indentation
+        script: |
+          const experiments = JSON.parse('${{ needs.pr-perf-eval.outputs.experiments }}');
+          let comment = `Perf eval finished:
+            | Suite | Experiment Name | URL |
+            | ----- | --------------- | --- |
+          `
+          for (const exp of experiments) {
+            comment += `| ${exp.suite} | ${exp.experiment_name} | ${exp.datastudio_url} |\n`
+          }
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment,
+          })
+
+        # yamllint enable rule:indentation

--- a/.github/workflows/perf_common.yaml
+++ b/.github/workflows/perf_common.yaml
@@ -1,0 +1,140 @@
+---
+name: perf-eval-common
+on:
+  workflow_call:
+    inputs:
+      suites:
+        required: true
+        description: "Comma separated list of suites to run"
+        type: string
+      ref:
+        required: false
+        default: ''
+        type: string
+      tags:
+        type: string
+        required: false
+        description: "Comma separated list of tags to add to experiments"
+    outputs:
+      experiments:
+        description: "JSON array of the experiments completed (including datastudio links and experiment names)"
+        value: ${{ jobs.get-perf-outputs.outputs.experiments }}
+    secrets:
+      PERF_GCLOUD_KEY:
+        required: true
+      PERF_PX_API_KEY:
+        required: true
+      BB_API_KEY:
+        required: true
+permissions:
+  contents: read
+jobs:
+  get-dev-image-with-extras:
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "dev_image_with_extras"
+      ref: ${{ inputs.ref }}
+  generate-perf-matrix:
+    needs: get-dev-image-with-extras
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.get-dev-image-with-extras.outputs.image-with-tag }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: get buildbuddy bazel config
+      uses: ./.github/actions/buildbuddy
+      with:
+        bb_api_key: ${{ secrets.BB_API_KEY }}
+    - name: Set matrix
+      id: set-matrix
+      run: |
+        matrix="$(bazel run //src/e2e_test/perf_tool -- github_matrix --suite="${{ inputs.suites }}")"
+        echo "Perf matrix: ${matrix}"
+        echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+  run-perf-eval:
+    needs: [get-dev-image-with-extras, generate-perf-matrix]
+    runs-on: ubuntu-latest-16-cores
+    container:
+      image: ${{ needs.get-dev-image-with-extras.outputs.image-with-tag }}
+      options: --cpus 15
+    strategy:
+      matrix: ${{ fromJson(needs.generate-perf-matrix.outputs.matrix) }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+    - id: create-gcloud-key
+      env:
+        SERVICE_ACCOUNT_KEY: ${{ secrets.PERF_GCLOUD_KEY }}
+      run: echo "$SERVICE_ACCOUNT_KEY" | base64 --decode > /tmp/gcloud.json && chmod 600 /tmp/gcloud.json
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - id: get-commit-sha
+      run: |
+        git log
+        echo "commit-sha=$(git log -n 1 --format="%H")" >> $GITHUB_OUTPUT
+    - name: get buildbuddy bazel config
+      uses: ./.github/actions/buildbuddy
+      with:
+        bb_api_key: ${{ secrets.BB_API_KEY }}
+    - name: activate gcloud service account
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: "/tmp/gcloud.json"
+      run: |
+        service_account="$(jq -r '.client_email' "$GOOGLE_APPLICATION_CREDENTIALS")"
+        gcloud auth activate-service-account "${service_account}" --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+    - name: bazel config
+      run: |
+        # Skaffold expects the <image>.tar file to exist in the local bazel cache,
+        # but that only happens with remote_download_outputs=toplevel
+        echo "build --remote_download_outputs=toplevel" >> .bazelrc
+    - name: Install Pixie CLI
+      run: |
+        bazel build -c opt //src/pixie_cli:px
+        p="$(bazel cquery -c opt //src/pixie_cli:px --output starlark --starlark:expr 'target.files.to_list()[0].path')"
+        cp "${p}" /usr/bin/px
+    - name: Run perf for ${{ matrix.suite }}/${{ matrix.experiment_name }}
+      id: run-perf
+      env:
+        PX_API_KEY: ${{ secrets.PERF_PX_API_KEY }}
+        GOOGLE_APPLICATION_CREDENTIALS: "/tmp/gcloud.json"
+      # yamllint disable rule:indentation
+      run: |
+        echo "$GOOGLE_APPLICATION_CREDENTIALS"
+        bazel run //src/e2e_test/perf_tool -- run --commit_sha "${{ steps.get-commit-sha.outputs.commit-sha }}" \
+          --gke_project pixie-oss \
+          --bq_project pixie-oss \
+          --container_repo "gcr.io/pixie-oss/pixie-perf" \
+          --ds_report_id "9701de3b-f906-4dd2-a1e9-48ca0b1e07e6" \
+          --tags "${{ inputs.tags }}" \
+          --suite "${{ matrix.suite }}" \
+          --experiment_name "${{ matrix.experiment_name }}" > run_output
+      # yamllint enable rule:indentation
+    - name: deactivate gcloud service account
+      run: gcloud auth revoke
+    # Github actions doesn't have native support for gathering outputs from matrix runs.
+    # So we upload an artifact for each one and gather them ourselves in `get-perf-outputs`.
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ hashFiles('run_output') }}
+        path: run_output
+        if-no-files-found: error
+  get-perf-outputs:
+    runs-on: ubuntu-latest
+    needs: run-perf-eval
+    outputs:
+      experiments: ${{ steps.get-outputs.outputs.run_output }}
+    steps:
+    - uses: actions/download-artifact@v3
+    - id: get-outputs
+      run: |
+        all_run_output="$(cat */run_output | jq --slurp -c '.[]')"
+        echo "${all_run_output}" | jq
+        echo "run_output=${all_run_output}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Summary: Adds a github action to run performance evaluations. The github action can be triggered three ways:
- automatically each night
- manually through github's workflow dispatch
- on PRs by having an admin comment `/perf <suites> <tags>`

Type of change: /kind test-infra

Test Plan: See #1037. I tested this by making a pull_request trigger for the action and testing on a separate pull request. We don't actually want that trigger so I removed it here.

