### PR TITLE
Move data table column selector to titlebar

### DIFF
--- a/src/ui/src/containers/live-data-table/live-data-table.tsx
+++ b/src/ui/src/containers/live-data-table/live-data-table.tsx
@@ -212,6 +212,7 @@ export interface LiveDataTableProps extends Pick<DataTableProps, 'onRowsRendered
   table: VizierTable;
   propagatedArgs?: Arguments;
   gutterColumns?: Array<string | CompleteColumnDef>;
+  setExternalControls?: React.RefCallback<React.ReactNode>;
 }
 
 const LiveDataTableImpl = React.memo<LiveDataTableProps>(({ table, ...options }) => {

--- a/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
+++ b/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
@@ -54,6 +54,13 @@ const useStyles = makeStyles(({ spacing, typography, palette }: Theme) => create
     '& $overload': { color: palette.foreground.three },
     '& $muted': { color: palette.foreground.three },
   },
+  externalControls: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    gap: spacing(1),
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
   overload: {
     fontStyle: 'italic',
     color: alpha(palette.foreground.one, 0.8),
@@ -127,20 +134,29 @@ export const QueryResultTable = React.memo<QueryResultTableProps>(({
     setVisibleStop(visibleStopIndex);
   }, []);
 
+  const [globalControls, setGlobalControls] = React.useState<React.ReactNode>(null);
+  const globalControlsRef = React.useCallback((el: React.ReactNode) => { setGlobalControls(el); }, []);
+
   React.useEffect(() => {
     if (setExternalControls) {
       setExternalControls(
-        <div className={classes.tableSummaryExtern}>
-          <TableSummary
-            visibleStart={visibleStart}
-            visibleStop={visibleStop}
-            numRows={numRows}
-            isOverload={isOverload}
-          />
+        <div className={classes.externalControls}>
+          <div className={classes.tableSummaryExtern}>
+            <TableSummary
+              visibleStart={visibleStart}
+              visibleStop={visibleStop}
+              numRows={numRows}
+              isOverload={isOverload}
+            />
+          </div>
+          {globalControls}
         </div>,
       );
     }
-  }, [setExternalControls, isOverload, numRows, visibleStart, visibleStop, classes.tableSummaryExtern]);
+  }, [
+    setExternalControls, isOverload, numRows, visibleStart, visibleStop, globalControls,
+    classes.tableSummaryExtern, classes.externalControls,
+  ]);
 
   return (
     <div className={classes.root}>
@@ -150,6 +166,7 @@ export const QueryResultTable = React.memo<QueryResultTableProps>(({
           gutterColumns={[display.gutterColumn, ...customGutters].filter(g => g)}
           propagatedArgs={propagatedArgs}
           onRowsRendered={onRowsRendered}
+          setExternalControls={setExternalControls ? globalControlsRef : null}
         />
       </div>
       {!setExternalControls && (

--- a/src/ui/src/containers/live/canvas.tsx
+++ b/src/ui/src/containers/live/canvas.tsx
@@ -455,6 +455,9 @@ const Canvas: React.FC<CanvasProps> = React.memo(({ editable, parentRef }) => {
     return '';
   }, [script?.code]);
 
+  const [affix, setAffix] = React.useState<React.ReactNode>(null);
+  const affixRef = React.useCallback((el: React.ReactNode) => { setAffix(el); }, []);
+
   const charts = React.useMemo(() => {
     const widgets = [];
     script.vis?.widgets.filter((currentWidget) => {
@@ -523,8 +526,13 @@ const Canvas: React.FC<CanvasProps> = React.memo(({ editable, parentRef }) => {
         {
           Array.from(tables.entries()).map(([tableName, table]) => (
             <Paper elevation={1} key={tableName} className={className}>
-              <div className={classes.widgetTitle}>{tableName}</div>
-              <QueryResultTable display={{} as QueryResultTableDisplay} table={table} propagatedArgs={propagatedArgs} />
+              <WidgetTitlebar title={tableName} affix={affix} />
+              <QueryResultTable
+                display={{} as QueryResultTableDisplay}
+                table={table}
+                propagatedArgs={propagatedArgs}
+                setExternalControls={affixRef}
+              />
             </Paper>
           ))
         }


### PR DESCRIPTION
Summary: Instead of a dedicated column with a blue button, put it in the titlebar as a gear. Also lets the column selector have up to two columns itself (if there are more than 8 options).

Looks like this now.
<img width="491" alt="image" src="https://user-images.githubusercontent.com/314133/231305571-c3cd7fd5-dcdd-4341-bb2b-5a26c88e84c9.png">

Relevant Issues: https://github.com/pixie-io/pixie/issues/1174

Test Plan: Load live view. Look at tables. Only the ones in the live view should be affected.

Type of change: /kind feature