### PR TITLE
[ci/bazel_build_deps] Remove tab character in cquery command

### DIFF
--- a/ci/bazel_build_deps.sh
+++ b/ci/bazel_build_deps.sh
@@ -141,7 +141,7 @@ function check_bpf_trigger() {
 starlark_cquery_file="ci/cquery_ignore_non_target_and_incompatible.bzl"
 function query_compatible_targets() {
   bazel_config="$1"
-  "${bazel_cquery[@]}" --config="${bazel_config}" --notool_deps --output=starlark --starlark:file "${starlark_cquery_file}"	"${@:2}" | grep -v "^None$" | sort | uniq
+  "${bazel_cquery[@]}" --config="${bazel_config}" --notool_deps --output=starlark --starlark:file "${starlark_cquery_file}" "${@:2}" | grep -v "^None$" | sort | uniq
 }
 
 compute_targets


### PR DESCRIPTION
Summary: For some reason there was a tab character in the bazel_build_deps script. For some unknown reason this tab character would cause `pipefail` to cause an error some of the time. Haven't really figured out why, but I tested with the changes in #1039, that used to cause a failure, and without the tab character the script works on those changes.

Type of change: /kind cleanup

Test Plan: Tested that the changes in #1039 no longer cause a failure in this script
