### PR TITLE
[Not to be reviewed] Instrument TLS tracing with validity checks and active syscall count histogram

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
@@ -46,13 +46,22 @@ BPF_HASH(openssl_symaddrs_map, uint32_t, struct openssl_symaddrs_t);
 //
 // This assumes that a given instance will not have 1024 or more cores and that the syscall count
 // will not be 64 or more.
-BPF_HISTOGRAM(openssl_active_nested_syscalls, uint32_t, 65536);
+static const uint32_t nested_syscalls_max = 0xffff;
+BPF_HISTOGRAM(openssl_active_nested_syscalls, uint32_t, nested_syscalls_max);
 
 BPF_ARRAY(openssl_trace_state, int, 1);
 static const uint32_t kErrorStatusIdx = 0;
 
 static const uint32_t kCPUIdOverflow = 1;
 static const uint32_t kSyscallCountOverflow = 2;
+static const uint32_t kNonNativeBIOUsageDetected = 3;
+static const uint32_t kMismatchedFDsDetected = 4;
+
+static const uint32_t syscall_count_bits = 6;
+static const uint32_t cpu_id_bits = 16 - syscall_count_bits;
+static const uint32_t cpu_id_bitmask = nested_syscalls_max >> syscall_count_bits;
+static const uint32_t syscall_count_bitmask = nested_syscalls_max >> cpu_id_bits;
+
 
 /***********************************************************
  * General helpers
@@ -127,40 +136,59 @@ static int get_fd(uint32_t tgid, void* ssl) {
 BPF_HASH(active_ssl_read_args_map, uint64_t, struct data_args_t);
 BPF_HASH(active_ssl_write_args_map, uint64_t, struct data_args_t);
 
-static __inline void eval_and_cleanup_userspace_call_detection(uint64_t pid_tgid) {
-  uint32_t* count_ptr = ssl_userspace_call_map.lookup(&pid_tgid);
+static __inline void eval_and_cleanup_user_space_call_detection(uint64_t pid_tgid) {
+  struct user_space_fd_t* user_space_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
 
-  if (count_ptr == NULL) {
-    // This state should not occur since ssl_userspace_call_map for a given pid_tgid is set to 0
+  if (user_space_fd_ptr == NULL) {
+    // This state should not occur since ssl_user_space_call_map for a given pid_tgid is set to 0
     // upon SSL_write and SSL_read entry.
     return;
   }
 
-  uint32_t count = *count_ptr;
+  uint32_t count = user_space_fd_ptr->count;
+  bool validated = user_space_fd_ptr->validated_socket;
+  bool mismatched_fds = user_space_fd_ptr->mismatched_fds;
+  int fd = user_space_fd_ptr->fd;
   uint32_t cpu_id = bpf_get_smp_processor_id();
-  if (count >= 64) {
-      int error_status_idx = kErrorStatusIdx;
-      int overflow_status_code = kSyscallCountOverflow;
-      openssl_trace_state.update(&error_status_idx, &overflow_status_code);
 
-      goto cleanup;
+  if (count > syscall_count_bitmask) {
+    int error_status_idx = kErrorStatusIdx;
+    int overflow_status_code = kSyscallCountOverflow;
+    openssl_trace_state.update(&error_status_idx, &overflow_status_code);
+
+    goto cleanup;
   }
 
-  if (cpu_id >= 1024) {
-      int error_status_idx = kErrorStatusIdx;
-      int overflow_status_code = kCPUIdOverflow;
-      openssl_trace_state.update(&error_status_idx, &overflow_status_code);
+  if (cpu_id > cpu_id_bitmask) {
+    int error_status_idx = kErrorStatusIdx;
+    int overflow_status_code = kCPUIdOverflow;
+    openssl_trace_state.update(&error_status_idx, &overflow_status_code);
 
-      goto cleanup;
+    goto cleanup;
+  }
+
+  if (fd != kInvalidFD && !validated) {
+    int error_status_idx = kErrorStatusIdx;
+    int status_code = kNonNativeBIOUsageDetected;
+    openssl_trace_state.update(&error_status_idx, &status_code);
+
+    goto cleanup;
+  }
+
+  if (mismatched_fds) {
+    int error_status_idx = kErrorStatusIdx;
+    int status_code = kMismatchedFDsDetected;
+    openssl_trace_state.update(&error_status_idx, &status_code);
+
+    goto cleanup;
   }
 
   uint32_t hist_key = (cpu_id << 6) | count;
-  bpf_trace_printk("Histogram key %d made of cpu id: %d and count: %d", hist_key, cpu_id, count);
   openssl_active_nested_syscalls.increment(hist_key);
 
 cleanup:
 
-  ssl_userspace_call_map.delete(&pid_tgid);
+  ssl_user_space_call_map.delete(&pid_tgid);
 }
 
 // Function signature being probed:
@@ -172,8 +200,12 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
   void* ssl = (void*)PT_REGS_PARM1(ctx);
   update_node_ssl_tls_wrap_map(ssl);
 
-  int count = 0;
-  ssl_userspace_call_map.update(&id, &count);
+  struct user_space_fd_t user_space_fd = {
+      .count = 0,
+      .fd = kInvalidFD,
+      .validated_socket = false,
+  };
+  ssl_user_space_call_map.update(&id, &user_space_fd);
 
   char* buf = (char*)PT_REGS_PARM2(ctx);
   int32_t fd = get_fd(tgid, ssl);
@@ -202,7 +234,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     process_openssl_data(ctx, id, kEgress, write_args);
   }
 
-  eval_and_cleanup_userspace_call_detection(id);
+  eval_and_cleanup_user_space_call_detection(id);
   active_ssl_write_args_map.delete(&id);
   return 0;
 }
@@ -216,8 +248,12 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
   void* ssl = (void*)PT_REGS_PARM1(ctx);
   update_node_ssl_tls_wrap_map(ssl);
 
-  int count = 0;
-  ssl_userspace_call_map.update(&id, &count);
+  struct user_space_fd_t user_space_fd = {
+      .count = 0,
+      .fd = kInvalidFD,
+      .validated_socket = false,
+  };
+  ssl_user_space_call_map.update(&id, &user_space_fd);
 
   char* buf = (char*)PT_REGS_PARM2(ctx);
   int32_t fd = get_fd(tgid, ssl);
@@ -246,7 +282,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     process_openssl_data(ctx, id, kIngress, read_args);
   }
 
-  eval_and_cleanup_userspace_call_detection(id);
+  eval_and_cleanup_user_space_call_detection(id);
 
   active_ssl_read_args_map.delete(&id);
   return 0;

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
@@ -184,6 +184,7 @@ static __inline void eval_and_cleanup_user_space_call_detection(uint64_t pid_tgi
   }
 
   uint32_t hist_key = (cpu_id << 6) | count;
+  bpf_trace_printk("Syscalls detected between SSL_write/SSL_read: %d and validated: %d", count, validated);
   openssl_active_nested_syscalls.increment(hist_key);
 
 cleanup:

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -164,12 +164,8 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
 template <typename T>
 using OpenSSLTraceDlsymTest = BaseOpenSSLTraceTest<T, false>;
 
-template <typename T>
-using OpenSSLTraceRawFptrsTest = BaseOpenSSLTraceTest<T, true>;
-
 #define OPENSSL_TYPED_TEST(TestCase, CodeBlock)            \
   TYPED_TEST(OpenSSLTraceDlsymTest, TestCase)              \
-  CodeBlock TYPED_TEST(OpenSSLTraceRawFptrsTest, TestCase) \
   CodeBlock
 
 TYPED_TEST_SUITE(OpenSSLTraceDlsymTest, OpenSSLServerImplementations);

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -630,8 +630,6 @@ void SocketTraceConnector::CheckTracerState() {
 
   int error_code;
   openssl_trace_state_->get_value(0, error_code);
-
-  LOG(WARNING) << absl::Substitute("openssl_trace_state_ error code was $0", error_code);
   DCHECK(error_code == 0);
 
   auto table = openssl_active_nested_syscalls_hist_->get_table_offline();
@@ -641,7 +639,7 @@ void SocketTraceConnector::CheckTracerState() {
 
       // Syscall count is the first 6 bits and cpu id is next 10 bits
       uint32_t syscall_count = key & 0x3f;
-      uint32_t cpu_id = (key >> 6) & 0x7ff;
+      uint32_t cpu_id = (key >> 6) & 0x3ff;
       LOG(WARNING) << absl::Substitute("Found syscall count of $0 for cpu $1 with frequency: $2", syscall_count, cpu_id, value);
   }
 }

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -118,6 +118,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   void InitContextImpl(ConnectorContext* ctx) override;
   void TransferDataImpl(ConnectorContext* ctx) override;
 
+  void CheckTracerState();
+
   // Perform actions that are not specifically targeting a table.
   // For example, drain perf buffers, deploy new uprobes, and update socket info manager.
   // If these were performed on every TransferData(), they would occur too frequently,
@@ -227,6 +229,9 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   ConnTrackersManager conn_trackers_mgr_;
 
   ConnStats conn_stats_;
+
+  std::unique_ptr<ebpf::BPFHashTable<uint32_t, uint32_t>> openssl_active_nested_syscalls_hist_;
+  std::unique_ptr<ebpf::BPFArrayTable<int>> openssl_trace_state_;
 
   absl::flat_hash_set<int> pids_to_trace_disable_;
 


### PR DESCRIPTION
Summary: Instrument TLS tracing with validity checks and active syscall count histogram

This PR is meant to document testing performed to understand how both BIO native and non BIO native tls tracing targets work. For BIO native cases, we expect OpenSSL to trigger the syscalls that issue io to the underlying socket fd. For non BIO native cases (netty, nodejs), `SSL_write` and `SSL_read` encrypt and decrypt memory buffers (custom bio type) and later issue the socket io themselves.

Relevant Issues: #692

Type of change: N/A

Test Plan: Ran the `openssl_trace_bpf_test` and `netty_tls_trace_bpf_test` and verified the following
- [x] Verified that nodejs and netty have 0 active syscalls recorded in the histogram ([P346](https://phab.corp.pixielabs.ai/P346)). The "count" is only assumed to be correct if validated is 1.
- [x] Verified that the curl, ruby and nginx processes have 1 or more active syscalls recorded in the histogram (see previous paste). More than one nested syscall can occur when io is not fully flushed (write tries to write X bytes but only gets Y written on the first try).