### PR TITLE
Use gcs mirror for busybox

### DIFF
--- a/bazel/pl_workspace.bzl
+++ b/bazel/pl_workspace.bzl
@@ -91,7 +91,7 @@ def qemu_with_kernel_deps():
 
     http_file(
         name = "busybox",
-        url = "https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox",
+        url = "https://storage.googleapis.com/pixie-dev-public/mirrors/busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox",
         sha256 = "6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba311348",
         downloaded_file_path = "busybox",
         executable = True,


### PR DESCRIPTION
Summary: We appear to be getting read timeouts for busybox.net on Jenkins, so I moved to using a mirror of the busybox binary on our own gcs.

Type of change: /kind cleanup

Test Plan: Tested that the binary has the same sha as before when downloaded from the mirror.
