### PR TITLE
Update and cleanup codeql action

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,16 +9,8 @@ on:
 permissions:
   contents: read
 jobs:
-  get-dev-image:
-    uses: ./.github/workflows/get_image.yaml
-    with:
-      image-base-name: "dev_image"
   analyze-go:
     runs-on: ubuntu-latest-16-cores
-    needs: get-dev-image
-    container:
-      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      options: --cpus 15
     permissions:
       actions: read
       contents: read
@@ -26,19 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9  # v4.0.0
-      # Strangely enough codeQL seems to complain about a too old installed go
-      # version and isn't using the one from our docker image. So setup go
-      # on the side.
       with:
-        cache: false  # We manually manage this for now.
         go-version-file: 'go.mod'
-    - name: go cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8  # v3.3.1
-      with:
-        path: /px/pkg/mod
-        key: go-cache-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          go-cache-
     - uses: github/codeql-action/init@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         languages: go
@@ -61,7 +42,6 @@ jobs:
     - uses: github/codeql-action/init@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         languages: ${{ matrix.language }}
-    - uses: github/codeql-action/autobuild@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
     - uses: github/codeql-action/analyze@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         category: "/language:${{matrix.language}}"

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ $(call make-lazy,yellow)
 $(call make-lazy,cyan)
 $(call make-lazy,term-reset)
 
+# This default target is invoked by CodeQL. Ensure that this is the first
+# target in this makefile.
+.PHONY: go
+go: ## A simple go build that ensure that the go code compiles.
+	CGO_ENABLED=0 go build ./...
+
 .PHONY: clean
 clean: ## Remove the bazel build directories.
 	$(BAZEL) clean


### PR DESCRIPTION
Summary: The golang codeql autobuilder invokes the top level makefile without any arguments. This
means that we run `bazel clean` by default. Instead add a `make go` command that runs a simple go
compilation. Also skip the use of our devimage since we need to install golang on the running via an
action anyway.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Ensured that the codeql analyses still work.
