### PR TITLE
Disable BZip2 when building libarchive

### DIFF
--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -118,6 +118,7 @@ cmake(
     ],
     cache_entries = {
         "ENABLE_ACL": "OFF",
+        "ENABLE_BZip2": "OFF",
         "ENABLE_CAT": "OFF",
         "ENABLE_CAT_SHARED": "OFF",
         "ENABLE_CNG": "OFF",


### PR DESCRIPTION
Summary: Building libarchive on a system that has bzlib installed
currently fails since CMake detects it and enables it but the
sysroot doesn't include bzlib. Since we don't rely on bzip support,
lets explicitly disable it in the CMAKE config.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: libarchive now builds successfully on my machine
