### PR TITLE
Remove unused cross bin from test group

### DIFF
--- a/src/stirling/obj_tools/testdata/go/BUILD.bazel
+++ b/src/stirling/obj_tools/testdata/go/BUILD.bazel
@@ -52,7 +52,6 @@ filegroup(
     testonly = True,
     srcs = [
         "sockshop_payments_service",
-        ":test_go_1_16_binary",
         ":test_go_1_17_binary",
         ":test_go_1_18_binary",
         ":test_go_1_19_binary",


### PR DESCRIPTION
Summary: TSIA

Type of change: /kind cleanup

Test Plan: bazel build and test still works.
