### PR TITLE
[1 of 4] Add `UnitConnector` to Stirling, useful as an API to one source connector.

### DIFF
--- a/src/stirling/core/data_tables.h
+++ b/src/stirling/core/data_tables.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "src/stirling/core/data_table.h"
+#include "src/stirling/core/types.h"
+
+namespace px {
+namespace stirling {
+
+class DataTables {
+ public:
+  template <size_t NumTableSchemas>
+  explicit DataTables(
+      const std::array<px::stirling::DataTableSchema, NumTableSchemas>& table_schemas) {
+    for (const auto& [id, table_schema] : Enumerate(table_schemas)) {
+      auto data_table = std::make_unique<DataTable>(id, table_schema);
+      data_table_ptrs_.push_back(data_table.get());
+      data_table_uptrs_.push_back(std::move(data_table));
+    }
+  }
+
+  std::vector<DataTable*> tables() { return data_table_ptrs_; }
+
+  DataTable* operator[](int idx) { return data_table_ptrs_[idx]; }
+
+ private:
+  std::vector<std::unique_ptr<DataTable>> data_table_uptrs_;
+  std::vector<DataTable*> data_table_ptrs_;
+};
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -121,7 +121,7 @@ class UnitConnector {
     // For the UPIDs, we use ASID=0 because UnitConnector is not meant for a multi-host env.
     constexpr uint32_t kASID = 0;
 
-    // A memory location that will be targetted by absl::SimpleAtoi; see below.
+    // A memory location that will be targeted by absl::SimpleAtoi; see below.
     uint32_t pid;
 
     // Eventually, this will be the return value from this fn.

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -320,6 +320,8 @@ class UnitConnector {
   }
 
   Status StartTransferDataThread() {
+    PX_RETURN_IF_ERROR(RefreshContextAndDeployUProbes());
+
     // About to start the transfer data thread. Level set our state now.
     transfer_exited_ = false;
     transfer_enable_ = true;

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -115,7 +115,7 @@ class UnitConnector {
     if (upids.size() == 0) {
       // Enter this branch if Init() is called with no arguments (i.e. with a default empty set).
       // ParsePidsFlag() inspects the value in FLAGS_pids to find any pids the user specified
-      // on the comand line.
+      // on the command line.
       PX_ASSIGN_OR_RETURN(upids, ParsePidsFlag());
     }
 

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -175,6 +175,10 @@ class UnitConnector {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
+    if (started_ || transfer_enable_) {
+      return error::Internal("Trasnfer data thread is running.");
+    }
+
     source_->TransferData(ctx_.get());
     return Status::OK();
   }

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -117,8 +117,7 @@ class UnitConnector {
       // Disable automatic context refresh.
       ctx_refresh_enabled_ = false;
       ctx_ = std::make_unique<StandaloneContext>(upids);
-    }
-    else if (FLAGS_pid == 0) {
+    } else if (FLAGS_pid == 0) {
       // All pids & automatic context refresh.
       ctx_refresh_enabled_ = true;
       ctx_ = std::make_unique<SystemWideStandaloneContext>();

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "src/common/base/statusor.h"
+#include "src/stirling/core/connector_context.h"
+#include "src/stirling/core/data_tables.h"
+#include "src/stirling/core/frequency_manager.h"
+
+DEFINE_uint32(pid, 0, "PID to profile. Use default value, -pid 0, to profile all processes.");
+
+namespace px {
+namespace stirling {
+
+template <typename T>
+class UnitConnector {
+  using time_point = std::chrono::steady_clock::time_point;
+
+ public:
+  UnitConnector() : data_tables_(T::kTables) {}
+
+  Status Init() {
+    source_ = T::Create("source_connector");
+
+    // Init() compiles the eBPF program and creates the eBPF perf buffer and maps needed
+    // to communicate data to/from eBPF.
+    PX_RETURN_IF_ERROR(source_->Init());
+
+    // Give the source connector data tables to write into.
+    source_->set_data_tables(data_tables_.tables());
+
+    return Status::OK();
+  }
+
+  Status VerifyInitted() {
+    if (source_ == nullptr) {
+      return error::Internal("Source connector has not been initted, or was already deallocated.");
+    }
+    return Status::OK();
+  }
+
+  Status Stop() {
+    // Pedantic, but better than bravely carrying on if something is wrong here.
+    PX_RETURN_IF_ERROR(VerifyInitted());
+
+    if (!started_) {
+      return error::Internal("UnitConnector::Start() has not been called yet.");
+    }
+    if (stopped_) {
+      return Status::OK();
+    }
+
+    // Stop transferring data.
+    PX_RETURN_IF_ERROR(StopTransferDataThread());
+
+    // Cleanup. Important!
+    PX_RETURN_IF_ERROR(source_->Stop());
+    stopped_ = true;
+
+    return Status::OK();
+  }
+
+  Status Start() {
+    // Pedantic, but better than bravely carrying on if something is wrong here.
+    PX_RETURN_IF_ERROR(VerifyInitted());
+
+    if (stopped_) {
+      return error::Internal("Already stopped.");
+    }
+    if (started_) {
+      return Status::OK();
+    }
+
+    PX_RETURN_IF_ERROR(StartTransferDataThread());
+    started_ = true;
+
+    return Status::OK();
+  }
+
+  ~UnitConnector() {
+    const auto status = Stop();
+    if (!status.ok()) {
+      LOG(FATAL) << "Stop() not ok: " << status.msg();
+    }
+
+    // More cleanup (invokes dtor of source connector). Prevent Stop() from being invoked twice.
+    source_ = nullptr;
+  }
+
+  StatusOr<types::ColumnWrapperRecordBatch> ConsumeRecords(const uint32_t table_num) {
+    tablets_ = source_->data_tables()[table_num]->ConsumeRecords();
+    if (tablets_.size() != 1) {
+      char const* const msg = "Expected exactly one table, found tablets_.size(): $0.";
+      return error::Internal(absl::Substitute(msg, tablets_.size()));
+    }
+    return tablets_[0].records;
+  }
+
+  T* RawPtr() { return source_.get(); }
+
+ private:
+  std::chrono::milliseconds TimeUntilNextTick(const time_point now)
+      ABSL_SHARED_LOCKS_REQUIRED(state_lock_) {
+    // Worst case, wake-up every so often.
+    constexpr std::chrono::milliseconds kMaxSleepDuration{1000};
+    auto wakeup_time = now + kMaxSleepDuration;
+    wakeup_time = std::min(wakeup_time, source_->sampling_freq_mgr().next());
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(wakeup_time - now);
+  }
+
+  Status TransferDataThread() {
+    constexpr auto kRunWindow = std::chrono::milliseconds{1};
+    auto time_until_next_tick = std::chrono::milliseconds::zero();
+    auto now = std::chrono::steady_clock::now();
+
+    FrequencyManager ctx_freq_mgr;
+    ctx_freq_mgr.set_period(std::chrono::milliseconds{200});
+
+    // This value can also be manipulated by the Stop() method.
+    transfer_enable_ = true;
+
+    while (transfer_enable_) {
+      // To batch up work, i.e. to do more work per wakeup, we want to run our data
+      // transfer or push data if its desired run time is anywhere between
+      // time "now" and time "now + window".
+      const auto now_plus_run_window = now + kRunWindow;
+
+      if (FLAGS_pid == 0) {
+        if (ctx_freq_mgr.Expired(now_plus_run_window)) {
+          ctx_ = std::make_unique<SystemWideStandaloneContext>();
+          now = std::chrono::steady_clock::now();
+          ctx_freq_mgr.Reset(now);
+        }
+      }
+
+      {
+        // Prevent main thread from trying to join or stop the profiler while this is happening.
+        absl::base_internal::SpinLockHolder lock(&state_lock_);
+
+        // Transfer data from eBPF to user space.
+        if (source_->sampling_freq_mgr().Expired(now_plus_run_window)) {
+          // Read the eBPF perf buffer and map that stores the profiling information.
+          // Data from eBPF is transferred into member data_table_.
+          source_->TransferData(ctx_.get());
+
+          // TransferData() is normally a significant amount of work: update "time now".
+          now = std::chrono::steady_clock::now();
+          source_->sampling_freq_mgr().Reset(now);
+        }
+
+        // Figure the time remaining until the next required data sample or push data.
+        time_until_next_tick = TimeUntilNextTick(now);
+      }
+
+      // Sleep, only if time_until_next_tick exceeds the "run window," i.e. if that time
+      // is long enough that Stirling should go to sleep. Otherwise, don't sleep and loop back
+      // through the sources, with the expectation that one of the sources triggers a call to
+      // either TransferData() or to PushData().
+      if (time_until_next_tick >= kRunWindow) {
+        std::this_thread::sleep_for(time_until_next_tick);
+
+        // We just went to sleep: update time now.
+        now = std::chrono::steady_clock::now();
+      }
+    }
+
+    source_->TransferData(ctx_.get());
+    return Status::OK();
+  }
+
+  Status StartTransferDataThread() {
+    if (FLAGS_pid == 0) {
+      // No PID specified. Go with "system wide" context.
+      ctx_ = std::make_unique<SystemWideStandaloneContext>();
+    } else {
+      // If FLAGS_pid is set, the user wants to collect data from a specific process.
+
+      // Get the process start time, used to construct the "UPID" or unique pid.
+      // UPID is conceptually useful when Pixie is running on multiple hosts:
+      // it includes a start timestamp (for recycled pids on a given host) and an address
+      // space id to distinguish between pids on different hosts.
+      PX_ASSIGN_OR_RETURN(const uint64_t ts, system::ProcParser().GetPIDStartTimeTicks(FLAGS_pid));
+
+      // Here, we use zero because the UnitSourceConnector is not meant for a multi-host env.
+      constexpr uint32_t kASID = 0;
+
+      // The stand alone context requires a set of UPIDs. We have just one in that set.
+      const absl::flat_hash_set<md::UPID> upids = {md::UPID(kASID, FLAGS_pid, ts)};
+
+      // Create the context to filter by pid.
+      ctx_ = std::make_unique<StandaloneContext>(upids);
+    }
+
+    // Create a thread to periodically read eBPF data.
+    transfer_data_thread_ = std::thread(&UnitConnector<T>::TransferDataThread, this);
+
+    return Status::OK();
+  }
+
+  Status StopTransferDataThread() {
+    if (transfer_data_thread_.joinable()) {
+      transfer_enable_ = false;
+      {
+        // Prevent transfer_data_thread_ from invoking TransferData().
+        absl::base_internal::SpinLockHolder lock(&state_lock_);
+
+        // Join the thread.
+        transfer_data_thread_.join();
+
+        // Transfer any remaining data from eBPF to user space.
+        source_->TransferData(ctx_.get());
+      }
+    }
+
+    return Status::OK();
+  }
+
+  // Data tables for the source connector.
+  DataTables data_tables_;
+
+  // The underlying data source. It will create an eBPF program that is periodically invoked
+  // to collect stack data.
+  std::unique_ptr<T> source_ = nullptr;
+
+  // A thread that periodically wakes up to read eBPF perf buffers and maps.
+  std::thread transfer_data_thread_;
+
+  // The lock and transfer enable flag are used by transfer_data_thread_.
+  absl::base_internal::SpinLock state_lock_;
+  std::atomic<bool> transfer_enable_ = false;
+  std::atomic<bool> started_ = false;
+  std::atomic<bool> stopped_ = false;
+
+  // The context can specify a set of processes to collect data from.
+  // Here, we either create a "system wide" context (all processes) or use just one PID.
+  std::unique_ptr<StandaloneContext> ctx_;
+
+  // Once data is collected, i.e. after StopTransferDataThread is called,
+  // the invoking program will call ConsumeRecords() and data will be aggregated into the
+  // data table schema(s) and this vector of tablets will be populated.
+  std::vector<TaggedRecordBatch> tablets_;
+};
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -103,7 +103,7 @@ class UnitConnector {
       LOG(FATAL) << "Stop() not ok: " << status.msg();
     }
 
-    // More cleanup (invokes dtor of source connector). Prevent Stop() from being invoked twice.
+    // Invokes dtor of the underlying source connector.
     source_ = nullptr;
   }
 

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -27,7 +27,7 @@
 #include "src/stirling/core/data_tables.h"
 #include "src/stirling/core/frequency_manager.h"
 
-DEFINE_string(pids, "", "PIDs to profile, e.g. -pids 132,133. All processes profiled by default.")
+DEFINE_string(pids, "", "PIDs to profile, e.g. -pids 132,133. All processes profiled by default.");
 
 namespace px {
 namespace stirling {
@@ -126,16 +126,15 @@ class UnitConnector {
 
     // Eventually, this will be the return value from this fn.
     absl::flat_hash_set<md::UPID> upids;
-    
+
     // Convert each string view pid to an int, then form a UPID.
     for (const auto& str_pid : str_pids) {
       const bool parsed_ok = absl::SimpleAtoi(str_pid, &pid);
 
       if (!parsed_ok) {
-        return error::Internal(abls::Substitute("Could not parse pid $0 to integer.", str_pid));
+        return error::Internal(absl::Substitute("Could not parse pid $0 to integer.", str_pid));
       }
       PX_ASSIGN_OR_RETURN(const uint64_t ts, system::ProcParser().GetPIDStartTimeTicks(pid));
-
 
       // The stand alone context requires a set of UPIDs. We have just one in that set.
       upids.insert(md::UPID(kASID, pid, ts));
@@ -143,7 +142,7 @@ class UnitConnector {
     return upids;
   }
 
-  Status Init(const absl::flat_hash_set<md::UPID>& upids = {}) {
+  Status Init(absl::flat_hash_set<md::UPID> upids = {}) {
     if (upids.size() == 0) {
       // Init() was called with its default arg., an empty set of UPIDs. Thus, check the value
       // in FLAGS_pids to populate the UPIDs set. The default for FLAGS_pids is an empty

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -149,11 +149,10 @@ class UnitConnector {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
-    // This method manipulates state normally managed by the transfer data thread.
-    // If the transfer data thread has been started, it is an error to try this.
-    // But, if we want to enable an explicit context refresh and blocking uprobe deploy,
-    // along with the transfer data thread, we can bring back the shared state lock.
-    if (started_ || transfer_enable_) {
+    // This method manipulates state normally managed by the transfer data thread. If the transfer
+    // data thread is running, it is an error to try this. If we want to enable this method in
+    // parallel with the transfer data thread, then an we can bring back the shared state lock.
+    if (transfer_enable_) {
       return error::Internal("Context is being managed by the transfer data thread.");
     }
 

--- a/src/stirling/e2e_tests/bpf_map_leak_bpf_test.cc
+++ b/src/stirling/e2e_tests/bpf_map_leak_bpf_test.cc
@@ -25,6 +25,7 @@
 #include "src/common/exec/exec.h"
 #include "src/common/testing/test_utils/container_runner.h"
 #include "src/common/testing/testing.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
 #include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
 #include "src/stirling/testing/common.h"
@@ -118,7 +119,7 @@ TEST_P(BPFMapLeakTest, UnclosedConnection) {
   FLAGS_stirling_conn_map_cleanup_threshold = 1;
   FLAGS_stirling_conn_stats_sampling_ratio = 1;
 
-  testing::DataTables data_tables(SocketTraceConnector::kTables);
+  DataTables data_tables(SocketTraceConnector::kTables);
 
   auto* socket_trace_connector = dynamic_cast<SocketTraceConnector*>(source_.get());
   ebpf::BPFHashTable<uint64_t, struct conn_info_t> conn_info_map =

--- a/src/stirling/source_connectors/jvm_stats/jvm_stats_connector_test.cc
+++ b/src/stirling/source_connectors/jvm_stats/jvm_stats_connector_test.cc
@@ -28,6 +28,7 @@
 #include "src/common/testing/test_environment.h"
 #include "src/common/testing/testing.h"
 #include "src/stirling/core/connector_context.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/source_connectors/jvm_stats/jvm_stats_table.h"
 #include "src/stirling/testing/common.h"
 
@@ -35,7 +36,6 @@ namespace px {
 namespace stirling {
 
 using ::px::stirling::testing::AccessRecordBatch;
-using ::px::stirling::testing::DataTables;
 using ::px::stirling::testing::FindRecordsMatchingPID;
 using ::px::stirling::testing::PIDToUPID;
 using ::px::stirling::testing::RecordBatchSizeIs;

--- a/src/stirling/source_connectors/proc_exit/proc_exit_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/proc_exit/proc_exit_trace_bpf_test.cc
@@ -21,6 +21,7 @@
 #include "src/common/exec/subprocess.h"
 #include "src/common/testing/testing.h"
 #include "src/stirling/core/connector_context.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/testing/common.h"
 
 namespace px {
@@ -39,7 +40,7 @@ TEST(ProcExitConnectorTest, TransferData) {
   EXPECT_OK(connector->Init());
   StandaloneContext context({md::UPID{0, 1, 1}});
 
-  testing::DataTables data_tables{ProcExitConnector::kTables};
+  DataTables data_tables{ProcExitConnector::kTables};
   DataTable* data_table = data_tables.tables().front();
 
   connector->set_data_tables(data_tables.tables());

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector_benchmark.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector_benchmark.cc
@@ -26,6 +26,7 @@
 #include "src/common/perf/memory_tracker.h"
 #include "src/common/perf/tcmalloc.h"
 #include "src/stirling/core/connector_context.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
 #include "src/stirling/source_connectors/socket_tracer/testing/benchmark_data_gen/data_gen.h"
 #include "src/stirling/source_connectors/socket_tracer/testing/benchmark_data_gen/generators.h"
@@ -44,7 +45,6 @@ using ::px::stirling::SocketTraceConnectorFriend;
 using ::px::stirling::SystemWideStandaloneContext;
 using ::px::stirling::testing::BenchmarkDataGenerationSpec;
 using ::px::stirling::testing::CQLQueryReqRespGen;
-using ::px::stirling::testing::DataTables;
 using ::px::stirling::testing::GapPosGenerator;
 using ::px::stirling::testing::GenerateBenchmarkData;
 using ::px::stirling::testing::HTTP1SingleReqRespGen;
@@ -68,7 +68,7 @@ enum class DisplayStatCategory {
   Throughput,
 };
 
-void CountOutput(px::stirling::testing::DataTables* tables, uint64_t* output_records,
+void CountOutput(px::stirling::DataTables* tables, uint64_t* output_records,
                  uint64_t* output_bytes) {
   for (auto tbl : tables->tables()) {
     auto tagged_records = tbl->ConsumeRecords();
@@ -129,7 +129,7 @@ static void BM_SocketTraceConnector(benchmark::State& state, BenchmarkDataGenera
       auto socket_trace_connector =
           static_cast<SocketTraceConnectorFriend*>(source_connector.get());
 
-      DataTables tables(SocketTraceConnector::kTables);
+      px::stirling::DataTables tables(SocketTraceConnector::kTables);
       source_connector->set_data_tables({tables.tables()});
       // Send control events to start all the connections. Control events are out of the scope of
       // this benchmark so we handle them before starting the timer.

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector_test.cc
@@ -29,7 +29,7 @@
 
 #include "src/common/testing/testing.h"
 #include "src/stirling/core/connector_context.h"
-#include "src/stirling/core/data_table.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/cql/test_utils.h"
 #include "src/stirling/source_connectors/socket_tracer/testing/event_generator.h"
 #include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_connector_friend.h"
@@ -172,7 +172,7 @@ class SocketTraceConnectorTest : public ::testing::Test {
     FLAGS_stirling_conn_stats_sampling_ratio = 1;
   }
 
-  testing::DataTables data_tables_{SocketTraceConnector::kTables};
+  DataTables data_tables_{SocketTraceConnector::kTables};
 
   DataTable* http_table_ = data_tables_[kHTTPTableNum];
   DataTable* cql_table_ = data_tables_[kCQLTableNum];

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_protocols_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_protocols_test.cc
@@ -27,7 +27,7 @@
 #include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.hpp"
 
 #include "src/common/testing/testing.h"
-#include "src/stirling/core/data_table.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/cql/test_utils.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mysql/test_data.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mysql/test_utils.h"
@@ -123,7 +123,7 @@ class SocketTraceConnectorTest : public ::testing::Test {
     FLAGS_stirling_check_proc_for_conn_close = false;
     FLAGS_stirling_conn_stats_sampling_ratio = 1;
 
-    data_tables_ = std::make_unique<testing::DataTables>(SocketTraceConnector::kTables);
+    data_tables_ = std::make_unique<DataTables>(SocketTraceConnector::kTables);
     connector_->set_data_tables(data_tables_->tables());
 
     // For convenience.
@@ -132,7 +132,7 @@ class SocketTraceConnectorTest : public ::testing::Test {
     cql_table_ = (*data_tables_)[SocketTraceConnector::kCQLTableNum];
   }
 
-  std::unique_ptr<testing::DataTables> data_tables_;
+  std::unique_ptr<DataTables> data_tables_;
   DataTable* http_table_;
   DataTable* mysql_table_;
   DataTable* cql_table_;

--- a/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
@@ -27,6 +27,7 @@
 #include <absl/base/internal/spinlock.h>
 
 #include "src/common/testing/testing.h"
+#include "src/stirling/core/data_tables.h"
 #include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
 #include "src/stirling/testing/common.h"
 

--- a/src/stirling/testing/common.h
+++ b/src/stirling/testing/common.h
@@ -66,29 +66,6 @@ MATCHER_P(RecordBatchSizeIs, size, absl::Substitute("is a RecordBatch having $0 
 
 MATCHER(ColWrapperIsEmpty, "is an empty ColumnWrapper") { return arg->Empty(); }
 
-// Create DataTable objects used by SocketConnector::TransferData() to write records to.
-class DataTables {
- public:
-  template <size_t NumTableSchemas>
-  explicit DataTables(
-      const std::array<px::stirling::DataTableSchema, NumTableSchemas>& table_schemas) {
-    uint64_t id = 0;
-    for (const DataTableSchema& table_schema : table_schemas) {
-      auto data_table = std::make_unique<DataTable>(id++, table_schema);
-      data_table_ptrs_.push_back(data_table.get());
-      data_table_uptrs_.push_back(std::move(data_table));
-    }
-  }
-
-  std::vector<DataTable*> tables() { return data_table_ptrs_; }
-
-  DataTable* operator[](int idx) { return data_table_ptrs_[idx]; }
-
- private:
-  std::vector<std::unique_ptr<DataTable>> data_table_uptrs_;
-  std::vector<DataTable*> data_table_ptrs_;
-};
-
 inline std::vector<size_t> FindRecordIdxMatchesPIDs(const types::ColumnWrapperRecordBatch& record,
                                                     int upid_column_idx,
                                                     const std::vector<int>& pids) {


### PR DESCRIPTION
Summary: We add class `UnitConnector` to wrap and provide an API to a source connector. This wrapper provides the necessary logic to drive a source connector in isolation (i.e. without using `stirling.cc`). It will be used for test fixtures (e.g. in the socket tracer and perf profiler) and for individual binaries (for the profiler, and for planned work on record and replay binaries).

Type of change: /kind feature

Test Plan: This code is not used (yet). In the next set of PRs, we will switch over test fixtures and stirling binaries to use the `UnitConnector`. Continued passing tests will be the test plan as we switch code over. See #1065.