### PR TITLE
Remove endpoint lock

### DIFF
--- a/k8s/vizier/base/metadata_role.yaml
+++ b/k8s/vizier/base/metadata_role.yaml
@@ -15,7 +15,6 @@ rules:
   resources:
   - pods
   - services
-  - endpoints
   - namespaces
   - replicasets
   - deployments

--- a/k8s/vizier/bootstrap/cloud_connector_role.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_role.yaml
@@ -64,7 +64,6 @@ rules:
   - px.dev
   resources:
   - secrets
-  - endpoints
   - pods
   - viziers
   verbs:

--- a/src/shared/services/election/election.go
+++ b/src/shared/services/election/election.go
@@ -107,24 +107,10 @@ func (le *K8sLeaderElectionMgr) runElection(ctx context.Context, callback func(s
 		Identity: id,
 	}
 
-	// We use a multilock in order to transition from EndpointsLock
-	// to LeaseLock.
-	// EndpointsLock are removed from k8s.io/client-go `v0.24.0`, so
-	// this transition needs to be completed before we can upgrade that
-	// dependency.
-	// TODO(vihang): Switch to a pure LeaseLock after atleast one
-	// release that uses a MulitLock.
-	lock := &resourcelock.MultiLock{
-		Primary: &resourcelock.EndpointsLock{
-			EndpointsMeta: obj,
-			Client:        client.CoreV1(),
-			LockConfig:    lockConfig,
-		},
-		Secondary: &resourcelock.LeaseLock{
-			LeaseMeta:  obj,
-			Client:     client.CoordinationV1(),
-			LockConfig: lockConfig,
-		},
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  obj,
+		Client:     client.CoordinationV1(),
+		LockConfig: lockConfig,
 	}
 
 	// start the leader election code loop


### PR DESCRIPTION
Summary: There have been multiple vizier releases since we
introduced Lease locks. This means that vizier installs should
be transitioned over and we no longer need endpoint locks. So
remove it.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deploy a prod vizier and skaffold a dev vizier afterwards.
