### PR TITLE
Add trivy scanning

### DIFF
--- a/.github/workflows/trivy_fs.yaml
+++ b/.github/workflows/trivy_fs.yaml
@@ -1,0 +1,29 @@
+---
+name: trivy-fs
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  schedule:
+  - cron: "50 22 * * *"
+permissions:
+  contents: read
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+    - uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee  # v0.9.2
+      with:
+        scan-type: 'fs'
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+    - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -1,0 +1,54 @@
+---
+name: trivy-images
+on:
+  push:
+    branches:
+    - main
+  schedule:
+  - cron: "37 19 * * *"
+permissions:
+  contents: read
+jobs:
+  get-dev-image:
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "dev_image_with_extras"
+  image-scan:
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: [cloud, operator, vizier]
+    runs-on: [self-hosted, nokvm]
+    needs: get-dev-image
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      options: --cpus 15
+      volumes:
+      - /etc/bazelrc:/etc/bazelrc
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: Use github bazel config
+      uses: ./.github/actions/bazelrc
+    - name: Build images
+      run: |
+        bazel build \
+        --//k8s:image_version=nightly --config=x86_64_sysroot \
+        //k8s/${{ matrix.artifact }}:image_bundle.tar //k8s/${{ matrix.artifact }}:list_image_bundle
+    - name: Load Images
+      run: |
+        docker load -i bazel-bin/k8s/${{ matrix.artifact }}/image_bundle.tar
+    - name: Scan Images
+      # yamllint disable rule:line-length
+      run: |
+        mkdir -p sarif/${{ matrix.artifact }}
+        ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
+      # yamllint enable rule:line-length
+    - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
+      with:
+        sarif_file: sarif/${{ matrix.artifact }}

--- a/k8s/cloud/BUILD.bazel
+++ b/k8s/cloud/BUILD.bazel
@@ -16,7 +16,7 @@
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
-load("//bazel:images.bzl", "DEV_PREFIX", "PROPRIETARY_PREFIX", "image_replacements")
+load("//bazel:images.bzl", "DEV_PREFIX", "PROPRIETARY_PREFIX", "image_replacements", "list_image_bundle")
 load("//bazel:kustomize.bzl", "kustomize_build")
 
 package(default_visibility = ["//visibility:public"])
@@ -83,6 +83,15 @@ kustomize_build(
 
 container_bundle(
     name = "image_bundle",
+    images = CLOUD_IMAGE_TO_LABEL,
+    toolchains = [
+        "//k8s:image_prefix",
+        "//k8s:bundle_version",
+    ],
+)
+
+list_image_bundle(
+    name = "list_image_bundle",
     images = CLOUD_IMAGE_TO_LABEL,
     toolchains = [
         "//k8s:image_prefix",


### PR DESCRIPTION
Summary: Add trivy based scanning for our repo and our built images.
Repo scanning is done on every commit, PR and nightly.
Image scanning will be done nightly (and on releases?)

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check github actions output from this PR.
