### PR TITLE
Update github bazelrc

### DIFF
--- a/ci/github/bazelrc
+++ b/ci/github/bazelrc
@@ -8,6 +8,8 @@ common --keep_going
 build --build_metadata=HOST=github-actions
 build --build_metadata=USER=github-actions
 build --build_metadata=REPO_URL=https://github.com/pixie-io/pixie
+build --build_metadata=ROLE=DEV
+build --build_metadata=VISIBILITY=PUBLIC
 build --verbose_failures
 
 test --verbose_failures


### PR DESCRIPTION
Summary: Set role to not `CI` since releaase or scan builds shouldn't
affect the test matrix. Also set visiblity to `PUBLIC`.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check Buildbuddy for release scans and trivy runs after this lands.
