### PR TITLE
Fix netty_tls test

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/BUILD.bazel
@@ -127,6 +127,7 @@ container_image(
     name = "thriftmux_base",
     base = DEFAULT_JAVA_BASE,
     debs = [
+        packages["libc6"],
         packages["libcrypt1"],
     ],
     tars = [


### PR DESCRIPTION
Summary: The netty_tls test started failing on main a few commits
ago. The failure is due to libcrypt not finding GLIBC_2.36.

The test last passed at 007a542 and first failed at f6821ed.

The `thriftmux_base` depends on `libcrypt1` and `libc6` but was not
explicitly including `libc6` as a deb dependency. Before 59a945e the
version of `libcrypt1` installed needed `GLIBC_2.25` and the base image
glibc was `GLIBC_2.30`. Now `libcrpyt1` needs `GLIBC_2.36` but the
base image is the same. So we need to explicitly include the newer deb
as a dependency to satisfy the requirement.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Run the netty_tls test locally, it passes now.