### PR TITLE
Command Palette: Fix missing quote logic

### DIFF
--- a/src/ui/src/components/command-palette/command-palette.tsx
+++ b/src/ui/src/components/command-palette/command-palette.tsx
@@ -21,6 +21,7 @@ import * as React from 'react';
 import { ScriptContext } from 'app/context/script-context';
 
 import { CommandPaletteTrigger } from './command-palette-trigger';
+import { quoteIfNeeded } from './providers/script/script-provider-common';
 
 export const CommandPalette = React.memo(() => {
   const { script, args } = React.useContext(ScriptContext);
@@ -31,15 +32,15 @@ export const CommandPalette = React.memo(() => {
     if (!script?.id) return '';
 
     // We always want to show the script first, and the start_time last.
-    const parts = [`script:${script.id}`];
+    const parts = [`script:${quoteIfNeeded(script.id)}`];
     const keys = [...Object.keys(args)];
     keys.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
 
     // For each key, add ` key:value` to the string (quoting the value if it needs it)
     for (const k of keys) {
       const valRaw = Array.isArray(args[k]) ? (args[k] as string[]).join(',') : (args[k] as string);
-      const v = /[":\s]/.test(valRaw) ? `"${valRaw}"` : valRaw;
-      parts.push(`${k}:${v || '""'}`);
+      const v = quoteIfNeeded(valRaw);
+      parts.push(`${k}:${v ?? ''}`);
     }
     return parts.join(' ');
   }, [script, args]);


### PR DESCRIPTION
Summary: When opening the Command Palette while working on the Scratch Pad script, it was failing to quote the space in the name (resulting in an invalid command).
This makes it use an existing utility function to correctly quote both the script name and any arguments that need it, when opening the Command Palette in the live view.

Test Plan: Open the Command Palette when editing the Scratch Pad script or a script whose arg values include a character that requires quoting.

Type of change: /kind bug

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
