### PR TITLE
Instrument OpenSSL tracing to detect validity of assumptions for new tls tracing method

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
@@ -112,7 +112,7 @@ static __inline void eval_and_cleanup_nested_syscall_detection(uint64_t pid_tgid
   struct nested_syscall_fd_t* nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
 
   if (nested_syscall_fd_ptr == NULL) {
-    // This state should not occur since ssl_user_space_call_map for a given pid_tgid is set to 0
+    // This state should not occur since ssl_user_space_call_map for a given pid_tgid is set
     // upon SSL_write and SSL_read entry.
     return;
   }

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -162,11 +162,12 @@ static __inline void set_conn_as_ssl(uint32_t tgid, int32_t fd) {
   conn_info->ssl = true;
 }
 
-// Writes the syscall fd to a BPF map to be later consumed by the tls tracing probes in
-// addition to ensuring that set_conn_as_ssl is called. The majority of probes should call
-// this on function entry, however, there are certain probes which are not exlusively used
-// for networking and therefore must defer this fd propagation to its ret probe (where it
-// can be validated it is socket related first via sock_event).
+// Writes the syscall fd to a BPF map key created by an active tls call (the SSL_write/SSL_read
+// probes and ensures that set_conn_as_ssl is called for the tgid and pid. The majority of syscall
+// probes should call this on function entry, however, there are certain probes which are
+// not exlusively used for networking (read/write/readev/writev) and therefore must defer
+// this fd propagation to its ret probe (where it can be validated it is socket related
+// first via sock_event).
 static __inline void propagate_fd_to_user_space_call(uint64_t pid_tgid, int fd) {
   struct nested_syscall_fd_t* nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
   if (nested_syscall_fd_ptr != NULL) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -91,6 +91,17 @@ BPF_HASH(active_write_args_map, uint64_t, struct data_args_t);
 // Key is {tgid, pid}.
 BPF_HASH(active_read_args_map, uint64_t, struct data_args_t);
 
+struct nested_syscall_fd_t {
+  int fd;
+  bool mismatched_fds;
+};
+
+// Map used to verify if SSL_write or SSL_read are on the stack during a syscall in
+// order to propagate the socket fd back to the SSL_write and SSL_read return probes.
+// Key is pid tgid.
+// Value is nested_syscall_fd struct.
+BPF_HASH(ssl_user_space_call_map, uint64_t, struct nested_syscall_fd_t);
+
 // Map from thread to its ongoing close() syscall's input argument.
 // Tracks close() call from entry -> exit.
 // Key is {tgid, pid}.
@@ -149,6 +160,29 @@ static __inline void set_conn_as_ssl(uint32_t tgid, int32_t fd) {
     return;
   }
   conn_info->ssl = true;
+}
+
+// Writes the syscall fd to a BPF map to be later consumed by the tls tracing probes in
+// addition to ensuring that set_conn_as_ssl is called. The majority of probes should call
+// this on function entry, however, there are certain probes which are not exlusively used
+// for networking and therefore must defer this fd propagation to its ret probe (where it
+// can be validated it is socket related first via sock_event).
+static __inline void propagate_fd_to_user_space_call(uint64_t pid_tgid, int fd) {
+  struct nested_syscall_fd_t*  nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
+  if (nested_syscall_fd_ptr != NULL) {
+    int expected_fd = nested_syscall_fd_ptr->fd;
+    if (expected_fd != kInvalidFD && expected_fd != fd) {
+      nested_syscall_fd_ptr->mismatched_fds = true;
+    }
+
+    nested_syscall_fd_ptr->fd = fd;
+
+    // TODO(ddelnano): Until the new tls tracing implementation is being rolled out
+    // the active user space tls function detection should not change the functionality
+    // of the existing tracing. This must be uncommented as part of pixie#1123.
+    // uint32_t tgid = pid_tgid >> 32;
+    // set_conn_as_ssl(tgid, fd);
+  }
 }
 
 static __inline struct socket_data_event_t* fill_socket_data_event(
@@ -1009,6 +1043,12 @@ int syscall__probe_ret_write(struct pt_regs* ctx) {
   // Unstash arguments, and process syscall.
   struct data_args_t* write_args = active_write_args_map.lookup(&id);
   if (write_args != NULL && write_args->sock_event) {
+    // Syscalls that aren't exclusively used for networking must be
+    // validated to be a sock_event before propagating a socket fd to the
+    // tls tracing probes
+    if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+      propagate_fd_to_user_space_call(id, write_args->fd);
+    }
     process_syscall_data(ctx, id, kEgress, write_args, bytes_count);
   }
 
@@ -1019,6 +1059,10 @@ int syscall__probe_ret_write(struct pt_regs* ctx) {
 // ssize_t send(int sockfd, const void *buf, size_t len, int flags);
 int syscall__probe_entry_send(struct pt_regs* ctx, int sockfd, char* buf, size_t len) {
   uint64_t id = bpf_get_current_pid_tgid();
+
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
 
   // Stash arguments.
   struct data_args_t write_args = {};
@@ -1065,6 +1109,12 @@ int syscall__probe_ret_read(struct pt_regs* ctx) {
   // Unstash arguments, and process syscall.
   struct data_args_t* read_args = active_read_args_map.lookup(&id);
   if (read_args != NULL && read_args->sock_event) {
+    // Syscalls that aren't exclusively used for networking must be
+    // validated to be a sock_event before propagating a socket fd to the
+    // tls tracing probes
+    if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+      propagate_fd_to_user_space_call(id, read_args->fd);
+    }
     process_syscall_data(ctx, id, kIngress, read_args, bytes_count);
   }
 
@@ -1075,6 +1125,10 @@ int syscall__probe_ret_read(struct pt_regs* ctx) {
 // ssize_t recv(int sockfd, void *buf, size_t len, int flags);
 int syscall__probe_entry_recv(struct pt_regs* ctx, int sockfd, char* buf, size_t len) {
   uint64_t id = bpf_get_current_pid_tgid();
+
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
 
   // Stash arguments.
   struct data_args_t read_args = {};
@@ -1105,6 +1159,10 @@ int syscall__probe_ret_recv(struct pt_regs* ctx) {
 int syscall__probe_entry_sendto(struct pt_regs* ctx, int sockfd, char* buf, size_t len, int flags,
                                 const struct sockaddr* dest_addr, socklen_t addrlen) {
   uint64_t id = bpf_get_current_pid_tgid();
+
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
 
   // Stash arguments.
   if (dest_addr != NULL) {
@@ -1165,6 +1223,10 @@ int syscall__probe_entry_recvfrom(struct pt_regs* ctx, int sockfd, char* buf, si
                                   struct sockaddr* src_addr, socklen_t* addrlen) {
   uint64_t id = bpf_get_current_pid_tgid();
 
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
+
   // Stash arguments.
   if (src_addr != NULL) {
     struct connect_args_t connect_args = {};
@@ -1208,6 +1270,10 @@ int syscall__probe_ret_recvfrom(struct pt_regs* ctx) {
 int syscall__probe_entry_sendmsg(struct pt_regs* ctx, int sockfd,
                                  const struct user_msghdr* msghdr) {
   uint64_t id = bpf_get_current_pid_tgid();
+
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
 
   if (msghdr != NULL) {
     // Stash arguments.
@@ -1254,6 +1320,10 @@ int syscall__probe_ret_sendmsg(struct pt_regs* ctx) {
 int syscall__probe_entry_sendmmsg(struct pt_regs* ctx, int sockfd, struct mmsghdr* msgvec,
                                   unsigned int vlen) {
   uint64_t id = bpf_get_current_pid_tgid();
+
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
 
   // TODO(oazizi): Right now, we only trace the first message in a sendmmsg() call.
   if (msgvec != NULL && vlen >= 1) {
@@ -1307,6 +1377,10 @@ int syscall__probe_ret_sendmmsg(struct pt_regs* ctx) {
 int syscall__probe_entry_recvmsg(struct pt_regs* ctx, int sockfd, struct user_msghdr* msghdr) {
   uint64_t id = bpf_get_current_pid_tgid();
 
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
+
   if (msghdr != NULL) {
     // Stash arguments.
     if (msghdr->msg_name != NULL) {
@@ -1354,6 +1428,10 @@ int syscall__probe_ret_recvmsg(struct pt_regs* ctx) {
 int syscall__probe_entry_recvmmsg(struct pt_regs* ctx, int sockfd, struct mmsghdr* msgvec,
                                   unsigned int vlen) {
   uint64_t id = bpf_get_current_pid_tgid();
+
+  if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+    propagate_fd_to_user_space_call(id, sockfd);
+  }
 
   // TODO(oazizi): Right now, we only trace the first message in a recvmmsg() call.
   if (msgvec != NULL && vlen >= 1) {
@@ -1425,6 +1503,12 @@ int syscall__probe_ret_writev(struct pt_regs* ctx) {
   // Unstash arguments, and process syscall.
   struct data_args_t* write_args = active_write_args_map.lookup(&id);
   if (write_args != NULL && write_args->sock_event) {
+    // Syscalls that aren't exclusively used for networking must be
+    // validated to be a sock_event before propagating a socket fd to the
+    // tls tracing probes
+    if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+      propagate_fd_to_user_space_call(id, write_args->fd);
+    }
     process_syscall_data_vecs(ctx, id, kEgress, write_args, bytes_count);
   }
 
@@ -1454,6 +1538,12 @@ int syscall__probe_ret_readv(struct pt_regs* ctx) {
   // Unstash arguments, and process syscall.
   struct data_args_t* read_args = active_read_args_map.lookup(&id);
   if (read_args != NULL && read_args->sock_event) {
+    // Syscalls that aren't exclusively used for networking must be
+    // validated to be a sock_event before propagating a socket fd to the
+    // tls tracing probes
+    if (ACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL) {
+      propagate_fd_to_user_space_call(id, read_args->fd);
+    }
     process_syscall_data_vecs(ctx, id, kIngress, read_args, bytes_count);
   }
 

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -168,7 +168,7 @@ static __inline void set_conn_as_ssl(uint32_t tgid, int32_t fd) {
 // for networking and therefore must defer this fd propagation to its ret probe (where it
 // can be validated it is socket related first via sock_event).
 static __inline void propagate_fd_to_user_space_call(uint64_t pid_tgid, int fd) {
-  struct nested_syscall_fd_t*  nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
+  struct nested_syscall_fd_t* nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
   if (nested_syscall_fd_ptr != NULL) {
     int expected_fd = nested_syscall_fd_ptr->fd;
     if (expected_fd != kInvalidFD && expected_fd != fd) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.h
@@ -292,3 +292,10 @@ struct sendfile_args_t {
   int32_t in_fd;
   size_t count;
 };
+
+static const uint32_t kOpenSSLTraceStatusIdx = 0;
+
+enum openssl_trace_errors_t {
+  kOpenSSLTraceOk = 0,
+  kOpenSSLMismatchedFDsDetected,
+};

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -164,12 +164,8 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
 template <typename T>
 using OpenSSLTraceDlsymTest = BaseOpenSSLTraceTest<T, false>;
 
-template <typename T>
-using OpenSSLTraceRawFptrsTest = BaseOpenSSLTraceTest<T, true>;
-
 #define OPENSSL_TYPED_TEST(TestCase, CodeBlock)            \
   TYPED_TEST(OpenSSLTraceDlsymTest, TestCase)              \
-  CodeBlock TYPED_TEST(OpenSSLTraceRawFptrsTest, TestCase) \
   CodeBlock
 
 TYPED_TEST_SUITE(OpenSSLTraceDlsymTest, OpenSSLServerImplementations);

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -164,8 +164,12 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
 template <typename T>
 using OpenSSLTraceDlsymTest = BaseOpenSSLTraceTest<T, false>;
 
+template <typename T>
+using OpenSSLTraceRawFptrsTest = BaseOpenSSLTraceTest<T, true>;
+
 #define OPENSSL_TYPED_TEST(TestCase, CodeBlock)            \
   TYPED_TEST(OpenSSLTraceDlsymTest, TestCase)              \
+  CodeBlock TYPED_TEST(OpenSSLTraceRawFptrsTest, TestCase) \
   CodeBlock
 
 TYPED_TEST_SUITE(OpenSSLTraceDlsymTest, OpenSSLServerImplementations);

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -166,10 +166,10 @@ constexpr size_t kMaxPBStringLen = 64;
 SocketTraceConnector::SocketTraceConnector(std::string_view source_name)
     : SourceConnector(source_name, kTables),
       conn_stats_(&conn_trackers_mgr_),
-      openssl_trace_mismatched_fds_counter_(
-          BuildCounter("openssl_trace_mismatched_fds",
-                       "Count of the times a syscall's fd was mismatched when detected fds from an "
-                       "active user space call")),
+      openssl_trace_mismatched_fds_counter_(BuildCounter(
+          "openssl_trace_mismatched_fds",
+          "Count of the times a syscall's fd was mismatched when detecting fds from an "
+          "active user space call")),
       uprobe_mgr_(this) {
   proc_parser_ = std::make_unique<system::ProcParser>();
   InitProtocolTransferSpecs();

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -630,6 +630,12 @@ void SocketTraceConnector::UpdateTrackerTraceLevel(ConnTracker* tracker) {
 // Verifies that our openssl tracing does not encounter conditions that invalidate our
 // assumptions and records error conditions in prometheus metrics.
 void SocketTraceConnector::CheckTracerState() {
+  // The check that state is not uninitialized is required for socket_trace_connector_test.
+  // Since it doesn't initialize the BPF program, accessing the map will fail.
+  if (state() == State::kUninitialized) {
+    return;
+  }
+
   int error_code;
   openssl_trace_state_->get_value(kOpenSSLTraceStatusIdx, error_code);
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -164,7 +164,13 @@ constexpr size_t kMaxHTTPHeadersBytes = 8192;
 constexpr size_t kMaxPBStringLen = 64;
 
 SocketTraceConnector::SocketTraceConnector(std::string_view source_name)
-    : SourceConnector(source_name, kTables), conn_stats_(&conn_trackers_mgr_), uprobe_mgr_(this) {
+    : SourceConnector(source_name, kTables),
+      conn_stats_(&conn_trackers_mgr_),
+      openssl_trace_mismatched_fds_counter_(
+          BuildCounter("openssl_trace_mismatched_fds",
+                       "Count of the times a syscall's fd was mismatched when detected fds from an "
+                       "active user space call")),
+      uprobe_mgr_(this) {
   proc_parser_ = std::make_unique<system::ProcParser>();
   InitProtocolTransferSpecs();
 }
@@ -402,6 +408,7 @@ Status SocketTraceConnector::InitBPF() {
       absl::StrCat("-DENABLE_NATS_TRACING=", protocol_transfer_specs_[kProtocolNATS].enabled),
       absl::StrCat("-DENABLE_AMQP_TRACING=", protocol_transfer_specs_[kProtocolAMQP].enabled),
       absl::StrCat("-DENABLE_MONGO_TRACING=", "true"),
+      absl::StrCat("-DACCESS_TLS_SK_FD_VIA_ACTIVE_SYSCALL=", "true"),
   };
   PX_RETURN_IF_ERROR(InitBPFProgram(socket_trace_bcc_script, defines));
 
@@ -477,6 +484,9 @@ Status SocketTraceConnector::InitImpl() {
 
   uprobe_mgr_.Init(protocol_transfer_specs_[kProtocolHTTP2].enabled,
                    FLAGS_stirling_disable_self_tracing);
+
+  openssl_trace_state_ =
+      std::make_unique<ebpf::BPFArrayTable<int>>(GetArrayTable<int>("openssl_trace_state"));
 
   return Status::OK();
 }
@@ -617,6 +627,24 @@ void SocketTraceConnector::UpdateTrackerTraceLevel(ConnTracker* tracker) {
   }
 }
 
+// Verifies that our openssl tracing does not encounter conditions that invalidate our
+// assumptions and records error conditions in prometheus metrics.
+void SocketTraceConnector::CheckTracerState() {
+  int error_code;
+  openssl_trace_state_->get_value(kOpenSSLTraceStatusIdx, error_code);
+
+  if (error_code == kOpenSSLMismatchedFDsDetected) {
+    openssl_trace_mismatched_fds_counter_.Increment();
+  }
+  DCHECK_EQ(error_code, kOpenSSLTraceOk);
+
+  // Reset the BPF map to its default value so that each occurrence
+  // can be detected.
+  if (error_code != kOpenSSLTraceOk) {
+    openssl_trace_state_->update_value(kOpenSSLTraceStatusIdx, kOpenSSLTraceOk);
+  }
+}
+
 void SocketTraceConnector::TransferDataImpl(ConnectorContext* ctx) {
   set_iteration_time(now_fn_());
 
@@ -689,6 +717,8 @@ void SocketTraceConnector::TransferDataImpl(ConnectorContext* ctx) {
 
     conn_tracker->IterationPostTick();
   }
+
+  CheckTracerState();
 
   // Once we've cleared all the debug trace levels for this pid, we can remove it from the list.
   pids_to_trace_disable_.clear();

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -31,6 +31,7 @@
 #include <absl/synchronization/mutex.h>
 
 #include "src/common/grpcutils/service_descriptor_database.h"
+#include "src/common/metrics/metrics.h"
 #include "src/common/system/socket_info.h"
 #include "src/stirling/bpf_tools/bcc_wrapper.h"
 #include "src/stirling/obj_tools/dwarf_reader.h"
@@ -117,6 +118,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   Status StopImpl() override;
   void InitContextImpl(ConnectorContext* ctx) override;
   void TransferDataImpl(ConnectorContext* ctx) override;
+
+  void CheckTracerState();
 
   // Perform actions that are not specifically targeting a table.
   // For example, drain perf buffers, deploy new uprobes, and update socket info manager.
@@ -227,6 +230,9 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   ConnTrackersManager conn_trackers_mgr_;
 
   ConnStats conn_stats_;
+
+  std::unique_ptr<ebpf::BPFArrayTable<int>> openssl_trace_state_;
+  prometheus::Counter& openssl_trace_mismatched_fds_counter_;
 
   absl::flat_hash_set<int> pids_to_trace_disable_;
 


### PR DESCRIPTION
Summary: Instrument OpenSSL tracing to detect validity of assumptions for new tls tracing method

After discussing #1123 with @oazizi000 and @etep, we decided that invest in stronger validation that the assumptions for that PR and our future tls tracing are valid. Instead of relying on struct offsets of user space data structures, the new tracing method will access a connection's socket fd from the underlying socket syscalls during `SSL_write` / `SSL_read` calls.

This technique should only be compatible with "BIO native" OpenSSL use cases, which are the OpenSSL use cases Pixie supports today. BIO native means that a compatible application uses a [BIO](https://wiki.openssl.org/index.php/BIO) provided by OpenSSL (via [SSL_set_fd](https://www.openssl.org/docs/manmaster/man3/SSL_set_fd.html)) and results in OpenSSL issuing read/write syscalls on your behalf for the underlying socket.

There are two situations we wanted to understand prior to proceeding with #1123: how custom BIO implementations behave (netty, nodejs, etc) and detecting unrelated (non socket) syscalls while `SSL_write` and `SSL_read` are on the stack. The former was verified with an experiment based on this change and is described in the Test Plan section below. We believe the latter should not occur, but the changes in this PR instrument this situation in order to detect if doest occur. Assuming this condition isn't encountered, we will proceed with #1132 (with the minor changes learned from this experiment).

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Verified the following:
- [x] `DCHECK` added to `socket_trace_connector` does not detect mismatched file descriptors for `openssl_trace_bpf_test` and `netty_tls_trace_bpf_test` ([P345](https://phab.corp.pixielabs.ai/P345) -- openssl_trace_bpf_test is still disabled - #699)
- [x] Verified with a BPF histogram that the number of active syscalls within SSL_write/SSL_read are non zero for BIO native use cases and zero for non BIO native cases (nodejs, netty). See more details in #1160