### PR TITLE
[perf-eval] Don't error on comments without slash command

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -47,6 +47,8 @@ jobs:
     outputs:
       suites: ${{ steps.parse.outputs.suites }}
       tags: ${{ steps.default-tags.outputs.tags }}
+      outcome: ${{ steps.default-tags.outcome }}
+    continue-on-error: true
     steps:
     - name: Check for /perf command
       uses: xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88
@@ -80,6 +82,7 @@ jobs:
   pr-perf-eval:
     name: PR Performance Evaluation
     needs: pr-perf-setup
+    if: ${{ needs.pr-perf-setup.outputs.outcome == 'success' }}
     uses: ./.github/workflows/perf_common.yaml
     with:
       suites: ${{ needs.pr-perf-setup.outputs.suites }}


### PR DESCRIPTION
Summary: Don't cause the workflow to error when a slash command is not present in the pr comment.

Type of change: /kind test-infra

Test Plan: Tested on my fork of the repo, saw that the perf-eval workflow no longer errors and also doesn't attempt to run the perf eval when the slash command is not there.
