### PR TITLE
[build] Remove HOME from action_env to improve caching.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,8 +2,6 @@
 
 # Use strict action env to prevent leaks of env vars.
 build --incompatible_strict_action_env
-# podman requires $HOME to be set to pull images from gcr.
-test --action_env=HOME
 # Passthrough GH_API_KEY from the environment.
 build --action_env=GH_API_KEY
 

--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -296,3 +296,9 @@ def stirling_test_images():
         "sha256:e04fc4e9b10508eed74c4154cb1f96d047dc0195b6ef0c9d4a38d6e24238778e",
         "pixie-oss/pixie-dev-public/python_grpc_1_19_0_helloworld:1.2",
     )
+
+    _gcr_io_image(
+        "emailservice_image",
+        "sha256:d42ee712cbb4806a8b922e303a5e6734f342dfb6c92c81284a289912165b7314",
+        "google-samples/microservices-demo/emailservice:v0.1.3",
+    )

--- a/src/common/system/socket_info_namespace_test.cc
+++ b/src/common/system/socket_info_namespace_test.cc
@@ -35,7 +35,7 @@ class NetNamespaceTest : public ::testing::Test {
  protected:
   void SetUp() override { ASSERT_OK(container_.Run()); }
 
-  DummyTestContainer container_;
+  EmailServiceContainer container_;
 };
 
 TEST_F(NetNamespaceTest, NetNamespace) {

--- a/src/common/testing/test_utils/BUILD.bazel
+++ b/src/common/testing/test_utils/BUILD.bazel
@@ -26,6 +26,10 @@ pl_cc_library(
         exclude = ["*_test.cc"],
     ),
     hdrs = glob(["*.h"]),
+    data = [
+        ":emailservice_image.tar",
+        ":sleep_container_image.tar",
+    ],
     tags = ["requires_docker"],
     deps = [
         "//src/common/exec:cc_library",
@@ -40,6 +44,11 @@ container_image(
         "echo started & sleep 100000000",
     ],
     entrypoint = ["/busybox/sh"],
+)
+
+container_image(
+    name = "emailservice_image",
+    base = "@emailservice_image//image",
 )
 
 # This test is useful for debugging flakiness on Jenkins BPF worker nodes,

--- a/src/common/testing/test_utils/test_container.h
+++ b/src/common/testing/test_utils/test_container.h
@@ -27,14 +27,15 @@
 namespace px {
 
 // TODO(oazizi): Remove all uses to this container in favor of SleepContainer below.
-class DummyTestContainer : public ContainerRunner {
+class EmailServiceContainer : public ContainerRunner {
  public:
-  DummyTestContainer() : ContainerRunner(kImage, kInstanceNamePrefix, kReadyMessage) {}
+  EmailServiceContainer()
+      : ContainerRunner(px::testing::BazelRunfilePath(kImage), kInstanceNamePrefix, kReadyMessage) {
+  }
 
  private:
-  static constexpr std::string_view kImage =
-      "gcr.io/google-samples/microservices-demo/emailservice:v0.1.3";
-  static constexpr std::string_view kInstanceNamePrefix = "dummy_container";
+  static constexpr std::string_view kImage = "src/common/testing/test_utils/emailservice_image.tar";
+  static constexpr std::string_view kInstanceNamePrefix = "emailservice_container";
   static constexpr std::string_view kReadyMessage = "listening on port: 8080";
 };
 


### PR DESCRIPTION
Summary: Removes `HOME` from the bazel `action_env` to improve caching. This was needed because we download some GCR images during the test. This moves the download to the bazel build phase to fix that issue.

Type of change: /kind cleanup

Test Plan: Relying on #ci:bpf-build to make sure tests still work without the action env.
