### PR TITLE
[plugin_db_updater] Fix dev and public plugin_db_updater jobs

### DIFF
--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -29,8 +29,6 @@ spec:
       containers:
       - name: updater
         image: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db:latest
-        command:
-        - /plugin_db_updater/load_db
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/public/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/plugin_db_updater_job.yaml
@@ -29,8 +29,6 @@ spec:
       containers:
       - name: updater
         image: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db:latest
-        command:
-        - /plugin_db_updater/load_db
         envFrom:
         - configMapRef:
             name: pl-db-config


### PR DESCRIPTION
Summary: Build changes for the `plugin_db_updater` lead to the path for the binary being incorrect in some of our k8s yamls. This fixes both the `dev` and `public` cloud deploys.

Type of change: /kind cleanup

Test Plan: Along with #1099, tested that a skaffold of `public` cloud works without errors.
