### PR TITLE
Implement new tls tracing method behind stirling cli flag (feature toggle)

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -18,6 +18,18 @@ load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
+# TODO(ddelnano): Remove once new tls tracing implementation is
+# the default and we are ready to enable tracing of openssl v3.
+config_setting(
+    name = "enable_openssl_v3_testing",
+    values = {"define": "enable_openssl_v3_testing=1"},
+)
+
+enable_openssl_v3_tracing_defines = select({
+    ":enable_openssl_v3_testing": ["ENABLE_OPENSSL_V3_TRACING"],
+    "//conditions:default": [],
+})
+
 pl_cc_library(
     name = "cc_library",
     srcs = glob(
@@ -28,6 +40,7 @@ pl_cc_library(
         ],
     ),
     hdrs = glob(["*.h"]),
+    defines = enable_openssl_v3_tracing_defines,
     deps = [
         "//src/common/exec:cc_library",
         "//src/common/grpcutils:cc_library",
@@ -434,6 +447,7 @@ pl_cc_test(
     name = "openssl_trace_bpf_test",
     timeout = "long",
     srcs = ["openssl_trace_bpf_test.cc"],
+    defines = enable_openssl_v3_tracing_defines,
     flaky = True,
     shard_count = 2,
     tags = [

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -14,8 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -15,14 +15,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
 # TODO(ddelnano): Remove once new tls tracing implementation is
 # the default and we are ready to enable tracing of openssl v3.
+bool_flag(
+    name = "enable_openssl_v3_testing_flag",
+    build_setting_default = False,
+)
+
 config_setting(
     name = "enable_openssl_v3_testing",
-    values = {"define": "enable_openssl_v3_testing=1"},
+    flag_values = {
+        ":enable_openssl_v3_testing_flag": "True",
+    },
 )
 
 enable_openssl_v3_tracing_defines = select({

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -180,11 +180,8 @@ static __inline void propagate_fd_to_user_space_call(uint64_t pid_tgid, int fd) 
       nested_syscall_fd_ptr->mismatched_fds = true;
     }
 
-    // TODO(ddelnano): Our existing functionality is not changed until we uncomment
-    // set_conn_as_ssl. We plan to switch over to the new functionality as part of
-    // pixie#1123.
-    // uint32_t tgid = pid_tgid >> 32;
-    // set_conn_as_ssl(tgid, fd);
+    uint32_t tgid = pid_tgid >> 32;
+    set_conn_as_ssl(tgid, fd);
   }
 }
 

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -173,7 +173,8 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
 typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper, NginxOpenSSL_3_0_7_ContainerWrapper>
     OpenSSLServerNestedSyscallFDImplementations;
 #else
-typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper> OpenSSLServerNestedSyscallFDImplementations;
+typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper>
+    OpenSSLServerNestedSyscallFDImplementations;
 #endif
 
 template <typename T>
@@ -182,8 +183,8 @@ using OpenSSLTraceTest = BaseOpenSSLTraceTest<T, false>;
 template <typename T>
 using OpenSSLTraceNestedSyscallFD = BaseOpenSSLTraceTest<T, true>;
 
-#define OPENSSL_TYPED_TEST(TestCase, CodeBlock)       \
-  TYPED_TEST(OpenSSLTraceTest, TestCase)              \
+#define OPENSSL_TYPED_TEST(TestCase, CodeBlock)               \
+  TYPED_TEST(OpenSSLTraceTest, TestCase)                      \
   CodeBlock TYPED_TEST(OpenSSLTraceNestedSyscallFD, TestCase) \
   CodeBlock
 

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -83,7 +83,7 @@ struct TraceRecords {
   std::vector<std::string> remote_address;
 };
 
-template <typename TServerContainer, bool TUseNewImpl>
+template <typename TServerContainer, bool UseNestedSyscallFD>
 class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing */ false> {
  protected:
   BaseOpenSSLTraceTest() {
@@ -121,7 +121,7 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTrac
   }
 
   TServerContainer server_;
-  bool use_new_tls_impl_ = TUseNewImpl;
+  bool use_new_tls_impl_ = UseNestedSyscallFD;
 };
 
 //-----------------------------------------------------------------------------
@@ -171,24 +171,24 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
 // the default and we are ready to enable tracing of openssl v3.
 #ifdef ENABLE_OPENSSL_V3_TRACING
 typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper, NginxOpenSSL_3_0_7_ContainerWrapper>
-    OpenSSLServerNewImplImplementations;
+    OpenSSLServerNestedSyscallFDImplementations;
 #else
-typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper> OpenSSLServerNewImplImplementations;
+typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper> OpenSSLServerNestedSyscallFDImplementations;
 #endif
 
 template <typename T>
 using OpenSSLTraceTest = BaseOpenSSLTraceTest<T, false>;
 
 template <typename T>
-using OpenSSLTraceNewImpl = BaseOpenSSLTraceTest<T, true>;
+using OpenSSLTraceNestedSyscallFD = BaseOpenSSLTraceTest<T, true>;
 
 #define OPENSSL_TYPED_TEST(TestCase, CodeBlock)       \
   TYPED_TEST(OpenSSLTraceTest, TestCase)              \
-  CodeBlock TYPED_TEST(OpenSSLTraceNewImpl, TestCase) \
+  CodeBlock TYPED_TEST(OpenSSLTraceNestedSyscallFD, TestCase) \
   CodeBlock
 
 TYPED_TEST_SUITE(OpenSSLTraceTest, OpenSSLServerImplementations);
-TYPED_TEST_SUITE(OpenSSLTraceNewImpl, OpenSSLServerNewImplImplementations);
+TYPED_TEST_SUITE(OpenSSLTraceNestedSyscallFD, OpenSSLServerNestedSyscallFDImplementations);
 
 OPENSSL_TYPED_TEST(ssl_capture_curl_client, {
   this->StartTransferDataThread();

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -173,8 +173,7 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
 typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper, NginxOpenSSL_3_0_7_ContainerWrapper>
     OpenSSLServerNewImplImplementations;
 #else
-typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper>
-    OpenSSLServerNewImplImplementations;
+typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper> OpenSSLServerNewImplImplementations;
 #endif
 
 template <typename T>
@@ -183,9 +182,10 @@ using OpenSSLTraceTest = BaseOpenSSLTraceTest<T, false>;
 template <typename T>
 using OpenSSLTraceNewImpl = BaseOpenSSLTraceTest<T, true>;
 
-#define OPENSSL_TYPED_TEST(TestCase, CodeBlock) \
-  TYPED_TEST(OpenSSLTraceTest, TestCase)        \
-  CodeBlock TYPED_TEST(OpenSSLTraceNewImpl, TestCase) CodeBlock
+#define OPENSSL_TYPED_TEST(TestCase, CodeBlock)       \
+  TYPED_TEST(OpenSSLTraceTest, TestCase)              \
+  CodeBlock TYPED_TEST(OpenSSLTraceNewImpl, TestCase) \
+  CodeBlock
 
 TYPED_TEST_SUITE(OpenSSLTraceTest, OpenSSLServerImplementations);
 TYPED_TEST_SUITE(OpenSSLTraceNewImpl, OpenSSLServerNewImplImplementations);

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -98,7 +98,7 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTrac
   }
 
   void SetUp() override {
-    FLAGS_access_tls_socket_fd_via_syscall = use_new_tls_impl_;
+    FLAGS_access_tls_socket_fd_via_syscall = UseNestedSyscallFD;
 
     SocketTraceBPFTestFixture::SetUp();
   }
@@ -121,7 +121,6 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTrac
   }
 
   TServerContainer server_;
-  bool use_new_tls_impl_ = UseNestedSyscallFD;
 };
 
 //-----------------------------------------------------------------------------

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -147,6 +147,13 @@ DEFINE_uint32(datastream_buffer_retention_size,
 DEFINE_uint64(max_body_bytes, gflags::Uint64FromEnv("PL_STIRLING_MAX_BODY_BYTES", 512),
               "The maximum number of bytes in the body of protocols like HTTP");
 
+DEFINE_bool(
+    access_tls_socket_fd_via_syscall,
+    gflags::BoolFromEnv("PL_ACCESS_TLS_SOCKET_FD_VIA_SYSCALL", false),
+    "If true, stirling will identify a socket's fd based on the underlying syscall (read, write, "
+    "etc) while a user space tls function call occurs. When false, stirling attempts to access the "
+    "socket fd by walking user space data structures which may be brittle.");
+
 OBJ_STRVIEW(socket_trace_bcc_script, socket_trace);
 
 namespace px {
@@ -408,7 +415,8 @@ Status SocketTraceConnector::InitBPF() {
       absl::StrCat("-DENABLE_NATS_TRACING=", protocol_transfer_specs_[kProtocolNATS].enabled),
       absl::StrCat("-DENABLE_AMQP_TRACING=", protocol_transfer_specs_[kProtocolAMQP].enabled),
       absl::StrCat("-DENABLE_MONGO_TRACING=", "true"),
-      absl::StrCat("-DACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL=", "true"),
+      absl::StrCat("-DACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL=",
+                   FLAGS_access_tls_socket_fd_via_syscall),
   };
   PX_RETURN_IF_ERROR(InitBPFProgram(socket_trace_bcc_script, defines));
 

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -70,8 +70,6 @@ void UProbeManager::Init(bool enable_http2_tracing, bool disable_self_probing) {
   cfg_enable_http2_tracing_ = enable_http2_tracing;
   cfg_disable_self_probing_ = disable_self_probing;
 
-  openssl_native_bio_map_ =
-      UserSpaceManagedBPFMap<uint32_t, bool>::Create(bcc_, "openssl_native_bio_map");
   openssl_symaddrs_map_ = UserSpaceManagedBPFMap<uint32_t, struct openssl_symaddrs_t>::Create(
       bcc_, "openssl_symaddrs_map");
   go_common_symaddrs_map_ = UserSpaceManagedBPFMap<uint32_t, struct go_common_symaddrs_t>::Create(
@@ -521,7 +519,6 @@ std::thread UProbeManager::RunDeployUProbesThread(const absl::flat_hash_set<md::
 
 void UProbeManager::CleanupPIDMaps(const absl::flat_hash_set<md::UPID>& deleted_upids) {
   for (const auto& pid : deleted_upids) {
-    openssl_native_bio_map_->RemoveValue(pid.pid());
     openssl_symaddrs_map_->RemoveValue(pid.pid());
     go_common_symaddrs_map_->RemoveValue(pid.pid());
     go_tls_symaddrs_map_->RemoveValue(pid.pid());

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -359,8 +359,6 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
 
       // TODO(ddelnano): Remove this conditional logic once the new tls tracing
       // implementation is the default.
-      if (!FLAGS_access_tls_socket_fd_via_syscall && spec.symbol == "SSL_set_fd") continue;
-
       if (FLAGS_access_tls_socket_fd_via_syscall) {
         spec.probe_fn = absl::Substitute("$0_syscall_fd_access", spec.probe_fn);
       }
@@ -421,11 +419,6 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid) {
   // These probes are attached on OpenSSL dynamic library (if present) as well.
   // Here they are attached on statically linked OpenSSL library (eg. for node).
   for (auto spec : kOpenSSLUProbes) {
-    // TODO(ddelnano): Restructure this once the tls tracing method is made the
-    // default. The SSL_new probe is node specific and should be refactored as
-    // part of this clean up.
-    if (spec.symbol == "SSL_set_fd") continue;
-
     spec.binary_path = host_proc_exe.string();
     PX_RETURN_IF_ERROR(LogAndAttachUProbe(spec));
   }

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -626,7 +626,6 @@ class UProbeManager {
   absl::flat_hash_set<std::string> grpc_c_probed_binaries_;
 
   // BPF maps through which the addresses of symbols for a given pid are communicated to uprobes.
-  std::unique_ptr<UserSpaceManagedBPFMap<uint32_t, bool>> openssl_native_bio_map_;
   std::unique_ptr<UserSpaceManagedBPFMap<uint32_t, struct openssl_symaddrs_t>>
       openssl_symaddrs_map_;
   std::unique_ptr<UserSpaceManagedBPFMap<uint32_t, struct go_common_symaddrs_t>>

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -429,12 +429,6 @@ class UProbeManager {
   inline static const auto kOpenSSLUProbes = MakeArray<bpf_tools::UProbeSpec>({
       bpf_tools::UProbeSpec{
           .binary_path = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
-          .symbol = "SSL_set_fd",
-          .attach_type = bpf_tools::BPFProbeAttachType::kEntry,
-          .probe_fn = "probe_SSL_set_fd",
-      },
-      bpf_tools::UProbeSpec{
-          .binary_path = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
           .symbol = "SSL_write",
           .attach_type = bpf_tools::BPFProbeAttachType::kEntry,
           .probe_fn = "probe_entry_SSL_write",


### PR DESCRIPTION
Summary: Implement new tls tracing method behind stirling cli flag (feature toggle)

The tls tracing method added in this PR determines a connection's identity (socket fd) through a different mechanism from our existing tracing. Instead of relying on struct offsets of user space data structures, it accesses the socket fd via the underlying socket syscalls while `SSL_write` / `SSL_read` calls occur. This is a prerequisite to support BoringSSL because its rolling release style makes the previous method of user space offsets untenable. This has the added benefit of reducing our maintenance cost for our existing OpenSSL tracing. Assuming future versions of OpenSSL maintain the same contract, we will not require any code changes to support them -- Pixie will gain OpenSSL v3 support once this new tracing is the default (as mentioned in the later testing).

Our assumption is that the applications that explicitly set the socket fd on the SSL struct (the applications supported by our previous tracing technique) -- [nginx](https://github.com/nginx/nginx/blob/dfe70f74a3558f05142fb552cea239add123d414/src/event/ngx_event_openssl.c#L1696), [python](https://github.com/python/cpython/blob/e375bff03736f809fbc234010c087ef9d7e0d384/Modules/_ssl.c#L836) all use Openssl with its native BIO interface. In order to verify that assumption, this change will be feature flagged and monitored carefully as its enabled on internal clusters. The existing [conn_stats_bytes metric](https://github.com/pixie-io/pixie/blob/f45ced1803e6e44406f20f1171c15a24f4d5a17a/src/stirling/source_connectors/socket_tracer/metrics.cc#L62) will be monitored for volume of tls traffic traced to verify there is no loss of instrumentation coverage between the new and old method.

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Verified the following
- [x] New test passes with `enable_openssl_v3_testing` bool flag enabled ([P336](https://phab.corp.pixielabs.ai/P336)). This verifies that the new tracing technique and the feature toggle are functional since our previous tracing does not support OpenSSL v3
- [x] Existing `openssl_trace_bpf_test` and `netty_tls_trace_bpf_test` passes ([P335](https://phab.corp.pixielabs.ai/P335)). This is explicitly mentioned since `openssl_trace_bpf_test` is still disabled #699
- [x] Verified the `bool_flag` added from PR feedback conditionally enables the OpenSSL v3 testing ([P337](https://phab.corp.pixielabs.ai/P337))
- [x] Validate metrics from #1161 to verify our assumptions are correct