### PR TITLE
[ci/bazel_build_deps] Fail if any piped command fails

### DIFF
--- a/ci/bazel_build_deps.sh
+++ b/ci/bazel_build_deps.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+set -o pipefail
 
 # This script finds all the Bazel targets based on which files are changed and flags passed in.
 


### PR DESCRIPTION
Summary: We implicitly ignored `bazel cquery` failures in `ci/bazel_build_deps.sh`, causing issues with .bazelrc configs to run 0 tests instead of failing when running `ci/bazel_build_deps.sh`.
This adds `set -o pipefail` so that piped commands still cause errors.

Type of change: /kind cleanup

Test Plan: Tested that `./ci/bazel_build_deps.sh` returns an exit code when there's an error in the .bazelrc config.
