### PR TITLE
Add nginx container image with OpenSSL v3 for future tls tracing test

### DIFF
--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -281,6 +281,14 @@ def stirling_test_images():
         "google-samples/microservices-demo/productcatalogservice:v0.2.0",
     )
 
+    # TODO(ddelnano): Replace with the gcr.io equivalent
+    container_pull(
+        name = "nginx_alpine_openssl_3_0_7_base_image",
+        registry = "index.docker.io",
+        digest = "sha256:3eb380b81387e9f2a49cb6e5e18db016e33d62c37ea0e9be2339e9f0b3e26170",
+        repository = "nginx:1.23.3-alpine",
+    )
+
     # Built and pushed by src/stirling/testing/demo_apps/py_grpc/update_gcr.sh
     _gcr_io_image(
         "py_grpc_helloworld_image",

--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -161,7 +161,6 @@ def stirling_test_images():
         "pixie-oss/pixie-dev-public/docker-deps/library/nginx",
     )
 
-
     # DNS server image for DNS tests.
     _gcr_io_image(
         "alpine_dns_base_image",

--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -155,6 +155,13 @@ def stirling_test_images():
         "pixie-oss/pixie-dev-public/docker-deps/library/nginx",
     )
 
+    _gcr_io_image(
+        "nginx_alpine_openssl_3_0_7_base_image",
+        "sha256:3eb380b81387e9f2a49cb6e5e18db016e33d62c37ea0e9be2339e9f0b3e26170",
+        "pixie-oss/pixie-dev-public/docker-deps/library/nginx",
+    )
+
+
     # DNS server image for DNS tests.
     _gcr_io_image(
         "alpine_dns_base_image",
@@ -279,14 +286,6 @@ def stirling_test_images():
         "productcatalogservice_v0_2_0",
         "sha256:1726e4dd813190ad1eae7f3c42483a3a83dd1676832bb7b04256455c8968d82a",
         "google-samples/microservices-demo/productcatalogservice:v0.2.0",
-    )
-
-    # TODO(ddelnano): Replace with the gcr.io equivalent
-    container_pull(
-        name = "nginx_alpine_openssl_3_0_7_base_image",
-        registry = "index.docker.io",
-        digest = "sha256:3eb380b81387e9f2a49cb6e5e18db016e33d62c37ea0e9be2339e9f0b3e26170",
-        repository = "nginx:1.23.3-alpine",
     )
 
     # Built and pushed by src/stirling/testing/demo_apps/py_grpc/update_gcr.sh

--- a/src/stirling/source_connectors/socket_tracer/testing/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/BUILD.bazel
@@ -51,6 +51,7 @@ pl_cc_test_library(
         "//src/stirling/source_connectors/socket_tracer/testing/containers:mysql_connector_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:mysql_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:nats_image.tar",
+        "//src/stirling/source_connectors/socket_tracer/testing/containers:nginx_alpine_openssl_3_0_7_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:nginx_openssl_1_1_0_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:nginx_openssl_1_1_1_image.tar",
         "//src/stirling/source_connectors/socket_tracer/testing/containers:node_12_3_1_image.tar",

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images.h
@@ -99,6 +99,24 @@ class NginxOpenSSL_1_1_1_Container : public ContainerRunner {
   static constexpr std::string_view kReadyMessage = "";
 };
 
+class NginxOpenSSL_3_0_7_Container : public ContainerRunner {
+ public:
+  NginxOpenSSL_3_0_7_Container()
+      : ContainerRunner(::px::testing::BazelRunfilePath(kBazelImageTar), kContainerNamePrefix,
+                        kReadyMessage) {}
+
+  int32_t NginxWorkerPID() const { return internal::GetNginxWorkerPID(process_pid()); }
+
+ private:
+  // Image is a modified nginx image created through bazel rules, and stored as a tar file.
+  // It is not pushed to any repo.
+  static constexpr std::string_view kBazelImageTar =
+      "src/stirling/source_connectors/socket_tracer/testing/containers/"
+      "nginx_alpine_openssl_3_0_7_image.tar";
+  static constexpr std::string_view kContainerNamePrefix = "nginx";
+  static constexpr std::string_view kReadyMessage = "";
+};
+
 class CurlContainer : public ContainerRunner {
  public:
   CurlContainer()

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
@@ -85,6 +85,16 @@ container_image(
 )
 
 container_image(
+    name = "nginx_alpine_openssl_3_0_7_image",
+    base = "@nginx_alpine_openssl_3_0_7_base_image//image",
+    layers = [
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/ssl:nginx_conf",
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/ssl:nginx_html",
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/ssl:ssl_keys_layer",
+    ],
+)
+
+container_image(
     name = "nats_image",
     base = "@nats_base_image//image",
     layers = [

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/ssl/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/ssl/BUILD.bazel
@@ -64,6 +64,14 @@ container_layer(
     files = ["nginx.conf"],
 )
 
+# Nginx 1.23 changes the format of the index.html. This layer is used
+# so that all of our nginx permutations can rely on the same assertion
+container_layer(
+    name = "nginx_html",
+    directory = "/usr/share/nginx/html",
+    files = ["index.html"],
+)
+
 pkg_tar(
     name = "node_client_server",
     srcs = [

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/ssl/index.html
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/ssl/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>


### PR DESCRIPTION
Summary: Add nginx container image with OpenSSL v3 for future tls tracing test

The tls tracing method developed for #692 will support dynamically linked OpenSSL v3 in addition to BoringSSL. In order to validate that the new tracing method works (in addition to its feature flag), I wanted to a test case that would prove the new implementation is in use.

The mirrored upstream nginx image added in this PR has a different `/index.html` compared to our existing images. This change adds a container layer containing the expected `index.html` so that the future test assertions can remain the same.

Relevant Issues: #692

Type of change: /kind test-infra

Test Plan: Verified that the resulting nginx container returns the same html file as our [existing](https://github.com/pixie-io/pixie/blob/86dfb11dcbf605fbec1a317192886e52416fa4aa/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel#L70) nginx [containers](https://github.com/pixie-io/pixie/blob/86dfb11dcbf605fbec1a317192886e52416fa4aa/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel#L79)
```
# Run the new nginx image and an existing one built from bazel
ddelnano@turing:~/code/pixie$ docker run -d -p 80:80 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:nginx_alpine_openssl_3_0_7_image
ddelnano@turing:~/code/pixie$ docker run -d -p 81:80 bazel/src/stirling/source_connectors/socket_tracer/testing/containers:nginx_openssl_1_1_1_image
48277f0656b2327de29917e063e80705c4f14e95d89081a0c8b9b4177846ca29

# Run the mirroed upstream image (used later to validate that the index.html is different)
ddelnano@turing:~/code/pixie$ docker run -d -p 82:80 gcr.io/pixie-oss/pixie-dev-public/docker-deps/library/nginx@sha256:3eb380b81387e9f2a49cb6e5e18db016e33d62c37ea0e9be2339e9f0b3e26170


# Verify that requests to `/` result in the same response
ddelnano@turing:~/code/pixie$ curl -s localhost:80 | sha256sum
38ffd4972ae513a0c79a8be4573403edcd709f0f572105362b08ff50cf6de521  -

ddelnano@turing:~/code/pixie$ curl -s localhost:81 | sha256sum
38ffd4972ae513a0c79a8be4573403edcd709f0f572105362b08ff50cf6de521  -

# Verify that the stock nginx 1.23 image returns a different index.html
ddelnano@turing:~/code/pixie$ curl -s localhost:82 | sha256sum
fb47468a2cd3953c7131431991afcc6a2703f14640520102eea0a685a7e8d6de  -
```