### PR TITLE
Restrict GITHUB_TOKEN permissions for perf eval workflow

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -20,7 +20,8 @@ on:
         description: 'Tags (comma separated)'
         type: string
         required: false
-
+permissions:
+  contents: read
 jobs:
   nightly-perf-eval:
     name: Nightly Performance Evaluation


### PR DESCRIPTION
Summary: TSIA

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Perf eval workflows should continue to work.
