### PR TITLE
Fix --short flag for `px deploy-key`

### DIFF
--- a/src/pixie_cli/pkg/cmd/deployment_key.go
+++ b/src/pixie_cli/pkg/cmd/deployment_key.go
@@ -84,7 +84,7 @@ var CreateDeployKeyCmd = &cobra.Command{
 			log.WithError(err).Fatal("Failed to generate deployment key")
 		}
 		if short {
-			utils.Infof(key)
+			fmt.Fprintf(os.Stdout, "%s\n", key)
 		} else {
 			utils.Infof("Generated deployment key: \nID: %s \nKey: %s", keyID, key)
 		}


### PR DESCRIPTION
Summary: We handle `--short` correctl for `px api-key`, but for some reason try to do it differently for `deploy-key`, so it doesn't actually write to stdout.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Bazel build CLI
