### PR TITLE
Allow kernel version to be configurable for qemu

### DIFF
--- a/bazel/pl_workspace.bzl
+++ b/bazel/pl_workspace.bzl
@@ -87,9 +87,27 @@ def pl_model_files():
 
 def qemu_with_kernel_deps():
     http_file(
+        name = "linux_build_4_14_304_x86_64",
+        url = "https://storage.googleapis.com/pixie-dev-public/kernel-build/20230228151027/linux-build-4.14.304.tar.gz",
+        sha256 = "58c474a6f3cf0c93af39d0549ddcb3e36b852026c42229fc6d4a40260e34329d",
+        downloaded_file_path = "linux-build.tar.gz",
+    )
+    http_file(
+        name = "linux_build_5_15_90_x86_64",
+        url = "https://storage.googleapis.com/pixie-dev-public/kernel-build/20230228151027/linux-build-5.15.90.tar.gz",
+        sha256 = "2960730ead8f9b20e97e68b1148ea5e208ecebcadc04a2bef99a5936a3d525fa",
+        downloaded_file_path = "linux-build.tar.gz",
+    )
+    http_file(
         name = "linux_build_5_18_19_x86_64",
         url = "https://storage.googleapis.com/pixie-dev-public/kernel-build/20230228151027/linux-build-5.18.19.tar.gz",
         sha256 = "3da6271916d253810e4ef2e587dd426ad1f9d1bbb98b5624994c378604e3de23",
+        downloaded_file_path = "linux-build.tar.gz",
+    )
+    http_file(
+        name = "linux_build_6_1_8_x86_64",
+        url = "https://storage.googleapis.com/pixie-dev-public/kernel-build/20230228151027/linux-build-6.1.8.tar.gz",
+        sha256 = "767aa4c6936330512de3c38e4b2036181a56d7d01158947c7ee8747402bd479c",
         downloaded_file_path = "linux-build.tar.gz",
     )
     http_file(

--- a/bazel/test_runners/qemu_with_kernel/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/BUILD.bazel
@@ -14,9 +14,74 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel/test_runners/qemu_with_kernel:runner.bzl", "qemu_with_kernel_test_runner")
+
+string_flag(
+    name = "kernel_version",
+    build_setting_default = "latest",
+    values = [
+        "oldest",
+        "4.14.304",
+        "5.15.90",
+        "5.18.19",
+        "6.1.8",
+        "latest",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "kernel_version_oldest",
+    flag_values = {
+        ":kernel_version": "oldest",
+    },
+)
+
+config_setting(
+    name = "kernel_version_4_14_304",
+    flag_values = {
+        ":kernel_version": "4.14.304",
+    },
+)
+
+config_setting(
+    name = "kernel_version_5_15_90",
+    flag_values = {
+        ":kernel_version": "5.15.90",
+    },
+)
+
+config_setting(
+    name = "kernel_version_5_18_19",
+    flag_values = {
+        ":kernel_version": "5.18.19",
+    },
+)
+
+config_setting(
+    name = "kernel_version_6_1_8",
+    flag_values = {
+        ":kernel_version": "6.1.8",
+    },
+)
+
+config_setting(
+    name = "kernel_version_latest",
+    flag_values = {
+        ":kernel_version": "latest",
+    },
+)
 
 qemu_with_kernel_test_runner(
     name = "runner",
+    kernel_image = select({
+        ":kernel_version_4_14_304": "@linux_build_4_14_304_x86_64//file:linux-build.tar.gz",
+        ":kernel_version_5_15_90": "@linux_build_5_15_90_x86_64//file:linux-build.tar.gz",
+        ":kernel_version_5_18_19": "@linux_build_5_18_19_x86_64//file:linux-build.tar.gz",
+        ":kernel_version_6_1_8": "@linux_build_6_1_8_x86_64//file:linux-build.tar.gz",
+        ":kernel_version_latest": "@linux_build_6_1_8_x86_64//file:linux-build.tar.gz",
+        ":kernel_version_oldest": "@linux_build_4_14_304_x86_64//file:linux-build.tar.gz",
+    }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Signed-off-by: Zain Asgar <zasgar@pixielabs.ai>

Summary: This allows kernel version to be passed via a flag. There is a set list of kernels that can be executed and they are built using
//tools/docker/kernel_builder.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: `bazel test -c opt --config=qemu-bpf  --cache_test_results=no --remote_download_outputs=all //src/stirling/source_connectors/socket_tracer:redis_trace_bpf_test --test_output=streamed --//bazel/test_runners/qemu_with_kernel:kernel_version=4.14.304`
`--//bazel/test_runners/qemu_with_kernel:kernel_version` can be set to different values. There is a bug with the 4.14.304 kernel config that'll be fixed next, but the others are working.

