### PR TITLE
Fix overloaded exit codes with qemu test runner

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/exit_qemu_with_status/exit_qemu_with_status.c
+++ b/bazel/test_runners/qemu_with_kernel/exit_qemu_with_status/exit_qemu_with_status.c
@@ -29,13 +29,17 @@ int main(int argc, char** argv) {
   }
   status = atoi(argv[1]);
 
-  if (ioperm(EXIT_PORT, 4, 1)) {
+  if (ioperm(EXIT_PORT, 8, 1)) {
     perror("ioperm");
     exit(1);
   }
 
   unsigned char statusb = (unsigned char)status;
-  // QEMU transforms this into 2*status + 1.
+  // QEMU transforms this into (status << 1) | 1;
+  // We don't want to interfere with qemu error code,
+  // so we further make sure the codes are > 128 for exit codes from our tests.
+  // If we shift by 6, the additinal shift of 1 by qemu will make the exit code > 128.
+  statusb |= (1 << 6);
   outb(statusb, EXIT_PORT);
 
   // Should never get here.

--- a/bazel/test_runners/qemu_with_kernel/run_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/run_qemu.sh
@@ -67,7 +67,7 @@ flags+=(-hda "${overlay_disk_image}")
 flags+=(-virtfs "local,path=${QEMU_TEST_FS_PATH},mount_tag=test_fs,security_model=mapped")
 
 # Exit device:
-flags+=(-device "isa-debug-exit,iobase=${QEMU_EXIT_BASE},iosize=0x4")
+flags+=(-device "isa-debug-exit,iobase=${QEMU_EXIT_BASE},iosize=0x8")
 
 # Kernel config:
 flags+=(-kernel "${QEMU_KERNEL_IMAGE}")
@@ -79,6 +79,13 @@ flags+=(-nographic)
 retval=0
 qemu-system-x86_64 "${flags[@]}" || retval=$?
 
-# The actual return value is need to be converted back.
-retval="$(echo "($retval-1)/2" | bc)"
+if [[ "${retval}" -gt 0 ]]; then
+    if [[ "${retval}" -lt 128 ]]; then
+	echo "QEMU failed to launch with status code: ${retval}"
+    else
+	retval="$(echo "($retval-128-1)/2" | bc)"
+	echo "Test failed with status: ${retval}"
+    fi
+fi
+
 exit "${retval}"


### PR DESCRIPTION
Summary: The test runner was overloading the exit codes so we can't differentiate qemu errors from test errors.
This makes the test errors return values offset by 128 so we assume that errors > 128 are test errors.

Relevant Issues: #709

Type of change: /kind test-infra

Test Plan: `bazel test -c opt --config=qemu-bpf  --cache_test_results=no --remote_download_outputs=all //src/stirling/source_connectors/socket_tracer:redis_trace_bpf_test --test_output=streamed`
Also tested with qemu failing to start.

