### PR TITLE
Always scroll hovered item into view in Command Palette

### DIFF
--- a/src/ui/src/components/command-palette/command-text-field.tsx
+++ b/src/ui/src/components/command-palette/command-text-field.tsx
@@ -222,7 +222,7 @@ export const CommandTextField = React.memo<CommandTextFieldProps>(({
     onHighlightChange: (event: React.SyntheticEvent, option: CommandCompletion, reason: string) => {
       setHighlightedCompletion(option);
       if (option && (reason === 'keyboard' || reason === 'auto')) {
-        // The event target is the text field if the reaon is keyboard, and missing if the reason is auto.
+        // The event target is the text field if the reason is keyboard, and missing if the reason is auto.
         // So instead, we manually find the element that got focused and scroll it into view.
         // Accounts for scroll-margin-top and therefore the sticky headers.
         setTimeout(() => {


### PR DESCRIPTION
Summary: Without this change, the browser already tries to scroll the selected option into view. However, due to `position: sticky`, there's a header that can obscure it. To account for that header, we use `scroll-margin-top` and force the browser to try again with `scrollIntoView`, which accounts for that property.
Fixes #1045

Relevant Issues: #1045

Test Plan: Open the Command Palette. Enter a query like script:. Using the arrow keys, scroll down a couple of pages, then scroll back up the same way. When moving to an option that's above the current scroll view, it should now fully scroll that option into view.

Type of change: /kind bug

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
