### PR TITLE
[java/agent] Make agent compatible with C.

### DIFF
--- a/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
@@ -21,7 +21,7 @@ package(default_visibility = ["//src/stirling:__subpackages__"])
 
 agent_files = [
     "Makefile.inner",
-    "agent.cc",
+    "agent.c",
     "raw_symbol_update.h",
 ]
 
@@ -67,7 +67,7 @@ pl_cc_library(
 cc_static_musl_binary(
     name = "px-java-agent",
     srcs = [
-        "agent.cc",
+        "agent.c",
         "agent_hash.h",
         "raw_symbol_update.h",
     ],

--- a/src/stirling/source_connectors/perf_profiler/java/agent/agent.c
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/agent.c
@@ -23,13 +23,15 @@
 // populate Java symbols that cannot be found by inspecting binaries (i.e. cannot be found
 // by the "normal" means used to find symbols in compiled binaries from C, C++, Go, and Rust).
 
+// LINT_C_FILE: Do not remove this line. It ensures cpplint treats this as a C file.
+
 #include <jvmti.h>
+#include <pthread.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-
-#include <mutex>
 
 #include "src/stirling/source_connectors/perf_profiler/java/agent/agent_hash.h"
 #include "src/stirling/source_connectors/perf_profiler/java/agent/raw_symbol_update.h"
@@ -40,16 +42,13 @@
     return err;                                                                                \
   }
 
-namespace {
-constexpr bool kUsingTxtLogFile = false;
-constexpr bool kUsingBinLogFile = true;
+static bool kUsingTxtLogFile = false;
+static bool kUsingBinLogFile = true;
 
-std::mutex g_mtx;
+pthread_mutex_t g_mtx = PTHREAD_MUTEX_INITIALIZER;
 bool g_callbacks_attached = false;
-FILE* g_log_file_ptr = nullptr;
-FILE* g_bin_file_ptr = nullptr;
-
-}  // namespace
+FILE* g_log_file_ptr = NULL;
+FILE* g_bin_file_ptr = NULL;
 
 void LogF(const char* format, ...) {
   if (g_log_file_ptr) {
@@ -69,10 +68,10 @@ void LogJvmtiError(jvmtiEnv* jvmti, const jvmtiError err_num, const char* help_m
     const char* const default_help_message = "";
 
     char* err_name_or_null;
-    jvmti->GetErrorName(err_num, &err_name_or_null);
+    (*jvmti)->GetErrorName(jvmti, err_num, &err_name_or_null);
 
-    const bool err_name_valid = err_name_or_null != nullptr;
-    const bool help_msg_valid = help_msg_or_null != nullptr;
+    const bool err_name_valid = err_name_or_null != NULL;
+    const bool help_msg_valid = help_msg_or_null != NULL;
 
     const char* const err_name_str = err_name_valid ? err_name_or_null : default_err_name_str;
     const char* const help_message = help_msg_valid ? help_msg_or_null : default_help_message;
@@ -82,21 +81,18 @@ void LogJvmtiError(jvmtiEnv* jvmti, const jvmtiError err_num, const char* help_m
 }
 
 void Deallocate(jvmtiEnv* jvmti, void* p) {
-  const jvmtiError error = jvmti->Deallocate((unsigned char*)p);
+  const jvmtiError error = (*jvmti)->Deallocate(jvmti, (unsigned char*)p);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "Deallocate() failure.");
   }
 }
 
-template <typename T>
-void FWriteRetryOnErr(FILE* f, T* p, const size_t n_total) {
-  constexpr size_t kElementSizeInBytes = 1;
-  constexpr uint32_t kMaxRetries = 5;
+void FWriteRetryOnErr(FILE* f, const char* write_ptr, const size_t n_total) {
+  static const size_t kElementSizeInBytes = 1;
+  static const uint32_t kMaxRetries = 5;
 
   uint32_t num_retries = 0;
   size_t n_written = 0;
-  const char* write_ptr = reinterpret_cast<const char*>(p);
-
   while (n_written < n_total) {
     if (num_retries > kMaxRetries) {
       LogF("[error] FWriteRetryOnErr() exceeded kMaxRetries: %d.", kMaxRetries);
@@ -112,54 +108,54 @@ void FWriteRetryOnErr(FILE* f, T* p, const size_t n_total) {
 void WriteSymbol(const uint64_t addr, const uint32_t code_size, const bool method_unload,
                  const char* const symbol_ptr, const char* const fn_sig_ptr,
                  const char* const class_sig_ptr) {
-  const bool fn_sig_valid = fn_sig_ptr != nullptr;
-  const bool symbol_valid = symbol_ptr != nullptr;
-  const bool class_sig_valid = class_sig_ptr != nullptr;
+  const bool fn_sig_valid = fn_sig_ptr != NULL;
+  const bool symbol_valid = symbol_ptr != NULL;
+  const bool class_sig_valid = class_sig_ptr != NULL;
 
   const char nullchar = '\0';
   const char* const fn_sig = fn_sig_valid ? fn_sig_ptr : &nullchar;
   const char* const symbol = symbol_valid ? symbol_ptr : &nullchar;
   const char* const class_sig = class_sig_valid ? class_sig_ptr : &nullchar;
 
-  px::stirling::java::RawSymbolUpdate symbol_metadata = {.addr = addr,
-                                                         .code_size = code_size,
-                                                         .symbol_size = 1 + strlen(symbol),
-                                                         .fn_sig_size = 1 + strlen(fn_sig),
-                                                         .class_sig_size = 1 + strlen(class_sig),
-                                                         .method_unload = method_unload};
+  struct RawSymbolUpdate symbol_metadata = {.addr = addr,
+                                            .code_size = code_size,
+                                            .symbol_size = 1 + strlen(symbol),
+                                            .fn_sig_size = 1 + strlen(fn_sig),
+                                            .class_sig_size = 1 + strlen(class_sig),
+                                            .method_unload = method_unload};
 
-  g_mtx.lock();
+  pthread_mutex_lock(&g_mtx);
   if (method_unload) {
     LogF("WriteSymbol|0x%016llx|unload", addr);
   } else {
     LogF("WriteSymbol|0x%016llx|%u|%s|%s|%s", addr, code_size, symbol, fn_sig, class_sig);
   }
-  if (g_bin_file_ptr != nullptr) {
-    FWriteRetryOnErr(g_bin_file_ptr, &symbol_metadata, sizeof(symbol_metadata));
+  if (g_bin_file_ptr != NULL) {
+    FWriteRetryOnErr(g_bin_file_ptr, (const char*)&symbol_metadata, sizeof(symbol_metadata));
     FWriteRetryOnErr(g_bin_file_ptr, symbol, symbol_metadata.symbol_size);
     FWriteRetryOnErr(g_bin_file_ptr, fn_sig, symbol_metadata.fn_sig_size);
     FWriteRetryOnErr(g_bin_file_ptr, class_sig, symbol_metadata.class_sig_size);
     fflush(g_bin_file_ptr);
   }
-  g_mtx.unlock();
+  pthread_mutex_unlock(&g_mtx);
 }
 
 void JNICALL CompiledMethodUnload(jvmtiEnv* jvmti, jmethodID method, const void* addr) {
-  const uint64_t code_addr = uint64_t(addr);
+  const uint64_t code_addr = (uint64_t)addr;
   const uint32_t code_size = 0;
   const bool method_unload = true;
-  const char* const symbol_ptr = nullptr;
-  const char* const fn_sig_ptr = nullptr;
-  const char* const class_sig_ptr = nullptr;
+  const char* const symbol_ptr = NULL;
+  const char* const fn_sig_ptr = NULL;
+  const char* const class_sig_ptr = NULL;
   WriteSymbol(code_addr, code_size, method_unload, symbol_ptr, fn_sig_ptr, class_sig_ptr);
 }
 
 void JNICALL DynamicCodeGenerated(jvmtiEnv* jvmti, const char* symbol, const void* addr,
                                   jint code_size) {
-  const uint64_t code_addr = uint64_t(addr);
+  const uint64_t code_addr = (uint64_t)addr;
   const bool method_unload = false;
-  const char* const fn_sig_ptr = nullptr;
-  const char* const class_sig_ptr = nullptr;
+  const char* const fn_sig_ptr = NULL;
+  const char* const class_sig_ptr = NULL;
   WriteSymbol(code_addr, code_size, method_unload, symbol, fn_sig_ptr, class_sig_ptr);
 }
 
@@ -172,19 +168,19 @@ void JNICALL CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method, jint code_siz
   char* fn_sig_ptr;
   char* class_sig_ptr;
 
-  error = jvmti->GetMethodName(method, &symbol_ptr, &fn_sig_ptr, nullptr);
+  error = (*jvmti)->GetMethodName(jvmti, method, &symbol_ptr, &fn_sig_ptr, NULL);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "GetMethodName() failure.");
     return;
   }
 
-  error = jvmti->GetMethodDeclaringClass(method, &java_class);
+  error = (*jvmti)->GetMethodDeclaringClass(jvmti, method, &java_class);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "GetMethodDeclaringClass() failure.");
     return;
   }
 
-  error = jvmti->GetClassSignature(java_class, &class_sig_ptr, nullptr);
+  error = (*jvmti)->GetClassSignature(jvmti, java_class, &class_sig_ptr, NULL);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "GetClassSignature() failure.");
     return;
@@ -207,21 +203,22 @@ void JNICALL CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method, jint code_siz
 
 jint SetNotificationModes(jvmtiEnv* jvmti) {
   jvmtiError error;
-  error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, nullptr);
+  error = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD,
+                                             NULL);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "Unable to set notification mode for CompiledMethodLoad.");
     return JNI_ERR;
   }
 
-  error =
-      jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, nullptr);
+  error = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                             JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "Unable to set notification mode for CompiledMethodUnload.");
     return JNI_ERR;
   }
 
-  error =
-      jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, nullptr);
+  error = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                             JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "Unable to set notification mode for DynamicCodeGenerated.");
     return JNI_ERR;
@@ -239,7 +236,7 @@ jint AddJVMTICapabilities(jvmtiEnv* jvmti) {
   capabilities.can_get_line_numbers = 1;
   capabilities.can_generate_compiled_method_load_events = 1;
 
-  error = jvmti->AddCapabilities(&capabilities);
+  error = (*jvmti)->AddCapabilities(jvmti, &capabilities);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "Unable to get necessary JVMTI capabilities.");
     return JNI_ERR;
@@ -257,7 +254,7 @@ jint SetCallbackFunctions(jvmtiEnv* jvmti) {
   callbacks.CompiledMethodUnload = &CompiledMethodUnload;
   callbacks.DynamicCodeGenerated = &DynamicCodeGenerated;
 
-  error = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  error = (*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(jvmtiEventCallbacks));
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "Unable to attach CompiledMethodLoad callback.");
     return JNI_ERR;
@@ -270,7 +267,7 @@ jint ReplayCallbacks(jvmtiEnv* jvmti) {
   jvmtiError error;
   jvmtiPhase phase;
 
-  error = jvmti->GetPhase(&phase);
+  error = (*jvmti)->GetPhase(jvmti, &phase);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "ReplayCallbacks(): GetPhase() error.");
     return JNI_ERR;
@@ -282,14 +279,14 @@ jint ReplayCallbacks(jvmtiEnv* jvmti) {
   }
 
   LogF("Replaying JIT code compile events.");
-  error = jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD);
+  error = (*jvmti)->GenerateEvents(jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD).");
     return JNI_ERR;
   }
 
   LogF("Replaying dynamic code gen. events.");
-  error = jvmti->GenerateEvents(JVMTI_EVENT_DYNAMIC_CODE_GENERATED);
+  error = (*jvmti)->GenerateEvents(jvmti, JVMTI_EVENT_DYNAMIC_CODE_GENERATED);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "GenerateEvents(JVMTI_EVENT_DYNAMIC_CODE_GENERATED).");
     return JNI_ERR;
@@ -301,7 +298,7 @@ jint CheckForOnLoadOrLivePhase(jvmtiEnv* jvmti) {
   jvmtiError error;
   jvmtiPhase phase;
 
-  error = jvmti->GetPhase(&phase);
+  error = (*jvmti)->GetPhase(jvmti, &phase);
   if (error != JVMTI_ERROR_NONE) {
     LogJvmtiError(jvmti, error, "CheckForOnLoadOrLivePhase(): GetPhase() error.");
     return JNI_ERR;
@@ -327,35 +324,37 @@ jint CheckForOnLoadOrLivePhase(jvmtiEnv* jvmti) {
   return JNI_OK;
 }
 
-FILE* FOpenLogFile(const std::string& file_path) {
-  FILE* f = fopen(file_path.c_str(), "w");
-  if (f == nullptr) {
-    LogF("[error] FOpenLogFile() Unable to open: %s.", file_path.c_str());
+FILE* FOpenLogFile(const char* file_path) {
+  FILE* f = fopen(file_path, "w");
+  if (f == NULL) {
+    LogF("[error] FOpenLogFile() Unable to open: %s.", file_path);
   }
   return f;
 }
 
 jint OpenLogFiles(const char* options) {
-  if (options == nullptr) {
+  if (options == NULL) {
     return JNI_ERR;
   }
 
-  std::string artifacts_path(options);
-  artifacts_path += std::string("-") + std::string(PX_JVMTI_AGENT_HASH);
+  g_log_file_ptr = NULL;
+  g_bin_file_ptr = NULL;
 
-  g_log_file_ptr = nullptr;
-  g_bin_file_ptr = nullptr;
-
+  char artifacts_path[512];
   if (kUsingTxtLogFile) {
+    snprintf(artifacts_path, sizeof(artifacts_path), "%s%s", options,
+             "-" PX_JVMTI_AGENT_HASH "/" TXT_SYMBOL_FILENAME);
     // TODO(jps): remove the txt based log file once we finalize java symbolization.
-    g_log_file_ptr = FOpenLogFile(artifacts_path + "/" + px::stirling::java::kTxtSymbolFileName);
-    if (g_log_file_ptr == nullptr) {
+    g_log_file_ptr = FOpenLogFile(artifacts_path);
+    if (g_log_file_ptr == NULL) {
       return JNI_ERR;
     }
   }
   if (kUsingBinLogFile) {
-    g_bin_file_ptr = FOpenLogFile(artifacts_path + "/" + px::stirling::java::kBinSymbolFileName);
-    if (g_bin_file_ptr == nullptr) {
+    snprintf(artifacts_path, sizeof(artifacts_path), "%s%s", options,
+             "-" PX_JVMTI_AGENT_HASH "/" BIN_SYMBOL_FILENAME);
+    g_bin_file_ptr = FOpenLogFile(artifacts_path);
+    if (g_bin_file_ptr == NULL) {
       return JNI_ERR;
     }
   }
@@ -364,19 +363,18 @@ jint OpenLogFiles(const char* options) {
 }
 
 jint GetJVMTIEnv(JavaVM* jvm, jvmtiEnv** jvmti) {
-  if (jvm == nullptr || jvmti == nullptr) {
+  if (jvm == NULL || jvmti == NULL) {
     return JNI_ERR;
   }
 
-  jint error = jvm->GetEnv(reinterpret_cast<void**>(jvmti), JVMTI_VERSION_1_0);
-  if (error != JNI_OK || *jvmti == nullptr) {
+  jint error = (*jvm)->GetEnv(jvm, (void**)jvmti, JVMTI_VERSION_1_0);
+  if (error != JNI_OK || *jvmti == NULL) {
     LogF("[error] Unable to access JVMTI.");
     return JNI_ERR;
   }
   return JNI_OK;
 }
 
-extern "C" {
 JNIEXPORT uint64_t PixieJavaAgentTestFn() {
   // This function is exported solely for the purpose of verifying that
   // dlopen + dlsym works as expected.
@@ -390,7 +388,7 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM* jvm, char* options, void* /*reserv
     return JNI_OK;
   }
 
-  static jvmtiEnv* jvmti = nullptr;
+  static jvmtiEnv* jvmti = NULL;
 
   PX_JVMTI_AGENT_RETURN_IF_ERROR(OpenLogFiles(options));
   PX_JVMTI_AGENT_RETURN_IF_ERROR(GetJVMTIEnv(jvm, &jvmti));
@@ -404,6 +402,5 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM* jvm, char* options, void* /*reserv
 }
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* /*reserved*/) {
-  return Agent_OnAttach(jvm, options, nullptr);
-}
+  return Agent_OnAttach(jvm, options, NULL);
 }

--- a/src/stirling/source_connectors/perf_profiler/java/agent/raw_symbol_update.h
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/raw_symbol_update.h
@@ -20,29 +20,36 @@
 
 #include <stdint.h>
 
+#define TXT_SYMBOL_FILENAME "java-symbols.txt"
+#define BIN_SYMBOL_FILENAME "java-symbols.bin"
+
+#ifdef __cplusplus
 namespace px {
 namespace stirling {
 namespace java {
+char const* const kBinSymbolFileName = BIN_SYMBOL_FILENAME;
+char const* const kTxtSymbolFileName = TXT_SYMBOL_FILENAME;
+#endif
 
-char const* const kBinSymbolFileName = "java-symbols.bin";
-char const* const kTxtSymbolFileName = "java-symbols.txt";
-
-class RawSymbolUpdate {
+struct RawSymbolUpdate {
+#ifdef __cplusplus
  public:
+  uint64_t TotalNumSymbolBytes() const { return symbol_size + fn_sig_size + class_sig_size; }
+  uint64_t SymbolOffset() const { return 0; }
+  uint64_t FnSigOffset() const { return symbol_size; }
+  uint64_t ClassSigOffset() const { return symbol_size + fn_sig_size; }
+  bool IsMethodUnload() const { return method_unload; }
+#endif
   uint64_t addr;
   uint64_t code_size;
   uint64_t symbol_size;
   uint64_t fn_sig_size;
   uint64_t class_sig_size;
   bool method_unload;
-
-  uint64_t TotalNumSymbolBytes() const { return symbol_size + fn_sig_size + class_sig_size; }
-  uint64_t SymbolOffset() const { return 0; }
-  uint64_t FnSigOffset() const { return symbol_size; }
-  uint64_t ClassSigOffset() const { return symbol_size + fn_sig_size; }
-  bool IsMethodUnload() const { return method_unload; }
 };
 
+#ifdef __cplusplus
 }  // namespace java
 }  // namespace stirling
 }  // namespace px
+#endif


### PR DESCRIPTION
Summary: We would like to build the java agent for ARM as well as x86. We could make a fully-featured musl c++ toolchain. However, that's a lot of work and its much easier to just build musl libc with bazel and statically link it. This won't work with C++ though, because we wont have a compatible libc++. The java agent doesn't really make use of many c++ features beyond std::mutex and std::string, which are easily replaced with C versions. This PR converts the java agent to be C compatible, removing its uses of c++ features.

Relevant Issues: #891

Type of change: /kind cleanup

Test Plan: Tested that java symbols still show up in the flamegraph with this new version of the agent.
