### PR TITLE
Add a tmpfs volume mount for Java containers in the perf profiler test.

### DIFF
--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -184,12 +184,12 @@ class ContainerSubProcesses final : public PerfProfilerTestSubProcesses {
   void StartAll() override {
     const system::ProcParser proc_parser;
     const auto timeout = std::chrono::seconds{2 * FLAGS_test_run_time};
-    const std::vector<std::string> options;
+    const std::vector<std::string> opts = {"--mount", "type=tmpfs,tmpfs-size=64M,destination=/tmp"};
     const std::vector<std::string> args;
     static constexpr bool kUseHostPidNamespace = false;
 
     for (size_t i = 0; i < kNumSubProcs; ++i) {
-      sub_processes_[i]->Run(timeout, options, args, kUseHostPidNamespace);
+      sub_processes_[i]->Run(timeout, opts, args, kUseHostPidNamespace);
 
       // Grab the PID and generate a UPID.
       const int pid = sub_processes_[i]->process_pid();


### PR DESCRIPTION
Summary: In the perf profiler bpf test, we add a tmpfs volume mount to the podman cmd line. This fixes a test flake where the perf profiler refuses to attach the Java symbolization agent because it cannot found enough tmpfs capacity.

Type of change: /kind bug fix

Test Plan: Existing tests pass.