### PR TITLE
Fix skaffold dev cloud deployment

### DIFF
--- a/k8s/cloud/dev/auth_deployment_patch.yaml
+++ b/k8s/cloud/dev/auth_deployment_patch.yaml
@@ -1,0 +1,18 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env
+  # yamllint disable rule:indentation
+  value: |
+    - name: PL_AUTH0_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: cloud-auth0-secrets
+          key: auth0-client-id
+          optional: true
+    - name: PL_AUTH0_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: cloud-auth0-secrets
+          key: auth0-client-secret
+          optional: true
+  # yamllint enable rule:indentation

--- a/k8s/cloud/dev/kustomization.yaml
+++ b/k8s/cloud/dev/kustomization.yaml
@@ -23,6 +23,11 @@ resources:
 - ../base
 - ../overlays/exposed_services_ilb
 - plugin_db_updater_job.yaml
+patches:
+- path: auth_deployment_patch.yaml
+  target:
+    kind: Deployment
+    labelSelector: name=auth-server
 patchesStrategicMerge:
 # bq_config is useful for testing, but we don't want dev clusters to typically send data to bq.
 # - bq_config.yaml


### PR DESCRIPTION
Summary: The dev cloud setup still uses auth0 and doesn't work unless these
secrets are passed through.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: skaffolding a dev cloud works now.
