### PR TITLE
Change codecov status reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,9 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true
 
 ignore:
 - "src/ui/.yarn"


### PR DESCRIPTION
Summary: This is similar to #833 but for the patch level coverage instead.
Commits on mainline show a failed status if patch coverage is less than
total coverage. Instead treat it as informational only.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan:  `cat codecov.yml | curl --data-binary @- https://codecov.io/validate`