### PR TITLE
[lint] Don't run cpplint on c files

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -74,7 +74,7 @@
     "cpplint": {
       "type": "cpplint",
       "include": [
-        "(\\.(c|cc|h)$)"
+        "(\\.(cc|h)$)"
       ],
       "exclude": [
         "(_objc\\.h$)"


### PR DESCRIPTION
Summary: cpplint makes c++ specific suggestions that shouldn't be applied to C only files. This avoids running the linter on C files.

Type of change: /kind cleanup

Test Plan: Tested that cpplint doesn't run on `.c` files.
