### PR TITLE
Add `access-tls-socket-fd-via-syscall` feature flag to cloud config manager

### DIFF
--- a/src/cloud/config_manager/controllers/vizier_feature_flags.go
+++ b/src/cloud/config_manager/controllers/vizier_feature_flags.go
@@ -42,6 +42,11 @@ var availableFeatureFlags = []*featureFlag{
 		VizierFlagName:  "PL_PROFILER_JAVA_SYMBOLS",
 		DefaultValue:    true,
 	},
+	{
+		FeatureFlagName: "access-tls-socket-fd-via-syscall",
+		VizierFlagName:  "PL_ACCESS_TLS_SOCKET_FD_VIA_SYSCALL",
+		DefaultValue:    false,
+	},
 }
 
 // NewVizierFeatureFlagClient creates a LaunchDarkly feature flag client if the SDK key is provided,


### PR DESCRIPTION
Summary: Add `access-tls-socket-fd-via-syscall` feature flag to cloud config manager

This feature flag will be used to opt internal clusters into the new tls tracing implementation developed in #1120. We may want a more sophisticated toggle for gradually opting in more clusters, but this will suffice for the initial set of testing (validating some hand picked clusters).

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Verified the following:
- [x] Deploying a new pixie install without launch darkly credentials results in the default, `false`, value ([P354](https://phab.corp.pixielabs.ai/P354))
- [x] Deploying a new pixie install with a cloud with launch darkly credentials results in a `true` value ([P355](https://phab.corp.pixielabs.ai/P355))