### PR TITLE
New table styling

### DIFF
--- a/src/ui/src/containers/live-data-table/data-table-details.tsx
+++ b/src/ui/src/containers/live-data-table/data-table-details.tsx
@@ -18,12 +18,12 @@
 
 import * as React from 'react';
 
-import { Close as CloseIcon } from '@mui/icons-material';
-import { IconButton, Typography } from '@mui/material';
-import { Theme, useTheme } from '@mui/material/styles';
+import { ContentCopy as CopyIcon, Close as CloseIcon } from '@mui/icons-material';
+import { IconButton, Tooltip, Typography } from '@mui/material';
+import { Theme } from '@mui/material/styles';
 import { createStyles, makeStyles } from '@mui/styles';
 
-import { buildClass } from 'app/components';
+import { buildClass, useSnackbar } from 'app/components';
 import { JSONData } from 'app/containers/format-data/json-data';
 
 const useDetailPaneClasses = makeStyles((theme: Theme) => createStyles({
@@ -31,19 +31,23 @@ const useDetailPaneClasses = makeStyles((theme: Theme) => createStyles({
     position: 'relative',
     flex: 1,
     whiteSpace: 'pre-wrap',
-    overflow: 'auto',
+    overflow: 'hidden',
+    backgroundColor: theme.palette.background.paper,
+    display: 'flex',
+    flexFlow: 'column nowrap',
   },
   horizontal: {
-    borderTop: `1px solid ${theme.palette.background.five}`,
+    borderTop: `1px solid ${theme.palette.background.six}`,
     minWidth: 0,
     minHeight: theme.spacing(30),
   },
   vertical: {
-    borderLeft: `1px solid ${theme.palette.background.five}`,
+    borderLeft: `1px solid ${theme.palette.background.six}`,
     minWidth: theme.spacing(30),
     minHeight: 0,
   },
   header: {
+    flex: '0 0 auto',
     display: 'flex',
     flexFlow: 'row nowrap',
     justifyContent: 'space-between',
@@ -53,36 +57,16 @@ const useDetailPaneClasses = makeStyles((theme: Theme) => createStyles({
     width: '100%',
     height: theme.spacing(5),
     background: theme.palette.background.paper,
-    // The parent has a Paper elevation=1, which uses an overlay to change shades. Match it.
-    // Only in dark mode; see https://mui.com/components/paper/#elevation toward the bottom.
-    backgroundImage: (theme.palette.mode === 'dark'
-      ? 'linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05))'
-      : 'none'
-    ),
-    paddingLeft: theme.spacing(2),
+    borderBottom: `1px solid ${theme.palette.background.six}`,
     '& > h4': {
       margin: 0,
       textTransform: 'uppercase',
     },
-    '@media not (prefers-reduced-motion: reduce)': {
-      transition: 'box-shadow .1s linear',
-    },
-  },
-  pinned: {
-    boxShadow: theme.shadows[1],
-  },
-  pinDetect: {
-    position: 'sticky',
-    opacity: 0,
-    pointerEvents: 'none',
-    height: theme.spacing(5),
-    width: '1px',
-    overflow: 'hidden',
-    marginTop: theme.spacing(-5),
   },
   content: {
+    flex: '1 1 auto',
     padding: theme.spacing(2),
-    paddingTop: 0,
+    overflow: 'auto',
   },
 }), { name: 'DetailPane' });
 
@@ -94,39 +78,29 @@ interface DetailPaneProps {
 
 export const DetailPane = React.memo<DetailPaneProps>(({ details, closeDetails, splitMode = 'vertical' }) => {
   const classes = useDetailPaneClasses();
-  const { spacing } = useTheme();
+  const showSnackbar = useSnackbar();
 
-  const [pinned, setPinned] = React.useState(false);
-
-  // Trickery with IntersectionObserver to add a shadow to the sidebar header when needed.
-  const root = React.useRef<HTMLDivElement>();
-  const detector = React.useRef<HTMLDivElement>();
-  const header = React.useRef<HTMLDivElement>();
-  React.useEffect(() => {
-    if (!(details && root.current && detector.current && header.current)) {
-      return () => {};
-    }
-
-    const target = detector.current;
-    const obs = new IntersectionObserver(
-      ([e]) => setPinned(e.intersectionRatio < 1),
-      { threshold: 1, root: root.current, rootMargin: spacing(5) },
+  const copyDetails = React.useCallback(() => {
+    if (!details) return;
+    const text = JSON.stringify(details, null, 2);
+    navigator.clipboard.writeText(text).then(
+      () => { showSnackbar({ message: 'Copied!' }); },
+      (err) => {
+        showSnackbar({ message: 'Error: could not copy details automatically' });
+        console.error(err);
+      },
     );
-    obs.observe(target);
-    return () => {
-      obs.unobserve(target);
-      setPinned(false);
-    };
-  }, [details, spacing]);
+  }, [details, showSnackbar]);
 
   if (!details) return null;
   return (
     <div
       className={buildClass(classes.details, classes[splitMode])}
-      ref={root}
     >
-      <div className={classes.pinDetect} ref={detector}></div>
-      <div className={buildClass(classes.header, pinned && classes.pinned)} ref={header}>
+      <div className={classes.header}>
+        <Tooltip title='Copy Details to Clipboard'>
+          <IconButton onClick={copyDetails}><CopyIcon /></IconButton>
+        </Tooltip>
         <Typography variant='h4'>Details</Typography>
         <IconButton
           aria-label='close details'

--- a/src/ui/src/containers/live-data-table/live-data-table.tsx
+++ b/src/ui/src/containers/live-data-table/live-data-table.tsx
@@ -75,7 +75,7 @@ function useConvertedTable(
 
   const [displayMap, setDisplayMap] = React.useState<Map<string, ColumnDisplayInfo>>(new Map());
 
-  const gutterWidth = parseInt(theme.spacing(3), 10); // 24px
+  const gutterWidth = parseInt(theme.spacing(4), 10); // 32px
 
   const convertColumn = React.useCallback<(col: Relation.ColumnInfo) => CompleteColumnDef>((col) => {
     const display = displayMap.get(col.getColumnName()) ?? displayInfoFromColumn(col);

--- a/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
+++ b/src/ui/src/containers/live-widgets/table/query-result-viewer.tsx
@@ -34,6 +34,11 @@ const useStyles = makeStyles(({ spacing, typography, palette }: Theme) => create
     display: 'flex',
     flexDirection: 'column',
     overflowX: 'hidden',
+    // Bypass the padding of the parent <Paper>, but keep the rounding of the border
+    margin: spacing(-0.75),
+    marginTop: 0,
+    borderBottomLeftRadius: 'inherit',
+    borderBottomRightRadius: 'inherit',
   },
   table: {
     display: 'flex',

--- a/src/ui/src/containers/live-widgets/utils/status-indicator.tsx
+++ b/src/ui/src/containers/live-widgets/utils/status-indicator.tsx
@@ -110,7 +110,7 @@ export function toStatusIndicator(status: any, semanticType: SemanticType) {
 
   return (
     <Tooltip title={tooltipMsg}>
-      <div>
+      <div style={{ textAlign: 'center' }}>
         <StatusCell statusGroup={statusGroup} />
       </div>
     </Tooltip>

--- a/src/ui/src/pages/configure-data-export/data-export-history.tsx
+++ b/src/ui/src/pages/configure-data-export/data-export-history.tsx
@@ -78,21 +78,43 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
   },
   paper: {
     flex: '1 0 auto',
-    padding: theme.spacing(1),
+    padding: theme.spacing(0.75),
     display: 'flex',
     flexFlow: 'column nowrap',
     justifyContent: 'stretch',
+
+    '& > *': {
+      flex: '1 1 auto',
+    },
   },
-  tableTitle: {
-    ...theme.typography.h3,
-    padding: theme.spacing(0.5),
-    color: theme.palette.foreground.two,
+  // Matching the one in canvas.tsx
+  titlebar: {
+    flex: '0 0 auto',
+    backgroundColor: theme.palette.background.four,
+    color: theme.palette.text.primary,
+    height: theme.spacing(6),
+    padding: theme.spacing(1.5),
+    margin: theme.spacing(-0.75),
+    marginBottom: 0,
+    borderTopLeftRadius: 'inherit',
+    borderTopRightRadius: 'inherit',
+    borderBottom: `1px ${theme.palette.background.two} solid`,
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  title: {
+    flex: '0 0 auto',
+    fontSize: theme.spacing(2),
+    fontWeight: 500,
     textTransform: 'capitalize',
-    marginBottom: theme.spacing(1.8),
   },
-  tableWrap: {
-    flex: '1 1 100%',
-    position: 'relative',
+  titleInfix: {
+    flex: '1 1 auto',
+  },
+  titleAffix: {
+    flex: '0 0 auto',
   },
 }), { name: 'DataExportHistory' });
 
@@ -224,6 +246,9 @@ export const DataExportHistory = React.memo<{
     setClusterByName: () => {},
   }), [cluster]);
 
+  const [titleAffix, setTitleAffix] = React.useState<React.ReactNode>(null);
+  const titleAffixRef = React.useCallback((el: React.ReactNode) => { setTitleAffix(el); }, []);
+
   return (
     /* eslint-disable react-memo/require-usememo */
     <div className={classes.root}>
@@ -276,19 +301,20 @@ export const DataExportHistory = React.memo<{
         <ResultsContext.Provider value={resultsCtx}>
           <ClusterContext.Provider value={clusterCtx}>
             <Paper className={classes.paper}>
-              <h3 className={classes.tableTitle}>Recent runs of script: {script.name}</h3>
-              <div className={classes.tableWrap}>
-                <div style={{ display: 'block', position: 'absolute', height: '100%', width: '100%' }}>
-                  <QueryResultTable
-                    display={{
-                      [DISPLAY_TYPE_KEY]: TABLE_DISPLAY_TYPE,
-                    }}
-                    propagatedArgs={{}}
-                    table={table}
-                    customGutters={[exportHistoryGutterCol]}
-                  />
-                </div>
+              <div className={classes.titlebar}>
+                <div className={classes.title}>Recent runs of script: {script.name}</div>
+                <div className={classes.titleInfix}>{' '}</div>
+                <div className={classes.titleAffix}>{titleAffix}</div>
               </div>
+              <QueryResultTable
+                display={{
+                  [DISPLAY_TYPE_KEY]: TABLE_DISPLAY_TYPE,
+                }}
+                propagatedArgs={{}}
+                table={table}
+                customGutters={[exportHistoryGutterCol]}
+                setExternalControls={titleAffixRef}
+              />
             </Paper>
           </ClusterContext.Provider>
         </ResultsContext.Provider>


### PR DESCRIPTION
Summary: Refreshing the appearance of data tables and detail views.
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/314133/231540230-a447cce9-4051-4207-bb09-c45f4ccffc1b.png">
Adds a copy button since it was trivial to do here.
Fixes #581

Relevant Issues: #1174,#581

Type of change: /kind feature

Test Plan: Load a script that uses a data table.
Open the data drawer.
Click a row to get details. Click the copy button within it, scroll within it.
Try resizing table columns.
New styling should be applied. More consistent colors, more visible row detail selection, subtle headers.