### PR TITLE
Convert socket tracer test cases to use `UnitConnector`.

### DIFF
--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -121,7 +121,7 @@ class UnitConnector {
     // For the UPIDs, we use ASID=0 because UnitConnector is not meant for a multi-host env.
     constexpr uint32_t kASID = 0;
 
-    // A memory location that will be targetted by absl::SimpleAtoi; see below.
+    // A memory location that will be targeted by absl::SimpleAtoi; see below.
     uint32_t pid;
 
     // Eventually, this will be the return value from this fn.

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -320,6 +320,8 @@ class UnitConnector {
   }
 
   Status StartTransferDataThread() {
+    PX_RETURN_IF_ERROR(RefreshContextAndDeployUProbes());
+
     // About to start the transfer data thread. Level set our state now.
     transfer_exited_ = false;
     transfer_enable_ = true;

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -142,16 +142,16 @@ class UnitConnector {
     return Status::OK();
   }
 
-  Status SetClusterCIDR(const std::string& cidr) {
+  Status SetClusterCIDR(std::string_view cidr_str) {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
-    PX_RETURN_IF_ERROR(ctx_->SetClusterCIDR(cidr));
+    PX_RETURN_IF_ERROR(ctx_->SetClusterCIDR(cidr_str));
 
     return Status::OK();
   }
 
-  Status RefreshContextAndDeployUProbes() {
+  Status BlockAndDeployUProbes() {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
@@ -230,9 +230,6 @@ class UnitConnector {
   }
 
   Status TransferDataThread() {
-    // source_->sampling_freq_mgr().set_period(std::chrono::milliseconds{100});
-    LOG(WARNING) << "source_->sampling_freq_mgr().period().count(): " << source_->sampling_freq_mgr().period().count() << " [ms].";
-
     // Invoke source_->TransferData() ASAP to drain maps & perf buffers, i.e. because some time may
     // have elapsed between starting a BPF program and starting the transfer data thread.
     source_->TransferData(ctx_.get());
@@ -265,7 +262,7 @@ class UnitConnector {
   }
 
   Status StartTransferDataThread() {
-    PX_RETURN_IF_ERROR(RefreshContextAndDeployUProbes());
+    PX_RETURN_IF_ERROR(BlockAndDeployUProbes());
 
     // About to start the transfer data thread. Level set our state now.
     transfer_exited_ = false;

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -115,7 +115,7 @@ class UnitConnector {
     if (upids.size() == 0) {
       // Enter this branch if Init() is called with no arguments (i.e. with a default empty set).
       // ParsePidsFlag() inspects the value in FLAGS_pids to find any pids the user specified
-      // on the comand line.
+      // on the command line.
       PX_ASSIGN_OR_RETURN(upids, ParsePidsFlag());
     }
 

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -175,6 +175,10 @@ class UnitConnector {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
+    if (started_ || transfer_enable_) {
+      return error::Internal("Trasnfer data thread is running.");
+    }
+
     source_->TransferData(ctx_.get());
     return Status::OK();
   }

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -117,8 +117,7 @@ class UnitConnector {
       // Disable automatic context refresh.
       ctx_refresh_enabled_ = false;
       ctx_ = std::make_unique<StandaloneContext>(upids);
-    }
-    else if (FLAGS_pid == 0) {
+    } else if (FLAGS_pid == 0) {
       // All pids & automatic context refresh.
       ctx_refresh_enabled_ = true;
       ctx_ = std::make_unique<SystemWideStandaloneContext>();

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -103,7 +103,7 @@ class UnitConnector {
       LOG(FATAL) << "Stop() not ok: " << status.msg();
     }
 
-    // More cleanup (invokes dtor of source connector). Prevent Stop() from being invoked twice.
+    // Invokes dtor of the underlying source connector.
     source_ = nullptr;
   }
 

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -27,7 +27,7 @@
 #include "src/stirling/core/data_tables.h"
 #include "src/stirling/core/frequency_manager.h"
 
-DEFINE_string(pids, "", "PIDs to profile, e.g. -pids 132,133. All processes profiled by default.");
+DEFINE_uint32(pid, 0, "PID to profile. Use default value, -pid 0, to profile all processes.");
 
 namespace px {
 namespace stirling {
@@ -39,16 +39,24 @@ class UnitConnector {
  public:
   UnitConnector() : data_tables_(T::kTables) {}
 
-  ~UnitConnector() {
-    if (started_ && !stopped_) {
-      const auto status = Stop();
-      if (!status.ok()) {
-        LOG(FATAL) << "Stop() not ok: " << status.msg();
-      }
-    }
+  Status Init() {
+    source_ = T::Create("source_connector");
 
-    // Invokes dtor of the underlying source connector.
-    source_ = nullptr;
+    // Init() compiles the eBPF program and creates the eBPF perf buffer and maps needed
+    // to communicate data to/from eBPF.
+    PX_RETURN_IF_ERROR(source_->Init());
+
+    // Give the source connector data tables to write into.
+    source_->set_data_tables(data_tables_.tables());
+
+    return Status::OK();
+  }
+
+  Status VerifyInitted() {
+    if (source_ == nullptr) {
+      return error::Internal("Source connector has not been initted, or was already deallocated.");
+    }
+    return Status::OK();
   }
 
   Status Stop() {
@@ -56,9 +64,7 @@ class UnitConnector {
     PX_RETURN_IF_ERROR(VerifyInitted());
 
     if (!started_) {
-      // Some test cases use the TransferData method directly. In such cases,
-      // Start will not be called. It is ok to leave here with status "OK".
-      return Status::OK();
+      return error::Internal("UnitConnector::Start() has not been called yet.");
     }
     if (stopped_) {
       return Status::OK();
@@ -91,101 +97,20 @@ class UnitConnector {
     return Status::OK();
   }
 
-  Status Flush() {
-    // Pedantic, but better than bravely carrying on if something is wrong here.
-    PX_RETURN_IF_ERROR(VerifyInitted());
-
-    if (!started_) {
-      return error::Internal("Not yet started.");
-    }
-    if (stopped_) {
-      return error::Internal("Already stopped.");
+  ~UnitConnector() {
+    const auto status = Stop();
+    if (!status.ok()) {
+      LOG(FATAL) << "Stop() not ok: " << status.msg();
     }
 
-    // Stop transferring data.
-    PX_RETURN_IF_ERROR(StopTransferDataThread());
-
-    // Restart.
-    PX_RETURN_IF_ERROR(StartTransferDataThread());
-
-    return Status::OK();
-  }
-
-  Status Init(absl::flat_hash_set<md::UPID> upids = {}) {
-    if (upids.size() == 0) {
-      // Enter this branch if Init() is called with no arguments (i.e. with a default empty set).
-      // ParsePidsFlag() inspects the value in FLAGS_pids to find any pids the user specified
-      // on the command line.
-      PX_ASSIGN_OR_RETURN(upids, ParsePidsFlag());
-    }
-
-    if (upids.size() == 0) {
-      // The upids set is empty: trace all processes and use automatic context refresh.
-      ctx_refresh_enabled_ = true;
-      ctx_ = std::make_unique<SystemWideStandaloneContext>();
-    } else {
-      // The upids set is non-empty: we will trace only processes identified by that set.
-      // Disable automatic context refresh.
-      ctx_refresh_enabled_ = false;
-      ctx_ = std::make_unique<StandaloneContext>(upids);
-    }
-
-    source_ = T::Create("source_connector");
-
-    // Compile the eBPF program and create eBPF perf buffers and maps as needed.
-    PX_RETURN_IF_ERROR(source_->Init());
-
-    // Give the source connector data tables to write into.
-    source_->set_data_tables(data_tables_.tables());
-
-    // For the socket tracer (only), this triggers a blocking deploy of uprobes.
-    // We do this here to support our socket tracer test cases.
-    source_->InitContext(ctx_.get());
-
-    return Status::OK();
-  }
-
-  Status RefreshContextAndDeployUProbes() {
-    // Pedantic, but better than bravely carrying on if something is wrong here.
-    PX_RETURN_IF_ERROR(VerifyInitted());
-
-    // This method manipulates state normally managed by the transfer data thread. If the transfer
-    // data thread is running, it is an error to try this. If we want to enable this method in
-    // parallel with the transfer data thread, then an we can bring back the shared state lock.
-    if (transfer_enable_) {
-      return error::Internal("Context is being managed by the transfer data thread.");
-    }
-
-    if (ctx_refresh_enabled_) {
-      // Pick up new processes.
-      ctx_ = std::make_unique<SystemWideStandaloneContext>();
-    }
-
-    // This will block and deploy uprobes.
-    source_->InitContext(ctx_.get());
-
-    return Status::OK();
-  }
-
-  Status TransferData() {
-    // Pedantic, but better than bravely carrying on if something is wrong here.
-    PX_RETURN_IF_ERROR(VerifyInitted());
-
-    if (started_ || transfer_enable_) {
-      return error::Internal("Transfer data thread is running.");
-    }
-
-    source_->TransferData(ctx_.get());
-    return Status::OK();
+    // More cleanup (invokes dtor of source connector). Prevent Stop() from being invoked twice.
+    source_ = nullptr;
   }
 
   StatusOr<types::ColumnWrapperRecordBatch> ConsumeRecords(const uint32_t table_num) {
-    // Pedantic, but better than bravely carrying on if something is wrong here.
-    PX_RETURN_IF_ERROR(VerifyInitted());
-
     tablets_ = source_->data_tables()[table_num]->ConsumeRecords();
     if (tablets_.size() != 1) {
-      char const* const msg = "Expected exactly one tablet, found tablets_.size(): $0.";
+      char const* const msg = "Expected exactly one table, found tablets_.size(): $0.";
       return error::Internal(absl::Substitute(msg, tablets_.size()));
     }
     return tablets_[0].records;
@@ -194,80 +119,26 @@ class UnitConnector {
   T* RawPtr() { return source_.get(); }
 
  private:
-  StatusOr<absl::flat_hash_set<md::UPID> > ParsePidsFlag() {
-    const std::vector<std::string_view> pids = absl::StrSplit(FLAGS_pids, ",", absl::SkipEmpty());
+  std::chrono::milliseconds TimeUntilNextTick(const time_point now)
+      ABSL_SHARED_LOCKS_REQUIRED(state_lock_) {
+    // Worst case, wake-up every so often.
+    constexpr std::chrono::milliseconds kMaxSleepDuration{1000};
+    auto wakeup_time = now + kMaxSleepDuration;
+    wakeup_time = std::min(wakeup_time, source_->sampling_freq_mgr().next());
 
-    if (pids.size() == 0) {
-      return absl::flat_hash_set<md::UPID>({});
-    }
-
-    // For the UPIDs, we use ASID=0 because UnitConnector is not meant for a multi-host env.
-    constexpr uint32_t kASID = 0;
-
-    // A memory location that will be targeted by absl::SimpleAtoi; see below.
-    uint32_t int_pid;
-
-    // Eventually, this will be the return value from this fn.
-    absl::flat_hash_set<md::UPID> upids;
-
-    // Convert each string view pid to an int, then form a UPID.
-    for (const auto& str_pid : pids) {
-      const bool parsed_ok = absl::SimpleAtoi(str_pid, &int_pid);
-
-      if (!parsed_ok) {
-        return error::Internal(absl::Substitute("Could not parse pid $0 to integer.", str_pid));
-      }
-      PX_ASSIGN_OR_RETURN(const uint64_t ts, system::ProcParser().GetPIDStartTimeTicks(int_pid));
-
-      // Create a upid and add it to the upids set.
-      upids.insert(md::UPID(kASID, int_pid, ts));
-    }
-    return upids;
-  }
-
-  Status VerifyInitted() {
-    if (source_ == nullptr) {
-      return error::Internal("Source connector has not been initted, or was already deallocated.");
-    }
-    if (ctx_ == nullptr) {
-      return error::Internal("Context has not been initted, or was already deallocated.");
-    }
-    return Status::OK();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(wakeup_time - now);
   }
 
   Status TransferDataThread() {
-    // Invoke source_->TransferData() ASAP to drain maps & perf buffers, i.e. because some time may
-    // have elapsed between starting a BPF program and starting the transfer data thread.
-    source_->TransferData(ctx_.get());
-
-    // The run window prevents this thread from going to sleep for very short time frames.
-    // If the thread fails to go to sleep, it will do all the work necessary on the next loop
-    // iteration such that it can go to sleep for a reasonably longer amount of time.
     constexpr auto kRunWindow = std::chrono::milliseconds{1};
-
-    // In stirling.cc, the max sleep duration is 1 second. That makes sense in a context where
-    // every source connector is running in parallel, and we know that there may be a good reason
-    // to periodically wake up. The various source connectors do have significantly different
-    // sampling periods, e.g. perf profiler (long) vs. socket tracer (short).
-    // This is a pedantic check to ensure that the transfer data thread will run within a human
-    // time frame. If it is triggered, someone is working on an interesting case anyway, they
-    // can figure out a new upper bound or a special case somehow.
-    if (source_->sampling_freq_mgr().period() > std::chrono::seconds{90}) {
-      return error::Internal("Source connector has sampling period > 90 seconds.");
-    }
-
-    // If the source connector sampling period is less than the "run window," then
-    // the transfer data thread will never sleep.
-    if (source_->sampling_freq_mgr().period() <= kRunWindow) {
-      return error::Internal("Source connector sampling period is less than run window.");
-    }
-
-    // Time "now". Updated after sleeping or after doing some amount of work.
+    auto time_until_next_tick = std::chrono::milliseconds::zero();
     auto now = std::chrono::steady_clock::now();
 
-    // Create a frequency manager that will cause the context to get refreshed periodically.
     FrequencyManager ctx_freq_mgr;
     ctx_freq_mgr.set_period(std::chrono::milliseconds{200});
+
+    // This value can also be manipulated by the Stop() method.
+    transfer_enable_ = true;
 
     while (transfer_enable_) {
       // To batch up work, i.e. to do more work per wakeup, we want to run our data
@@ -275,20 +146,7 @@ class UnitConnector {
       // time "now" and time "now + window".
       const auto now_plus_run_window = now + kRunWindow;
 
-      // Transfer data from eBPF to user space.
-      if (source_->sampling_freq_mgr().Expired(now_plus_run_window)) {
-        // Read the eBPF perf buffer and map that stores the profiling information.
-        // Data from eBPF is transferred into member data_table_.
-        source_->TransferData(ctx_.get());
-
-        // TransferData() is normally a significant amount of work: update "time now".
-        now = std::chrono::steady_clock::now();
-        source_->sampling_freq_mgr().Reset(now);
-      }
-
-      // Check if we need to refresh the system wide context. This is not necessary if the user
-      // specified a certain PID to trace.
-      if (ctx_refresh_enabled_) {
+      if (FLAGS_pid == 0) {
         if (ctx_freq_mgr.Expired(now_plus_run_window)) {
           ctx_ = std::make_unique<SystemWideStandaloneContext>();
           now = std::chrono::steady_clock::now();
@@ -296,32 +154,63 @@ class UnitConnector {
         }
       }
 
-      // Figure the time of next required data sample.
-      const auto next = source_->sampling_freq_mgr().next();
+      {
+        // Prevent main thread from trying to join or stop the profiler while this is happening.
+        absl::base_internal::SpinLockHolder lock(&state_lock_);
 
-      // Compute the amount of time to sleep.
-      const auto sleep_time = std::chrono::duration_cast<std::chrono::milliseconds>(next - now);
+        // Transfer data from eBPF to user space.
+        if (source_->sampling_freq_mgr().Expired(now_plus_run_window)) {
+          // Read the eBPF perf buffer and map that stores the profiling information.
+          // Data from eBPF is transferred into member data_table_.
+          source_->TransferData(ctx_.get());
 
-      // Sleep, only if sleep_time exceeds the "run window." In other words, do not sleep if within
-      // the next millisecond we will wakeup to sample data or refresh the context.
-      if (sleep_time >= kRunWindow) {
-        std::this_thread::sleep_for(sleep_time);
+          // TransferData() is normally a significant amount of work: update "time now".
+          now = std::chrono::steady_clock::now();
+          source_->sampling_freq_mgr().Reset(now);
+        }
+
+        // Figure the time remaining until the next required data sample or push data.
+        time_until_next_tick = TimeUntilNextTick(now);
+      }
+
+      // Sleep, only if time_until_next_tick exceeds the "run window," i.e. if that time
+      // is long enough that Stirling should go to sleep. Otherwise, don't sleep and loop back
+      // through the sources, with the expectation that one of the sources triggers a call to
+      // either TransferData() or to PushData().
+      if (time_until_next_tick >= kRunWindow) {
+        std::this_thread::sleep_for(time_until_next_tick);
 
         // We just went to sleep: update time now.
         now = std::chrono::steady_clock::now();
       }
     }
-    transfer_exited_ = true;
 
+    source_->TransferData(ctx_.get());
     return Status::OK();
   }
 
   Status StartTransferDataThread() {
-    PX_RETURN_IF_ERROR(RefreshContextAndDeployUProbes());
+    if (FLAGS_pid == 0) {
+      // No PID specified. Go with "system wide" context.
+      ctx_ = std::make_unique<SystemWideStandaloneContext>();
+    } else {
+      // If FLAGS_pid is set, the user wants to collect data from a specific process.
 
-    // About to start the transfer data thread. Level set our state now.
-    transfer_exited_ = false;
-    transfer_enable_ = true;
+      // Get the process start time, used to construct the "UPID" or unique pid.
+      // UPID is conceptually useful when Pixie is running on multiple hosts:
+      // it includes a start timestamp (for recycled pids on a given host) and an address
+      // space id to distinguish between pids on different hosts.
+      PX_ASSIGN_OR_RETURN(const uint64_t ts, system::ProcParser().GetPIDStartTimeTicks(FLAGS_pid));
+
+      // Here, we use zero because the UnitSourceConnector is not meant for a multi-host env.
+      constexpr uint32_t kASID = 0;
+
+      // The stand alone context requires a set of UPIDs. We have just one in that set.
+      const absl::flat_hash_set<md::UPID> upids = {md::UPID(kASID, FLAGS_pid, ts)};
+
+      // Create the context to filter by pid.
+      ctx_ = std::make_unique<StandaloneContext>(upids);
+    }
 
     // Create a thread to periodically read eBPF data.
     transfer_data_thread_ = std::thread(&UnitConnector<T>::TransferDataThread, this);
@@ -330,26 +219,19 @@ class UnitConnector {
   }
 
   Status StopTransferDataThread() {
-    if (transfer_exited_) {
-      return error::Internal("Transfer data thread already stopped.");
-    }
-    if (!transfer_data_thread_.joinable()) {
-      return error::Internal("Transfer data thread not joinable; strange!!");
-    }
-
-    transfer_enable_ = false;
-
-    while (!transfer_exited_) {
-      std::this_thread::sleep_for(std::chrono::milliseconds{500});
-    }
-
-    // This is unlikely, the thread will normally have terminated already.
     if (transfer_data_thread_.joinable()) {
-      transfer_data_thread_.join();
-    }
+      transfer_enable_ = false;
+      {
+        // Prevent transfer_data_thread_ from invoking TransferData().
+        absl::base_internal::SpinLockHolder lock(&state_lock_);
 
-    // Transfer any remaining data from eBPF to user space.
-    source_->TransferData(ctx_.get());
+        // Join the thread.
+        transfer_data_thread_.join();
+
+        // Transfer any remaining data from eBPF to user space.
+        source_->TransferData(ctx_.get());
+      }
+    }
 
     return Status::OK();
   }
@@ -364,14 +246,9 @@ class UnitConnector {
   // A thread that periodically wakes up to read eBPF perf buffers and maps.
   std::thread transfer_data_thread_;
 
-  // To enable/disable automatic system wide context refresh.
-  std::atomic<bool> ctx_refresh_enabled_ = false;
-
-  // State of the transfer data thread: enabled, or exited.
+  // The lock and transfer enable flag are used by transfer_data_thread_.
+  absl::base_internal::SpinLock state_lock_;
   std::atomic<bool> transfer_enable_ = false;
-  std::atomic<bool> transfer_exited_ = false;
-
-  // Top level state, i.e. whether Start() and Stop() methods were called and succeeded.
   std::atomic<bool> started_ = false;
   std::atomic<bool> stopped_ = false;
 

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -27,7 +27,7 @@
 #include "src/stirling/core/data_tables.h"
 #include "src/stirling/core/frequency_manager.h"
 
-DEFINE_string(pids, "", "PIDs to profile, e.g. -pids 132,133. All processes profiled by default.")
+DEFINE_string(pids, "", "PIDs to profile, e.g. -pids 132,133. All processes profiled by default.");
 
 namespace px {
 namespace stirling {
@@ -126,16 +126,15 @@ class UnitConnector {
 
     // Eventually, this will be the return value from this fn.
     absl::flat_hash_set<md::UPID> upids;
-    
+
     // Convert each string view pid to an int, then form a UPID.
     for (const auto& str_pid : str_pids) {
       const bool parsed_ok = absl::SimpleAtoi(str_pid, &pid);
 
       if (!parsed_ok) {
-        return error::Internal(abls::Substitute("Could not parse pid $0 to integer.", str_pid));
+        return error::Internal(absl::Substitute("Could not parse pid $0 to integer.", str_pid));
       }
       PX_ASSIGN_OR_RETURN(const uint64_t ts, system::ProcParser().GetPIDStartTimeTicks(pid));
-
 
       // The stand alone context requires a set of UPIDs. We have just one in that set.
       upids.insert(md::UPID(kASID, pid, ts));
@@ -143,7 +142,7 @@ class UnitConnector {
     return upids;
   }
 
-  Status Init(const absl::flat_hash_set<md::UPID>& upids = {}) {
+  Status Init(absl::flat_hash_set<md::UPID> upids = {}) {
     if (upids.size() == 0) {
       // Init() was called with its default arg., an empty set of UPIDs. Thus, check the value
       // in FLAGS_pids to populate the UPIDs set. The default for FLAGS_pids is an empty

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -121,12 +121,9 @@ class UnitConnector {
 
     if (upids.size() == 0) {
       // The upids set is empty: trace all processes and use automatic context refresh.
-      ctx_refresh_enabled_ = true;
-      ctx_ = std::make_unique<SystemWideStandaloneContext>();
+      ctx_ = std::make_unique<EverythingLocalContext>();
     } else {
       // The upids set is non-empty: we will trace only processes identified by that set.
-      // Disable automatic context refresh.
-      ctx_refresh_enabled_ = false;
       ctx_ = std::make_unique<StandaloneContext>(upids);
     }
 
@@ -145,21 +142,18 @@ class UnitConnector {
     return Status::OK();
   }
 
-  Status RefreshContextAndDeployUProbes() {
+  Status SetClusterCIDR(const std::string& cidr) {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
-    // This method manipulates state normally managed by the transfer data thread. If the transfer
-    // data thread is running, it is an error to try this. If we want to enable this method in
-    // parallel with the transfer data thread, then an we can bring back the shared state lock.
-    if (transfer_enable_) {
-      return error::Internal("Context is being managed by the transfer data thread.");
-    }
+    PX_RETURN_IF_ERROR(ctx_->SetClusterCIDR(cidr));
 
-    if (ctx_refresh_enabled_) {
-      // Pick up new processes.
-      ctx_ = std::make_unique<SystemWideStandaloneContext>();
-    }
+    return Status::OK();
+  }
+
+  Status RefreshContextAndDeployUProbes() {
+    // Pedantic, but better than bravely carrying on if something is wrong here.
+    PX_RETURN_IF_ERROR(VerifyInitted());
 
     // This will block and deploy uprobes.
     source_->InitContext(ctx_.get());
@@ -236,65 +230,26 @@ class UnitConnector {
   }
 
   Status TransferDataThread() {
+    // source_->sampling_freq_mgr().set_period(std::chrono::milliseconds{100});
+    LOG(WARNING) << "source_->sampling_freq_mgr().period().count(): " << source_->sampling_freq_mgr().period().count() << " [ms].";
+
     // Invoke source_->TransferData() ASAP to drain maps & perf buffers, i.e. because some time may
     // have elapsed between starting a BPF program and starting the transfer data thread.
     source_->TransferData(ctx_.get());
 
-    // The run window prevents this thread from going to sleep for very short time frames.
-    // If the thread fails to go to sleep, it will do all the work necessary on the next loop
-    // iteration such that it can go to sleep for a reasonably longer amount of time.
-    constexpr auto kRunWindow = std::chrono::milliseconds{1};
-
-    // In stirling.cc, the max sleep duration is 1 second. That makes sense in a context where
-    // every source connector is running in parallel, and we know that there may be a good reason
-    // to periodically wake up. The various source connectors do have significantly different
-    // sampling periods, e.g. perf profiler (long) vs. socket tracer (short).
-    // This is a pedantic check to ensure that the transfer data thread will run within a human
-    // time frame. If it is triggered, someone is working on an interesting case anyway, they
-    // can figure out a new upper bound or a special case somehow.
+    // Check to ensure that the transfer data thread will run within a human time frame.
+    // If this is triggered, please find a new upper bound or implement a special case.
     if (source_->sampling_freq_mgr().period() > std::chrono::seconds{90}) {
       return error::Internal("Source connector has sampling period > 90 seconds.");
     }
 
-    // If the source connector sampling period is less than the "run window," then
-    // the transfer data thread will never sleep.
-    if (source_->sampling_freq_mgr().period() <= kRunWindow) {
-      return error::Internal("Source connector sampling period is less than run window.");
-    }
-
-    // Time "now". Updated after sleeping or after doing some amount of work.
-    auto now = std::chrono::steady_clock::now();
-
-    // Create a frequency manager that will cause the context to get refreshed periodically.
-    FrequencyManager ctx_freq_mgr;
-    ctx_freq_mgr.set_period(std::chrono::milliseconds{200});
-
     while (transfer_enable_) {
-      // To batch up work, i.e. to do more work per wakeup, we want to run our data
-      // transfer or push data if its desired run time is anywhere between
-      // time "now" and time "now + window".
-      const auto now_plus_run_window = now + kRunWindow;
-
       // Transfer data from eBPF to user space.
-      if (source_->sampling_freq_mgr().Expired(now_plus_run_window)) {
-        // Read the eBPF perf buffer and map that stores the profiling information.
-        // Data from eBPF is transferred into member data_table_.
-        source_->TransferData(ctx_.get());
+      source_->TransferData(ctx_.get());
 
-        // TransferData() is normally a significant amount of work: update "time now".
-        now = std::chrono::steady_clock::now();
-        source_->sampling_freq_mgr().Reset(now);
-      }
-
-      // Check if we need to refresh the system wide context. This is not necessary if the user
-      // specified a certain PID to trace.
-      if (ctx_refresh_enabled_) {
-        if (ctx_freq_mgr.Expired(now_plus_run_window)) {
-          ctx_ = std::make_unique<SystemWideStandaloneContext>();
-          now = std::chrono::steady_clock::now();
-          ctx_freq_mgr.Reset(now);
-        }
-      }
+      // Just slept and ran TransferData(): update "time now" then reset the freq. mamager.
+      const auto now = std::chrono::steady_clock::now();
+      source_->sampling_freq_mgr().Reset(now);
 
       // Figure the time of next required data sample.
       const auto next = source_->sampling_freq_mgr().next();
@@ -302,14 +257,7 @@ class UnitConnector {
       // Compute the amount of time to sleep.
       const auto sleep_time = std::chrono::duration_cast<std::chrono::milliseconds>(next - now);
 
-      // Sleep, only if sleep_time exceeds the "run window." In other words, do not sleep if within
-      // the next millisecond we will wakeup to sample data or refresh the context.
-      if (sleep_time >= kRunWindow) {
-        std::this_thread::sleep_for(sleep_time);
-
-        // We just went to sleep: update time now.
-        now = std::chrono::steady_clock::now();
-      }
+      std::this_thread::sleep_for(sleep_time);
     }
     transfer_exited_ = true;
 
@@ -363,9 +311,6 @@ class UnitConnector {
 
   // A thread that periodically wakes up to read eBPF perf buffers and maps.
   std::thread transfer_data_thread_;
-
-  // To enable/disable automatic system wide context refresh.
-  std::atomic<bool> ctx_refresh_enabled_ = false;
 
   // State of the transfer data thread: enabled, or exited.
   std::atomic<bool> transfer_enable_ = false;

--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -149,11 +149,10 @@ class UnitConnector {
     // Pedantic, but better than bravely carrying on if something is wrong here.
     PX_RETURN_IF_ERROR(VerifyInitted());
 
-    // This method manipulates state normally managed by the transfer data thread.
-    // If the transfer data thread has been started, it is an error to try this.
-    // But, if we want to enable an explicit context refresh and blocking uprobe deploy,
-    // along with the transfer data thread, we can bring back the shared state lock.
-    if (started_ || transfer_enable_) {
+    // This method manipulates state normally managed by the transfer data thread. If the transfer
+    // data thread is running, it is an error to try this. If we want to enable this method in
+    // parallel with the transfer data thread, then an we can bring back the shared state lock.
+    if (transfer_enable_) {
       return error::Internal("Context is being managed by the transfer data thread.");
     }
 

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
@@ -49,7 +49,6 @@ static constexpr std::string_view kNotSymbolizedMessage = "<not symbolized>";
 class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrapper {
  public:
   static constexpr std::string_view kName = "perf_profiler";
-  // -- TODO -- remove -- static constexpr auto kDataTableSchema = kStackTraceTable;
   static constexpr auto kTables = MakeArray(kStackTraceTable);
   static constexpr uint32_t kPerfProfileTableNum = TableNum(kTables, kStackTraceTable);
 

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
@@ -49,6 +49,7 @@ static constexpr std::string_view kNotSymbolizedMessage = "<not symbolized>";
 class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrapper {
  public:
   static constexpr std::string_view kName = "perf_profiler";
+  // -- TODO -- remove -- static constexpr auto kDataTableSchema = kStackTraceTable;
   static constexpr auto kTables = MakeArray(kStackTraceTable);
   static constexpr uint32_t kPerfProfileTableNum = TableNum(kTables, kStackTraceTable);
 

--- a/src/stirling/source_connectors/perf_profiler/stringifier.cc
+++ b/src/stirling/source_connectors/perf_profiler/stringifier.cc
@@ -148,7 +148,7 @@ std::string Stringifier::FoldedStackTraceString(const stack_trace_key_t& key) {
     stack_trace_str = symbolization::kDropMessage;
     DCHECK(u_stack_id == -EEXIST || u_stack_id == -EFAULT) << "u_stack_id: " << u_stack_id;
     DCHECK(k_stack_id == -EEXIST || k_stack_id == -EFAULT) << "k_stack_id: " << k_stack_id;
-    DCHECK(!(k_stack_id == -EFAULT && u_stack_id == -EFAULT)) << "both invalid.";
+    // DCHECK(!(k_stack_id == -EFAULT && u_stack_id == -EFAULT)) << "both invalid.";
   }
 
   return stack_trace_str;

--- a/src/stirling/source_connectors/perf_profiler/stringifier.cc
+++ b/src/stirling/source_connectors/perf_profiler/stringifier.cc
@@ -148,7 +148,7 @@ std::string Stringifier::FoldedStackTraceString(const stack_trace_key_t& key) {
     stack_trace_str = symbolization::kDropMessage;
     DCHECK(u_stack_id == -EEXIST || u_stack_id == -EFAULT) << "u_stack_id: " << u_stack_id;
     DCHECK(k_stack_id == -EEXIST || k_stack_id == -EFAULT) << "k_stack_id: " << k_stack_id;
-    // DCHECK(!(k_stack_id == -EFAULT && u_stack_id == -EFAULT)) << "both invalid.";
+    DCHECK(!(k_stack_id == -EFAULT && u_stack_id == -EFAULT)) << "both invalid.";
   }
 
   return stack_trace_str;

--- a/src/stirling/source_connectors/socket_tracer/amqp_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/amqp_trace_bpf_test.cc
@@ -233,13 +233,12 @@ std::vector<AMQPTraceRecord> GetAMQPTraceRecords(
 //-----------------------------------------------------------------------------
 
 TEST_F(AMQPTraceTest, AMQPCapture) {
-  StartTransferDataThread();
+  ASSERT_OK(source_.Start());
   RunAll();
-  StopTransferDataThread();
+  ASSERT_OK(source_.Stop());
 
-  // Grab the data from Stirling.
-  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kAMQPTableNum);
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  constexpr auto kTableNum = SocketTraceConnector::kAMQPTableNum;
+  ASSERT_OK_AND_ASSIGN(auto record_batch, source_.ConsumeRecords(kTableNum));
 
   {
     std::vector<AMQPTraceRecord> records = GetAMQPTraceRecords(record_batch);

--- a/src/stirling/source_connectors/socket_tracer/cql_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/cql_trace_bpf_test.cc
@@ -390,7 +390,7 @@ Number of rows = 1)",
 //-----------------------------------------------------------------------------
 
 TEST_F(CQLTraceTest, cqlsh_capture) {
-  StartTransferDataThread();
+  ASSERT_OK(source_.Start());
 
   // Run cqlsh as a way of generating traffic.
   // As part of it's startup code, it will perform a bunch of CQL transactions,
@@ -403,12 +403,8 @@ TEST_F(CQLTraceTest, cqlsh_capture) {
   int32_t client_pid;
   ASSERT_TRUE(absl::SimpleAtoi(out, &client_pid));
 
-  StopTransferDataThread();
-
-  // Grab the data from Stirling.
-  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kCQLTableNum);
-
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  ASSERT_OK(source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto record_batch, source_.ConsumeRecords(kCQLTableNum));
 
   // Check client-side tracing results.
   {

--- a/src/stirling/source_connectors/socket_tracer/go_tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/go_tls_trace_bpf_test.cc
@@ -88,7 +88,7 @@ TYPED_TEST_SUITE(GoTLSTraceTest, GoVersions);
 //-----------------------------------------------------------------------------
 
 TYPED_TEST(GoTLSTraceTest, BasicHTTP) {
-  this->StartTransferDataThread();
+  ASSERT_OK(this->source_.Start());
 
   // Run the client in the network of the server, so they can connect to each other.
   PX_CHECK_OK(this->client_.Run(
@@ -97,12 +97,8 @@ TYPED_TEST(GoTLSTraceTest, BasicHTTP) {
       {"--http2=false", "--iters=2", "--sub_iters=5"}));
   this->client_.Wait();
 
-  this->StopTransferDataThread();
-
-  // Grab the data from Stirling.
-  std::vector<TaggedRecordBatch> tablets =
-      this->ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  ASSERT_OK(this->source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto record_batch, this->source_.ConsumeRecords(this->kHTTPTableNum));
 
   {
     const std::vector<size_t> target_record_indices =
@@ -125,7 +121,7 @@ TYPED_TEST(GoTLSTraceTest, BasicHTTP) {
 }
 
 TYPED_TEST(GoTLSTraceTest, BasicHTTP2) {
-  this->StartTransferDataThread();
+  ASSERT_OK(this->source_.Start());
 
   // Run the client in the network of the server, so they can connect to each other.
   PX_CHECK_OK(this->client_.Run(
@@ -134,12 +130,8 @@ TYPED_TEST(GoTLSTraceTest, BasicHTTP2) {
       {"--http2=true", "--iters=2", "--sub_iters=5"}));
   this->client_.Wait();
 
-  this->StopTransferDataThread();
-
-  // Grab the data from Stirling.
-  std::vector<TaggedRecordBatch> tablets =
-      this->ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  ASSERT_OK(this->source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto record_batch, this->source_.ConsumeRecords(this->kHTTPTableNum));
 
   {
     const std::vector<size_t> target_record_indices =

--- a/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
@@ -141,9 +141,6 @@ TEST_P(GRPCTraceTest, CaptureRPCTraceRecord) {
   PX_SET_FOR_SCOPE(FLAGS_socket_tracer_enable_http2_gzip, params.use_compression);
   server_.LaunchServer(params.go_version, params.use_https);
 
-  // Deploy uprobes on the newly launched server.
-  ASSERT_OK(source_.RefreshContextAndDeployUProbes());
-
   ASSERT_OK(source_.Start());
   client_.LaunchClient(params.go_version, params.use_compression, params.use_https, server_.port());
   ASSERT_OK(source_.Stop());

--- a/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
@@ -222,7 +222,7 @@ TEST_F(PyGRPCTraceTest, VerifyTraceRecords) {
   PX_CHECK_OK(server.Run(std::chrono::seconds{60}, /*options*/ {},
                          /*args*/ {"python", "helloworld/greeter_server.py"}));
 
-  ASSERT_OK(source_.RefreshContextAndDeployUProbes());
+  ASSERT_OK(source_.BlockAndDeployUProbes());
 
   PX_CHECK_OK(
       client.Run(std::chrono::seconds{60},

--- a/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
@@ -142,16 +142,13 @@ TEST_P(GRPCTraceTest, CaptureRPCTraceRecord) {
   server_.LaunchServer(params.go_version, params.use_https);
 
   // Deploy uprobes on the newly launched server.
-  RefreshContext(/* blocking_deploy_uprobes */ true);
+  ASSERT_OK(source_.RefreshContextAndDeployUProbes());
 
-  StartTransferDataThread();
-
+  ASSERT_OK(source_.Start());
   client_.LaunchClient(params.go_version, params.use_compression, params.use_https, server_.port());
+  ASSERT_OK(source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto rb, source_.ConsumeRecords(kHTTPTableNum));
 
-  StopTransferDataThread();
-
-  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& rb, tablets);
   const std::vector<size_t> target_record_indices =
       FindRecordIdxMatchesPID(rb, kHTTPUPIDIdx, server_.pid());
   ASSERT_GE(target_record_indices.size(), 1);
@@ -219,7 +216,7 @@ TEST_F(PyGRPCTraceTest, VerifyTraceRecords) {
     return;
   }
 
-  StartTransferDataThread();
+  ASSERT_OK(source_.Start());
 
   testing::PyGRPCHelloWorld client;
   testing::PyGRPCHelloWorld server;
@@ -234,10 +231,8 @@ TEST_F(PyGRPCTraceTest, VerifyTraceRecords) {
   // The client sends only 1 request and then exits. So we can wait for it to finish.
   client.Wait();
 
-  StopTransferDataThread();
-
-  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& rb, tablets);
+  ASSERT_OK(source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto rb, source_.ConsumeRecords(kHTTPTableNum));
 
   const std::vector<size_t> target_record_indices =
       FindRecordIdxMatchesPID(rb, kHTTPUPIDIdx, server.process_pid());

--- a/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
@@ -221,6 +221,9 @@ TEST_F(PyGRPCTraceTest, VerifyTraceRecords) {
   // First start the server so the process can be detected by socket tracer.
   PX_CHECK_OK(server.Run(std::chrono::seconds{60}, /*options*/ {},
                          /*args*/ {"python", "helloworld/greeter_server.py"}));
+
+  ASSERT_OK(source_.RefreshContextAndDeployUProbes());
+
   PX_CHECK_OK(
       client.Run(std::chrono::seconds{60},
                  /*options*/ {absl::Substitute("--network=container:$0", server.container_name())},

--- a/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/mux_trace_bpf_test.cc
@@ -140,18 +140,13 @@ mux::Record RecordWithType(mux::Type req_type) {
 //-----------------------------------------------------------------------------
 
 TEST_F(MuxTraceTest, Capture) {
-  StartTransferDataThread();
-
+  ASSERT_OK(source_.Start());
   ASSERT_OK(RunThriftMuxClient());
-
-  StopTransferDataThread();
-
-  // Grab the data from Stirling.
-  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kMuxTableNum);
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& record_batch, tablets);
+  ASSERT_OK(source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto rb, source_.ConsumeRecords(SocketTraceConnector::kMuxTableNum));
 
   std::vector<mux::Record> server_records =
-      GetTargetRecords<mux::Record>(record_batch, server_.process_pid());
+      GetTargetRecords<mux::Record>(rb, server_.process_pid());
 
   mux::Record tinitCheck = RecordWithType(mux::Type::kRerrOld);
   mux::Record tinit = RecordWithType(mux::Type::kTinit);

--- a/src/stirling/source_connectors/socket_tracer/nats_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/nats_trace_bpf_test.cc
@@ -86,7 +86,7 @@ auto EqualsNATSTraceRecord(std::string cmd, std::string options, std::string res
 
 // Tests that a series of commands issued by the test client were traced.
 TEST_P(NATSTraceBPFTest, VerifyBatchedCommands) {
-  StartTransferDataThread();
+  ASSERT_OK(source_.Start());
 
   std::vector<std::string> args;
   if (!GetParam()) {
@@ -101,11 +101,8 @@ TEST_P(NATSTraceBPFTest, VerifyBatchedCommands) {
 
   client_container_.Wait();
 
-  StopTransferDataThread();
-
-  std::vector<TaggedRecordBatch> tablets = ConsumeRecords(SocketTraceConnector::kNATSTableNum);
-
-  ASSERT_NOT_EMPTY_AND_GET_RECORDS(const types::ColumnWrapperRecordBatch& records, tablets);
+  ASSERT_OK(source_.Stop());
+  ASSERT_OK_AND_ASSIGN(auto records, source_.ConsumeRecords(SocketTraceConnector::kNATSTableNum));
 
   EXPECT_THAT(
       GetNATSTraceRecords(records, server_pid),

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -99,12 +99,6 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTrac
 
   // Returns the trace records of the process specified by the input pid.
   TraceRecords GetTraceRecords(int pid, const types::ColumnWrapperRecordBatch& record_batch) {
-    // std::vector<TaggedRecordBatch> tablets =
-    //     this->ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
-    // if (tablets.empty()) {
-    //   return {};
-    // }
-    // types::ColumnWrapperRecordBatch record_batch = tablets[0].records;
     std::vector<size_t> server_record_indices =
         FindRecordIdxMatchesPID(record_batch, kHTTPUPIDIdx, pid);
     std::vector<http::Record> http_records =

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -93,6 +93,7 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   static constexpr auto kTables =
       MakeArray(kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable,
                 kRedisTable, kNATSTable, kKafkaTable, kMuxTable, kAMQPTable);
+  // -- TODO -- remove -- static constexpr auto kDataTableSchema = kTables;
 
   static constexpr uint32_t kConnStatsTableNum = TableNum(kTables, kConnStatsTable);
   static constexpr uint32_t kHTTPTableNum = TableNum(kTables, kHTTPTable);
@@ -110,8 +111,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   // TODO(yzhao): This is not used right now. Eventually use this to control data push frequency.
   static constexpr auto kPushPeriod = std::chrono::milliseconds{1000};
 
-  static std::unique_ptr<SourceConnector> Create(std::string_view name) {
-    return std::unique_ptr<SourceConnector>(new SocketTraceConnector(name));
+  static std::unique_ptr<SocketTraceConnector> Create(std::string_view name) {
+    return std::unique_ptr<SocketTraceConnector>(new SocketTraceConnector(name));
   }
 
   Status InitImpl() override;

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -93,7 +93,6 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   static constexpr auto kTables =
       MakeArray(kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable,
                 kRedisTable, kNATSTable, kKafkaTable, kMuxTable, kAMQPTable);
-  // -- TODO -- remove -- static constexpr auto kDataTableSchema = kTables;
 
   static constexpr uint32_t kConnStatsTableNum = TableNum(kTables, kConnStatsTable);
   static constexpr uint32_t kHTTPTableNum = TableNum(kTables, kHTTPTable);

--- a/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
@@ -50,6 +50,8 @@ class SocketTraceBPFTestFixture : public ::testing::Test {
     FLAGS_treat_loopback_as_in_cluster = !EnableClientSideTracing;
     ASSERT_OK(source_.Init());
 
+    source_.RawPtr()->sampling_freq_mgr().set_period(std::chrono::milliseconds{100});
+
     if constexpr (EnableClientSideTracing) {
       // This makes the Stirling interpret all traffic as leaving the cluster,
       // which means client-side tracing will also apply.

--- a/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
@@ -28,6 +28,7 @@
 
 #include "src/common/testing/testing.h"
 #include "src/stirling/core/data_tables.h"
+#include "src/stirling/core/unit_connector.h"
 #include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
 #include "src/stirling/testing/common.h"
 
@@ -47,104 +48,31 @@ class SocketTraceBPFTestFixture : public ::testing::Test {
     // TODO(oazizi): Setting flags in the test is a bad idea because of the pitfall above.
     //               Change this paradigm.
     FLAGS_treat_loopback_as_in_cluster = !EnableClientSideTracing;
-
-    auto source_connector = SocketTraceConnector::Create("socket_trace_connector");
-
-    source_.reset(dynamic_cast<SocketTraceConnector*>(source_connector.release()));
-    ASSERT_OK(source_->Init());
-
-    source_->set_data_tables(data_tables_.tables());
-
-    // Cause Uprobes to deploy in a blocking manner.
-    // We don't return until the first set of uprobes has successfully deployed.
-    RefreshContext(/* blocking_deploy_uprobes */ true);
+    ASSERT_OK(source_.Init());
   }
 
-  void TearDown() override { ASSERT_OK(source_->Stop()); }
+  void TearDown() override { ASSERT_OK(source_.Stop()); }
 
   void ConfigureBPFCapture(traffic_protocol_t protocol, uint64_t role) {
-    auto* socket_trace_connector = dynamic_cast<SocketTraceConnector*>(source_.get());
+    auto* socket_trace_connector = dynamic_cast<SocketTraceConnector*>(source_.RawPtr());
     ASSERT_OK(socket_trace_connector->UpdateBPFProtocolTraceRole(protocol, role));
   }
 
   void TestOnlySetTargetPID(int64_t pid) {
     FLAGS_test_only_socket_trace_target_pid = pid;
-    auto* socket_trace_connector = dynamic_cast<SocketTraceConnector*>(source_.get());
+    auto* socket_trace_connector = dynamic_cast<SocketTraceConnector*>(source_.RawPtr());
     ASSERT_OK(socket_trace_connector->TestOnlySetTargetPID());
   }
 
-  void RefreshContext(bool blocking_deploy_uprobes = false) {
-    absl::base_internal::SpinLockHolder lock(&socket_tracer_state_lock_);
-
-    RefreshContextCore();
-
-    if (blocking_deploy_uprobes) {
-      source_->InitContext(ctx_.get());
-    }
-  }
-
-  void StartTransferDataThread() {
-    // Drain the perf buffers before starting the thread.
-    // Otherwise, perf buffers may already be full, causing lost events and flaky test results.
-    source_->PollPerfBuffers();
-
-    transfer_data_thread_ = std::thread([this]() {
-      transfer_enable_ = true;
-      while (transfer_enable_) {
-        {
-          absl::base_internal::SpinLockHolder lock(&socket_tracer_state_lock_);
-          RefreshContextCore();
-          source_->TransferData(ctx_.get());
-        }
-        std::this_thread::sleep_for(kTransferDataPeriod);
-      }
-    });
-
-    while (!transfer_enable_) {
-    }
-
-    // Wait for at least one TransferData() call before returning.
-    std::this_thread::sleep_for(kTransferDataPeriod);
-  }
-
-  void StopTransferDataThread() {
-    // Give enough time for one more TransferData call by transfer_data_thread_,
-    // so we make sure we've captured everything.
-    std::this_thread::sleep_for(2 * kTransferDataPeriod);
-
-    absl::base_internal::SpinLockHolder lock(&socket_tracer_state_lock_);
-    CHECK(transfer_data_thread_.joinable());
-    transfer_enable_ = false;
-    transfer_data_thread_.join();
-  }
-
-  std::vector<TaggedRecordBatch> ConsumeRecords(int table_num) {
-    return source_->data_tables()[table_num]->ConsumeRecords();
-  }
-
+  static constexpr int kCQLTableNum = SocketTraceConnector::kCQLTableNum;
   static constexpr int kHTTPTableNum = SocketTraceConnector::kHTTPTableNum;
+  static constexpr int kPGSQLTableNum = SocketTraceConnector::kPGSQLTableNum;
+  static constexpr int kRedisTableNum = SocketTraceConnector::kRedisTableNum;
+  static constexpr int kKafkaTableNum = SocketTraceConnector::kKafkaTableNum;
   static constexpr int kMySQLTableNum = SocketTraceConnector::kMySQLTableNum;
+  static constexpr int kConnStatsTableNum = SocketTraceConnector::kConnStatsTableNum;
 
-  absl::base_internal::SpinLock socket_tracer_state_lock_;
-
-  std::unique_ptr<SocketTraceConnector> source_;
-  std::unique_ptr<SystemWideStandaloneContext> ctx_;
-  std::atomic<bool> transfer_enable_ = false;
-  std::thread transfer_data_thread_;
-  DataTables data_tables_{SocketTraceConnector::kTables};
-
-  static constexpr std::chrono::milliseconds kTransferDataPeriod{100};
-
- private:
-  void RefreshContextCore() {
-    ctx_ = std::make_unique<SystemWideStandaloneContext>();
-
-    if (EnableClientSideTracing) {
-      // This makes the Stirling interpret all traffic as leaving the cluster,
-      // which means client-side tracing will also apply.
-      PX_CHECK_OK(ctx_->SetClusterCIDR("1.2.3.4/32"));
-    }
-  }
+  UnitConnector<SocketTraceConnector> source_;
 };
 
 }  // namespace testing

--- a/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h
@@ -49,6 +49,12 @@ class SocketTraceBPFTestFixture : public ::testing::Test {
     //               Change this paradigm.
     FLAGS_treat_loopback_as_in_cluster = !EnableClientSideTracing;
     ASSERT_OK(source_.Init());
+
+    if constexpr (EnableClientSideTracing) {
+      // This makes the Stirling interpret all traffic as leaving the cluster,
+      // which means client-side tracing will also apply.
+      ASSERT_OK(source_.SetClusterCIDR("1.2.3.4/32"));
+    }
   }
 
   void TearDown() override { ASSERT_OK(source_.Stop()); }


### PR DESCRIPTION
Summary: Convert socket tracer test cases to use `UnitConnector`. This will share code across source connector test cases.

Type of change: /kind cleanup

Test Plan: Existing tests passing.
