### PR TITLE
[perf-eval] Continue even if one of the perf evals fails

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -96,6 +96,7 @@ jobs:
     secrets: inherit
   pr-perf-comment:
     name: Comment results on PR
+    if: success() || failure()
     needs: pr-perf-eval
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/perf_common.yaml
+++ b/.github/workflows/perf_common.yaml
@@ -66,6 +66,7 @@ jobs:
       - /etc/bazelrc:/etc/bazelrc
     strategy:
       matrix: ${{ fromJson(needs.generate-perf-matrix.outputs.matrix) }}
+      fail-fast: false
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -127,6 +128,7 @@ jobs:
         if-no-files-found: error
   get-perf-outputs:
     runs-on: ubuntu-latest
+    if: success() || failure()
     needs: run-perf-eval
     outputs:
       experiments: ${{ steps.get-outputs.outputs.run_output }}


### PR DESCRIPTION
Summary: Before, if a single perf experiment failed it would immediately cancel the other experiments and not report results for any suceeding experiments. Now it will continue to run the other experiments and report successful experiments in the PR comment.

Type of change: /kind cleanup

Test Plan: N/A
