### PR TITLE
[actions] Run gazelle and go mod tidy on PRs

### DIFF
--- a/.github/workflows/pr_genfiles.yml
+++ b/.github/workflows/pr_genfiles.yml
@@ -45,6 +45,9 @@ jobs:
           - '**/*.proto'
           sql:
           - '**/*.sql'
+          gobuild:
+          - '**/*.BUILD'
+          - 'go.mod'
     - name: Run go generate
       if: ${{ steps.changes.outputs.go == 'true' || steps.changes.outputs.sql == 'true' }}
       run: go generate ./...
@@ -57,6 +60,9 @@ jobs:
     - name: Run update graphql schema
       if: ${{ steps.changes.outputs.graphql == 'true' }}
       run: src/cloud/api/controllers/schema/update.sh
+    - name: Run make go-setup
+      if: ${{ steps.changes.outputs.go == 'true' || steps.changes.outputs.gobuild == 'true' }}
+      run: make go-setup
     - name: Fail if any files changed
       shell: bash
       # yamllint disable rule:indentation


### PR DESCRIPTION
Summary: Run `make gazelle` and `make go-setup` on PRs and fail if there are any changes as a result.

Type of change: /kind test-infra

Test Plan: Testing with this PR to see if a change to `go.mod` causes a check failure.
