### PR TITLE
Change common names for service-tls-certs

### DIFF
--- a/scripts/create_cloud_secrets.sh
+++ b/scripts/create_cloud_secrets.sh
@@ -71,13 +71,13 @@ openssl genrsa -out ca.key 4096
 openssl req -new -x509 -sha256 -days 365 -key ca.key -out ca.crt -subj "/O=Pixie/CN=pixie.local"
 
 openssl genrsa -out server.key 4096
-openssl req -new -sha256 -key server.key -out server.csr -config ssl.conf -subj "/O=Pixie/CN=pixie.local"
+openssl req -new -sha256 -key server.key -out server.csr -config ssl.conf -subj "/O=Pixie/CN=pixie.server"
 
 openssl x509 -req -sha256 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 \
     -out server.crt -extensions req_ext -extfile ssl.conf
 
 openssl genrsa -out client.key 4096
-openssl req -new -sha256 -key client.key -out client.csr -config ssl.conf -subj "/O=Pixie/CN=pixie.local"
+openssl req -new -sha256 -key client.key -out client.csr -config ssl.conf -subj "/O=Pixie/CN=pixie.client"
 
 openssl x509 -req -sha256 -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 \
     -out client.crt -extensions req_ext -extfile ssl.conf


### PR DESCRIPTION
Summary: I have found a bug when deploying **air gapped** Pixie in my production environment. Upon deploying Vizier, the kelvin pod and PEM daemonset pods continuously fail. The logs of these two pods show that they are **not connecting to the NATS** pod properly due to an **SSL handshake error**. (logs below) This error is also mentioned in [this comment](https://github.com/pixie-io/pixie/issues/266#issuecomment-1344073741).

Digging into NATS source code, the exact failure is in [this line](https://github.com/nats-io/nats.c/blob/main/src/conn.c#L733) and because OpenSSL not recognizing the self-signed certificates. This was the same behaviour as described in this [Slack thread](https://l.messenger.com/l.php?u=https%3A%2F%2Fpixie-community.slack.com%2Farchives%2FCQ63KEVFY%2Fp1678330664066339&h=AT252QgZMmb3wRhaHnX7uwaQXlL8_AJ29l2kUJ57vZaxJrN2iHmN_5L2cjB9-kiFWXl2SeJyx5aGe_a8oY8oqNojtheiRnETkV48FJLIGPkFpGh5BHI6UGGCs18mHVmOnFhML8IcH7-HV0p_VTiloA).

After looking online, one solution for a similar problem (also _error 18_ for _self-signed certificate_) [here ](https://stackoverflow.com/questions/19726138/openssl-error-18-at-0-depth-lookupself-signed-certificate) suggests that the problem comes from the client and server using the same common name. It says that _When OpenSSL prompts you for the Common Name for each certificate, use different names._ Applying this change resolved the errors in my kelvin and PEM

Details: The logs of kelvin and PEM both show this error
```
Error: 29 - SSL Error - (conn.c:737): SSL handshake error: 18:self signed certificate:depth=0:cert=/O=Pixie/CN=pixie.local:issuer=/O=Pixie/CN=pixie.local
Stack: (library version: 3.3.0)
  01 - _makeTLSConn
  02 - _checkForSecure
  03 - _processExpectedInfo
  04 - _processConnInit
  05 - _connect
  06 - natsConnection_Connect
F20230308 00:19:29.935109     1 statusor.h:148] Check failed: _s.ok() Bad Status: Unknown : Failed to connect to NATS, nats_status=29
* Check failure stack trace: *
E20230308 00:19:29.935145     1 signal_action.cc:63] Caught Aborted, suspect faulting address 0x1. Trace:
************************
PC: @     0x7ffac7ade7f3  (unknown)  abort
    @     0x557dee56e4c3  (unknown)  google::LogMessage::SendToLog()
    @     0x557dee56e7dc  (unknown)  google::LogMessage::Flush()
    @     0x557dee570219  (unknown)  google::LogMessageFatal::~LogMessageFatal()
    @     0x557ded52ba85  (unknown)  px::StatusOr<>::ConsumeValueOrDie()
    @     0x557ded52b11a  (unknown)  main
    @     0x7ffac7adfd90  (unknown)  (unknown)
    @     0x7ffac7adfe40  (unknown)  __libc_start_main
    @     0x557ded52a7e5  (unknown)  _start
************************
Threads: 6
Stack trace:
PC: @     0x557dee622174  (unknown)  execute_native_thread_routine
    @     0x7ffac7b4ab43  (unknown)  (unknown)
    @     0x7ffac7bdca00  (unknown)  (unknown)
Threads: 1
Stack trace:
PC: @     0x557dee49fb23  (unknown)  px::SignalAction::SigHandler()
    @     0x7ffac7af8520  (unknown)  (unknown)
    @     0x7ffac7b4ca7c  (unknown)  pthread_kill
    @     0x7ffac7af8476  (unknown)  gsignal
    @     0x7ffac7ade7f3  (unknown)  abort
    @     0x557dee56e4c3  (unknown)  google::LogMessage::SendToLog()
    @     0x557dee56e7dc  (unknown)  google::LogMessage::Flush()
    @     0x557dee570219  (unknown)  google::LogMessageFatal::~LogMessageFatal()
    @     0x557ded52ba85  (unknown)  px::StatusOr<>::ConsumeValueOrDie()
    @     0x557ded52b11a  (unknown)  main
    @     0x7ffac7adfd90  (unknown)  (unknown)
    @     0x7ffac7adfe40  (unknown)  __libc_start_main
    @     0x557ded52a7e5  (unknown)  _start
E20230308 00:19:29.949421     1 signal_action.cc:63] Caught Segmentation fault, suspect faulting address (nil). Trace:
************************
PC: @     0x557dee56e7dc  (unknown)  google::LogMessage::Flush()
    @     0x557dee570219  (unknown)  google::LogMessageFatal::~LogMessageFatal()
    @     0x557ded52ba85  (unknown)  px::StatusOr<>::ConsumeValueOrDie()
    @     0x557ded52b11a  (unknown)  main
    @     0x7ffac7adfd90  (unknown)  (unknown)
    @     0x7ffac7adfe40  (unknown)  __libc_start_main
    @     0x557ded52a7e5  (unknown)  _start
************************
Threads: 6
Stack trace:
PC: @     0x557dee622174  (unknown)  execute_native_thread_routine
    @     0x7ffac7b4ab43  (unknown)  (unknown)
    @     0x7ffac7bdca00  (unknown)  (unknown)
Threads: 1
Stack trace:
PC: @     0x557dee49fb23  (unknown)  px::SignalAction::SigHandler()
    @     0x7ffac7af8520  (unknown)  (unknown)
    @     0x7ffac7ade898  (unknown)  abort
    @     0x557dee56e4c3  (unknown)  google::LogMessage::SendToLog()
    @     0x557dee56e7dc  (unknown)  google::LogMessage::Flush()
    @     0x557dee570219  (unknown)  google::LogMessageFatal::~LogMessageFatal()
    @     0x557ded52ba85  (unknown)  px::StatusOr<>::ConsumeValueOrDie()
    @     0x557ded52b11a  (unknown)  main
    @     0x7ffac7adfd90  (unknown)  (unknown)
    @     0x7ffac7adfe40  (unknown)  __libc_start_main
    @     0x557ded52a7e5  (unknown)  _start
```

Meanwhile, the logs of my NATS pod also shows a corresponding error from the other side of the handshake
```
TLS handshake error: remote error: tls: unknown certificate authority
```

Type of change: /kind bug

Test Plan: I tried to make many other changes that did not work, such as
1. creating a brand new local CA & certificate
2. adding more possible DNS names in the alt_names section of the certificate creation
3. injecting the cert files in through the yamls and docker containers, and physically loading them in by ssh-ing into the pods

After making this modification in the PR, it solved the problem of the SSL handshake. Both Kelvin and PEM are able to start properly and connect to NATS.