### PR TITLE
Disable kafka_bpf_test under qemu

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -419,6 +419,7 @@ pl_cc_test(
     flaky = True,
     tags = [
         "cpu:16",
+        "no_qemu",
         "requires_bpf",
     ],
     deps = [


### PR DESCRIPTION
Summary: This test currently fails under qemu and needs to be debugged.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: N/A

