### PR TITLE
Update dark color palette

### DIFF
--- a/src/ui/src/components/auth/signup-marcom.tsx
+++ b/src/ui/src/components/auth/signup-marcom.tsx
@@ -35,7 +35,7 @@ import { Logo } from 'configurable/logo';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => createStyles({
   heading: {
-    color: palette.foreground.white,
+    color: palette.foreground.two,
     textAlign: 'center',
   },
   message: {
@@ -49,10 +49,10 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => createStyles({
     marginTop: spacing(5),
     alignItems: 'center',
     background: `linear-gradient(180deg, ${alpha(
-      palette.background.two,
+      palette.background.four,
       0.87,
     )},
-    ${alpha(palette.background.three, 0.22)})`,
+    ${alpha(palette.background.five, 0.22)})`,
     boxShadow: `2px 2px 2px 0px ${palette.background.default}`,
     paddingLeft: spacing(2),
     paddingRight: spacing(2),

--- a/src/ui/src/components/autocomplete/autocomplete.tsx
+++ b/src/ui/src/components/autocomplete/autocomplete.tsx
@@ -38,14 +38,14 @@ import { Key } from './key';
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
-    backgroundColor: theme.palette.background.three,
+    backgroundColor: theme.palette.background.five,
     cursor: 'text',
     display: 'flex',
     flexDirection: 'column',
     ...scrollbarStyles(theme),
   },
   input: {
-    backgroundColor: theme.palette.background.two,
+    backgroundColor: theme.palette.background.four,
   },
   completions: {
     flex: 1,

--- a/src/ui/src/components/breadcrumbs/__snapshots__/breadcrumbs-test.tsx.snap
+++ b/src/ui/src/components/breadcrumbs/__snapshots__/breadcrumbs-test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Breadcrumbs/> renders correctly 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 css-djkxwx-MuiPaper-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 css-2psz7m-MuiPaper-root"
   >
     <div
       class="Breadcrumbs-breadcrumbs-1"

--- a/src/ui/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/ui/src/components/breadcrumbs/breadcrumbs.tsx
@@ -137,7 +137,7 @@ const useDialogStyles = makeStyles((theme: Theme) => createStyles({
     backgroundColor: theme.palette.foreground.grey3,
     padding: theme.spacing(2),
     borderTop: 'solid 1px',
-    borderColor: theme.palette.background.three,
+    borderColor: theme.palette.background.five,
   },
 }), { name: 'DialogDropdown' });
 

--- a/src/ui/src/components/command-palette/command-text-field.tsx
+++ b/src/ui/src/components/command-palette/command-text-field.tsx
@@ -147,7 +147,7 @@ const useFieldStyles = makeStyles((theme: Theme) => createStyles({
       padding: theme.spacing(1),
 
       '&.Mui-focused': {
-        backgroundColor: theme.palette.background.two,
+        backgroundColor: theme.palette.background.four,
       },
     },
     '&:not(:last-of-type)': {
@@ -160,7 +160,10 @@ const useFieldStyles = makeStyles((theme: Theme) => createStyles({
     top: 0,
     left: 0,
     padding: theme.spacing(0.5),
-    backgroundColor: lighten(theme.palette.background.three, 0.015), // To cover what's behind it
+    // The options background is made by mixing translucent colors; this needs to be opaque to cover scroll siblings.
+    backgroundColor: theme.palette.mode === 'dark'
+      ? lighten(theme.palette.background.five, 0.025)
+      : theme.palette.background.five,
   },
   paperDetails: {
     flex: '4 0 40%',

--- a/src/ui/src/components/data-table/data-table.tsx
+++ b/src/ui/src/components/data-table/data-table.tsx
@@ -107,7 +107,7 @@ const useDataTableStyles = makeStyles((theme: Theme) => createStyles({
   },
   bodyRow: {
     '&:not(:last-child)': {
-      borderBottom: `1px solid ${theme.palette.background.three}`,
+      borderBottom: `1px solid ${theme.palette.background.five}`,
     },
   },
   bodyRowSelectable: {
@@ -128,7 +128,7 @@ const useDataTableStyles = makeStyles((theme: Theme) => createStyles({
     alignItems: 'center',
     padding: `0 ${theme.spacing(1)}`,
     height: `${ROW_HEIGHT_PX}px`, // Ensures the border stretches. See cellContents for the rest.
-    borderRight: `1px solid ${theme.palette.background.three}`,
+    borderRight: `1px solid ${theme.palette.background.five}`,
     '&:last-of-type': {
       borderRightWidth: 0,
     },

--- a/src/ui/src/components/mui-theme.tsx
+++ b/src/ui/src/components/mui-theme.tsx
@@ -17,7 +17,7 @@
  */
 
 
-import { PaletteMode } from '@mui/material';
+import { alpha, PaletteMode } from '@mui/material';
 import { createTheme, Theme, type ThemeOptions as OriginalThemeOptions } from '@mui/material/styles';
 import type {
   PaletteOptions as AugmentedPaletteOptions,
@@ -25,6 +25,72 @@ import type {
 } from '@mui/material/styles/createPalette';
 import { Shadows } from '@mui/material/styles/shadows';
 import { deepmerge } from '@mui/utils';
+
+// These aren't quite the Material UI colors, but they follow the same principles.
+const COLORS = {
+  PRIMARY: {
+    '100': '#D0FBFB',
+    '200': '#A1F7F7',
+    '300': '#6DF3F3',
+    '400': '#35EEEE',
+    '500': '#12D6D6', // Brand primary color!
+    '600': '#0DA0A0',
+    '700': '#096C6C',
+    '800': '#053838',
+    '900': '#031C1C',
+  },
+  SECONDARY: {
+    '100': '#E0F4FF',
+    '200': '#C2EAFF',
+    '300': '#99DBFF',
+    '400': '#61C8FF',
+    '500': '#24B2FF',
+    '600': '#0095E5',
+    '700': '#006EA8',
+    '800': '#004266',
+    '900': '#002133',
+  },
+  NEUTRAL: {
+    '100': '#FFFFFF',
+    '200': '#E6E6EA',
+    '300': '#C3C3CB',
+    '400': '#686875',
+    '500': '#4E4E4E',
+    '600': '#3B3B3B',
+    '700': '#333333',
+    '800': '#232323',
+    '850': '#1E1E1E',
+    '900': '#121212',
+    '1000': '#0A0A0A',
+  },
+  SUCCESS: {
+    '300': '#50F6CE',
+    '400': '#20F3C1',
+    '500': '#0BD3A3',
+    '600': '#0AC296',
+  },
+  ERROR: {
+    '300': '#FFA8B0',
+    '400': '#FF7582',
+    '500': '#FF5E6D',
+    '600': '#FF4C5D',
+  },
+  WARNING: {
+    '300': '#FACA6B',
+    '400': '#F8B83A',
+    '500': '#F6A609',
+    '600': '#E79C08',
+  },
+  INFO: {
+    '300': '#B5E4FD',
+    '400': '#83D2FB',
+    '500': '#53C0FA',
+    '600': '#20ADF9',
+  },
+  // Note: these two colors are similar enough that RGB interpolation doesn't create a noticeable grey zone.
+  // If it did, we'd need to manually compute a few middle points in a colorspace like HCL or LAB to get a better one.
+  GRADIENT: 'linear-gradient(to right, #00DBA6 0%, #24B2FF 100%)',
+};
 
 interface SyntaxPalette {
   /** Default color for tokens that don't match any other rules */
@@ -99,7 +165,6 @@ declare module '@mui/material/styles/createPalette' {
       grey3: string;
       grey4: string;
       grey5: string;
-      white: string;
     };
     sideBar: {
       color: string;
@@ -178,7 +243,7 @@ export const scrollbarStyles = (theme: Theme) => {
       width: theme.spacing(2),
       height: theme.spacing(2),
     },
-    '& ::-webkit-scrollbar-track': commonStyle(theme.palette.background.one),
+    '& ::-webkit-scrollbar-track': commonStyle(theme.palette.background.default),
     '& ::-webkit-scrollbar-thumb': commonStyle(theme.palette.foreground.grey2),
     '& ::-webkit-scrollbar-corner': {
       backgroundColor: 'transparent',
@@ -245,23 +310,23 @@ export const COMMON_THEME = {
   },
   palette: {
     sideBar: {
-      color: '#161616',
+      color: COLORS.NEUTRAL[900],
       colorShadow: '#000000',
       colorShadowOpacity: 0.5,
     },
     common: {
       black: '#000000',
-      white: '#ffffff',
+      white: '#FFFFFF',
     },
     primary: {
-      main: '#12d6d6',
-      dark: '#17aaaa',
-      light: '#3ef3f3',
+      main: COLORS.PRIMARY[500],
+      dark: COLORS.PRIMARY[600],
+      light: COLORS.PRIMARY[400],
     },
     secondary: {
-      main: '#24b2ff',
-      dark: '#21a1e7',
-      light: '#79d0ff',
+      main: COLORS.SECONDARY[500],
+      dark: COLORS.SECONDARY[600],
+      light: COLORS.SECONDARY[400],
     },
     action: {
       active: '#a6a8ae', // foreground 1.
@@ -367,7 +432,7 @@ type DeepPartial<T> = T extends object ? {
   [P in keyof T]?: DeepPartial<T[P]>;
 } : T;
 
-function addSyntaxToPalette(base: DeepPartial<AugmentedPaletteOptions>): AugmentedPaletteOptions {
+function augmentPalette(base: DeepPartial<AugmentedPaletteOptions>): AugmentedPaletteOptions {
   const merged: Omit<AugmentedPaletteOptions, 'syntax'> = deepmerge<any>(
     COMMON_THEME.palette,
     base,
@@ -381,14 +446,14 @@ function addSyntaxToPalette(base: DeepPartial<AugmentedPaletteOptions>): Augment
       divider: merged.foreground.three,
       error: (merged.error as Required<SimplePaletteColorOptions>).main,
       boolean: (merged.success as Required<SimplePaletteColorOptions>).main,
-      number: (merged.secondary as Required<SimplePaletteColorOptions>).main,
+      number: (merged.info as Required<SimplePaletteColorOptions>).main,
       string: merged.mode === 'dark' ? merged.graph.ramp[0] : merged.graph.ramp[2],
       nullish: merged.foreground.three,
     },
   };
 }
 
-function getMuiThemeComponents(palette: DeepPartial<AugmentedPaletteOptions>) {
+function augmentComponents(palette: DeepPartial<AugmentedPaletteOptions>) {
   return deepmerge(
     COMMON_THEME.components,
     {
@@ -407,56 +472,55 @@ function getMuiThemeComponents(palette: DeepPartial<AugmentedPaletteOptions>) {
 export const DARK_BASE = {
   palette: {
     mode: 'dark' as const,
-    divider: '#272822',
+    divider: COLORS.NEUTRAL[800],
     foreground: {
-      one: '#b2b5bb',
-      two: '#f2f2f2',
-      three: '#9696a5',
-      grey1: '#4a4c4f',
-      grey2: '#353738',
-      grey3: '#212324',
-      grey4: '#596274',
-      grey5: '#dbdde0',
-      white: '#ffffff',
+      one: COLORS.NEUTRAL[300],
+      two: COLORS.NEUTRAL[200],
+      three: COLORS.NEUTRAL[400],
+      grey1: COLORS.NEUTRAL[500],
+      grey2: COLORS.NEUTRAL[700],
+      grey3: COLORS.NEUTRAL[800],
+      grey4: COLORS.NEUTRAL[400],
+      grey5: COLORS.NEUTRAL[200],
     },
     background: {
-      default: '#121212',
-      paper: '#121212',
-      one: '#121212',
-      two: '#212324',
-      three: '#353535',
-      four: '#161616',
-      five: '#090909',
-      six: '#242424',
+      default: COLORS.NEUTRAL[900],
+      paper: COLORS.NEUTRAL[900],
+      one: COLORS.NEUTRAL[1000],
+      two: COLORS.NEUTRAL[900],
+      three: COLORS.NEUTRAL[850],
+      four: COLORS.NEUTRAL[800],
+      five: COLORS.NEUTRAL[700],
+      six: COLORS.NEUTRAL[600],
     },
     text: {
-      primary: '#e2e5ee',
-      secondary: '#ffffff',
-      disabled: 'rgba(226, 229, 238, 0.7)', // 70% opacity of primary
+      primary: COLORS.NEUTRAL[200],
+      secondary: COLORS.NEUTRAL[100],
+      disabled: alpha(COLORS.NEUTRAL[200], 0.7),
     },
     border: {
-      focused: '1px solid rgba(255, 255, 255, 0.2)',
-      unFocused: '1px solid rgba(255, 255, 255, 0.1)',
+      focused: `1px solid ${alpha(COLORS.NEUTRAL[100], 0.2)}`,
+      unFocused: `1px solid ${alpha(COLORS.NEUTRAL[100], 0.1)}`,
     },
     success: {
-      main: '#00dba6',
-      dark: '#00bd8f',
-      light: '#4dffd4',
+      main: COLORS.SUCCESS[500],
+      dark: COLORS.SUCCESS[600],
+      light: COLORS.SUCCESS[400],
     },
     warning: {
-      main: '#f6a609',
-      dark: '#dc9406',
-      light: '#ffc656',
+      main: COLORS.WARNING[500],
+      dark: COLORS.WARNING[600],
+      light: COLORS.WARNING[400],
     },
-    info: { // Same as secondary
-      main: '#24b2ff',
-      dark: '#21a1e7',
-      light: '#79d0ff',
+    info: {
+      main: COLORS.INFO[500],
+      dark: COLORS.INFO[600],
+      light: COLORS.INFO[400],
     },
     error: {
-      main: '#ff5e6d',
-      dark: '#e54e5c',
-      light: '#ff9fa8',
+      main: COLORS.ERROR[500],
+      dark: COLORS.ERROR[600],
+      light: COLORS.ERROR[400],
     },
     graph: {
       flamegraph: {
@@ -471,7 +535,7 @@ export const DARK_BASE = {
     MuiDivider: {
       styleOverrides: {
         root: {
-          backgroundColor: '#353535', // background three.
+          backgroundColor: COLORS.NEUTRAL[700],
         },
       },
     },
@@ -491,17 +555,16 @@ export const LIGHT_BASE = {
       grey3: '#f6f6f6',
       grey4: '#a9adb1',
       grey5: '#000000',
-      white: '#ffffff',
     },
     background: {
       default: '#f6f6f6',
       paper: '#fbfbfb',
-      one: '#fbfbfb',
-      two: '#ffffff',
-      three: '#f5f5f5',
-      four: '#f8f9fa',
-      five: '#fbfcfd',
-      six: '#ffffff',
+      one: '#ffffff',
+      two: '#fbfbfb',
+      three: '#fbfcfd',
+      four: '#ffffff',
+      five: '#f5f5f5',
+      six: '#f8f9fa',
     },
     text: {
       primary: 'rgba(0, 0, 0, 0.87)', // Material default
@@ -513,24 +576,24 @@ export const LIGHT_BASE = {
       unFocused: '1px solid rgba(0, 0, 0, 0.1)',
     },
     success: {
-      main: '#00bd8f',
-      dark: '#4dffd4',
-      light: '#00dba6',
+      main: COLORS.SUCCESS[500],
+      dark: COLORS.SUCCESS[600],
+      light: COLORS.SUCCESS[400],
     },
     warning: {
-      main: '#dc9406',
-      dark: '#ffc656',
-      light: '#f6a609',
+      main: COLORS.WARNING[500],
+      dark: COLORS.WARNING[600],
+      light: COLORS.WARNING[400],
     },
-    info: { // Same as secondary
-      main: '#24b2ff',
-      dark: '#21a1e7',
-      light: '#79d0ff',
+    info: {
+      main: COLORS.INFO[500],
+      dark: COLORS.INFO[600],
+      light: COLORS.INFO[400],
     },
     error: {
-      main: '#e54e5c',
-      dark: '#ff9fa8',
-      light: '#ff5e6d',
+      main: COLORS.ERROR[500],
+      dark: COLORS.ERROR[600],
+      light: COLORS.ERROR[400],
     },
     graph: {
       flamegraph: {
@@ -545,7 +608,7 @@ export const LIGHT_BASE = {
     MuiDivider: {
       styleOverrides: {
         root: {
-          backgroundColor: '#a9adb1', // background three.
+          backgroundColor: '#a9adb1', // foreground three.
         },
       },
     },
@@ -556,8 +619,8 @@ export function createPixieTheme(options: DeepPartial<OriginalThemeOptions>): Th
   const base = options?.palette?.mode === 'light' ? LIGHT_BASE : DARK_BASE;
   const merged: OriginalThemeOptions = deepmerge<any>(COMMON_THEME, base, { clone: true });
   // When a custom theme override is given, we only copy color and shadow information (as we know those are safe)
-  merged.palette = addSyntaxToPalette(deepmerge(merged.palette, options.palette ?? {}, { clone: true }));
-  merged.components = getMuiThemeComponents(merged.palette);
+  merged.palette = augmentPalette(deepmerge(merged.palette, options.palette ?? {}, { clone: true }));
+  merged.components = augmentComponents(merged.palette);
   if (Array.isArray(options.shadows) && options.shadows.length) merged.shadows = options.shadows as Shadows;
   return createTheme(merged);
 }

--- a/src/ui/src/components/snackbar/snackbar.tsx
+++ b/src/ui/src/components/snackbar/snackbar.tsx
@@ -46,7 +46,7 @@ type SnackbarState = {
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   snackbar: {
-    backgroundColor: theme.palette.background.three,
+    backgroundColor: theme.palette.background.five,
     color: theme.palette.text.secondary,
   },
 }), { name: 'Snackbar' });

--- a/src/ui/src/components/split-pane/split-pane.tsx
+++ b/src/ui/src/components/split-pane/split-pane.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
     height: '100%',
     '& .gutter': {
-      backgroundColor: theme.palette.background.three,
+      backgroundColor: theme.palette.background.five,
     },
   },
   pane: {
@@ -50,7 +50,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     fontWeight: theme.typography.fontWeightMedium,
     padding: theme.spacing(0.75, 3),
     cursor: 'pointer',
-    backgroundColor: theme.palette.background.three,
+    backgroundColor: theme.palette.background.five,
   },
   paneContent: {
     flex: '1',

--- a/src/ui/src/containers/App/topbar.tsx
+++ b/src/ui/src/containers/App/topbar.tsx
@@ -79,7 +79,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     height: theme.spacing(3),
   },
   managedDomainBanner: {
-    background: theme.palette.background.one,
+    background: theme.palette.background.two,
     fontSize: theme.typography.caption.fontSize,
     fontStyle: 'italic',
     opacity: 0.8,

--- a/src/ui/src/containers/editor/editor.tsx
+++ b/src/ui/src/containers/editor/editor.tsx
@@ -28,7 +28,6 @@ import {
   EDITOR_THEME_MAP,
   LazyPanel,
   ResizableDrawer,
-  Spinner,
 } from 'app/components';
 import { usePluginList } from 'app/containers/admin/plugins/plugin-gql';
 import { SCRATCH_SCRIPT } from 'app/containers/App/scripts-context';
@@ -55,7 +54,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
   tabs: {
     display: 'flex',
     flexDirection: 'row',
-    backgroundColor: theme.palette.background.three,
+    backgroundColor: theme.palette.background.five,
     alignItems: 'center',
   },
   panel: {

--- a/src/ui/src/containers/live-data-table/data-table-details.tsx
+++ b/src/ui/src/containers/live-data-table/data-table-details.tsx
@@ -34,12 +34,12 @@ const useDetailPaneClasses = makeStyles((theme: Theme) => createStyles({
     overflow: 'auto',
   },
   horizontal: {
-    borderTop: `1px solid ${theme.palette.background.three}`,
+    borderTop: `1px solid ${theme.palette.background.five}`,
     minWidth: 0,
     minHeight: theme.spacing(30),
   },
   vertical: {
-    borderLeft: `1px solid ${theme.palette.background.three}`,
+    borderLeft: `1px solid ${theme.palette.background.five}`,
     minWidth: theme.spacing(30),
     minHeight: 0,
   },

--- a/src/ui/src/containers/live/convert-to-vega-spec/flamegraph.ts
+++ b/src/ui/src/containers/live/convert-to-vega-spec/flamegraph.ts
@@ -233,7 +233,7 @@ export function convertToStacktraceFlameGraph(
         x2: { signal: 'main_width' },
         y: { signal: 'minimap_height' },
         y2: { signal: `minimap_height + ${SEPARATOR_HEIGHT}` },
-        fill: { value: theme.palette.background.six },
+        fill: { value: theme.palette.background.four },
       },
     },
   });
@@ -275,7 +275,7 @@ export function convertToStacktraceFlameGraph(
         y: { scale: 'y', field: 'y0' },
         y2: { scale: 'y', field: 'y1' },
         strokeWidth: { value: 1 },
-        stroke: { value: theme.palette.background.six },
+        stroke: { value: theme.palette.background.four },
         zindex: { value: 0 },
       },
       hover: {
@@ -299,7 +299,7 @@ export function convertToStacktraceFlameGraph(
         dx: { value: 8 },
         font: { value: COMMON_THEME.typography.monospace.fontFamily },
         fontWeight: { value: 400 },
-        fill: { value: theme.palette.background.four },
+        fill: { value: theme.palette.background.three },
       },
       update: {
         x: { scale: 'x', field: 'x0' },

--- a/src/ui/src/containers/live/shortcuts.tsx
+++ b/src/ui/src/containers/live/shortcuts.tsx
@@ -108,9 +108,9 @@ const useShortcutHelpStyles = makeStyles((theme: Theme) => createStyles({
     padding: theme.spacing(2),
   },
   key: {
-    border: `solid 2px ${theme.palette.background.three}`,
+    border: `solid 2px ${theme.palette.background.five}`,
     borderRadius: '5px',
-    backgroundColor: theme.palette.background.two,
+    backgroundColor: theme.palette.background.four,
     textTransform: 'capitalize',
     height: theme.spacing(4),
     minWidth: theme.spacing(4),
@@ -123,7 +123,7 @@ const useShortcutHelpStyles = makeStyles((theme: Theme) => createStyles({
   row: {
     display: 'flex',
     flexDirection: 'row',
-    borderBottom: `solid 1px ${theme.palette.background.three}`,
+    borderBottom: `solid 1px ${theme.palette.background.five}`,
     alignItems: 'center',
   },
   sequence: {


### PR DESCRIPTION
Summary: Simplifies to fewer colors, but still very similar to the previous ones.
Footer and `nullish` strings in table details are the only ones that are easy to notice changed; they're more muted now.
The light theme and graph colors will get their own changes when design updates are ready for them.
Before (most noticeable difference selected)
<img width="326" alt="image" src="https://user-images.githubusercontent.com/314133/230225652-92616f78-7f25-432b-b8c9-52aed92d6150.png">

After
<img width="182" alt="image" src="https://user-images.githubusercontent.com/314133/230225553-56c3b431-fea2-4597-8f5a-0b144aec9276.png">


Relevant Issues: #1174

Test Plan: Look at the live and admin views side-by-side with and without the change.
Light mode should be unaffected.
Graphs should be unaffected.
The footer and `nullish` fields in table details are a bit more muted.
The blue in table details is almost imperceptibly different.
A few of the neutral grays are almost imperceptibly different.

Type of change: /kind cleanup

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
