### PR TITLE
[musl build] Build musl libc with bazel.

### DIFF
--- a/bazel/external/musl.BUILD
+++ b/bazel/external/musl.BUILD
@@ -1,0 +1,14 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "musl",
+    lib_source = ":all",
+    configure_options = ["--disable-shared"],
+    out_static_libs = ["libc.a"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/pl_build_system.bzl
+++ b/bazel/pl_build_system.bzl
@@ -213,6 +213,20 @@ def pl_cc_binary(
         features = pl_default_features(),
     )
 
+def pl_cc_musl_binary(name, **kwargs):
+    if not "copts" in kwargs:
+        kwargs["copts"] = []
+    kwargs["copts"] = kwargs["copts"] + ["-nostdlib", "-nostdinc"]
+
+    if not "linkopts" in kwargs:
+        kwargs["linkopts"] = []
+    kwargs["linkopts"]  = kwargs["linkopts"] + ["-nostdlib"]
+
+    if not "deps" in kwargs:
+        kwargs["deps"] = []
+    kwargs["deps"] = kwargs["deps"] + ["@org_libc_musl//:musl"]
+    cc_binary(name = name, **kwargs)
+
 # PL C++ test targets should be specified with this function.
 def pl_cc_test(
         name,

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -183,6 +183,8 @@ def _cc_deps():
     _include_all_repo("com_github_libuv_libuv", patches = ["//bazel/external:libuv.patch"], patch_args = ["-p1"])
     _include_all_repo("com_github_libarchive_libarchive", patches = ["//bazel/external:libarchive.patch"], patch_args = ["-p1"])
 
+    _bazel_repo("org_libc_musl", build_file = "//bazel/external:musl.BUILD")
+
 def _java_deps():
     _bazel_repo("com_oracle_openjdk_18", build_file = "//bazel/external:jdk_includes.BUILD")
     remote_java_repository(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -401,6 +401,11 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "tensorflow-2.11.0",
         urls = ["https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz"],
     ),
+    org_libc_musl = dict(
+        sha256 = "7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4",
+        strip_prefix = "musl-1.2.3",
+        urls = ["http://musl.libc.org/releases/musl-1.2.3.tar.gz"],
+    ),
     rules_foreign_cc = dict(
         sha256 = "6041f1374ff32ba711564374ad8e007aef77f71561a7ce784123b9b4b88614fc",
         strip_prefix = "rules_foreign_cc-0.8.0",


### PR DESCRIPTION
Summary: Uses bazel to build musl libc. Adds `pl_cc_musl_binary` to build a `cc_binary` using musl. This macro is currently unused but will be used to build the java agent.

Type of change: /kind cleanup.

Test Plan: Tested that binaries built with `pl_cc_musl_binary` work.
