### PR TITLE
Add env vars used by release version stamping

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
+        BUILD_NUMBER: ${{ github.run_attempt }}
+        JOB_NAME: ${{ github.job }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -75,6 +77,8 @@ jobs:
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
+        BUILD_NUMBER: ${{ github.run_attempt }}
+        JOB_NAME: ${{ github.job }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -107,6 +111,8 @@ jobs:
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
+        BUILD_NUMBER: ${{ github.run_attempt }}
+        JOB_NAME: ${{ github.job }}
         GH_API_KEY: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |


### PR DESCRIPTION
Summary: The `save_version_info` and `get_workspace_status` scripts rely
on these env vars. Else the xdef-ed versions are incorrect and cannot
be parsed by the semver lib we use.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Will test on a fork with a separate bucket.
