### PR TITLE
[artifacts] Use the same bucket for RCs as official releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         ./ci/vizier_build_release.sh
     - name: Build & Export Docs
       env:
-        PXL_DOCS_GCS_PATH: "gs://pl-docs/pxl-docs.json"
+        PXL_DOCS_GCS_PATH: "gs://pixie-dev-public/pxl-docs.json"
       run: |
         docs="$(mktemp)"
         bazel run //src/carnot/docstring:docstring -- --output_json "${docs}"

--- a/ci/operator_build_release.sh
+++ b/ci/operator_build_release.sh
@@ -50,7 +50,7 @@ if [[ $release_tag == *"-"* ]]; then
   deleter_image_path="gcr.io/pixie-oss/pixie-dev/operator/vizier_deleter:${release_tag}"
   channel="dev"
   channels="dev"
-  bucket="pixie-dev"
+  # Use the same bucket as above.
   # The previous version should be the 1st item in the tags. Since this is a non-release build,
   # the first item in the tags is the previous release.
   prev_tag=$(echo "$tags" | sed -n '1 p')

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -37,8 +37,7 @@ bucket="pixie-dev-public"
 extra_bazel_args=()
 if [[ $release_tag == *"-"* ]]; then
   build_type="--//k8s:build_type=dev"
-  # TODO(vihang/michelle): Revisit this bucket.
-  bucket="pixie-prod-artifacts"
+  # Use the same bucket as above for RCs
 fi
 
 output_path="gs://${bucket}/vizier/${release_tag}"

--- a/k8s/cloud/base/artifact_config.yaml
+++ b/k8s/cloud/base/artifact_config.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: pl-artifact-config
 data:
-  PL_ARTIFACT_BUCKET: pixie-prod-artifacts
-  PL_RELEASE_ARTIFACT_BUCKET: pixie-dev-public
+  PL_ARTIFACT_BUCKET: pixie-dev-public
   PL_ARTIFACT_MANIFEST_BUCKET: pixie-dev-public
   PL_SA_KEY_PATH: /creds/service_account.json

--- a/src/cloud/artifact_tracker/artifact_tracker_server.go
+++ b/src/cloud/artifact_tracker/artifact_tracker_server.go
@@ -45,7 +45,6 @@ import (
 
 func init() {
 	pflag.String("artifact_bucket", "pl-artifacts", "The name of the artifact bucket.")
-	pflag.String("release_artifact_bucket", "pl-artifacts", "The name of the artifact bucket containing official releases.")
 	pflag.String("sa_key_path", "/creds/service_account.json", "The path to the service account JSON file.")
 	pflag.String("vizier_version", "", "If specified, the db will not be queried. The only vizier version is assumed to be the one specified.")
 	pflag.String("cli_version", "", "If specified, the db will not be queried. The only CLI version is assumed to be the one specified.")
@@ -99,8 +98,7 @@ func main() {
 	env := artifacttrackerenv.New()
 
 	bucket := viper.GetString("artifact_bucket")
-	releaseBucket := viper.GetString("release_artifact_bucket")
-	svr := controllers.NewServer(stiface.AdaptClient(client), bucket, releaseBucket, saCfg)
+	svr := controllers.NewServer(stiface.AdaptClient(client), bucket, saCfg)
 
 	// If any versions are not hardcoded, then we need to poll for the artifact manifest.
 	if (viper.GetString("vizier_version") == "") || (viper.GetString("cli_version") == "") || (viper.GetString("operator_version") == "") {


### PR DESCRIPTION
Summary: Switches vizier and operator RCs to use the same bucket as official releases. Updates the `artifact_tracker` to not attempt to sign RC download links.

Type of change: /kind cleanup.

Test Plan: Existing tests pass. Will deploy to testing to make sure it works.
