### PR TITLE
Make vizier version parsing in vzmgr more tolerant

### DIFF
--- a/src/cloud/vzmgr/controllers/vizier_updater.go
+++ b/src/cloud/vzmgr/controllers/vizier_updater.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -250,7 +251,11 @@ func (u *Updater) VersionUpToDate(version string) bool {
 		// TODO(vihang): Investigate and consider marking these as needing an update.
 		return true // This happens for some viziers, let's call them uptodate for now.
 	}
-	vzVersion, err := semver.Parse(version)
+	// We have a set of viziers where the meta in the version isn't tolerated by
+	// the semver lib. To successfully parse those versions, just drop the meta before
+	// parsing.
+	versionNoMeta, _, _ := strings.Cut(version, "+")
+	vzVersion, err := semver.Parse(versionNoMeta)
 	if err != nil {
 		log.WithError(err).Error("Invalid version string reported")
 		return true

--- a/src/cloud/vzmgr/controllers/vizier_updater_test.go
+++ b/src/cloud/vzmgr/controllers/vizier_updater_test.go
@@ -132,7 +132,11 @@ func TestUpdater_VersionUpToDate(t *testing.T) {
 
 	assert.True(t, updater.VersionUpToDate("0.4.1"))
 	assert.True(t, updater.VersionUpToDate("0.4.2-pre-rc1"))
+	assert.True(t, updater.VersionUpToDate("0.4.1+meta.is.good"))
+	assert.True(t, updater.VersionUpToDate("0.4.1+meta.is...bad"))
 	assert.False(t, updater.VersionUpToDate("0.3.1"))
+	assert.False(t, updater.VersionUpToDate("0.3.1+meta.is.good"))
+	assert.False(t, updater.VersionUpToDate("0.3.1+meta.is...bad"))
 	assert.True(t, updater.VersionUpToDate("0.0.0-dev+Modified.0000000.19700101000000.0"))
 }
 


### PR DESCRIPTION
Summary: The latest vizier release includes an empty sub-section
in the meta for the version. The semver lib treats these versions
as bad and doesn't parse them. So instead drop the meta before
parsing.

This should 1) reduce vzmgr spamming the logs and 2) fix updates
for those viziers.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Check cloud logs after skaffolding a cloud and deploying
a vizier with bad meta to it.
