### PR TITLE
Update dependabot file to track all possible deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,157 @@ updates:
   directory: "/src/ui"
   schedule:
     interval: "daily"
-  # Alert but don't open PRs
+  # Disable version updates but keep security updates
   open-pull-requests-limit: 0
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: "daily"
-  # Alert but don't open PRs
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+
+- package-ecosystem: pip
+  directory: /bazel/external/ubuntu_packages
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/api/python/doc
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/api/python
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/datagen/pii/privy
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /src/e2e_test/protocol_loadtest/http/wrk
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /src/experimental/multi_arch
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/stirling/protocol_inference
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/stirling/source_connectors/socket_tracer/testing/containers/amqp
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /src/stirling/source_connectors/socket_tracer/testing/containers/mysql
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /src/stirling/testing/demo_apps/py_grpc
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /src/stirling/testing/demo_apps/py_grpc
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+
+- package-ecosystem: docker
+  directory: /tools/docker/clang_deb_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/copybara
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/curl_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/elasticsearch
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/gperftools_deb_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/graalvm_archive_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/kernel_builder
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/linux_headers_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/musl_cross_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/sysroot_creator
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
+  open-pull-requests-limit: 0
+- package-ecosystem: docker
+  directory: /tools/docker/user_dev_image
+  schedule:
+    interval: daily
+  # Disable version updates but keep security updates
   open-pull-requests-limit: 0


### PR DESCRIPTION
Summary: This will let dependabot auto create security
fixes but not version bumps for the various deps we have.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Wait for the next dependabot run after this lands.
