### PR TITLE
Exempt qemu from tmpfs sandbox

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,7 +54,9 @@ build --strip=never
 # when multiple instances are running simultaneously.
 # It is also generally not a bad idea, since it improves heremeticity.
 # For more context, see: https://github.com/bazelbuild/bazel/issues/3236
-test --sandbox_tmpfs_path=/tmp
+# We can't use this for qemu because it breaks the 9p fs. Since we can't
+# remove these flags we just set them for all our configs.
+test:tmp_sandbox --sandbox_tmpfs_path=/tmp
 
 # This flag prevents rules_docker from transitioning the platform for our images.
 # Since our target platform is the same as the containers we use,
@@ -95,21 +97,25 @@ test:aarch64_sysroot --test_timeout=180,600,1800,3600
 test:aarch64_sysroot --test_env=QEMU_STRACE
 test:aarch64_sysroot --test_tag_filters=-no_libcpp,-requires_root,-requires_bpf,-disabled,-requires_full_qemu_emulation
 
-
 # Build for Clang using Libc++.
 build:clang --config=clang-base
 build:clang --//bazel:enable_libcpp
 build:clang --features=libc++ --features=-libstdc++
 build:clang --build_tag_filters=-no_libcpp
 build:clang --test_tag_filters=-no_libcpp,-requires_root,-requires_bpf,-disabled
-
+test:clang --config=tmp-sandbox
 
 # Build for Clang with libstdc++:
 build:clang-libstdc++ --config=clang-base
 build:clang-libstdc++ --//bazel/cc_toolchains:compiler=clang
 build:clang-libstdc++ --//bazel/cc_toolchains:libc_version=gnu
+test:clang-libstdc++ --config=tmp-sandbox
 
-build:qemu-bpf --config=clang
+build:qemu-bpf --config=clang-base
+build:qemu-bpf --//bazel:enable_libcpp
+build:qemu-bpf --features=libc++ --features=-libstdc++
+build:qemu-bpf --build_tag_filters=-no_libcpp
+build:qemu-bpf --test_tag_filters=-no_libcpp,-requires_root,-requires_bpf,-disabled
 build:qemu-bpf --sandbox_fake_username
 build:qemu-bpf --//bazel/cc_toolchains:libc_version=glibc2_36
 build:qemu-bpf --//bazel/test_runners:test_runner=qemu_with_kernel
@@ -127,6 +133,7 @@ build:gcc --copt -Wno-error=maybe-uninitialized
 build:gcc --build_tag_filters=-no_gcc
 build:gcc --test_tag_filters=-no_gcc,-requires_root,-requires_bpf,-disabled
 build:gcc --//bazel/cc_toolchains:compiler=gcc
+test:gcc --config=tmp-sandbox
 
 
 # bazel build --config asan ...


### PR DESCRIPTION
Summary: Tmpfs does not work with qemu because we can't use tmpfs to host a plan9 volume right now.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: This works without changing sandbox tmpfs setting:
```bazel test -c opt --config=qemu-bpf  --cache_test_results=no --remote_download_outputs=all //src/stirling/source_connectors/socket_tracer:redis_trace_bpf_test --test_output=streamed --//bazel/test_runners/qemu_with_kernel:kernel_version=latest```

The rest of the test should pass in Jenkins. #ci:bpf-build.

