### PR TITLE
Fix "`GLIBC_2.32' not found" error in plugin updater job

### DIFF
--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -20,7 +20,7 @@ spec:
         args:
         - |
             trap "touch /tmp/pod/terminated" EXIT
-            /plugin_db_updater/load_db
+            src/cloud/plugin/load_db/load_db_/load_db
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/src/cloud/plugin/load_db/BUILD.bazel
+++ b/src/cloud/plugin/load_db/BUILD.bazel
@@ -55,7 +55,7 @@ pl_go_binary(
 
 container_image(
     name = "db_base_image",
-    # We need a debug image because the artifact_db_updater_job calls busybox to set a TRAP.
+    # We need a debug image because the plugin_updater calls busybox to set a TRAP.
     base = "//:pl_cc_base_debug_image",
 )
 

--- a/src/cloud/plugin/load_db/BUILD.bazel
+++ b/src/cloud/plugin/load_db/BUILD.bazel
@@ -16,9 +16,8 @@
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_test")
+load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image", "pl_go_test")
 
 go_library(
     name = "load_db_lib",
@@ -54,19 +53,16 @@ pl_go_binary(
     visibility = ["//visibility:public"],
 )
 
-container_layer(
-    name = "plugin_db_updater_go_layer",
-    directory = "/plugin_db_updater",
-    files = [":load_db"],
-    visibility = ["//src:__subpackages__"],
+container_image(
+    name = "db_base_image",
+    # We need a debug image because the artifact_db_updater_job calls busybox to set a TRAP.
+    base = "//:pl_cc_base_debug_image",
 )
 
-container_image(
+pl_go_image(
     name = "plugin_db_updater_image",
-    base = "@base_image_debug//image",
-    layers = [
-        ":plugin_db_updater_go_layer",
-    ],
+    base = ":db_base_image",
+    binary = ":load_db",
     visibility = [
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",


### PR DESCRIPTION
Summary: Build changes broke the plugin updater job. This PR updates the build configs/YAMLs for the plugin updater job to match the artifact updater job, since they both require `busybox` to set a TRAP.

Relevant Issues: #1084

Type of change: /kind bug

Test Plan: Skaffold deploy cloud and verify plugin job runs

