### PR TITLE
Force copy the files in qemu runner

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/launcher.sh
+++ b/bazel/test_runners/qemu_with_kernel/launcher.sh
@@ -85,13 +85,13 @@ done
 # so we resolve them into the copy.
 runfiles_path="$(path_qemu_sandbox "${RUNFILES_DIR}")"
 mkdir -p "${runfiles_path}"
-cp -aL "${RUNFILES_DIR}"/* "${runfiles_path}"
+cp -afL "${RUNFILES_DIR}"/* "${runfiles_path}"
 
 # Copy over testlog file.
 testlogs_dir="${TEST_WARNINGS_OUTPUT_FILE%%/testlogs/*}/testlogs/"
 qemu_warnings_file=$(strip_pwd_from_path "${TEST_WARNINGS_OUTPUT_FILE}")
 qemu_testlogs_dir="${qemu_warnings_file/${qemu_warnings_file##*/testlogs/}}"
-cp -aL "${testlogs_dir}/" "${tmpdir_for_sandbox}/${qemu_testlogs_dir}/"
+cp -afL "${testlogs_dir}/" "${tmpdir_for_sandbox}/${qemu_testlogs_dir}/"
 
 # Copy the test runner and test cmd into the sandbox.
 test_runner_file="${tmpdir_for_sandbox}/test_runner_inside_qemu.sh"
@@ -106,7 +106,7 @@ chmod +x "${test_cmd_path}"
 printf "export test_base=%s\n" "${test_base}" >> "${test_env_file}"
 printf "export test_exec_path=%s\n" "${test_cmd_path_in_qemu}" >> "${test_env_file}"
 
-cp -aL "${BAZEL_QEMU_TEST_RUNNER_PATH}" "${test_runner_file}"
+cp -afL "${BAZEL_QEMU_TEST_RUNNER_PATH}" "${test_runner_file}"
 
 # Launch the qemu test.
 retval=0
@@ -121,6 +121,6 @@ testlogs_dir="${TEST_WARNINGS_OUTPUT_FILE%%/testlogs/*}/testlogs/"
 qemu_warnings_file=$(strip_pwd_from_path "${TEST_WARNINGS_OUTPUT_FILE}")
 qemu_testlogs_dir="${qemu_warnings_file/${qemu_warnings_file##*/testlogs/}}"
 
-cp -aL "${tmpdir_for_sandbox}/${qemu_testlogs_dir}/" "${testlogs_dir}/"
+cp -afL "${tmpdir_for_sandbox}/${qemu_testlogs_dir}/" "${testlogs_dir}/"
 
 exit $retval


### PR DESCRIPTION
Summary: If files already exist (due to a previous flaky run) we fail to copy the new test results. This makes
the copy forced to make sure it's overriden.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: bazel test, jenkins

