### PR TITLE
Change to OVMF bios is available

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/run_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/run_qemu.sh
@@ -76,6 +76,13 @@ flags+=(-append "console=ttyS0 root=/dev/sda")
 # Disable graphics mode.
 flags+=(-nographic)
 
+# Change to the OVMF bios if it exists.
+# This fixes issues with terminal/screen cocrruption after running qemu.
+ovmf_bios=/usr/share/ovmf/OVMF.fd
+if [[ -e "${ovmf_bios}" ]]; then
+  flags+=(-bios "${ovmf_bios}")
+fi
+
 retval=0
 qemu-system-x86_64 "${flags[@]}" || retval=$?
 


### PR DESCRIPTION
Summary: This fixes screen corruption issue when running qemu. The default seabios
sends a bunch of control codes that mess up the terminal.

Relevant Issues: N/A

Type of change: /kind test-infra

Test Plan: Run QEMU test.


