### PR TITLE
Prevent qemu test runner false positive builds by adding a kvm/qemu validation check

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/run_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/run_qemu.sh
@@ -76,6 +76,11 @@ flags+=(-append "console=ttyS0 root=/dev/sda")
 # Disable graphics mode.
 flags+=(-nographic)
 
+if ! virt-host-validate qemu -q; then
+  echo "'virt-host-validate qemu' failed to validate qemu is functional. Check the output of the 'virt-host-validate' command and resolve any issues before retrying";
+  exit 1;
+fi
+
 retval=0
 qemu-system-x86_64 "${flags[@]}" || retval=$?
 


### PR DESCRIPTION
Summary: Prevent qemu test runner false positive builds by adding a kvm/qemu validation check

The qemu test runner silently fails when kvm is not accessible. This causes bazel to believe all tests have passed when the tests weren't started as seen in this output ([P331](https://phab.corp.pixielabs.ai/P331)). This change addresses this false positive by verifying that qemu/kvm are functional before attempting to run a VM.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: Verified that bazel reports failed tests when a qemu vm fails to start ([P330](https://phab.corp.pixielabs.ai/P330))

This test was performed when my user account could not access `/dev/kvm`(missing kvm group access).