### PR TITLE
Upgrade debs used in images

### DIFF
--- a/bazel/external/ubuntu_packages/debs.json
+++ b/bazel/external/ubuntu_packages/debs.json
@@ -1,30 +1,30 @@
 [
    {
-      "path": "main/e/elfutils/libelf1_0.186-1build1_amd64.deb",
-      "checksum": "8effc4d7a0cc341bcf6cb11af0134f3defa6292376ecfdfc697a9b228606345c"
+      "path": "main/e/elfutils/libelf1_0.188-2.1_amd64.deb",
+      "checksum": "2322cad1fc9623303a57e7e4d10ee9af4ce976e1b46bbf770548baead810571e"
    },
    {
-      "path": "main/g/glibc/libc6_2.35-0ubuntu3_amd64.deb",
-      "checksum": "ea9a27e0ebdd0cfc9c750d94f8074f3a35d1f97dcc77ae04c370fb498a6b6db2"
+      "path": "main/g/glibc/libc6_2.37-0ubuntu2_amd64.deb",
+      "checksum": "f5a98389a7e33881a9e4b95439377389ff95b40ae9aa7f951a07848c6394dc76"
    },
    {
-      "path": "main/libx/libxcrypt/libcrypt1_4.4.27-1_amd64.deb",
-      "checksum": "3fa566e9f861a08736cbc5a97562d9d6e4f0c00450fbeafcb6d7583423b04a98"
+      "path": "main/libx/libxcrypt/libcrypt1_4.4.33-2_amd64.deb",
+      "checksum": "9a9aee10c7804ff678719fb2887fa4758d5d94c7cb03c1b50fbccb0c4ee43dcc"
    },
    {
-      "path": "main/n/ncurses/libtinfo6_6.3-2_amd64.deb",
-      "checksum": "5f7618187c6d1924ec758c2d5422c67377af92ecb21695008edf83a2d0c85ecd"
+      "path": "main/n/ncurses/libtinfo6_6.4-2_amd64.deb",
+      "checksum": "9627a3d3d2b9fed9fc5828962a52a6f70de8bb73dca9a9a432cab4b0159e68cb"
    },
    {
-      "path": "main/libu/libunwind/libunwind8_1.3.2-2build2_amd64.deb",
-      "checksum": "475ae509da614dd5d7210f605fd5894a3c98b6fb8c18738b16d8d4b700553c30"
+      "path": "main/libu/libunwind/libunwind8_1.6.2-3_amd64.deb",
+      "checksum": "571cb2968ba9eaa817ae3bad792e4dbb80950c72d28b92ea3ea67becd08e8711"
    },
    {
-      "path": "main/x/xz-utils/liblzma5_5.2.5-2ubuntu1_amd64.deb",
-      "checksum": "8f1c46e7d3f5102a5e4fdca7c949728a343ba71c2a7c124118df2c13d4c444f7"
+      "path": "main/x/xz-utils/liblzma5_5.4.1-0.2_amd64.deb",
+      "checksum": "2c9c51f281997ce5963e3b22b928dec13adafb8e3079bc02f89e51db9891bfd2"
    },
    {
-      "path": "main/z/zlib/zlib1g_1.2.11.dfsg-2ubuntu9_amd64.deb",
-      "checksum": "52449467942cc943d651fd16867014e9339f3657935fc09b75b3347aa5a78066"
+      "path": "main/z/zlib/zlib1g_1.2.13.dfsg-1ubuntu4_amd64.deb",
+      "checksum": "6962be4748fb4a36837353fdacdfd4199057eb70b893896fbb8b85e4ce9c7d94"
    }
 ]

--- a/bazel/external/ubuntu_packages/packages.bzl
+++ b/bazel/external/ubuntu_packages/packages.bzl
@@ -20,44 +20,44 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def download_ubuntu_packages():
     http_file(
         name = "libc6",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libc6_2.35-0ubuntu3_amd64.deb"],
-        sha256 = "16281f1199723ff302ac05fc9daa647fa1cdc420b547a3b5a83e81cb40f0aea5",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libc6_2.37-0ubuntu2_amd64.deb"],
+        sha256 = "fa0000caeb2cb82d5e356e118d61f506c36f5aec93c7e5a32fffe88fcc52dddc",
         downloaded_file_path = "out.deb",
     )
     http_file(
         name = "libcrypt1",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libcrypt1_4.4.27-1_amd64.deb"],
-        sha256 = "a274c2812e9aff29fe0abb7e950ba67d08aea5c9ffce1efe363d63a08e51038c",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libcrypt1_4.4.33-2_amd64.deb"],
+        sha256 = "5f85ffd4593773e7c80e993755a26b765b43edfd2ffef47c57847849b199cc19",
         downloaded_file_path = "out.deb",
     )
     http_file(
         name = "libelf1",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libelf1_0.186-1build1_amd64.deb"],
-        sha256 = "0b1d4cc19f2ce7be012616cefb5a1f26813fa35d62aafb4bf4a849acc4b2afc2",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libelf1_0.188-2.1_amd64.deb"],
+        sha256 = "b6cb48799302b5f8a0e4bd7ce7b474a9b8f9aab8f335bee0be76316467b99c6d",
         downloaded_file_path = "out.deb",
     )
     http_file(
         name = "liblzma5",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/liblzma5_5.2.5-2ubuntu1_amd64.deb"],
-        sha256 = "b5da99dbb2ff0e6e1ce44ba7e37be8dd452ffb09c92546dd469f49371fca1e47",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/liblzma5_5.4.1-0.2_amd64.deb"],
+        sha256 = "2eb9eec6d213ea17938ef5c552f360a1093386acfe185e8c7cccdc60b984744d",
         downloaded_file_path = "out.deb",
     )
     http_file(
         name = "libtinfo6",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libtinfo6_6.3-2_amd64.deb"],
-        sha256 = "9751c8bfed7d4ecca1460f51e9a0e5ea1a5a270743855e31b328d86c8d692524",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libtinfo6_6.4-2_amd64.deb"],
+        sha256 = "9d857ace717312b56acf7775b23e6400eef98c1eb7b0db111a799709c6d97353",
         downloaded_file_path = "out.deb",
     )
     http_file(
         name = "libunwind8",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libunwind8_1.3.2-2build2_amd64.deb"],
-        sha256 = "d257e00e37886bd38040f0a79a79e961ffbf774119d63bfaebe46bf372003f19",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/libunwind8_1.6.2-3_amd64.deb"],
+        sha256 = "1edfbbbed5daa516a497f531b1c525b3d3512a95e3de7cc0ec2e3e4b00c9d2fd",
         downloaded_file_path = "out.deb",
     )
     http_file(
         name = "zlib1g",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/zlib1g_1.2.11.dfsg-2ubuntu9_amd64.deb"],
-        sha256 = "da0ef2adaece0ba09a40d169872136e98d1917adbb13099dfcaee72d9ec1f8d8",
+        urls = ["https://storage.googleapis.com/pixie-dev-public/ubuntu-debs/1655507056/zlib1g_1.2.13.dfsg-1ubuntu4_amd64.deb"],
+        sha256 = "47f800d1e53a459286601eb56b85a96ed21fc2434fcd6c70ceca5bc5779c4b88",
         downloaded_file_path = "out.deb",
     )
 


### PR DESCRIPTION
Summary: This upgrades all debs to latest avilable versions.
The addresses a CVE in our published images.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: All RCs should continue to work as expected.
