### PR TITLE
Restrict GITHUB_TOKEN permissions for get_image workflow

### DIFF
--- a/.github/workflows/get_image.yaml
+++ b/.github/workflows/get_image.yaml
@@ -13,6 +13,8 @@ on:
       image-with-tag:
         description: "A image with tag (from docker.properties) for the requested image"
         value: ${{ jobs.get-image.outputs.image-with-tag }}
+permissions:
+  contents: read
 jobs:
   get-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Summary: TSIA

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: The workflow should continue to run without issues.
