### PR TITLE
[artifact manifests] Add `ArtifactManifest.Merge` to merge two manifests

### DIFF
--- a/src/shared/artifacts/manifest/BUILD.bazel
+++ b/src/shared/artifacts/manifest/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     srcs = [
         "json.go",
         "manifest.go",
+        "merge.go",
         "sorted.go",
     ],
     importpath = "px.dev/pixie/src/shared/artifacts/manifest",
@@ -30,6 +31,7 @@ go_library(
     deps = [
         "//src/shared/artifacts/versionspb:versions_pl_go_proto",
         "@com_github_gogo_protobuf//jsonpb",
+        "@com_github_gogo_protobuf//proto",
         "@org_golang_x_mod//semver",
     ],
 )

--- a/src/shared/artifacts/manifest/merge.go
+++ b/src/shared/artifacts/manifest/merge.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package manifest
+
+import (
+	"sort"
+
+	"github.com/gogo/protobuf/proto"
+
+	"px.dev/pixie/src/shared/artifacts/versionspb"
+)
+
+// Merge returns a new ArtifactManifest with the artifacts merged. On conflicts, values in `updates` take precedence.
+func (a *ArtifactManifest) Merge(updates *ArtifactManifest) *ArtifactManifest {
+	merged := &ArtifactManifest{
+		sets: make(map[string]*sortedArtifactSet),
+	}
+	for name, set := range a.sets {
+		merged.sets[name] = set
+	}
+	for name, set := range updates.sets {
+		base, ok := merged.sets[name]
+		if !ok {
+			merged.sets[name] = set
+			continue
+		}
+		merged.sets[name] = base.Merge(set)
+	}
+	return merged
+}
+
+func (as *sortedArtifactSet) Merge(updates *sortedArtifactSet) *sortedArtifactSet {
+	merged := &sortedArtifactSet{
+		name:      as.name,
+		artifacts: as.artifacts[:],
+	}
+	for _, a := range updates.artifacts {
+		baseIndex := -1
+		for i, other := range merged.artifacts {
+			if a.VersionStr == other.VersionStr {
+				baseIndex = i
+			}
+		}
+		if baseIndex == -1 {
+			merged.artifacts = append(merged.artifacts, a)
+			continue
+		}
+		merged.artifacts[baseIndex] = mergeArtifact(merged.artifacts[baseIndex], a)
+	}
+	sort.Sort(merged)
+	return merged
+}
+
+func mergeArtifact(base, updates *versionspb.Artifact) *versionspb.Artifact {
+	merged := proto.Clone(base).(*versionspb.Artifact)
+	merged.Timestamp = updates.Timestamp
+	merged.CommitHash = updates.CommitHash
+	merged.AvailableArtifacts = updates.AvailableArtifacts
+	merged.Changelog = updates.Changelog
+	return merged
+}

--- a/src/shared/artifacts/manifest/sorted.go
+++ b/src/shared/artifacts/manifest/sorted.go
@@ -62,6 +62,10 @@ func newSortedArtifactSetFromProto(pb *versionspb.ArtifactSet) *sortedArtifactSe
 }
 
 func artifactCompare(a, b *versionspb.Artifact) bool {
+	return versionCompare(a.VersionStr, b.VersionStr)
+}
+
+func versionCompare(a, b string) bool {
 	// Sort the semantic versions in descending order.
-	return semver.Compare("v"+a.VersionStr, "v"+b.VersionStr) > 0
+	return semver.Compare("v"+a, "v"+b) >= 0
 }


### PR DESCRIPTION
Summary: A future PR will create a `manifest_updater` utility to update an existing manifest with new entries. To enable such a utility we need a way to merge two manifests together. This PR adds a `Merge` method to `ArtifactManifest` to create a new merged manifest from two manifests.

Type of change: /kind cleanup

Test Plan: Added tests for the new `Merge` method.
