### PR TITLE
Cleanup operator release job from Jenkins

### DIFF
--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -511,38 +511,6 @@ controller:
                 }
               }
           - script: >
-              multibranchPipelineJob("pixie-release/operator") {
-                branchSources {
-                  branchSource {
-                    source {
-                      git {
-                        id('pixie-operator')
-                        remote('https://github.com/pixie-io/pixie.git')
-                        credentialsId('buildbot-ssh')
-                        traits {
-                          gitTagDiscovery()
-                          headWildcardFilter {
-                            includes("release/operator/*")
-                            excludes('')
-                          }
-                        }
-                      }
-                    }
-                    buildStrategies {
-                      buildTags {
-                        atMostDays('1')
-                        atLeastDays('0')
-                      }
-                    }
-                  }
-                }
-                triggers {
-                  periodicFolderTrigger {
-                    interval('1m')
-                  }
-                }
-              }
-          - script: >
               multibranchPipelineJob("pixie-release/cloud") {
                 branchSources {
                   branchSource {


### PR DESCRIPTION
Summary: We are adding our release builds to GH actions. As a result, we don't need this operator release job in jenkins.px.dev, since it's been completely unused.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deploy to Jenkins
