### PR TITLE
Match EmptyInputProvider style to other providers

### DIFF
--- a/src/ui/src/components/command-palette/command-providers.tsx
+++ b/src/ui/src/components/command-palette/command-providers.tsx
@@ -21,7 +21,11 @@ import * as React from 'react';
 import { makeCancellable } from 'app/utils/cancellable-promise';
 
 import { CommandProvider, CommandProviderResult } from './providers/command-provider';
-import { useScriptCommandProvider, useScriptCommandIsValidProvider } from './providers/script';
+import {
+  useScriptCommandProvider,
+  useScriptCommandIsValidProvider,
+  useEmptyInputScriptProvider,
+} from './providers/script';
 
 function isFulfilled<T>(res: PromiseSettledResult<T>): res is PromiseFulfilledResult<T> {
   return res.status === 'fulfilled';
@@ -35,6 +39,7 @@ export const useCommandProviders: (
 ) => {
   const providers: ReturnType<CommandProvider>[] = [
     useScriptCommandIsValidProvider(),
+    useEmptyInputScriptProvider(),
     useScriptCommandProvider(),
   ];
 

--- a/src/ui/src/components/command-palette/providers/script/empty-input-provider.tsx
+++ b/src/ui/src/components/command-palette/providers/script/empty-input-provider.tsx
@@ -18,8 +18,34 @@
 
 import * as React from 'react';
 
-import { CommandProvider } from 'app/components/command-palette/providers/command-provider';
+import { PixieCommandIcon as ScriptIcon } from 'app/components';
+import {
+  CommandProvider,
+  CommandProviderResult,
+} from 'app/components/command-palette/providers/command-provider';
+import { SCRATCH_SCRIPT } from 'app/containers/App/scripts-context';
 import { GQLAutocompleteEntityKind } from 'app/types/schema';
+
+import { CompletionDescription, CompletionLabel, quoteIfNeeded } from './script-provider-common';
+
+const DEFAULT: CommandProviderResult = {
+  providerName: 'EmptyInputScriptProvider',
+  completions: [],
+  hasAdditionalMatches: false,
+};
+
+const suggestions = [
+  {
+    sel: `script:${quoteIfNeeded(SCRATCH_SCRIPT.id)}`,
+    label: SCRATCH_SCRIPT.title,
+    desc: SCRATCH_SCRIPT.description,
+  },
+  {
+    sel: 'script:px/cluster start_time:-5m',
+    label: 'px/cluster',
+    desc: 'Read the high-level status of your cluster: namespaces, pods, performance metrics, etc.',
+  },
+];
 
 /**
  * On an empty input, suggests commonly-used script commands. On a non-empty input, doesn't suggest anything.
@@ -27,14 +53,15 @@ import { GQLAutocompleteEntityKind } from 'app/types/schema';
 export const useEmptyInputScriptProvider: CommandProvider = () => {
   return React.useCallback(async (input: string) => {
     return {
-      providerName: 'Suggested Scripts',
-      hasAdditionalMatches: false,
-      completions: !input.trim().length ? [{
-        key: GQLAutocompleteEntityKind.AEK_SCRIPT,
-        label: 'script:px/cluster',
-        description: 'Read the high-level status of your cluster: namespaces, pods, performance metrics, etc.',
-        onSelect: () => ['script:px/cluster start_time:-5m', 32],
-      }] : [], // No suggestions if the input has meaningful text in it already.
+      ...DEFAULT,
+      completions: input.trim().length ? [] : suggestions.map(({ sel, label, desc }, i) => ({
+        heading: 'Suggested Scripts',
+        key: GQLAutocompleteEntityKind.AEK_SCRIPT + '_' + i,
+        // eslint-disable-next-line react-memo/require-usememo
+        label: <CompletionLabel icon={<ScriptIcon />} input={label} highlights={[]} />,
+        description: <CompletionDescription title={label} body={desc} />,
+        onSelect: () => [sel, sel.length] as [string, number],
+      })),
     };
   }, []);
 };

--- a/src/ui/src/components/command-palette/providers/script/script-provider.tsx
+++ b/src/ui/src/components/command-palette/providers/script/script-provider.tsx
@@ -35,7 +35,6 @@ import {
 import { Script } from 'app/utils/script-bundle';
 
 import {
-  useEmptyInputScriptProvider,
   useMissingScriptProvider,
 } from '.';
 import { CommandPaletteContext } from '../../command-palette-context';
@@ -211,7 +210,6 @@ export const useScriptCommandProvider: CommandProvider = () => {
 
   const { setOpen } = React.useContext(CommandPaletteContext);
 
-  const emptyInputProvider = useEmptyInputScriptProvider();
   const missingScriptProvider = useMissingScriptProvider();
   const bareValueProvider = useSuggestFromValue();
   const keyedValueProvider = useSuggestFromKeyedValue();
@@ -228,8 +226,8 @@ export const useScriptCommandProvider: CommandProvider = () => {
 
     const cta = getScriptCommandCta(input, selection, scripts, setScriptAndArgs, () => setOpen(false));
     if (!input.trim().length) {
-      // With a blank input, offer common fully-filled commands to try.
-      return emptyInputProvider(input, selection);
+      // Defer to emptyInputScriptProvider (defined elsewhere)
+      return { providerName: 'Scripts', completions: [], hasAdditionalMatches: false, cta };
     } else if (inputIsOneLongString) {
       // If the entire input is just text, try treating it as one giant value token.
       const newInput = quoteIfNeeded(parsed.tokens.map(({ text }) => text).join(''));
@@ -254,7 +252,7 @@ export const useScriptCommandProvider: CommandProvider = () => {
       return { ...res, cta };
     }
   }, [
-    bareValueProvider, emptyInputProvider, missingScriptProvider, keyedValueProvider,
+    bareValueProvider, missingScriptProvider, keyedValueProvider,
     scripts, setScriptAndArgs, setOpen,
   ]);
 };


### PR DESCRIPTION
Summary: It wasn't presenting the right type of icon or description before, nor the Scratch Pad.
Before...
<img width="814" alt="image" src="https://user-images.githubusercontent.com/314133/226751183-a9172ba8-6711-4f4f-8471-d42cb6eb380f.png">
After...
<img width="814" alt="image" src="https://user-images.githubusercontent.com/314133/226751324-8e231a79-3c51-49bd-9dd3-856512baa143.png">

Test Plan: Try the empty input in the Command Palette.

Type of change: /kind bug

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
