### PR TITLE
[actions] Optionally add remote_download_outputs=toplevel

### DIFF
--- a/.github/actions/bazelrc/action.yaml
+++ b/.github/actions/bazelrc/action.yaml
@@ -1,6 +1,10 @@
 ---
 name: Use github bazel config
 description: Uses ci/github/bazelrc, and adds BES config from ci/bes-oss-k8s.bazelrc. Must be run on self-hosted runner.
+inputs:
+  download_toplevel:
+    description: 'whether to download cached toplevel files during bazel builds'
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -11,4 +15,9 @@ runs:
   - name: Copy BES bazel config
     run: |
       cp ci/bes-oss-k8s.bazelrc bes.bazelrc
+    shell: bash
+  - name: Add remote_download_outputs=toplevel
+    if: inputs.download_toplevel == 'true'
+    run: |
+      echo "build --remote_download_outputs=toplevel" >> github.bazelrc
     shell: bash

--- a/.github/workflows/perf_common.yaml
+++ b/.github/workflows/perf_common.yaml
@@ -84,17 +84,14 @@ jobs:
         echo "commit-sha=$(git log -n 1 --format="%H")" >> $GITHUB_OUTPUT
     - name: Use github bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        download_toplevel: 'true'
     - name: activate gcloud service account
       env:
         GOOGLE_APPLICATION_CREDENTIALS: "/tmp/gcloud.json"
       run: |
         service_account="$(jq -r '.client_email' "$GOOGLE_APPLICATION_CREDENTIALS")"
         gcloud auth activate-service-account "${service_account}" --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
-    - name: bazel config
-      run: |
-        # Skaffold expects the <image>.tar file to exist in the local bazel cache,
-        # but that only happens with remote_download_outputs=toplevel
-        echo "build --remote_download_outputs=toplevel" >> .bazelrc
     - name: Install Pixie CLI
       run: |
         bazel build -c opt //src/pixie_cli:px

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -38,6 +38,8 @@ jobs:
       run: git config --global --add safe.directory `pwd`
     - name: Use github bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        download_toplevel: 'true'
     - name: Build images
       run: |
         bazel build \

--- a/ci/github/bazelrc
+++ b/ci/github/bazelrc
@@ -39,6 +39,3 @@ test --local_cpu_resources=14
 
 build --jobs 16
 test --jobs 16
-
-# We need toplevel downloads in order to run tests that use container tars.
-build --remote_download_outputs=toplevel


### PR DESCRIPTION
Summary: We don't want to have `--remote_download_outputs=toplevel` for all of the github actions build. However, trivy fails without it so we add an option to add it.

Type of change: /kind test-infra

Test Plan: Testing in this PR with trivy. Will also cut an RC to make sure the release builds still work.
