### PR TITLE
Separate titlebar for Live widgets

### DIFF
--- a/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
+++ b/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
@@ -87,8 +87,9 @@ const TableSummary = React.memo<{
     return (
       <span>
         Showing {visibleStart + 1} - {visibleStop + 1}
-        <span className={classes.muted}>&nbsp;out of&nbsp;</span>
+        <span className={classes.muted}>{' out of '}</span>
         {numRows} records
+        {overloadWarning}
       </span>
     );
   }

--- a/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
+++ b/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
@@ -47,11 +47,53 @@ const useStyles = makeStyles(({ spacing, typography, palette }: Theme) => create
     textAlign: 'right',
     ...typography.subtitle2,
   },
+  tableSummaryExtern: { // For when this is sent up to a widget titlebar
+    ...typography.caption,
+    color: palette.foreground.one,
+
+    '& $overload': { color: palette.foreground.three },
+    '& $muted': { color: palette.foreground.three },
+  },
   overload: {
     fontStyle: 'italic',
     color: alpha(palette.foreground.one, 0.8),
   },
+  muted: {
+    color: alpha(palette.foreground.one, 0.8),
+  },
 }), { name: 'QueryResultViewer' });
+
+const TableSummary = React.memo<{
+  visibleStart: number, visibleStop: number, numRows: number, isOverload: boolean,
+}>(({
+  visibleStart, visibleStop, numRows, isOverload,
+}) => {
+  const classes = useStyles();
+
+  const overloadWarning = isOverload
+    ? <span className={classes.overload}>{' (keeping only latest to reduce memory pressure)'}</span>
+    : '';
+
+  const count = visibleStop - visibleStart + 1;
+
+  if (count <= 0) {
+    return <span>No records to show</span>;
+  } else if (count >= numRows) {
+    return <>
+      <span>Showing {count} records</span>
+      {overloadWarning}
+    </>;
+  } else {
+    return (
+      <span>
+        Showing {visibleStart + 1} - {visibleStop + 1}
+        <span className={classes.muted}>&nbsp;out of&nbsp;</span>
+        {numRows} records
+      </span>
+    );
+  }
+});
+TableSummary.displayName = 'TableSummary';
 
 export interface QueryResultTableDisplay extends WidgetDisplay {
   gutterColumn?: string,
@@ -62,35 +104,42 @@ export interface QueryResultTableProps {
   table: VizierTable;
   propagatedArgs: Arguments;
   customGutters?: Array<CompleteColumnDef>;
+  /** If set, controls including the table summary will be rendered to this ref instead of underneath the table */
+  setExternalControls?: React.RefCallback<React.ReactNode>;
 }
 
 export const QueryResultTable = React.memo<QueryResultTableProps>(({
-  display, table, propagatedArgs, customGutters = [],
+  display, table, propagatedArgs, customGutters = [], setExternalControls,
 }) => {
   const classes = useStyles();
   const { streaming } = React.useContext(ResultsContext);
 
   // Ensures the summary updates while streaming queries.
   const numRows = useLatestRowCount(table.name);
-  const showOverloadWarning = streaming && numRows >= ROW_RETENTION_LIMIT;
+  const isOverload = streaming && numRows >= ROW_RETENTION_LIMIT;
 
   const [visibleStart, setVisibleStart] = React.useState(1);
   const [visibleStop, setVisibleStop] = React.useState(1);
-  const visibleRowSummary = React.useMemo(() => {
-    const count = visibleStop - visibleStart + 1;
-    let text = `Showing ${visibleStart + 1} - ${visibleStop + 1} / ${numRows} records`;
-    if (count <= 0) {
-      text = 'No records to show';
-    } else if (count >= numRows) {
-      text = '\xa0'; // non-breaking space
-    }
-    return text;
-  }, [numRows, visibleStart, visibleStop]);
 
   const onRowsRendered = React.useCallback(({ visibleStartIndex, visibleStopIndex }) => {
     setVisibleStart(visibleStartIndex);
     setVisibleStop(visibleStopIndex);
   }, []);
+
+  React.useEffect(() => {
+    if (setExternalControls) {
+      setExternalControls(
+        <div className={classes.tableSummaryExtern}>
+          <TableSummary
+            visibleStart={visibleStart}
+            visibleStop={visibleStop}
+            numRows={numRows}
+            isOverload={isOverload}
+          />
+        </div>,
+      );
+    }
+  }, [setExternalControls, isOverload, numRows, visibleStart, visibleStop, classes.tableSummaryExtern]);
 
   return (
     <div className={classes.root}>
@@ -102,12 +151,16 @@ export const QueryResultTable = React.memo<QueryResultTableProps>(({
           onRowsRendered={onRowsRendered}
         />
       </div>
-      <div className={classes.tableSummary}>
-        <span>{visibleRowSummary}</span>
-        {showOverloadWarning && (
-          <span className={classes.overload}>{' (keeping only latest to reduce memory pressure)'}</span>
-        )}
-      </div>
+      {!setExternalControls && (
+        <div className={classes.tableSummary}>
+          <TableSummary
+            visibleStart={visibleStart}
+            visibleStop={visibleStop}
+            numRows={numRows}
+            isOverload={isOverload}
+          />
+        </div>
+      )}
     </div>
   );
 });

--- a/src/ui/src/containers/live/canvas.tsx
+++ b/src/ui/src/containers/live/canvas.tsx
@@ -195,14 +195,11 @@ const VegaWidget: React.FC<VegaWidgetProps> = React.memo(({
 });
 VegaWidget.displayName = 'VegaWidget';
 
-// TODO(NickLanam): This likely needs the affix to be a passed ref for the graphs and table to put their controls in it.
-// TODO(NickLanam): Need to make sure StatChart uses this too, data drawer also needs something for controls?
 const WidgetTitlebar = React.memo<{
   title: string,
   affix?: React.ReactNode,
 }>(({ title, affix }) => {
   const classes = useStyles();
-  React.useEffect(() => { console.info('Affix changed', affix); }, [affix]);
   return (
     <div className={classes.widgetTitlebar}>
       <div className={classes.widgetTitle}>{title}</div>

--- a/src/ui/src/containers/live/canvas.tsx
+++ b/src/ui/src/containers/live/canvas.tsx
@@ -97,12 +97,32 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
       },
     },
   },
+  widgetTitlebar: {
+    backgroundColor: theme.palette.background.four,
+    color: theme.palette.text.primary,
+    height: theme.spacing(6),
+    padding: theme.spacing(1.5),
+    margin: theme.spacing(-0.75),
+    marginBottom: 0,
+    borderTopLeftRadius: 'inherit',
+    borderTopRightRadius: 'inherit',
+    borderBottom: `1px ${theme.palette.background.two} solid`,
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
   widgetTitle: {
-    ...theme.typography.h3,
-    padding: theme.spacing(0.5),
-    color: theme.palette.foreground.two,
+    flex: '0 0 auto',
+    fontSize: theme.spacing(2),
+    fontWeight: 500,
     textTransform: 'capitalize',
-    marginBottom: theme.spacing(1.8),
+  },
+  widgetInfix: {
+    flex: '1 1 auto',
+  },
+  widgetAffix: {
+    flex: '0 0 auto',
   },
   chart: {
     flex: 1,
@@ -175,6 +195,24 @@ const VegaWidget: React.FC<VegaWidgetProps> = React.memo(({
 });
 VegaWidget.displayName = 'VegaWidget';
 
+// TODO(NickLanam): This likely needs the affix to be a passed ref for the graphs and table to put their controls in it.
+// TODO(NickLanam): Need to make sure StatChart uses this too, data drawer also needs something for controls?
+const WidgetTitlebar = React.memo<{
+  title: string,
+  affix?: React.ReactNode,
+}>(({ title, affix }) => {
+  const classes = useStyles();
+  React.useEffect(() => { console.info('Affix changed', affix); }, [affix]);
+  return (
+    <div className={classes.widgetTitlebar}>
+      <div className={classes.widgetTitle}>{title}</div>
+      <div className={classes.widgetInfix}>{' '}</div>
+      <div className={classes.widgetAffix}>{affix}</div>
+    </div>
+  );
+});
+WidgetTitlebar.displayName = 'WidgetTitlebar';
+
 const WidgetDisplay: React.FC<{
   display: VisWidgetDisplay,
   table: VizierTable,
@@ -186,12 +224,14 @@ const WidgetDisplay: React.FC<{
   display, table, tableName, widgetName, propagatedArgs, emptyTableMsg,
 }) => {
   const classes = useStyles();
+  const [affix, setAffix] = React.useState<React.ReactNode>(null);
+  const affixRef = React.useCallback((el: React.ReactNode) => { setAffix(el); }, []);
 
   // Before we do any other processing, check if we have the chart that exist entirely in the vis spec with no data
   if (display[DISPLAY_TYPE_KEY] === TEXT_CHART_DISPLAY_TYPE) {
     return (
       <>
-        <div className={classes.widgetTitle}>{widgetName}</div>
+        <WidgetTitlebar title={widgetName} />
         <TextChart display={display as TextChartDisplay} />
       </>
     );
@@ -209,11 +249,12 @@ const WidgetDisplay: React.FC<{
   if (display[DISPLAY_TYPE_KEY] === TABLE_DISPLAY_TYPE) {
     return (
       <>
-        <div className={classes.widgetTitle}>{widgetName}</div>
+        <WidgetTitlebar title={widgetName} affix={affix} />
         <QueryResultTable
           display={display as QueryResultTableDisplay}
           table={table}
           propagatedArgs={propagatedArgs}
+          setExternalControls={affixRef}
         />
       </>
     );
@@ -224,7 +265,7 @@ const WidgetDisplay: React.FC<{
   if (display[DISPLAY_TYPE_KEY] === GRAPH_DISPLAY_TYPE) {
     return (
       <div className={classes.graphContainer}>
-        <div className={classes.widgetTitle}>{widgetName}</div>
+        <WidgetTitlebar title={widgetName} />
         <GraphWidget
           display={display as GraphDisplay}
           data={parsedTable}
@@ -238,7 +279,7 @@ const WidgetDisplay: React.FC<{
   if (display[DISPLAY_TYPE_KEY] === REQUEST_GRAPH_DISPLAY_TYPE) {
     return (
       <>
-        <div className={classes.widgetTitle}>{widgetName}</div>
+        <WidgetTitlebar title={widgetName} />
         <RequestGraphWidget
           display={display as RequestGraphDisplay}
           data={parsedTable}
@@ -250,6 +291,7 @@ const WidgetDisplay: React.FC<{
   }
 
   if (display[DISPLAY_TYPE_KEY] === STAT_CHART_DISPLAY_TYPE) {
+    // This one does not get a titlebar, as it puts its title with the text (stylistic choice)
     return (
       <StatChart
         title={widgetName}
@@ -263,7 +305,7 @@ const WidgetDisplay: React.FC<{
   try {
     return (
       <>
-        <div className={classes.widgetTitle}>{widgetName}</div>
+        <WidgetTitlebar title={widgetName} />
         <React.Suspense fallback={<div className={classes.spinner}><Spinner /></div>}>
           <VegaWidget
             tableName={tableName}


### PR DESCRIPTION
Summary: Makes live widgets use a tiny bit less vertical space, while looking more readable.
Moves the table "Showing X of Y rows" text into this space.
More diffs to come moving other stuff into this bar, from tables and graphs in particular.

- Before: <img width="1341" alt="image" src="https://user-images.githubusercontent.com/314133/231243915-100c43ea-5546-4db0-b348-94166138a9a7.png">

- After: <img width="1343" alt="image" src="https://user-images.githubusercontent.com/314133/231243837-47cff8c9-0cc7-461c-b838-318cba4368b5.png">


Relevant Issues: #1174

Test Plan: Load live view. Look at tables, graphs, etc.
This only affects the live view for now.

Type of change: /kind feature
