### PR TITLE
Add autoscaler annotations to OLM CatalogSource object

### DIFF
--- a/k8s/operator/helm/values.yaml
+++ b/k8s/operator/helm/values.yaml
@@ -18,7 +18,8 @@ olmBundleChannel: "stable"
 # Optional annotations and labels for CatalogSource.
 olmCatalogSource:
   # Optional custom annotations to add to deployed pods managed by CatalogSource object.
-  annotations: {}
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   # Optional custom labels to add to deployed pods managed by CatalogSource object.
   labels: {}
 ## Vizier configuration


### PR DESCRIPTION
Summary: #1118 reports an issue where the autoscaler doesn't autoscale down catalogsource nodes because it is missing an annotation. #1138 allows the ability to add custom annotations to the catalogsource. However, after some thought, we should just include the autoscaler annotation by default.

Relevant Issues: Fixes #1118

Type of change: /kind cleanup

Test Plan: Create operator rc, helm install the chart and verify that the catalogsource pod now has the annotation.
