### PR TITLE
Increase disk size for BPF test instances

### DIFF
--- a/ci/bpf/00_create_instance.sh
+++ b/ci/bpf/00_create_instance.sh
@@ -62,7 +62,7 @@ gcloud beta compute instances create \
   --instance-termination-action=DELETE --max-run-duration=10800s \
   --service-account="jenkins-worker@${GCP_PROJECT}.iam.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/cloud-platform \
-  --create-disk="auto-delete=yes,boot=yes,device-name=instance-1,image=${IMAGE_TO_USE},mode=rw,size=100,type=projects/${GCP_PROJECT}/zones/us-central1-a/diskTypes/pd-ssd"
+  --create-disk="auto-delete=yes,boot=yes,device-name=instance-1,image=${IMAGE_TO_USE},mode=rw,size=256,type=projects/${GCP_PROJECT}/zones/us-central1-a/diskTypes/pd-ssd"
 
 cleanup() {
   gcloud compute instances delete \


### PR DESCRIPTION
Summary: In #1149 I saw the test instances running out of disk space.
I manually watched the disk as the tests were running and saw disk
usage peak north of 100Gi. This new limit should be enough for now
and leave us room for growth.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Run BPF tests on #1149 with additional space. They pass.
