### PR TITLE
Update the bazel version check

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "px")
 
 load("//:workspace.bzl", "check_min_bazel_version")
 
-check_min_bazel_version("5.1.1")
+check_min_bazel_version("6.0.0")
 
 load("//bazel:repositories.bzl", "pl_cc_toolchain_deps", "pl_deps")
 


### PR DESCRIPTION
Summary: The presense of `incompatible_remove_rule_name_parameter` in
our bazelrc means that the repo doesn't build with bazel 5.
So update the check to indicate the same.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Builds still work with bazel 6.
