### PR TITLE
[actions] Add github action for building vizier and operator releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,82 @@
+---
+name: releases
+on:
+  push:
+    tags:
+    - release/**
+permissions:
+  contents: read
+jobs:
+  get-dev-image:
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "dev_image_with_extras"
+  build-vizier-release:
+    if: contains(github.event.ref, 'release/vizier')
+    name: Vizier Release
+    runs-on: [self-hosted, nokvm]
+    needs: get-dev-image
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      options: --cpus 15
+      volumes:
+      - /etc/bazelrc:/etc/bazelrc
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: Setup gcloud docker creds
+      run: gcloud init && gcloud auth configure-docker
+    - name: Use github bazel config
+      uses: ./.github/actions/bazelrc
+    - name: Build & Push Artifacts
+      env:
+        REF: ${{ github.event.ref }}
+      shell: bash
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        ./ci/vizier_build_release.sh
+    - name: Build & Export Docs
+      env:
+        PXL_DOCS_GCS_PATH: "gs://pl-docs/pxl-docs.json"
+      run: |
+        docs="$(mktemp)"
+        bazel run //src/carnot/docstring:docstring -- --output_json "${docs}"
+        gsutil cp "${docs}" "${PXL_DOCS_GCS_PATH}"
+    - name: Update Manifest
+      env:
+        ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+      run: ./ci/update_artifact_manifest.sh
+  build-operator-release:
+    if: contains(github.event.ref, 'release/operator')
+    name: Operator Release
+    runs-on: [self-hosted, nokvm]
+    needs: get-dev-image
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      options: --cpus 15
+      volumes:
+      - /etc/bazelrc:/etc/bazelrc
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: Setup gcloud docker creds
+      run: gcloud init && gcloud auth configure-docker
+    - name: Use github bazel config
+      uses: ./.github/actions/bazelrc
+    - name: Build & Push Artifacts
+      env:
+        REF: ${{ github.event.ref }}
+      shell: bash
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        ./ci/operator_build_release.sh
+    - name: Update Manifest
+      env:
+        ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+      run: ./ci/update_artifact_manifest.sh


### PR DESCRIPTION
Summary: Adds github actions to build and push vizier and operator releases, whenever a release tag is pushed to the repo. The release builds also update the artifact manifest in GCS with the new artifact versions.

Type of change: /kind test-infra

Test Plan: Built vizier and operator releases on my own fork of the repo. Deployed the new artifact tracker in a self-hosted cloud, and was able to deploy vizier with my new operator and vizier prerelease versions.
