### PR TITLE
support kubeconfig options when using kubectl command

### DIFF
--- a/src/pixie_cli/pkg/utils/checks.go
+++ b/src/pixie_cli/pkg/utils/checks.go
@@ -209,7 +209,8 @@ var (
 		return nil
 	})
 	hasKubectlCheck = NamedCheck(fmt.Sprintf("Kubectl > %s is present", kubectlMinVersion), func() error {
-		result, err := exec.Command("kubectl", "version", "-o", "yaml").Output()
+		cmd := k8s.KubectlCmd("version", "-o", "yaml")
+		result, err := cmd.Output()
 		if err != nil {
 			return err
 		}
@@ -237,7 +238,8 @@ var (
 		return nil
 	})
 	userCanCreateNamespace = NamedCheck("User can create namespace", func() error {
-		result, err := exec.Command("kubectl", "auth", "can-i", "create", "namespace").Output()
+		cmd := k8s.KubectlCmd("auth", "can-i", "create", "namespace")
+		result, err := cmd.Output()
 		if err != nil {
 			return err
 		}

--- a/src/utils/shared/k8s/BUILD.bazel
+++ b/src/utils/shared/k8s/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "apply.go",
         "auth.go",
         "delete.go",
+        "kubectl.go",
         "logs.go",
         "secrets.go",
         "selector.go",

--- a/src/utils/shared/k8s/kubectl.go
+++ b/src/utils/shared/k8s/kubectl.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package k8s
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func KubectlCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("kubectl", args...)
+	if *kubeconfig != "" {
+		cmd.Env = append(cmd.Environ(), fmt.Sprintf("KUBECONFIG=%s", *kubeconfig))
+	}
+	return cmd
+}


### PR DESCRIPTION
support kubeconfig options when using kubectl command

Summary: When deploy using  `px --kubeconfig THE_KUBE_FILE deploy`,
it failed with error `✕    Kubectl > 1.10.0 is present  ERR: exit status 1`.

And I found the px cli has the `--kubeconfig` option, but the internal
kubectl command didn't respect it.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Run `px deploy` with `--kubeconfig` option should work without
problem.
