### PR TITLE
Add endpoints back to metadata role

### DIFF
--- a/k8s/vizier/base/metadata_role.yaml
+++ b/k8s/vizier/base/metadata_role.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - pods
   - services
+  - endpoints
   - namespaces
   - replicasets
   - deployments


### PR DESCRIPTION
Summary: We were seeing a bug where services weren't showing in our metadata. Turns out we accidentally removed endpoints from our metadata role. This adds it back in.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Skaffold deploy
