### PR TITLE
[artifact manifests] Add `ArtifactManifest` type to represent a manifest file

### DIFF
--- a/src/shared/artifacts/manifest/BUILD.bazel
+++ b/src/shared/artifacts/manifest/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@px//bazel:pl_build_system.bzl", "pl_go_test")
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "manifest",
+    srcs = [
+        "json.go",
+        "manifest.go",
+        "sorted.go",
+    ],
+    importpath = "px.dev/pixie/src/shared/artifacts/manifest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/shared/artifacts/versionspb:versions_pl_go_proto",
+        "@com_github_gogo_protobuf//jsonpb",
+        "@org_golang_x_mod//semver",
+    ],
+)
+
+pl_go_test(
+    name = "manifest_test",
+    srcs = ["manifest_test.go"],
+    deps = [
+        ":manifest",
+        "//src/shared/artifacts/versionspb:versions_pl_go_proto",
+        "@com_github_gogo_protobuf//jsonpb",
+        "@com_github_gogo_protobuf//types",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/src/shared/artifacts/manifest/json.go
+++ b/src/shared/artifacts/manifest/json.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+
+	"github.com/gogo/protobuf/jsonpb"
+
+	"px.dev/pixie/src/shared/artifacts/versionspb"
+)
+
+// UnmarshalJSON decodes a json array of artifact sets into an ArtifactManifest.
+func (a *ArtifactManifest) UnmarshalJSON(b []byte) error {
+	a.sets = make(map[string]*sortedArtifactSet)
+	l := []*sortedArtifactSet{}
+	if err := json.Unmarshal(b, &l); err != nil {
+		return err
+	}
+	for _, as := range l {
+		a.sets[as.name] = as
+	}
+	return nil
+}
+
+// MarshalJSON marshals a slice of artifact sets into a json array.
+func (a *ArtifactManifest) MarshalJSON() ([]byte, error) {
+	l := make([]*sortedArtifactSet, 0, len(a.sets))
+	for _, as := range a.sets {
+		l = append(l, as)
+	}
+	// marshal ArtifactSets sorted by Name.
+	sort.Slice(l, func(i, j int) bool {
+		return l[i].name < l[j].name
+	})
+	return json.Marshal(l)
+}
+
+func (as *sortedArtifactSet) UnmarshalJSON(b []byte) error {
+	pb := &versionspb.ArtifactSet{}
+	if err := jsonpb.Unmarshal(bytes.NewReader(b), pb); err != nil {
+		return err
+	}
+	as.name = pb.Name
+	as.artifacts = pb.Artifact
+	sort.Sort(as)
+	return nil
+}
+
+func (as *sortedArtifactSet) MarshalJSON() ([]byte, error) {
+	pb := as.toProto()
+	var b bytes.Buffer
+	if err := (&jsonpb.Marshaler{}).Marshal(&b, pb); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}

--- a/src/shared/artifacts/manifest/manifest.go
+++ b/src/shared/artifacts/manifest/manifest.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manifest
+
+import (
+	"encoding/json"
+	"io"
+
+	"px.dev/pixie/src/shared/artifacts/versionspb"
+)
+
+// ArtifactManifest represents a manifest file listing artifact sets.
+// Internally, the artifacts are sorted by their versions, with newer versions first.
+type ArtifactManifest struct {
+	sets map[string]*sortedArtifactSet
+}
+
+// ReadArtifactManifest reads an ArtifactManifest from a json stream.
+func ReadArtifactManifest(r io.Reader) (*ArtifactManifest, error) {
+	dec := json.NewDecoder(r)
+	m := &ArtifactManifest{}
+	if err := dec.Decode(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Write writes an artifact manifest in JSON format to the given io.Writer.
+func (a *ArtifactManifest) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	return enc.Encode(a)
+}
+
+// ArtifactSets returns the list of protobuf artifact sets in this manifest.
+func (a *ArtifactManifest) ArtifactSets() []*versionspb.ArtifactSet {
+	pb := make([]*versionspb.ArtifactSet, 0, len(a.sets))
+	for _, as := range a.sets {
+		pb = append(pb, as.toProto())
+	}
+	return pb
+}
+
+// NewArtifactManifestFromProto returns a new ArtifactManifest from a list of ArtifactSet protobufs.
+func NewArtifactManifestFromProto(pb []*versionspb.ArtifactSet) *ArtifactManifest {
+	m := &ArtifactManifest{
+		sets: make(map[string]*sortedArtifactSet, len(pb)),
+	}
+	for _, as := range pb {
+		m.sets[as.Name] = newSortedArtifactSetFromProto(as)
+	}
+	return m
+}

--- a/src/shared/artifacts/manifest/manifest_test.go
+++ b/src/shared/artifacts/manifest/manifest_test.go
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manifest_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+
+	"px.dev/pixie/src/shared/artifacts/manifest"
+	"px.dev/pixie/src/shared/artifacts/versionspb"
+)
+
+func TestManifest_JSONDecode(t *testing.T) {
+	time1 := time.Date(2023, time.March, 23, 0, 24, 33, 10, time.UTC)
+	time1Proto, err := types.TimestampProto(time1)
+	require.NoError(t, err)
+	time1Str, err := (&jsonpb.Marshaler{}).MarshalToString(time1Proto)
+	require.NoError(t, err)
+	time1Str = strings.Trim(time1Str, `"`)
+
+	testCases := []struct {
+		name                 string
+		json                 string
+		expectedArtifactSets []*versionspb.ArtifactSet
+	}{
+		{
+			name: "single artifact set",
+			json: fmt.Sprintf(`
+[
+  {"name": "vizier", "artifact": [{
+    "timestamp": "%s",
+    "commitHash": "1234",
+    "versionStr": "0.12.17",
+    "availableArtifacts": [
+      "AT_CONTAINER_SET_LINUX_AMD64",
+      "AT_CONTAINER_SET_YAMLS",
+      "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+    ],
+    "changelog": "changelog1"
+  }]}
+]
+`, time1Str),
+			expectedArtifactSets: []*versionspb.ArtifactSet{
+				{
+					Name: "vizier",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "1234",
+							VersionStr: "0.12.17",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple artifact sets",
+			json: fmt.Sprintf(`
+[
+  {"name": "vizier", "artifact": [{
+    "timestamp": "%s",
+    "commitHash": "1234",
+    "versionStr": "0.12.17",
+    "availableArtifacts": [
+      "AT_CONTAINER_SET_LINUX_AMD64",
+      "AT_CONTAINER_SET_YAMLS",
+      "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+    ],
+    "changelog": "changelog1"
+  }]},
+  {"name": "cli", "artifact": [{
+    "timestamp": "%s",
+    "commitHash": "abcd",
+    "versionStr": "0.1.1",
+    "availableArtifacts": [
+      "AT_LINUX_AMD64",
+      "AT_DARWIN_AMD64"
+    ],
+    "changelog": "changelog2"
+  }]}
+]
+`, time1Str, time1Str),
+			expectedArtifactSets: []*versionspb.ArtifactSet{
+				{
+					Name: "vizier",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "1234",
+							VersionStr: "0.12.17",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog1",
+						},
+					},
+				},
+				{
+					Name: "cli",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "abcd",
+							VersionStr: "0.1.1",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_LINUX_AMD64,
+								versionspb.AT_DARWIN_AMD64,
+							},
+							Changelog: "changelog2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple artifacts sorted",
+			json: fmt.Sprintf(`
+[
+  {"name": "vizier", "artifact": [
+    {
+      "timestamp": "%s",
+      "commitHash": "1234",
+      "versionStr": "0.12.9",
+      "availableArtifacts": [
+        "AT_CONTAINER_SET_LINUX_AMD64",
+        "AT_CONTAINER_SET_YAMLS",
+        "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+      ],
+      "changelog": "changelog1"
+    },
+    {
+      "timestamp": "%s",
+      "commitHash": "abcd",
+      "versionStr": "0.12.10",
+      "availableArtifacts": [
+        "AT_CONTAINER_SET_LINUX_AMD64",
+        "AT_CONTAINER_SET_YAMLS",
+        "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+      ],
+      "changelog": "changelog2"
+    }
+  ]}
+]
+`, time1Str, time1Str),
+			expectedArtifactSets: []*versionspb.ArtifactSet{
+				{
+					Name: "vizier",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "abcd",
+							VersionStr: "0.12.10",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog2",
+						},
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "1234",
+							VersionStr: "0.12.9",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := strings.NewReader(tc.json)
+			m, err := manifest.ReadArtifactManifest(r)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expectedArtifactSets, m.ArtifactSets())
+		})
+	}
+}
+
+func TestManifest_JSONEncode(t *testing.T) {
+	time1 := time.Date(2023, time.March, 23, 0, 24, 33, 10, time.UTC)
+	time1Proto, err := types.TimestampProto(time1)
+	require.NoError(t, err)
+	time1Str, err := (&jsonpb.Marshaler{}).MarshalToString(time1Proto)
+	require.NoError(t, err)
+	time1Str = strings.Trim(time1Str, `"`)
+
+	testCases := []struct {
+		name         string
+		expectedJSON string
+		artifactSets []*versionspb.ArtifactSet
+	}{
+		{
+			name: "multiple artifact sets",
+			expectedJSON: fmt.Sprintf(`
+[
+  {"name": "cli", "artifact": [{
+    "timestamp": "%s",
+    "commitHash": "abcd",
+    "versionStr": "0.1.1",
+    "availableArtifacts": [
+      "AT_LINUX_AMD64",
+      "AT_DARWIN_AMD64"
+    ],
+    "changelog": "changelog2"
+  }]},
+  {"name": "vizier", "artifact": [{
+    "timestamp": "%s",
+    "commitHash": "1234",
+    "versionStr": "0.12.17",
+    "availableArtifacts": [
+      "AT_CONTAINER_SET_LINUX_AMD64",
+      "AT_CONTAINER_SET_YAMLS",
+      "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+    ],
+    "changelog": "changelog1"
+  }]}
+]
+`, time1Str, time1Str),
+			artifactSets: []*versionspb.ArtifactSet{
+				{
+					Name: "vizier",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "1234",
+							VersionStr: "0.12.17",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog1",
+						},
+					},
+				},
+				{
+					Name: "cli",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "abcd",
+							VersionStr: "0.1.1",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_LINUX_AMD64,
+								versionspb.AT_DARWIN_AMD64,
+							},
+							Changelog: "changelog2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple artifacts sorted",
+			expectedJSON: fmt.Sprintf(`
+[
+  {"name": "vizier", "artifact": [
+    {
+      "timestamp": "%s",
+      "commitHash": "abcd",
+      "versionStr": "0.12.10",
+      "availableArtifacts": [
+        "AT_CONTAINER_SET_LINUX_AMD64",
+        "AT_CONTAINER_SET_YAMLS",
+        "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+      ],
+      "changelog": "changelog2"
+    },
+    {
+      "timestamp": "%s",
+      "commitHash": "1234",
+      "versionStr": "0.12.9",
+      "availableArtifacts": [
+        "AT_CONTAINER_SET_LINUX_AMD64",
+        "AT_CONTAINER_SET_YAMLS",
+        "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+      ],
+      "changelog": "changelog1"
+    }
+  ]}
+]
+`, time1Str, time1Str),
+			artifactSets: []*versionspb.ArtifactSet{
+				{
+					Name: "vizier",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "1234",
+							VersionStr: "0.12.9",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog1",
+						},
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "abcd",
+							VersionStr: "0.12.10",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := &json.RawMessage{}
+			err := json.Unmarshal([]byte(tc.expectedJSON), raw)
+			require.NoError(t, err)
+			bytes, err := json.Marshal(raw)
+			require.NoError(t, err)
+			expectedJSON := string(bytes)
+
+			m := manifest.NewArtifactManifestFromProto(tc.artifactSets)
+
+			w := &strings.Builder{}
+			err = m.Write(w)
+			require.NoError(t, err)
+			require.Equal(t, expectedJSON, strings.Trim(w.String(), "\n"))
+		})
+	}
+}

--- a/src/shared/artifacts/manifest/sorted.go
+++ b/src/shared/artifacts/manifest/sorted.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manifest
+
+import (
+	"sort"
+
+	"golang.org/x/mod/semver"
+
+	"px.dev/pixie/src/shared/artifacts/versionspb"
+)
+
+// sortedArtifactSet keeps it artifacts in version descending order (newer versions first).
+type sortedArtifactSet struct {
+	name      string
+	artifacts []*versionspb.Artifact
+}
+
+func (as *sortedArtifactSet) Len() int {
+	return len(as.artifacts)
+}
+
+func (as *sortedArtifactSet) Less(i, j int) bool {
+	return artifactCompare(as.artifacts[i], as.artifacts[j])
+}
+
+func (as *sortedArtifactSet) Swap(i, j int) {
+	as.artifacts[i], as.artifacts[j] = as.artifacts[j], as.artifacts[i]
+}
+
+func (as *sortedArtifactSet) toProto() *versionspb.ArtifactSet {
+	pb := &versionspb.ArtifactSet{
+		Name:     as.name,
+		Artifact: as.artifacts,
+	}
+	return pb
+}
+
+func newSortedArtifactSetFromProto(pb *versionspb.ArtifactSet) *sortedArtifactSet {
+	as := &sortedArtifactSet{
+		name:      pb.Name,
+		artifacts: pb.Artifact,
+	}
+	sort.Sort(as)
+	return as
+}
+
+func artifactCompare(a, b *versionspb.Artifact) bool {
+	// Sort the semantic versions in descending order.
+	return semver.Compare("v"+a.VersionStr, "v"+b.VersionStr) > 0
+}


### PR DESCRIPTION
Summary: This PR adds `ArtifactManifest` which is a golang representation of an artifact manifest file. In the future, the artifact tracker will pull a manifest file from GCS, decode it into this type, and then query for artifacts from `ArtifactManifest` directly. This PR adds support for json serialization/deserialization for artifact manifests. Internally, the artifacts in the manifest are stored in version sorted order, such that newer versions are first. This will enable faster version-ordered queries of manifests in the future.

Type of change: /kind cleanup

Test Plan: Added tests for `ArtifactManifest` serialization/deserialization.
