### PR TITLE
Run all trivy runs on PRs

### DIFF
--- a/.github/workflows/trivy_fs.yaml
+++ b/.github/workflows/trivy_fs.yaml
@@ -5,6 +5,8 @@ on:
     branches:
     - main
   pull_request:
+    branches:
+    - main
   schedule:
   - cron: "50 22 * * *"
 permissions:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
   schedule:
   - cron: "37 19 * * *"
 permissions:


### PR DESCRIPTION
Summary: Github code scanning doesn't like only some subscanners for a tool
to run on a PR. It warns with a message like the following:
`Code scanning cannot determine the alerts introduced by this pull request, because 3 configurations present on refs/heads/main were not found`
So run both the trivy_fs and trivy_image scanners on PRs.
Also set the target branch for PRs since Code scanning seems to rely on that
too.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Code scanning status on PRs should not produce warnings after this.
