### PR TITLE
[releases] Fix version stamping for github action releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
+        ./ci/save_version_info.sh
         ./ci/vizier_build_release.sh
     - name: Build & Export Docs
       env:
@@ -77,6 +78,7 @@ jobs:
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
+        ./ci/save_version_info.sh
         ./ci/operator_build_release.sh
     - name: Update Manifest
       env:
@@ -109,4 +111,5 @@ jobs:
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
+        ./ci/save_version_info.sh
         ./ci/cloud_build_release.sh -p


### PR DESCRIPTION
Summary: We weren't running the `save_version_info.sh` script so all release builds were being stamped with a 0.0.0-dev version.

Type of change: /kind cleanup

Test Plan: Testing an RC based off of this PR.
