### PR TITLE
Download a specific go toolchain for the codeql workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -25,6 +25,13 @@ jobs:
       security-events: write
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9  # v4.0.0
+      # Strangely enough codeQL seems to complain about a too old installed go
+      # version and isn't using the one from our docker image. So setup go
+      # on the side.
+      with:
+        cache: false  # We manually manage this for now.
+        go-version-file: 'go.mod'
     - name: go cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8  # v3.3.1
       with:


### PR DESCRIPTION
Summary: CodeQL go analysis happens to be using some older version
of the toolchain. This fixes the same.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check the codeql go run after this lands.
