### PR TITLE
Fix perf profiler bug causing higher BPF map utilization and add `DCHECK` and metrics for error conditions

### DIFF
--- a/src/stirling/source_connectors/perf_profiler/bcc_bpf/profiler.c
+++ b/src/stirling/source_connectors/perf_profiler/bcc_bpf/profiler.c
@@ -62,7 +62,7 @@ BPF_ARRAY(profiler_state, uint64_t, kProfilerStateVectorSize);
 int sample_call_stack(struct bpf_perf_event_data* ctx) {
   int transfer_count_idx = kTransferCountIdx;
   int sample_count_a_idx = kSampleCountAIdx;
-  int sample_count_b_idx = kSampleCountAIdx;
+  int sample_count_b_idx = kSampleCountBIdx;
   int error_status_idx = kErrorStatusIdx;
 
   uint64_t* transfer_count_ptr = profiler_state.lookup(&transfer_count_idx);

--- a/src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h
+++ b/src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h
@@ -55,5 +55,6 @@ static const uint32_t kOverflowBitPos = 0;
 static const uint32_t kMapReadFailureBitPos = 1;
 
 // The error codes, themselves:
+static const uint64_t kPerfProfilerStatusOk = 0ULL;
 static const uint64_t kOverflowError = 1ULL << kOverflowBitPos;
 static const uint64_t kMapReadFailureError = 1ULL << kMapReadFailureBitPos;

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
@@ -61,6 +61,12 @@ PerfProfileConnector::PerfProfileConnector(std::string_view source_name)
       sampling_period_(
           std::chrono::milliseconds{1000 * FLAGS_stirling_profiler_table_update_period_seconds}),
       push_period_(sampling_period_ / 2),
+      profiler_state_overflow_counter_(BuildCounter(
+          "perf_profiler_overflow",
+          "Count of times the perf profiler overran CFG_OVERRUN_THRESHOLD")),
+      profiler_state_map_read_error_counter_(BuildCounter(
+          "perf_profiler_map_read_error",
+          "Count of times the perf profiler encountered a map lookup error")),
       stats_log_interval_(std::chrono::minutes(FLAGS_stirling_profiler_log_period_minutes) /
                           sampling_period_) {
   constexpr auto kMaxSamplingPeriod = std::chrono::milliseconds{30000};
@@ -354,6 +360,27 @@ void PerfProfileConnector::ProcessBPFStackTraces(ConnectorContext* ctx, DataTabl
   profiler_state_->update_value(sample_count_idx, 0);
 }
 
+void PerfProfileConnector::CheckProfilerState() {
+  uint64_t error_code;
+  profiler_state_->get_value(kErrorStatusIdx, error_code);
+
+  DCHECK_EQ(error_code, kPerfProfilerStatusOk);
+
+  switch (error_code) {
+      case kOverflowError:
+        profiler_state_overflow_counter_.Increment();
+        break;
+      case kMapReadFailureError:
+        profiler_state_map_read_error_counter_.Increment();
+        break;
+  }
+  // Reset the BPF map to its default value so that each occurrence
+  // can be detected.
+  if (error_code != kPerfProfilerStatusOk) {
+    profiler_state_->update_value(kErrorStatusIdx, 0);
+  }
+}
+
 void PerfProfileConnector::TransferDataImpl(ConnectorContext* ctx) {
   DCHECK_EQ(data_tables_.size(), 1U);
 
@@ -374,6 +401,8 @@ void PerfProfileConnector::TransferDataImpl(ConnectorContext* ctx) {
   if (sampling_freq_mgr_.count() % stats_log_interval_ == 0) {
     PrintStats();
   }
+
+  CheckProfilerState();
 }
 
 void PerfProfileConnector::PrintStats() const {

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
@@ -61,12 +61,12 @@ PerfProfileConnector::PerfProfileConnector(std::string_view source_name)
       sampling_period_(
           std::chrono::milliseconds{1000 * FLAGS_stirling_profiler_table_update_period_seconds}),
       push_period_(sampling_period_ / 2),
-      profiler_state_overflow_counter_(BuildCounter(
-          "perf_profiler_overflow",
-          "Count of times the perf profiler overran CFG_OVERRUN_THRESHOLD")),
-      profiler_state_map_read_error_counter_(BuildCounter(
-          "perf_profiler_map_read_error",
-          "Count of times the perf profiler encountered a map lookup error")),
+      profiler_state_overflow_counter_(
+          BuildCounter("perf_profiler_overflow",
+                       "Count of times the perf profiler overran CFG_OVERRUN_THRESHOLD")),
+      profiler_state_map_read_error_counter_(
+          BuildCounter("perf_profiler_map_read_error",
+                       "Count of times the perf profiler encountered a map lookup error")),
       stats_log_interval_(std::chrono::minutes(FLAGS_stirling_profiler_log_period_minutes) /
                           sampling_period_) {
   constexpr auto kMaxSamplingPeriod = std::chrono::milliseconds{30000};
@@ -367,12 +367,12 @@ void PerfProfileConnector::CheckProfilerState() {
   DCHECK_EQ(error_code, kPerfProfilerStatusOk);
 
   switch (error_code) {
-      case kOverflowError:
-        profiler_state_overflow_counter_.Increment();
-        break;
-      case kMapReadFailureError:
-        profiler_state_map_read_error_counter_.Increment();
-        break;
+    case kOverflowError:
+      profiler_state_overflow_counter_.Increment();
+      break;
+    case kMapReadFailureError:
+      profiler_state_map_read_error_counter_.Increment();
+      break;
   }
   // Reset the BPF map to its default value so that each occurrence
   // can be detected.

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "src/common/metrics/metrics.h"
 #include "src/shared/types/types.h"
 #include "src/stirling/bpf_tools/bcc_wrapper.h"
 #include "src/stirling/core/source_connector.h"
@@ -101,14 +102,17 @@ class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrappe
   void CleanupSymbolizers(const absl::flat_hash_set<md::UPID>& deleted_upids);
 
   void PrintStats() const;
+  void CheckProfilerState();
 
   // data structures shared with BPF:
   std::unique_ptr<ebpf::BPFStackTable> stack_traces_a_;
   std::unique_ptr<ebpf::BPFStackTable> stack_traces_b_;
 
   std::unique_ptr<ebpf::BPFArrayTable<uint64_t>> profiler_state_;
+  prometheus::Counter& profiler_state_overflow_counter_;
+  prometheus::Counter& profiler_state_map_read_error_counter_;
 
-  // Number of iterations, where each iteration is drains the information collectid in BPF.
+  // Number of iterations, where each iteration is drains the information collected in BPF.
   uint64_t transfer_count_ = 0;
 
   // Tracks unique stack trace ids, for the lifetime of Stirling:


### PR DESCRIPTION
Summary: Fix perf profiler bug causing higher BPF map utilization and add `DCHECK` and metrics for error conditions

The perf profiler connector (and soon the socket trace connector - #1161) record error conditions in a BPF map. While the perf profiler has instrumented this value for a while, we haven't leveraged using this data in anyway. This change `DCHECK`s the error condition in addition to adding prometheus metrics.

This `DCHECK` caught a bug in our map switching logic. The perf profiler has an "A" and "B" map and alternates between them. Prior to this change we were using the A map exclusively since our variable for B was accidentally pointing to A ([source](https://github.com/pixie-io/pixie/blob/cf071f3608de5500213cef05ddb1bba88544ea66/src/stirling/source_connectors/perf_profiler/bcc_bpf/profiler.c#L64-L65)).

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Verified the following:
- [x] `DCHECK` triggers on the first commit of this PR ([P351](https://phab.corp.pixielabs.ai/P351))
- [x] Verified that the overflow prometheus metric value is incremented when the overflow condition occurs ([P350](https://phab.corp.pixielabs.ai/P350))
- [x] `DCHECK` no longer occurs with `profiler.c` fix

Changelog Message:
- Fixed a bug that may lead to missing stack frames for the continuous profiler. We believe this situation is unlikely to occur since our buffers are sized with sufficient margin.