### PR TITLE
Command Palette Reducers

### DIFF
--- a/src/ui/src/components/command-palette/providers/command-provider.ts
+++ b/src/ui/src/components/command-palette/providers/command-provider.ts
@@ -46,17 +46,28 @@ export interface CommandCompletion {
   cta?: CommandCta;
 }
 
-export interface CommandProviderResult {
+export interface CommandProviderState {
+  input: string;
+  selection: [start: number, end: number];
   providerName: string;
+  loading: boolean;
   completions: CommandCompletion[];
   hasAdditionalMatches: boolean;
   cta?: CommandCta;
 }
 
+export type CommandProviderDispatchAction = (
+  // Invoke: tell the provider to start looking for results and to dispatch updates to itself as they come in
+  { type: 'invoke', input: string; selection: [start: number, end: number ] }
+  // Cancel: tells the provider to stop any running searches and consider itself loaded (if not already)
+  | { type: 'cancel' }
+);
+
 /**
- * A React hook (to can access contexts) that returns a callback to fetch input completions to the command palette.
+ * A React hook that returns a [state, dispatch] from useReducer(), to fetch input completions to the command palette.
  * Note: these are consumed in CommandPaletteContextProvider; can't use anything from that context (dependency cycle).
  */
-export type CommandProvider = () => (
-  (input: string, selection: [start: number, end: number]) => Promise<CommandProviderResult>
-);
+export type CommandProvider = () => [
+  state: CommandProviderState,
+  dispatch: React.Dispatch<CommandProviderDispatchAction>,
+];

--- a/src/ui/src/components/command-palette/providers/script/missing-script-provider.tsx
+++ b/src/ui/src/components/command-palette/providers/script/missing-script-provider.tsx
@@ -21,22 +21,232 @@ import * as React from 'react';
 import { PixieAPIContext, PixieAPIClient } from 'app/api';
 import { ClusterContext } from 'app/common/cluster-context';
 import { PixieCommandIcon as ScriptIcon } from 'app/components';
-import { parse } from 'app/components/command-palette/parser';
-import { CommandProvider } from 'app/components/command-palette/providers/command-provider';
+import { parse, ParseResult, Token } from 'app/components/command-palette/parser';
+import {
+  CommandCompletion,
+  CommandProvider,
+  CommandProviderDispatchAction,
+  CommandProviderState,
+} from 'app/components/command-palette/providers/command-provider';
 import { ScriptsContext } from 'app/containers/App/scripts-context';
+import { ScriptContext } from 'app/context/script-context';
+import { CancellablePromise, makeCancellable } from 'app/utils/cancellable-promise';
+import { checkExhaustive } from 'app/utils/check-exhaustive';
+import { Script } from 'app/utils/script-bundle';
 import { highlightNamespacedScoredMatch, highlightScoredMatch } from 'app/utils/string-search';
 
+import { CommandPaletteContext } from '../../command-palette-context';
 import {
   CompletionDescription,
   CompletionLabel,
   getSelectedKeyAndValueToken,
   quoteIfNeeded,
 } from './script-provider-common';
+import { getScriptCommandCta } from './script-provider-cta';
 import {
   getAllFieldSuggestions,
   getFullScriptSuggestions,
   getSuggestedArgsFromPossibleEntity,
 } from './script-suggestions';
+
+type DecoratedCompletion = CommandCompletion & { forScript: string };
+
+const DEFAULT: CommandProviderState = Object.freeze({
+  input: '',
+  selection: [0, 0],
+  providerName: 'MissingScriptProvider',
+  loading: false,
+  completions: [],
+  hasAdditionalMatches: false,
+});
+
+function getCompletionsFromArgMatch(
+  parsed: ParseResult,
+  presentKeys: string[],
+  possibleScripts: Script[],
+): DecoratedCompletion[] {
+  const completions = [];
+  for (const argScript of possibleScripts) {
+    const candidates = argScript.vis.variables.map(v => v.name);
+    const matches = candidates.map(c => {
+      for (const p of presentKeys) {
+        const h = highlightScoredMatch(p, c);
+        return { arg: c, search: p, match: h };
+      }
+    }).filter(m => m.match.isMatch);
+    if (!matches.length) continue; // Only looking for scripts where at least one arg matches
+
+    matches.sort((ma, mb) => ma.match.distance - mb.match.distance);
+    const goToArg = matches[0];
+    goToArg.match.distance += 1; // Penalize arg and entity matches compared to script name matches for sorting later
+    const adjustedHighlight = goToArg.match.highlights.map(v => v + `${argScript.id} (`.length);
+    completions.push({
+      match: goToArg.match,
+      forScript: argScript.id,
+      heading: 'Script Arguments',
+      key: `missing_script_entity_${argScript.id}`,
+      description: (
+        <CompletionDescription
+          title={argScript.id}
+          body={argScript.description}
+          hint={`matched on argument: ${goToArg.arg}`}
+        />
+      ),
+      label: (
+        <CompletionLabel
+          input={`${argScript.id} (${goToArg.arg})`}
+          // eslint-disable-next-line react-memo/require-usememo
+          icon={<ScriptIcon />}
+          highlights={adjustedHighlight}
+        />
+      ),
+      onSelect: () => {
+        const argNames = argScript.vis.variables.map(v => v.name);
+        argNames.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
+
+        let out = `script:${quoteIfNeeded(argScript.id)}`;
+        let caret = 0;
+        for (const arg of argNames) {
+          const dflt = argScript.vis.variables.find(a => a.name === arg).defaultValue ?? '';
+          const val = parsed.kvMap?.get(arg) ?? /* TODO: Consider the bare value that partially matched here */ dflt;
+          out += ` ${arg}:${quoteIfNeeded(val)}`;
+          if (!caret || arg === goToArg.arg) caret = out.length;
+        }
+
+        return [out, caret];
+      },
+    });
+  }
+
+  return completions;
+}
+
+async function getCompletionsFromEntityMatch(
+  keyToken: Token,
+  valueToken: Token,
+  parsed: ParseResult,
+  possibleScripts: Script[],
+  clusterUID: string,
+  client: PixieAPIClient,
+  scripts: Map<string, Script>,
+): Promise<DecoratedCompletion[]> {
+  const completions = [];
+  if (!keyToken && valueToken?.value.length && possibleScripts.length > 0) {
+    if (!parsed.kvMap?.size) {
+      const entitySuggestions = await getAllFieldSuggestions(valueToken.value, clusterUID, client);
+      const matchedByEntity = getSuggestedArgsFromPossibleEntity(possibleScripts, entitySuggestions);
+
+      for (const scriptId in matchedByEntity) {
+        const cs = scripts.get(scriptId);
+        const goToArg = [...Object.keys(matchedByEntity[scriptId])][0];
+
+        completions.push({
+          match: {
+            isMatch: true,
+            // This match came from Elastic, which is using a totally different matching method than the UI does.
+            // So, we roughly convert the quality of that match to vaguely resemble what the UI measures.
+            // We also penalize it a little bit compared to arg matches and script name matches for sorting.
+            distance: Math.abs(goToArg.length - matchedByEntity[scriptId][goToArg][0].matchedIndexes.length) + 2,
+            highlights: [], // We're not actually highlighting here; the search was run against a different string.
+          },
+          forScript: scriptId,
+          heading: 'Entities for Script Arguments',
+          key: `missing_script_entity_${scriptId}`,
+          description: (
+            <CompletionDescription
+              title={cs.id}
+              body={cs.description}
+              hint={`matched on argument: ${goToArg}`}
+            />
+          ),
+          label: (
+            // eslint-disable-next-line react-memo/require-usememo
+            <CompletionLabel input={`${scriptId} (${goToArg})`} icon={<ScriptIcon />} highlights={[]} />
+          ),
+          onSelect: () => {
+            const argNames = cs.vis.variables.map(v => v.name);
+            argNames.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
+
+            let out = `script:${quoteIfNeeded(cs.id)}`;
+            let caret = 0;
+            for (const arg of argNames) {
+              const dflt = cs.vis.variables.find(a => a.name === arg).defaultValue ?? '';
+              const val = (arg === goToArg ? valueToken.value : parsed.kvMap?.get(arg)) ?? dflt;
+              out += ` ${arg}:${quoteIfNeeded(val)}`;
+              if (!caret || arg === goToArg) caret = out.length;
+            }
+
+            return [out, caret];
+          },
+        });
+      }
+    }
+    // NOTE: If this line is reached, we have a bare value, no script, and there ARE other keys. For now, this will
+    //  just stick to the arg-matching logic above and not try to handle the bare value.
+  }
+
+  return completions;
+}
+
+function getCompletionsFromScriptNameMatch(
+  keyToken: Token,
+  valueToken: Token,
+  parsed: ParseResult,
+  possibleScripts: Script[],
+): DecoratedCompletion[] {
+  const highlightedIds = possibleScripts.map(s => ({
+    script: s,
+    match: highlightNamespacedScoredMatch(
+      parsed.kvMap?.get('script') ?? valueToken?.value ?? parsed.input,
+      s.id,
+      '/',
+    ),
+  }));
+
+  return highlightedIds.filter(({ match }) => match.isMatch).map(({ script: cs, match }) => ({
+    match,
+    forScript: cs.id,
+    heading: 'Scripts',
+    key: `missing_script_${cs.id}`,
+    description: <CompletionDescription title={cs.id} body={cs.description} />,
+    label: (
+      // eslint-disable-next-line react-memo/require-usememo
+      <CompletionLabel input={cs.id} icon={<ScriptIcon />} highlights={match.highlights} />
+    ),
+    onSelect: () => {
+      const argNames = cs.vis.variables.map(v => v.name);
+      argNames.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
+
+      let out = `script:${quoteIfNeeded(cs.id)}`;
+      let caret = 0;
+      for (const arg of argNames) {
+        const dflt = cs.vis.variables.find(a => a.name === arg).defaultValue ?? '';
+        const val = parsed.kvMap?.get(arg) ?? dflt;
+        out += ` ${arg}:${quoteIfNeeded(val)}`;
+        if (!caret || arg === keyToken?.value) caret = out.length;
+      }
+
+      return [out, caret];
+    },
+  }));
+}
+
+function collect(
+  fromNames: DecoratedCompletion[],
+  fromArgs: DecoratedCompletion[],
+  fromEntities: DecoratedCompletion[],
+) {
+  const seenScripts = new Set<string>();
+  const completions = [];
+  for (const comp of [...fromNames, ...fromArgs, ...fromEntities]) {
+    if (seenScripts.has(comp.forScript)) continue;
+    seenScripts.add(comp.forScript);
+    completions.push(comp);
+  }
+
+  completions.sort((a, b) => a.match.distance - b.match.distance);
+  return completions;
+}
 
 /**
  * If the input doesn't currently have a `script:something` pair, try suggesting scripts that make sense with the input.
@@ -47,26 +257,53 @@ export const useMissingScriptProvider: CommandProvider = () => {
   const clusterUID = React.useContext(ClusterContext)?.selectedClusterUID ?? null;
   const client = React.useContext(PixieAPIContext) as PixieAPIClient;
   const scripts = React.useContext(ScriptsContext)?.scripts;
+  const { setScriptAndArgs } = React.useContext(ScriptContext);
+  const { setOpen } = React.useContext(CommandPaletteContext);
 
-  return React.useCallback(async (input, selection) => {
-    const noMatchesOutput = { providerName: 'PxL Scripts', completions: [], hasAdditionalMatches: false };
+  const [promises, setPromises] = React.useState<CancellablePromise[]>([]);
+  const [state, setState] = React.useState<CommandProviderState>(DEFAULT);
 
+  const invoke = React.useCallback((
+    input: string,
+    selection: [start: number, end: number],
+  ) => {
     const parsed = parse(input, selection);
+    const { keyToken, valueToken } = getSelectedKeyAndValueToken(parsed);
     const hasScriptKey = parsed.kvMap?.has('script');
     const script = scripts?.get(parsed.kvMap?.get('script') ?? '') ?? null;
+    const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
 
     // This provider is only relevant if there is NOT a known script selected yet, and there are scripts to find.
-    if (script || !scripts) return noMatchesOutput;
+    // It also expects there to be input, either one long string or a focused (selecting only one key/val pair) input.
+    const selectionTooBroad = keyToken && valueToken && keyToken.relatedToken !== valueToken;
+    const inputIsOneLongString = parsed.tokens.every(({ type }) => type === 'value' || type === 'none');
 
-    const { keyToken, valueToken } = getSelectedKeyAndValueToken(parsed);
+    if (
+      !input.trim().length
+      || script
+      || !scripts
+      || (selectionTooBroad && !inputIsOneLongString)
+      || (!keyToken && !valueToken)
+    ) {
+      setState(DEFAULT);
+      return [];
+    }
+
+    // We have input, but there are no keys... try again as if it were one string
+    if (inputIsOneLongString && parsed.tokens.length > 1) {
+      const newInput = quoteIfNeeded(parsed.tokens.map(({ text }) => text).join('').trim());
+      return invoke(newInput, selection);
+    }
 
     // We're filling the script arg itself, skip all remaining logic
     if (keyToken?.value === 'script') {
       const partial = valueToken?.value ?? '';
-      return {
-        providerName: 'PxL Scripts',
+      setState({
+        ...DEFAULT,
+        cta,
         ...getFullScriptSuggestions(partial, scripts),
-      };
+      });
+      return [];
     }
 
     let possibleScripts = [...scripts.values()];
@@ -74,7 +311,8 @@ export const useMissingScriptProvider: CommandProvider = () => {
     // If there's a script:something but it doesn't match a known script yet, filter the possible matches based on that
     if (hasScriptKey && !script && keyToken?.value !== 'script') {
       const partial = parsed.kvMap.get('script');
-      possibleScripts = possibleScripts.filter(({ id }) => highlightScoredMatch(partial, id).highlights.length > 0);
+      possibleScripts = possibleScripts.filter(
+        ({ id }) => highlightNamespacedScoredMatch(partial, id, '/').isMatch);
     }
 
     // Now, look for scripts in the remaining options that have at least one of the args present in the input.
@@ -82,174 +320,50 @@ export const useMissingScriptProvider: CommandProvider = () => {
     const presentKeys = [...(parsed.kvMap?.keys() ?? [])].filter(k => k !== 'script');
     if (valueToken?.value && !keyToken) presentKeys.push(valueToken.value);
 
-    const completionsFromArgMatch = [];
-    for (const argScript of possibleScripts) {
-      const candidates = argScript.vis.variables.map(v => v.name);
-      const matches = candidates.map(c => {
-        for (const p of presentKeys) {
-          const h = highlightScoredMatch(p, c);
-          return { arg: c, search: p, match: h };
-        }
-      }).filter(m => m.match.isMatch);
-      if (!matches.length) continue; // Only looking for scripts where at least one arg matches
+    const fromArgs = getCompletionsFromArgMatch(parsed, presentKeys, possibleScripts);
+    const fromEntitiesPromise = makeCancellable(getCompletionsFromEntityMatch(
+      keyToken, valueToken, parsed, possibleScripts, clusterUID, client, scripts));
+    const fromNames = getCompletionsFromScriptNameMatch(keyToken, valueToken, parsed, possibleScripts);
 
-      matches.sort((ma, mb) => ma.match.distance - mb.match.distance);
-      const goToArg = matches[0];
-      goToArg.match.distance += 1; // Penalize arg and entity matches compared to script name matches for sorting later
-      const adjustedHighlight = goToArg.match.highlights.map(v => v + `${argScript.id} (`.length);
-      completionsFromArgMatch.push({
-        match: goToArg.match,
-        forScript: argScript.id,
-        heading: 'Script Arguments',
-        key: `missing_script_entity_${argScript.id}`,
-        description: (
-          <CompletionDescription
-            title={argScript.id}
-            body={argScript.description}
-            hint={`matched on argument: ${goToArg.arg}`}
-          />
-        ),
-        label: (
-          <CompletionLabel
-            input={`${argScript.id} (${goToArg.arg})`}
-            // eslint-disable-next-line react-memo/require-usememo
-            icon={<ScriptIcon />}
-            highlights={adjustedHighlight}
-          />
-        ),
-        onSelect: () => {
-          const argNames = argScript.vis.variables.map(v => v.name);
-          argNames.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
+    const firstCompletions = collect(fromNames, fromArgs, []);
+    setState({
+      ...DEFAULT,
+      loading: true,
+      completions: firstCompletions.slice(0, 25),
+      hasAdditionalMatches: firstCompletions.length > 25,
+      cta,
+    });
 
-          let out = `script:${quoteIfNeeded(argScript.id)}`;
-          let caret = 0;
-          for (const arg of argNames) {
-            const dflt = argScript.vis.variables.find(a => a.name === arg).defaultValue ?? '';
-            const val = parsed.kvMap?.get(arg) ?? /* TODO: Consider the bare value that partially matched here */ dflt;
-            out += ` ${arg}:${quoteIfNeeded(val)}`;
-            if (!caret || arg === goToArg.arg) caret = out.length;
-          }
-
-          return [out, caret];
-        },
+    fromEntitiesPromise.then((fromEntities) => {
+      const finalCompletions = collect(fromNames, fromArgs, fromEntities);
+      setState({
+        ...DEFAULT,
+        loading: false,
+        completions: finalCompletions.slice(0, 25),
+        hasAdditionalMatches: finalCompletions.length > 25,
+        cta,
       });
+    });
+
+    return [fromEntitiesPromise];
+  }, [client, clusterUID, scripts, setOpen, setScriptAndArgs]);
+
+  const dispatch = React.useCallback((action: CommandProviderDispatchAction) => {
+    const { type } = action;
+    switch (type) {
+      case 'cancel':
+        for (const p of promises) p.cancel();
+        setState((prev) => ({ ...prev, loading: false }));
+        break;
+      case 'invoke':
+        for (const p of promises) p.cancel();
+        setState({ ...DEFAULT, loading: true });
+        setPromises(invoke(action.input, action.selection));
+        // Invoke it all here...
+        break;
+      default: checkExhaustive(type);
     }
+  }, [promises, invoke]);
 
-    // If there are no keys at all yet, just filter the script list
-    const completionsFromEntityMatch = [];
-    if (!keyToken && valueToken?.value.length && possibleScripts.length > 0) {
-      if (!parsed.kvMap?.size) {
-        const entitySuggestions = await getAllFieldSuggestions(valueToken.value, clusterUID, client);
-        const matchedByEntity = getSuggestedArgsFromPossibleEntity(possibleScripts, entitySuggestions);
-
-        // TODO: This is wrong if we're matching on an arg with a bare value token. Gotta split that logic out.
-        possibleScripts = possibleScripts.filter(({ id }) => (
-          highlightNamespacedScoredMatch(valueToken.value, id, '/').isMatch
-        ));
-        for (const scriptId in matchedByEntity) {
-          const cs = scripts.get(scriptId);
-          const goToArg = [...Object.keys(matchedByEntity[scriptId])][0];
-
-          completionsFromEntityMatch.push({
-            match: {
-              isMatch: true,
-              // This match came from Elastic, which is using a totally different matching method than the UI does.
-              // So, we roughly convert the quality of that match to vaguely resemble what the UI measures.
-              // We also penalize it a little bit compared to arg matches and script name matches for sorting.
-              distance: Math.abs(goToArg.length - matchedByEntity[scriptId][goToArg][0].matchedIndexes.length) + 2,
-              highlights: [], // We're not actually highlighting here; the search was run against a different string.
-            },
-            forScript: scriptId,
-            heading: 'Entities for Script Arguments',
-            key: `missing_script_entity_${scriptId}`,
-            description: (
-              <CompletionDescription
-                title={cs.id}
-                body={cs.description}
-                hint={`matched on argument: ${goToArg}`}
-              />
-            ),
-            label: (
-              // eslint-disable-next-line react-memo/require-usememo
-              <CompletionLabel input={`${scriptId} (${goToArg})`} icon={<ScriptIcon />} highlights={[]} />
-            ),
-            onSelect: () => {
-              const argNames = cs.vis.variables.map(v => v.name);
-              argNames.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
-
-              let out = `script:${quoteIfNeeded(cs.id)}`;
-              let caret = 0;
-              for (const arg of argNames) {
-                const dflt = cs.vis.variables.find(a => a.name === arg).defaultValue ?? '';
-                const val = (arg === goToArg ? valueToken.value : parsed.kvMap?.get(arg)) ?? dflt;
-                out += ` ${arg}:${quoteIfNeeded(val)}`;
-                if (!caret || arg === goToArg) caret = out.length;
-              }
-
-              return [out, caret];
-            },
-          });
-        }
-      }
-      // NOTE: If this line is reached, we have a bare value, no script, and there ARE other keys. For now, this will
-      //  just stick to the arg-matching logic above and not try to handle the bare value.
-    }
-
-    if (!possibleScripts.length && !completionsFromEntityMatch.length && !completionsFromArgMatch.length) {
-      return noMatchesOutput;
-    }
-
-    const highlightedIds = possibleScripts.map(s => ({
-      script: s,
-      match: highlightNamespacedScoredMatch(
-        parsed.kvMap?.get('script') ?? valueToken?.value ?? parsed.input,
-        s.id,
-        '/',
-      ),
-    }));
-
-    const completionsFromNameMatch = highlightedIds.map(({ script: cs, match }) => ({
-      match,
-      forScript: cs.id,
-      heading: 'Scripts',
-      key: `missing_script_${cs.id}`,
-      description: <CompletionDescription title={cs.id} body={cs.description} />,
-      label: (
-        // eslint-disable-next-line react-memo/require-usememo
-        <CompletionLabel input={cs.id} icon={<ScriptIcon />} highlights={match.highlights} />
-      ),
-      onSelect: () => {
-        const argNames = cs.vis.variables.map(v => v.name);
-        argNames.sort((a, b) => +(a === 'start_time') - +(b === 'start_time'));
-
-        let out = `script:${quoteIfNeeded(cs.id)}`;
-        let caret = 0;
-        for (const arg of argNames) {
-          const dflt = cs.vis.variables.find(a => a.name === arg).defaultValue ?? '';
-          const val = parsed.kvMap?.get(arg) ?? dflt;
-          out += ` ${arg}:${quoteIfNeeded(val)}`;
-          if (!caret || arg === keyToken?.value) caret = out.length;
-        }
-
-        return [out, caret];
-      },
-    }));
-
-    // Now combine all of the suggestion types, but only keep one suggestion for each script if multiple exist.
-    const seenScripts = new Set<string>();
-    const completions = [];
-    for (const comp of [...completionsFromNameMatch, ...completionsFromArgMatch, ...completionsFromEntityMatch]) {
-      if (seenScripts.has(comp.forScript)) continue;
-      seenScripts.add(comp.forScript);
-      completions.push(comp);
-    }
-
-    completions.sort((a, b) => a.match.distance - b.match.distance);
-
-    return {
-      providerName: 'PxL Scripts',
-      completions: completions.slice(0, 25),
-      hasAdditionalMatches: completions.length > 25,
-    };
-  }, [scripts, client, clusterUID]);
+  return [state, dispatch];
 };

--- a/src/ui/src/components/command-palette/providers/script/script-command-is-valid-provider.tsx
+++ b/src/ui/src/components/command-palette/providers/script/script-command-is-valid-provider.tsx
@@ -22,42 +22,60 @@ import { Box } from '@mui/material';
 
 import { PlayIcon } from 'app/components';
 import { CommandPaletteContext } from 'app/components/command-palette/command-palette-context';
-import { CommandProvider } from 'app/components/command-palette/providers/command-provider';
+import {
+  CommandProvider,
+  CommandProviderDispatchAction,
+  CommandProviderState,
+} from 'app/components/command-palette/providers/command-provider';
 import { ScriptsContext } from 'app/containers/App/scripts-context';
 import { ScriptContext } from 'app/context/script-context';
+import { checkExhaustive } from 'app/utils/check-exhaustive';
 
 import { CompletionDescription } from './script-provider-common';
 import { getScriptCommandCta } from './script-provider-cta';
+
+const DEFAULT: CommandProviderState = {
+  input: '',
+  selection: [0, 0],
+  providerName: 'ScriptCommandIsValidProvider',
+  loading: false,
+  completions: [],
+  hasAdditionalMatches: false,
+};
 
 export const useScriptCommandIsValidProvider: CommandProvider = () => {
   const scripts = React.useContext(ScriptsContext)?.scripts;
   const { setScriptAndArgs } = React.useContext(ScriptContext);
   const { setOpen } = React.useContext(CommandPaletteContext);
 
-  return React.useCallback(async (input: string, selection: [number, number]) => {
-    const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
-    const completions = (!cta || cta.disabled) ? [] : [{
-      key: 'run-valid-script',
-      label: (
-        // eslint-disable-next-line react-memo/require-usememo
-        <Box sx={{ display: 'flex', gap: 1, flexFlow: 'row nowrap' }}>
-          <PlayIcon />
-          <strong>Run This Script</strong>
-        </Box>
-      ),
-      description: (
-        <CompletionDescription title='Run Script Command' body='Script command is valid.' />
-      ),
-      onSelect: () => {
-        if (cta.disabled === false) cta.action();
-      }, // Doesn't change the input.
-    }];
-
-    return {
-      providerName: 'Run Script',
-      hasAdditionalMatches: false,
-      completions,
-      cta,
-    };
-  }, [scripts, setOpen, setScriptAndArgs]);
+  return React.useReducer(
+    (prevState: CommandProviderState, action: CommandProviderDispatchAction) => {
+      const { type } = action;
+      switch (type) {
+        case 'cancel': return { ...prevState, loading: false };
+        case 'invoke': {
+          const { input, selection } = action;
+          const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
+          const completions = (!cta || cta.disabled) ? [] : [{
+            key: 'run-valid-script',
+            label: (
+              // eslint-disable-next-line react-memo/require-usememo
+              <Box sx={{ display: 'flex', gap: 1, flexFlow: 'row nowrap' }}>
+                <PlayIcon />
+                <strong>Run This Script</strong>
+              </Box>
+            ),
+            description: (
+              <CompletionDescription title='Run Script Command' body='Script command is valid.' />
+            ),
+            onSelect: () => {
+              if (cta.disabled === false) cta.action();
+            }, // Doesn't change the input.
+          }];
+          return { ...prevState, input, selection, completions, cta };
+        }
+        default: checkExhaustive(type);
+      }
+    }, DEFAULT,
+  );
 };

--- a/src/ui/src/components/command-palette/providers/script/script-provider-cta.tsx
+++ b/src/ui/src/components/command-palette/providers/script/script-provider-cta.tsx
@@ -41,7 +41,8 @@ export function isScriptCommandValid(kvMap: Map<string, string>, scripts: Map<st
   for (const arg of script.vis.variables) {
     const val = kvMap.get(arg.name);
     const clearValidValues = arg.validValues?.includes(val) ?? true;
-    if (!clearValidValues || !kvMap.has(arg.name)) return false;
+    const required = !arg.defaultValue && !arg.validValues?.length;
+    if (!clearValidValues || !kvMap.has(arg.name) || (required && !kvMap.get(arg.name)?.trim().length)) return false;
   }
 
   // Extraneous keys are errors

--- a/src/ui/src/components/command-palette/providers/script/script-provider.tsx
+++ b/src/ui/src/components/command-palette/providers/script/script-provider.tsx
@@ -24,7 +24,8 @@ import { ClusterIcon, NamespaceIcon, PodIcon, ServiceIcon } from 'app/components
 import { parse, ParseResult, Token } from 'app/components/command-palette/parser';
 import {
   CommandProvider,
-  CommandProviderResult,
+  CommandProviderDispatchAction,
+  CommandProviderState,
 } from 'app/components/command-palette/providers/command-provider';
 import { ScriptsContext } from 'app/containers/App/scripts-context';
 import { ScriptContext } from 'app/context/script-context';
@@ -32,18 +33,16 @@ import {
   GQLAutocompleteFieldResult,
   GQLAutocompleteEntityKind,
 } from 'app/types/schema';
+import { CancellablePromise, makeCancellable } from 'app/utils/cancellable-promise';
+import { checkExhaustive } from 'app/utils/check-exhaustive';
 import { Script } from 'app/utils/script-bundle';
 
-import {
-  useMissingScriptProvider,
-} from '.';
 import { CommandPaletteContext } from '../../command-palette-context';
 import {
   CompletionLabel,
   getFieldSuggestions,
   getOnSelectSetKeyVal,
   getSelectedKeyAndValueToken,
-  quoteIfNeeded,
 } from './script-provider-common';
 import { getScriptCommandCta, isScriptCommandValid } from './script-provider-cta';
 import {
@@ -52,68 +51,53 @@ import {
   getScriptArgValueSuggestions,
 } from './script-suggestions';
 
+const DEFAULT: CommandProviderState = Object.freeze({
+  input: '',
+  selection: [0, 0],
+  providerName: 'ScriptProvider',
+  loading: false,
+  completions: [],
+  hasAdditionalMatches: false,
+});
 
-/**
- * Get suggestions for a bare value (not attached to a key token) somewhere in the current string.
- * This is the most complex suggester, as the possibilities depend on what else is already in the full input.
- *
- * For example, if the input is `script:px/http_data st` and the caret is at the end, `bare` is `st` here,
- * suggestions might include `script:px/http_data start_time:` (fill out the argument).
- * Alternatively, if there's an argument with set `validValues`, and `st` matches one of those, it might also suggest
- * adding that argument and setting its value to the matched one.
- *
- * But if the input is just `pod`, we might suggest `script:px/pod ...`, or any other script that takes `pod` as an arg,
- * or any script that takes a namespace arg where one of the namespaces happens to be named `pod`, and so on.
- */
-async function suggestFromBare(
-  parsed: ParseResult,
-  selectedToken: Token,
-  clusterUID: string,
-  client: PixieAPIClient,
-  scripts: Map<string, Script>,
-): Promise<CommandProviderResult> {
-  const script: Script | null = scripts.get(parsed.kvMap.get('script') ?? '') ?? null;
+function useBaseProvider(
+  suggester: (input: string, selection: [number, number]) => Promise<CommandProviderState>,
+): ReturnType<CommandProvider> {
+  const [promise, setPromise] = React.useState<CancellablePromise<Partial<CommandProviderState>>>(null);
+  const [state, setState] = React.useState(DEFAULT);
+  const dispatch = React.useCallback((action: CommandProviderDispatchAction) => {
+    const { type } = action;
+    switch (type) {
+      case 'cancel':
+        promise?.cancel();
+        setPromise(null);
+        setState((prev) => ({ ...prev, loading: false }));
+        break;
+      case 'invoke': {
+        promise?.cancel();
+        setState(DEFAULT);
+        const p = makeCancellable(suggester(action.input, action.selection));
+        setPromise(p);
+        p.then((res) => {
+          setState({ ...DEFAULT, ...res });
+        });
+        break;
+      }
+      default: checkExhaustive(type);
+    }
+  }, [promise, suggester]);
 
-  // If there is already a script, its arguments all come into play.
-  const argSuggestions = script
-    ? await getScriptArgSuggestions(parsed, selectedToken, clusterUID, client, script)
-    : { completions: [], hasAdditionalMatches: false };
-
-  const valueSuggestions = script
-    ? getScriptArgValueSuggestions(parsed, selectedToken, script)
-    : { completions: [], hasAdditionalMatches: false };
-
-  const hasAdditionalMatches = argSuggestions.hasAdditionalMatches || valueSuggestions.hasAdditionalMatches;
-
-  return {
-    providerName: 'Scripts',
-    completions: [
-      ...argSuggestions.completions,
-      ...valueSuggestions.completions,
-    ],
-    hasAdditionalMatches,
-  };
+  return [state, dispatch];
 }
 
-function useSuggestFromValue() {
-  const clusterUID = React.useContext(ClusterContext)?.selectedClusterUID ?? null;
-  const client = React.useContext(PixieAPIContext) as PixieAPIClient;
-  const scripts = React.useContext(ScriptsContext)?.scripts;
-  return React.useCallback((input: string, selection: [number, number]) => {
-    const parsed = parse(input, selection);
-    let valueToken = getSelectedKeyAndValueToken(parsed).valueToken ?? null;
-    if (!valueToken) valueToken = parsed.selectedTokens[0].token; // In case the selection was between two spaces
-    return suggestFromBare(parsed, valueToken, clusterUID, client, scripts);
-  }, [scripts, clusterUID, client]);
-}
-
+/** @see {@link useScriptCommandFromKeyedValueProvider} */
 async function suggestFromKey(
   parsed: ParseResult,
   keyToken: Token,
   clusterUID: string,
   client: PixieAPIClient,
   scripts: Map<string, Script>,
-): Promise<CommandProviderResult> {
+): Promise<Partial<CommandProviderState>> {
   const valueToken = keyToken.relatedToken ?? null;
 
   let heading: string;
@@ -155,9 +139,15 @@ async function suggestFromKey(
           valueToken?.text || '', GQLAutocompleteEntityKind.AEK_NODE, clusterUID, client);
         break;
       default:
-        heading = 'MISSED THIS CASE';
-        icon = <PodIcon />;
-        result = { suggestions: [], hasAdditionalMatches: false };
+        if (foundArg.validValues?.length) {
+          const { completions, hasAdditionalMatches } = getScriptArgValueSuggestions(
+            parsed, valueToken ?? keyToken, script);
+          return { providerName: 'Scripts', completions, hasAdditionalMatches };
+        } else {
+          heading = 'Unmatched';
+          icon = <PodIcon />;
+          result = { suggestions: [], hasAdditionalMatches: false };
+        }
         break;
     }
   } else {
@@ -178,81 +168,123 @@ async function suggestFromKey(
   };
 }
 
-function useSuggestFromKeyedValue() {
+/**
+ * Get suggestions for a key:value pair somewhere in the current string. Also works on `key:` (no value).
+ *
+ * For example, if the caret is at the end of the following inputs...
+ * `script:pod` -> Look for script with `pod` in the name
+ * `script:px/pod pod:foo` -> Look for Pod entities, since that argument to `px/pod` only takes those entities.
+ * `script:px/node groupby:` -> The `groupby` argument has a strict set of `validValues`, so look through only those.
+ */
+export const useScriptCommandFromKeyedValueProvider: CommandProvider = () => {
   const clusterUID = React.useContext(ClusterContext)?.selectedClusterUID ?? null;
   const client = React.useContext(PixieAPIContext) as PixieAPIClient;
   const scripts = React.useContext(ScriptsContext)?.scripts;
-  return React.useCallback((input: string, selection: [number, number]) => {
+  const { setScriptAndArgs } = React.useContext(ScriptContext);
+  const { setOpen } = React.useContext(CommandPaletteContext);
+
+  const suggester = React.useCallback(async (input: string, selection: [number, number]) => {
     const parsed = parse(input, selection);
-    const { keyToken } = getSelectedKeyAndValueToken(parsed);
-    if (!keyToken) throw new Error('Called suggestFromKeyedValue, but there is no key token related to the selection');
-    return suggestFromKey(parsed, keyToken, clusterUID, client, scripts);
-  }, [client, clusterUID, scripts]);
+    const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
+    const { keyToken, valueToken } = getSelectedKeyAndValueToken(parsed);
+
+    const selectionTooBroad = keyToken && valueToken && keyToken.relatedToken !== valueToken;
+    const inputIsOneLongString = parsed.tokens.every(({ type }) => type === 'value' || type === 'none');
+    const script = scripts?.get(parsed.kvMap?.get('script') ?? '') ?? null;
+
+    if (
+      !input.trim().length
+      || inputIsOneLongString
+      || selectionTooBroad
+      || !keyToken
+      || (!script && valueToken)
+    ) {
+      return { ...DEFAULT, cta };
+    }
+    return { ...DEFAULT, ...(await suggestFromKey(parsed, keyToken, clusterUID, client, scripts)), cta };
+  }, [client, clusterUID, scripts, setOpen, setScriptAndArgs]);
+
+  return useBaseProvider(suggester);
+};
+
+/** @see {@link useScriptCommandFromValueProvider} */
+async function suggestFromBare(
+  parsed: ParseResult,
+  selectedToken: Token,
+  clusterUID: string,
+  client: PixieAPIClient,
+  scripts: Map<string, Script>,
+): Promise<Partial<CommandProviderState>> {
+  const script: Script | null = scripts.get(parsed.kvMap.get('script') ?? '') ?? null;
+
+  // If there is already a script, its arguments all come into play.
+  const argSuggestions = script
+    ? await getScriptArgSuggestions(parsed, selectedToken, clusterUID, client, script)
+    : { completions: [], hasAdditionalMatches: false };
+
+  const valueSuggestions = script
+    ? getScriptArgValueSuggestions(parsed, selectedToken, script)
+    : { completions: [], hasAdditionalMatches: false };
+
+  const hasAdditionalMatches = argSuggestions.hasAdditionalMatches || valueSuggestions.hasAdditionalMatches;
+
+  return {
+    providerName: 'Scripts',
+    completions: [
+      ...argSuggestions.completions,
+      ...valueSuggestions.completions,
+    ],
+    hasAdditionalMatches,
+  };
 }
 
 /**
- * Provides PxL Script commands, such as `script:px/cluster start_time:-5m`, and understands the nuances involved to
- * suggest the parts of the command separately.
+ * Get suggestions for a bare value (not attached to a key token) somewhere in the current string.
+ * This is the most complex suggester, as the possibilities depend on what else is already in the full input.
  *
- * Some examples of what it will suggest (the ‸ symbol represents the user's text caret or selection):
- * `` (empty input) -> `script:px/cluster start_time:-5m‸`, recommends some common commands
- * `script:px/cluster ‸` -> `script:px/cluster start_time:‸`, discovers missing arguments
- * `script:px/pod foo‸` -> `script:px/pod pod:foo_pod`, discovers missing arguments with hints
- * `script:po‸d` -> `script:px/pod pod:‸ start_time:-5m` finishes the script, prefills default arguments, and tabs to
- *   the first argument that the user needs to fill in. Then, it will suggest completions for that argument.
- * `pod:foo‸` -> `script:px/pod pod:foo‸`, finds scripts that take args in the input if the script isn't set yet
- * `foo‸` -> `script:px/foo ...`, `script:px/pod pod:...`, can suggest many things based on what the input matches here
- * `script:px/namespace namespace:foo‸` -> suggests namespaces directly since that arg for that script accepts them
+ * For example, if the input is `script:px/http_data st` and the caret is at the end, `bare` is `st` here,
+ * suggestions might include `script:px/http_data start_time:` (fill out the argument).
+ * Alternatively, if there's an argument with set `validValues`, and `st` matches one of those, it might also suggest
+ * adding that argument and setting its value to the matched one.
+ *
+ * But if the input is just `pod`, we might suggest `script:px/pod ...`, or any other script that takes `pod` as an arg,
+ * or any script that takes a namespace arg where one of the namespaces happens to be named `pod`, and so on.
  */
-export const useScriptCommandProvider: CommandProvider = () => {
+export const useScriptCommandFromValueProvider: CommandProvider = () => {
+  const clusterUID = React.useContext(ClusterContext)?.selectedClusterUID ?? null;
+  const client = React.useContext(PixieAPIContext) as PixieAPIClient;
   const scripts = React.useContext(ScriptsContext)?.scripts;
   const { setScriptAndArgs } = React.useContext(ScriptContext);
-
   const { setOpen } = React.useContext(CommandPaletteContext);
 
-  const missingScriptProvider = useMissingScriptProvider();
-  const bareValueProvider = useSuggestFromValue();
-  const keyedValueProvider = useSuggestFromKeyedValue();
-
-  return React.useCallback(async (input, selection) => {
+  const suggester = React.useCallback(async (input: string, selection: [number, number]) => {
     const parsed = parse(input, selection);
+    const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
+    const sel = getSelectedKeyAndValueToken(parsed);
 
-    const { keyToken, valueToken } = getSelectedKeyAndValueToken(parsed);
+    // In case selection was between two spaces, grab the nearest token (will be null on empty input)
+    if (!sel.valueToken) sel.valueToken = parsed.selectedTokens[0]?.token ?? null;
+    const { keyToken, valueToken } = sel;
 
     const selectionTooBroad = keyToken && valueToken && keyToken.relatedToken !== valueToken;
     const inputIsOneLongString = parsed.tokens.every(({ type }) => type === 'value' || type === 'none');
     const script = scripts?.get(parsed.kvMap?.get('script') ?? '') ?? null;
     const commandFullyFilled = isScriptCommandValid(parsed.kvMap ?? new Map(), scripts ?? new Map());
 
-    const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
-    if (!input.trim().length) {
-      // Defer to emptyInputScriptProvider (defined elsewhere)
-      return { providerName: 'Scripts', completions: [], hasAdditionalMatches: false, cta };
-    } else if (inputIsOneLongString) {
-      // If the entire input is just text, try treating it as one giant value token.
-      const newInput = quoteIfNeeded(parsed.tokens.map(({ text }) => text).join(''));
-      const res = await missingScriptProvider(newInput, [newInput.length, newInput.length]);
-      return { ...res, cta };
-    } else if (selectionTooBroad || (!keyToken && !valueToken && commandFullyFilled)) {
-      // Either selection crosses multiple key:value pairs,
-      // Or it doesn't cross any and the command is already fully valid (all required args exist and are valid)
-      return { providerName: 'Scripts', completions: [], hasAdditionalMatches: false, cta };
-    } else if (!script && (keyToken || valueToken)) {
-      // We don't have a (valid) script, but do have some input. Try to suggest scripts that make sense with the input.
-      const res = await missingScriptProvider(parsed.input, parsed.selection);
-      return { ...res, cta };
-    } else if (keyToken) {
-      // There is a script, and we have either `key:` or `key:value`. This is the simplest scenario.
-      const res = await keyedValueProvider(parsed.input, parsed.selection);
-      return { ...res, cta };
-    } else {
-      // We have a bare string (not part of a key:value pair). This is the most complex scenario.
-      // This also comes up if the caret is between two spaces, or between a space and the start/end of the input.
-      const res = await bareValueProvider(parsed.input, parsed.selection);
-      return { ...res, cta };
+    if (
+      !input.trim().length
+      || !script
+      || inputIsOneLongString
+      || selectionTooBroad
+      || keyToken
+      || !valueToken
+      || commandFullyFilled
+    ) {
+      return { ...DEFAULT, cta };
     }
-  }, [
-    bareValueProvider, missingScriptProvider, keyedValueProvider,
-    scripts, setScriptAndArgs, setOpen,
-  ]);
+
+    return { ...DEFAULT, ...(await suggestFromBare(parsed, valueToken, clusterUID, client, scripts)), cta };
+  }, [scripts, setScriptAndArgs, clusterUID, client, setOpen]);
+
+  return useBaseProvider(suggester);
 };

--- a/src/ui/src/components/command-palette/providers/script/script-suggestions.tsx
+++ b/src/ui/src/components/command-palette/providers/script/script-suggestions.tsx
@@ -24,7 +24,7 @@ import { PixieAPIClient } from 'app/api';
 import { isPixieEmbedded } from 'app/common/embed-context';
 import { PixieCommandIcon as ScriptIcon } from 'app/components';
 import { ParseResult, Token } from 'app/components/command-palette/parser';
-import { CommandProviderResult } from 'app/components/command-palette/providers/command-provider';
+import { CommandProviderState } from 'app/components/command-palette/providers/command-provider';
 import { SCRATCH_SCRIPT } from 'app/containers/App/scripts-context';
 import { pxTypeToEntityType } from 'app/containers/live/autocomplete-utils';
 import { GQLAutocompleteEntityKind, GQLAutocompleteFieldResult, GQLAutocompleteSuggestion } from 'app/types/schema';
@@ -93,10 +93,13 @@ export function getFullScriptSuggestions(
   partial: string,
   scripts: Map<string, Script>,
   focusArg?: string,
-): CommandProviderResult {
+): CommandProviderState {
   const idSuggestions = getScriptIdSuggestions(partial, scripts);
   return {
+    input: partial,
+    selection: [0, 0],
     providerName: 'getFullScriptSuggestions',
+    loading: false,
     completions: idSuggestions.suggestions.map(({ name, description, matchedIndexes }, i) => {
       return {
         heading: 'Scripts',


### PR DESCRIPTION
Summary: Makes the Command Palette behave more asynchronously, with some bugfixes along the way.
- Switches providers from `Promise` to `useReducer`, so they can update in stages
- Flattens the provider structure so they aren't nested (fixes a few collisions)
- Fixes `validValues` suggestions and required arg checks (side benefits of the above)
- Ultimately, results come in faster, bounce less, and handle errors better

This PR was preceded by: #939, #1046, #1047, #1053, #1076, #1079, and #1080. There will be more after it to continue improving the experience, especially when there are many results.

Type of change: /kind bug

Test Plan: Use the Command Palette. It should feel a bit snappier, a bit less error-prone, and it should handle `validValues` correctly now (try `px/nodes`'s `groupby` argument). It should also correctly prevent running a script that's missing a required argument, such as `px/service` until the `service:` arg is filled. Also try emptying the input and just typing something like "svc", it should now prioritize results across groups.

