### PR TITLE
Upgrade docker dep in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.1.6 // indirect
 	github.com/docker/cli v20.10.11+incompatible // indirect
-	github.com/docker/docker v20.10.7+incompatible // indirect
+	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/elliotchance/orderedmap v1.5.0 // indirect


### PR DESCRIPTION
Summary: We rename and import docker/docker as moby/moby but the dependabot
tooling seems to not accurately detect that the replaced version is new enough
to address the open CVEs. So upgrade the docker/docker import too.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: This change is a no-op.
