### PR TITLE
[artifact manifests] Add script for updating artifact manifest file

### DIFF
--- a/ci/update_artifact_manifest.sh
+++ b/ci/update_artifact_manifest.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+repo_path="$(git rev-parse --show-toplevel)"
+manifest_bucket="${ARTIFACT_MANIFEST_BUCKET:-pixie-dev}"
+manifest_path="manifest.json"
+versions_file="${VERSIONS_FILE:-${repo_path}/src/utils/artifacts/artifact_db_updater/VERSIONS.json}"
+
+manifest_updates="$(mktemp)"
+# For now we manually change the versions_file into an array of ArtifactSets instead of an individual artifact set.
+# This avoids changing versions_gen and artifact_db_updater.
+jq '[.]' < "${versions_file}" > "${manifest_updates}"
+
+bazel run //src/utils/artifacts/manifest_updater -- --manifest_bucket="${manifest_bucket}" --manifest_path="${manifest_path}" --manifest_updates="${manifest_updates}"
+
+rm "${manifest_updates}"


### PR DESCRIPTION
Summary: Adds script to run `manifest_updater` using the `VERSIONS.json` file to update the current manifest. This script will be run as part of each of the release processes.

Type of change: /kind test-infra

Test Plan: Tested that the script properly updates the manifest file on GCS with any changes from the VERSIONS.json file.
