### PR TITLE
Remove unused proxy_image

### DIFF
--- a/k8s/cloud/BUILD.bazel
+++ b/k8s/cloud/BUILD.bazel
@@ -33,7 +33,7 @@ CLOUD_IMAGE_TO_LABEL = {
     "$(IMAGE_PREFIX)cloud/plugin_server_image:$(BUNDLE_VERSION)": "//src/cloud/plugin:plugin_server_image",
     "$(IMAGE_PREFIX)cloud/profile_server_image:$(BUNDLE_VERSION)": "//src/cloud/profile:profile_server_image",
     "$(IMAGE_PREFIX)cloud/project_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/project_manager:project_manager_server_image",
-    "$(IMAGE_PREFIX)cloud/proxy_server_image:$(BUNDLE_VERSION)": "//src/cloud/proxy:proxy_prod_server_image",
+    "$(IMAGE_PREFIX)cloud/proxy_server_image:$(BUNDLE_VERSION)": "//src/cloud/proxy:proxy_server_image",
     "$(IMAGE_PREFIX)cloud/scriptmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/scriptmgr:scriptmgr_server_image",
     "$(IMAGE_PREFIX)cloud/vzconn_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzconn:vzconn_server_image",
     "$(IMAGE_PREFIX)cloud/vzmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzmgr:vzmgr_server_image",

--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -18,7 +18,7 @@ build:
   - image: gcr.io/pixie-oss/pixie-dev/cloud/proxy_server_image
     context: .
     bazel:
-      target: //src/cloud/proxy:proxy_prod_server_image.tar
+      target: //src/cloud/proxy:proxy_server_image.tar
   - image: gcr.io/pixie-oss/pixie-dev/cloud/plugin_server_image
     context: .
     bazel:

--- a/src/cloud/proxy/BUILD.bazel
+++ b/src/cloud/proxy/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
 
@@ -65,7 +64,7 @@ container_layer(
 )
 
 container_image(
-    name = "proxy_prod_server_image",
+    name = "proxy_server_image",
     base = "@openresty//image",
     cmd = ["/scripts/entrypoint.sh"],
     entrypoint = ["/bin/bash"],
@@ -80,28 +79,4 @@ container_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_image(
-    name = "proxy_dev_server_image",
-    base = "@openresty//image",
-    cmd = ["/scripts/entrypoint.sh"],
-    entrypoint = ["/bin/bash"],
-    layers = [
-        ":conf",
-        ":entrypoint",
-    ],
-    visibility = [
-        "//k8s:__subpackages__",
-        "//src/cloud:__subpackages__",
-    ],
-)
-
-container_push(
-    name = "push_proxy_dev_server_image",
-    format = "Docker",
-    image = ":proxy_dev_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/proxy_dev_image",
-    tag = "{STABLE_BUILD_TAG}",
 )


### PR DESCRIPTION
Summary: The proxy image had two versions, but the dev image has never been used
as far as I can tell. Remove it to reduce maintenance burden.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: All builds and tests work. skaffold cloud works.
