### PR TITLE
[actions] Add build-cloud-release github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,3 +82,31 @@ jobs:
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
       run: ./ci/update_artifact_manifest.sh
+  build-cloud-release:
+    if: contains(github.event.ref, 'release/cloud')
+    name: Cloud Release
+    runs-on: [self-hosted, nokvm]
+    needs: get-dev-image
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      options: --cpus 15
+      volumes:
+      - /etc/bazelrc:/etc/bazelrc
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: Setup gcloud docker creds
+      run: gcloud init && gcloud auth configure-docker
+    - name: Use github bazel config
+      uses: ./.github/actions/bazelrc
+    - name: Build & Push Artifacts
+      env:
+        REF: ${{ github.event.ref }}
+        GH_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        ./ci/cloud_build_release.sh -p


### PR DESCRIPTION
Summary: Adds a github action to build a public cloud release, whenever a `release/cloud` tag is pushed.

Type of change: /kind test-infra

Test Plan: Tested on my fork that the public cloud release builds successfully.
