### PR TITLE
Fixed a ingress issue which prevented `px.cloudapi` calls

### DIFF
--- a/k8s/cloud/overlays/exposed_services_nginx/cloud_ingress_grpcs.yaml
+++ b/k8s/cloud/overlays/exposed_services_nginx/cloud_ingress_grpcs.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: plc
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+    nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
   ingressClassName: nginx
   tls:
@@ -18,91 +19,28 @@ spec:
   - host: pixie.example.com
     http:
       paths:
-      - path: /pl.cloudapi.ArtifactTracker/
+      - path: /pl.cloudapi.(.*)
         pathType: Prefix
         backend:
           service:
             name: cloud-proxy-service
             port:
               number: 5555
-      - path: /px.services.VZConnService/
+      - path: /px.services.(.*)
         pathType: Prefix
         backend:
           service:
             name: vzconn-service
             port:
               number: 51600
-      - path: /px.cloudapi.ArtifactTracker/
+      - path: /px.cloudapi.(.*)
         pathType: Prefix
         backend:
           service:
-            name: cloud-proxy-service
+            name: api-service
             port:
-              number: 5555
-      - path: /px.cloudapi.APIKeyManager/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.AuthService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.ConfigService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.OrganizationService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.PluginService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.UserService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.VizierClusterInfo/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.VizierDeploymentKeyManager/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.VizierImageAuthorization/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.api.vizierpb.VizierService/
+              number: 51200
+      - path: /px.api.(.*)
         pathType: Prefix
         backend:
           service:
@@ -112,91 +50,28 @@ spec:
   - host: work.pixie.example.com
     http:
       paths:
-      - path: /pl.cloudapi.ArtifactTracker/
+      - path: /pl.cloudapi.(.*)
         pathType: Prefix
         backend:
           service:
             name: cloud-proxy-service
             port:
               number: 5555
-      - path: /px.services.VZConnService/
+      - path: /px.services.(.*)
         pathType: Prefix
         backend:
           service:
             name: vzconn-service
             port:
               number: 51600
-      - path: /px.cloudapi.ArtifactTracker/
+      - path: /px.cloudapi.(.*)
         pathType: Prefix
         backend:
           service:
-            name: cloud-proxy-service
+            name: api-service
             port:
-              number: 5555
-      - path: /px.cloudapi.APIKeyManager/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.AuthService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.ConfigService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.OrganizationService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.PluginService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.UserService/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.VizierClusterInfo/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.VizierDeploymentKeyManager/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.cloudapi.VizierImageAuthorization/
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
-      - path: /px.api.vizierpb.VizierService/
+              number: 51200
+      - path: /px.api.(.*)
         pathType: Prefix
         backend:
           service:

--- a/k8s/cloud/overlays/exposed_services_nginx/cloud_ingress_grpcs.yaml
+++ b/k8s/cloud/overlays/exposed_services_nginx/cloud_ingress_grpcs.yaml
@@ -19,13 +19,6 @@ spec:
   - host: pixie.example.com
     http:
       paths:
-      - path: /pl.cloudapi.(.*)
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
       - path: /px.services.(.*)
         pathType: Prefix
         backend:
@@ -50,13 +43,6 @@ spec:
   - host: work.pixie.example.com
     http:
       paths:
-      - path: /pl.cloudapi.(.*)
-        pathType: Prefix
-        backend:
-          service:
-            name: cloud-proxy-service
-            port:
-              number: 5555
       - path: /px.services.(.*)
         pathType: Prefix
         backend:


### PR DESCRIPTION
Summary: We have observed that the existing gRPC ingress is not functioning properly for any API call made for the `/px.cloudapi.*` path. This issue is due to the problem with the nginx ingress, where it sets the $HOST header of the request to upstream_balancer. This issue has been reported and documented in https://github.com/kubernetes/ingress-nginx/issues/8843.

As a result, when the traffic hits the cloud proxy service, it returns a 404 error since the request is picked up from the [default_server](https://github.com/pixie-io/pixie/blob/main/src/cloud/proxy/nginx.conf#L78) instead of [@PL_DOMAIN_NAME@](https://github.com/pixie-io/pixie/blob/main/src/cloud/proxy/nginx.conf#L101) server. To resolve this issue, we have set the ingress controller to direct the route to traffic to api-server. This has resolved the issue and restored the functionality of the gRPC ingress.

In addition, we have simplified the ingress rules by using regex since the nginx ingress controller supports regex path matching. This change has improved the readability of the ingress rules.

Relevant Issues: Could be related to https://github.com/pixie-io/pixie/issues/611, we also experience the same issue while login using `px` cli.

Type of change: /kind bug

Test Plan: Deploy the pixie self hosted cloud with this ingress, try using `px auth login --manual`.