### PR TITLE
Upgrade OLM to v0.24

### DIFF
--- a/k8s/operator/helm/templates/00_olm.yaml
+++ b/k8s/operator/helm/templates/00_olm.yaml
@@ -66,7 +66,7 @@ spec:
           - $(OPERATOR_NAMESPACE)
           - --writeStatusName
           - ""
-          image: {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-olm{{ else }}quay.io/operator-framework/olm@sha256:b706ee6583c4c3cf8059d44234c8a4505804adcc742bcddb3d1e2f6eff3d6519{{ end }}
+          image: {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-{{ else }}quay.io/operator-framework/{{ end }}olm@sha256:f9ea8cef95ac9b31021401d4863711a5eec904536b449724e0f00357548a31e7
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -83,7 +83,6 @@ spec:
               port: 8080
           terminationMessagePolicy: FallbackToLogsOnError
           env:
-
           - name: OPERATOR_NAMESPACE
             valueFrom:
               fieldRef:
@@ -94,8 +93,6 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
-
-
       nodeSelector:
         kubernetes.io/os: linux
 ---
@@ -128,8 +125,8 @@ spec:
           - {{ .Values.olmNamespace }}
           - -configmapServerImage={{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-{{ else }}quay.io/operator-framework/{{ end }}configmap-operator-registry:latest
           - -util-image
-          -  {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-olm{{ else }}quay.io/operator-framework/olm@sha256:b706ee6583c4c3cf8059d44234c8a4505804adcc742bcddb3d1e2f6eff3d6519{{ end }}
-          image: {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-olm{{ else }}quay.io/operator-framework/olm@sha256:b706ee6583c4c3cf8059d44234c8a4505804adcc742bcddb3d1e2f6eff3d6519{{ end }}
+          -  {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-{{ else }}quay.io/operator-framework/{{ end }}olm@sha256:f9ea8cef95ac9b31021401d4863711a5eec904536b449724e0f00357548a31e7
+          image: {{ if .Values.registry }}{{ .Values.registry }}/quay.io-operator-framework-{{ else }}quay.io/operator-framework/{{ end }}olm@sha256:f9ea8cef95ac9b31021401d4863711a5eec904536b449724e0f00357548a31e7
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -146,13 +143,10 @@ spec:
               port: 8080
           terminationMessagePolicy: FallbackToLogsOnError
           env:
-
           resources:
             requests:
               cpu: 10m
               memory: 80Mi
-
-
       nodeSelector:
         kubernetes.io/os: linux
 ---

--- a/k8s/operator/helm/templates/00_olm.yaml
+++ b/k8s/operator/helm/templates/00_olm.yaml
@@ -95,6 +95,23 @@ spec:
               memory: 160Mi
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -149,6 +166,23 @@ spec:
               memory: 80Mi
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Summary: This upgrades OLM to v0.24 where the multiarch images should
now finally work on ARM.
This also updates the custom registry paths for the images to ensure
that the image hash is specified when using a custom registry too.

Relevant Issues: #892

Type of change: /kind feature

Test Plan: Will cut a RC and test.
