### PR TITLE
Update vega-lite

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -138,7 +138,7 @@
     "universal-cookie": "^4.0.4",
     "vega": "5.23.0",
     "vega-embed": "^6.15.0",
-    "vega-lite": "4.17.0",
+    "vega-lite": "5.6.1",
     "vega-scale": "^7.0.0",
     "vega-scenegraph": "4.9.2",
     "vega-typings": "~0.23.0",

--- a/src/ui/yarn.lock
+++ b/src/ui/yarn.lock
@@ -2800,7 +2800,7 @@ __metadata:
     url-loader: ^4.1.1
     vega: 5.23.0
     vega-embed: ^6.15.0
-    vega-lite: 4.17.0
+    vega-lite: 5.6.1
     vega-scale: ^7.0.0
     vega-scenegraph: 4.9.2
     vega-typings: ~0.23.0
@@ -3000,10 +3000,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/clone@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "@types/clone@npm:2.1.0"
-  checksum: 72a2f2dfce0af10caf1dd01f48fd909ef5a6be535313e7a34a1b7065b815f0c5b19a264c0c4f59de6a5b6c20ac535bab3fbb9d6e9fbea80c74b446d1ed56554c
+"@types/clone@npm:~2.1.1":
+  version: 2.1.1
+  resolution: "@types/clone@npm:2.1.1"
+  checksum: bda9668b9d6e0875d64bbe00763676f566e8647bc224333a03ac7fd66655dfed56a98a9f8304d0145c4411b964649c84c4d1a03adbdb6547eafb9ab8f303d254
   languageName: node
   linkType: hard
 
@@ -3094,13 +3094,6 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 12a2a0e6c4b993fc0854bec665906788aea0d8ee4392389d7a98a5de1eefdd33c9e1e40a91f3afd274011119c506f7b4126acb97fae62ae20b654974d44cba12
-  languageName: node
-  linkType: hard
-
-"@types/fast-json-stable-stringify@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@types/fast-json-stable-stringify@npm:2.0.0"
-  checksum: 021f80e037327fcb055eb650850c0df66ba56a98d2023dd79f47a3bf54d1a009a164da1f27436c9a26e116eff24fe7e32d1583dea77405b1b0468889b57e11a7
   languageName: node
   linkType: hard
 
@@ -4425,13 +4418,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-flat-polyfill@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "array-flat-polyfill@npm:1.0.1"
-  checksum: 5d578b191a7f145a1351a4962df9a14d905060c7dfcd8f85062954b7a44b2bff1c9d2bff2d56b07756de774d5e9e4feafe4572f5641b1e9c8a968aca5cbe4902
-  languageName: node
-  linkType: hard
-
 "array-flatten@npm:1.1.1":
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
@@ -5424,7 +5410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^7.0.0, cliui@npm:^7.0.2":
+"cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
   dependencies:
@@ -5432,6 +5418,17 @@ __metadata:
     strip-ansi: ^6.0.0
     wrap-ansi: ^7.0.0
   checksum: ce2e8f578a4813806788ac399b9e866297740eecd4ad1823c27fd344d78b22c5f8597d548adbcc46f0573e43e21e751f39446c5a5e804a12aace402b7a315d7f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
   languageName: node
   linkType: hard
 
@@ -7135,7 +7132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.0.2, escalade@npm:^3.1.1":
+"escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
   checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
@@ -10397,17 +10394,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stringify-pretty-compact@npm:^3.0.0":
+"json-stringify-pretty-compact@npm:^3.0.0, json-stringify-pretty-compact@npm:~3.0.0":
   version: 3.0.0
   resolution: "json-stringify-pretty-compact@npm:3.0.0"
   checksum: 01ab5c5c8260299414868d96db97f53aef93c290fe469edd9a1363818e795006e01c952fa2fd7b47cbbab506d5768998eccc25e1da4fa2ccfebd1788c6098791
-  languageName: node
-  linkType: hard
-
-"json-stringify-pretty-compact@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "json-stringify-pretty-compact@npm:2.0.0"
-  checksum: b476aa4ce2728cc7d89bffc4e99433015efc7065313cb90b7a6450cfd934aa3a61846ee9040c79ce00c44ca046cdd6ec0113157c9b895c85b7529c3056d6a1ea
   languageName: node
   linkType: hard
 
@@ -14397,7 +14387,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0":
+"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -15000,10 +14990,10 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:~2.0.3":
-  version: 2.0.3
-  resolution: "tslib@npm:2.0.3"
-  checksum: 00fcdd1f9995c9f8eb6a4a1ad03f55bc95946321b7f55434182dddac259d4e095fedf78a84f73b6e32dd3f881d9281f09cb583123d3159ed4bdac9ad7393ef8b
+"tslib@npm:~2.5.0":
+  version: 2.5.0
+  resolution: "tslib@npm:2.5.0"
+  checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
   languageName: node
   linkType: hard
 
@@ -15510,36 +15500,20 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-event-selector@npm:^3.0.1, vega-event-selector@npm:~3.0.1":
+"vega-event-selector@npm:^3.0.1, vega-event-selector@npm:~3.0.0, vega-event-selector@npm:~3.0.1":
   version: 3.0.1
   resolution: "vega-event-selector@npm:3.0.1"
   checksum: 66d09b5800a19a9b0c75f28811b140a1a2e70e84be6d6f87c568cdbce6e17c8e195f130f4e3de5d6dc737142d1f46f4fe7645177e154582cc8ba27c6845b54e8
   languageName: node
   linkType: hard
 
-"vega-event-selector@npm:~2.0.6":
-  version: 2.0.6
-  resolution: "vega-event-selector@npm:2.0.6"
-  checksum: 411f53c8fafc89cc12f9167cd6082cf55a5f5be835dd793dfed89a2942d72d13c0db36c7e7614b4a85aa85c9d62bac6f5fddaf482c6a246a303a78b245b1e3fc
-  languageName: node
-  linkType: hard
-
-"vega-expression@npm:^5.0.1, vega-expression@npm:~5.0.1":
+"vega-expression@npm:^5.0.1, vega-expression@npm:~5.0.0, vega-expression@npm:~5.0.1":
   version: 5.0.1
   resolution: "vega-expression@npm:5.0.1"
   dependencies:
     "@types/estree": ^1.0.0
     vega-util: ^1.17.1
   checksum: 396e950209a98a3fb1e28ba554f179c07aaeac7d11cfac9298a2af0b98456d69ec6573ecc7f21eff6f9f95bbfa8c59a1093d25e8ce586d0c0c589c230784db17
-  languageName: node
-  linkType: hard
-
-"vega-expression@npm:~3.0.0":
-  version: 3.0.1
-  resolution: "vega-expression@npm:3.0.1"
-  dependencies:
-    vega-util: ^1.15.2
-  checksum: 7fec6e2873db8c45fb06c3c332dd817287aee6cb46fe2563ca835821f3f4dd47bec06e1280464a83b17da7e2ef7b0e6aa5fa89af2fdb2ad0e7fae5f1f660661f
   languageName: node
   linkType: hard
 
@@ -15625,30 +15599,28 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-lite@npm:4.17.0":
-  version: 4.17.0
-  resolution: "vega-lite@npm:4.17.0"
+"vega-lite@npm:5.6.1":
+  version: 5.6.1
+  resolution: "vega-lite@npm:5.6.1"
   dependencies:
-    "@types/clone": ~2.1.0
-    "@types/fast-json-stable-stringify": ^2.0.0
-    array-flat-polyfill: ^1.0.1
+    "@types/clone": ~2.1.1
     clone: ~2.1.2
     fast-deep-equal: ~3.1.3
     fast-json-stable-stringify: ~2.1.0
-    json-stringify-pretty-compact: ~2.0.0
-    tslib: ~2.0.3
-    vega-event-selector: ~2.0.6
-    vega-expression: ~3.0.0
-    vega-util: ~1.16.0
-    yargs: ~16.0.3
+    json-stringify-pretty-compact: ~3.0.0
+    tslib: ~2.5.0
+    vega-event-selector: ~3.0.0
+    vega-expression: ~5.0.0
+    vega-util: ~1.17.0
+    yargs: ~17.6.2
   peerDependencies:
-    vega: ^5.17.0
+    vega: ^5.22.0
   bin:
     vl2pdf: bin/vl2pdf
     vl2png: bin/vl2png
     vl2svg: bin/vl2svg
     vl2vg: bin/vl2vg
-  checksum: 5562982e166fb8d514f44366f37715a9507727b0eee1c2e53c6191d286df930c36fca2df20d0b0d036f674ce21c0e8da6e944f1fc699552fda3dcdb11679959b
+  checksum: a06cbd0531cc71a7aeacae3ffde936a80d3cf58ff5942fb89f3544a7b5e0e055f00069dd51950cd09d667f0eefbeb12c7dccb64dd43cbb23b9eff2be1a990979
   languageName: node
   linkType: hard
 
@@ -15834,17 +15806,10 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vega-util@npm:^1.15.2, vega-util@npm:^1.16.0, vega-util@npm:^1.17.1, vega-util@npm:~1.17.1":
+"vega-util@npm:^1.15.2, vega-util@npm:^1.16.0, vega-util@npm:^1.17.1, vega-util@npm:~1.17.0, vega-util@npm:~1.17.1":
   version: 1.17.1
   resolution: "vega-util@npm:1.17.1"
   checksum: aa8b6a43bd38f49aea6d97988cdc2bdae6e0adb59080287b87dc82b9b7246faa87a20d2c143e700ba5669adaa249dd27b88b3c74c4b4df9fa6a510381c575713
-  languageName: node
-  linkType: hard
-
-"vega-util@npm:~1.16.0":
-  version: 1.16.1
-  resolution: "vega-util@npm:1.16.1"
-  checksum: e88091f6235fb5a563a8865e0c317d77454a2c696df62572551a3629fde1b53bba2643b800238b0b28c479d5f900fb1c3547ccc7250f27dcca743308f9052fea
   languageName: node
   linkType: hard
 
@@ -16483,7 +16448,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"y18n@npm:^5.0.1, y18n@npm:^5.0.5":
+"y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30
@@ -16504,10 +16469,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.0.0, yargs-parser@npm:^20.2.2":
+"yargs-parser@npm:^20.2.2":
   version: 20.2.7
   resolution: "yargs-parser@npm:20.2.7"
   checksum: ec0ea9e1b5699977380583f5ab1c0e2c6fc5f1ed374eb3053c458df00c543effba53628ad3297f3ccc769660518d5e376fd1cfb298b8e37077421aca8d75ae89
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
   languageName: node
   linkType: hard
 
@@ -16526,18 +16498,18 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"yargs@npm:~16.0.3":
-  version: 16.0.3
-  resolution: "yargs@npm:16.0.3"
+"yargs@npm:~17.6.2":
+  version: 17.6.2
+  resolution: "yargs@npm:17.6.2"
   dependencies:
-    cliui: ^7.0.0
-    escalade: ^3.0.2
+    cliui: ^8.0.1
+    escalade: ^3.1.1
     get-caller-file: ^2.0.5
     require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.1
-    yargs-parser: ^20.0.0
-  checksum: e59676cfc84ae64c59200d066b9c9a736ef8c54bac909ea56e3578332f54aff4da64ce9ce9e595e25529cb3f4063a1902adf3bc08313ae1bf808563c8c6e348a
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 47da1b0d854fa16d45a3ded57b716b013b2179022352a5f7467409da5a04a1eef5b3b3d97a2dfc13e8bbe5f2ffc0afe3bc6a4a72f8254e60f5a4bd7947138643
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>

Summary: From 4.17 to 5.6.1. This resolves the last remaining warning in the UI build (about re-exporting defaults).
It doesn't appear to impact any of our charts at all. They are not faster, not slower, they have exactly the same bugs as before.

Type of change: /kind cleanup

Test Plan: Test various charts, such as with `px/node`. They should behave exactly the same.
The UI build should no longer emit a warning about default re-exports.
