### PR TITLE
[actions] Add github action for CLI release.

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -1,0 +1,158 @@
+---
+name: cli-release
+on:
+  push:
+    tags:
+    - release/cli/**
+permissions:
+  contents: read
+env:
+  VERSIONS_FILE: "VERSIONS.json"
+jobs:
+  get-dev-image:
+    uses: ./.github/workflows/get_image.yaml
+    with:
+      image-base-name: "dev_image_with_extras"
+  build-cli-release:
+    name: Build CLI Release
+    runs-on: [self-hosted, nokvm]
+    needs: get-dev-image
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      options: --cpus 15 --privileged --cgroupns host
+      volumes:
+      - /etc/bazelrc:/etc/bazelrc
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: Setup gcloud docker creds
+      run: gcloud init && gcloud auth configure-docker
+    - name: Setup podman
+      run: |
+        # With some kernel configs (eg. COS), podman only works with legacy iptables.
+        update-alternatives --set iptables /usr/sbin/iptables-legacy
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    - name: Get GPG Key from secrets
+      env:
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+      run: |
+        echo "$BUILDBOT_GPG_KEY_B64" | base64 --decode > /tmp/gpg.key
+    - name: Build & Push Artifacts
+      env:
+        REF: ${{ github.event.ref }}
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        BUILDBOT_GPG_KEY_FILE: "/tmp/gpg.key"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BUILD_NUMBER: ${{ github.run_attempt }}
+        JOB_NAME: ${{ github.job }}
+      shell: bash
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        mkdir -p "artifacts/"
+        export ARTIFACTS_DIR="$(realpath artifacts/)"
+        ./ci/save_version_info.sh
+        ./ci/cli_build_release.sh
+    - name: Upload Github Artifacts
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: linux-artifacts
+        path: artifacts/
+    - name: Update Manifest
+      env:
+        ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+      run: ./ci/update_artifact_manifest.sh
+  sign-cli-release:
+    name: Sign CLI Release for MacOS
+    runs-on: macos-latest
+    needs: build-cli-release
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: Install gon
+      run: brew install mitchellh/gon/gon
+    - name: Sign CLI release
+      env:
+        REF: ${{ github.event.ref }}
+        AC_PASSWD: ${{ secrets.APPLE_ID_PASSWORD }}
+        KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        CERT_BASE64: ${{ secrets.APPLE_SIGN_CERT_B64 }}
+        CERT_PASSWORD: ${{ secrets.APPLE_SIGN_CERT_PASSWORD }}
+      shell: bash
+      run: |
+        export CERT_PATH="pixie.cert"
+        echo -n "$CERT_BASE64" | base64 --decode -o "$CERT_PATH"
+        export TAG_NAME="${REF#*/tags/}"
+        mkdir -p "artifacts/"
+        export ARTIFACTS_DIR="$(pwd)/artifacts"
+        ./ci/cli_merge_sign.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: macos-artifacts
+        path: artifacts/
+  push-signed-cli-artifacts:
+    name: Push Signed CLI Artifacts for MacOS
+    runs-on: [self-hosted, nokvm]
+    needs: [get-dev-image, sign-cli-release]
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+      with:
+        name: macos-artifacts
+    - name: Get GPG Key from secrets
+      env:
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+      run: |
+        echo "$BUILDBOT_GPG_KEY_B64" | base64 --decode > /tmp/gpg.key
+    - name: Upload signed CLI
+      env:
+        REF: ${{ github.event.ref }}
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        BUILDBOT_GPG_KEY_FILE: "/tmp/gpg.key"
+      shell: bash
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        mkdir -p "artifacts/"
+        export ARTIFACTS_DIR="$(pwd)/artifacts"
+        ./ci/cli_upload_signed.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: macos-artifacts
+        path: artifacts/
+  create-github-cli-release:
+    name: Create CLI Release on Github
+    runs-on: ubuntu-latest
+    needs: push-signed-cli-artifacts
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - name: Create Release
+      env:
+        REF: ${{ github.event.ref }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: pixie-io
+        REPO: pixie
+      shell: bash
+      # yamllint disable rule:indentation
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        # actions/checkout doesn't get the tag annotation properly.
+        git fetch origin tag "${TAG_NAME}" -f
+        export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
+        gh release create "${TAG_NAME}" --title "CLI ${TAG_NAME#release/cli/}" \
+          --notes $'Pixie CLI Release:\n'"${changelog}"
+        gh release upload "${TAG_NAME}" linux-artifacts/* macos-artifacts/*
+      # yamllint enable rule:indentation

--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -25,6 +25,7 @@ repo_path=$(bazel info workspace)
 printenv
 
 versions_file="$(realpath "${VERSIONS_FILE:?}")"
+artifacts_dir="${ARTIFACTS_DIR:-$(mktemp -d)}"
 release_tag=${TAG_NAME##*/v}
 linux_arch=x86_64
 pkg_prefix="pixie-px-${release_tag}.${linux_arch}"
@@ -33,31 +34,30 @@ echo "The release tag is: ${release_tag}"
 linux_binary=$(bazel cquery //src/pixie_cli:px -c opt --output starlark --starlark:expr "target.files.to_list()[0].path" 2> /dev/null)
 darwin_amd64_binary=$(bazel cquery -c opt //src/pixie_cli:px_darwin_amd64 --output starlark --starlark:expr "target.files.to_list()[0].path" 2> /dev/null)
 darwin_arm64_binary=$(bazel cquery -c opt //src/pixie_cli:px_darwin_arm64 --output starlark --starlark:expr "target.files.to_list()[0].path" 2> /dev/null)
-docker_repo="pixielabs/px"
 
 bazel run -c opt //src/utils/artifacts/versions_gen:versions_gen -- \
       --repo_path "${repo_path}" --artifact_name cli --versions_file "${versions_file}"
 
 bazel build -c opt --stamp //src/pixie_cli:px_darwin_amd64 //src/pixie_cli:px_darwin_arm64 //src/pixie_cli:px
 
+# Avoid dealing with bazel's symlinks by copying binaries into a temp dir.
+binary_dir="$(mktemp -d)"
+cp "${linux_binary}" "${binary_dir}"
+linux_binary="${binary_dir}/$(basename "${linux_binary}")"
+cp "${darwin_amd64_binary}" "${binary_dir}"
+darwin_amd64_binary="${binary_dir}/$(basename "${darwin_amd64_binary}")"
+cp "${darwin_arm64_binary}" "${binary_dir}"
+darwin_arm64_binary="${binary_dir}/$(basename "${darwin_arm64_binary}")"
+
 # Create and push docker image.
 bazel run -c opt --stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
-    # Make tmp directory, because the binary path is a symlink.
-    # We need to move the tmp directory to a shared location between the mounted
-    # docker volume and the host.
-    tmp_dir="$(mktemp -d)"
-    cp -RaL "${linux_binary}" "${tmp_dir}"
-    mv "${tmp_dir}" /mnt/disks/jenkins/sharedDir
-    tmp_subpath="$(echo "${tmp_dir}" | cut -d'/' -f3-)"
-    mkdir -p /mnt/disks/jenkins/sharedDir/image
-
     # Create rpm package.
-    docker run -i --rm \
-           -v "/mnt/disks/jenkins/sharedDir/${tmp_subpath}:/src/" \
-           -v "/mnt/disks/jenkins/sharedDir/image:/image" \
-           cdrx/fpm-fedora:24 \
+    podman run -i --rm \
+           -v "${binary_dir}:/src/" \
+           -v "$(pwd):/image" \
+           docker.io/cdrx/fpm-fedora:24 \
            fpm \
            -f \
            -p "/image/${pkg_prefix}.rpm" \
@@ -69,10 +69,10 @@ if [[ ! "$release_tag" == *"-"* ]]; then
            px
 
     # Create deb package.
-    docker run -i --rm \
-           -v "/mnt/disks/jenkins/sharedDir/${tmp_subpath}:/src/" \
-           -v "/mnt/disks/jenkins/sharedDir/image:/image" \
-           cdrx/fpm-ubuntu:18.04 \
+    podman run -i --rm \
+           -v "${binary_dir}:/src/" \
+           -v "$(pwd):/image" \
+           docker.io/cdrx/fpm-ubuntu:18.04 \
            fpm \
            -f \
            -p "/image/${pkg_prefix}.deb" \
@@ -83,13 +83,7 @@ if [[ ! "$release_tag" == *"-"* ]]; then
            --prefix /usr/local/bin \
            px
 
-    # Push officially releases to docker hub.
-    bazel run -c opt --stamp //src/pixie_cli:push_px_image_to_docker
-
-    # Update latest tag.
-    docker pull "${docker_repo}:${release_tag}"
-    docker tag "${docker_repo}:${release_tag}" "${docker_repo}:latest"
-    docker push "${docker_repo}:latest"
+   # TODO(james): Add push to docker hub/quay.io.
 fi
 
 gpg --no-tty --batch --yes --import "${BUILDBOT_GPG_KEY_FILE}"
@@ -102,26 +96,20 @@ write_artifacts_to_gcs() {
 
     if [[ ! "$release_tag" == *"-"* ]]; then
         # RPM/DEB only exists for release builds.
-        copy_artifact_to_gcs "${output_path}" "/mnt/disks/jenkins/sharedDir/image/${pkg_prefix}.deb" "pixie-px.${linux_arch}.deb"
-        copy_artifact_to_gcs "${output_path}" "/mnt/disks/jenkins/sharedDir/image/${pkg_prefix}.rpm" "pixie-px.${linux_arch}.rpm"
+        copy_artifact_to_gcs "${output_path}" "$(pwd)/${pkg_prefix}.deb" "pixie-px.${linux_arch}.deb"
+        copy_artifact_to_gcs "${output_path}" "$(pwd)/${pkg_prefix}.rpm" "pixie-px.${linux_arch}.rpm"
     fi
 }
 
-write_artifacts_to_gh() {
-    gh release create "${TAG_NAME}" --repo=pixie-io/pixie --notes "Pixie CLI Release"
+sign_artifacts() {
+    cp "${linux_binary}" "${artifacts_dir}/cli_linux_amd64"
+    cp "$(pwd)/${pkg_prefix}.deb" "${artifacts_dir}/pixie-px.${linux_arch}.deb"
+    cp "$(pwd)/${pkg_prefix}.rpm" "${artifacts_dir}/pixie-px.${linux_arch}.rpm"
 
-    tmp_dir="$(mktemp -d)"
-
-    cp "${linux_binary}" "${tmp_dir}/cli_linux_amd64"
-    cp "/mnt/disks/jenkins/sharedDir/image/${pkg_prefix}.deb" "${tmp_dir}/pixie-px.${linux_arch}.deb"
-    cp "/mnt/disks/jenkins/sharedDir/image/${pkg_prefix}.rpm" "${tmp_dir}/pixie-px.${linux_arch}.rpm"
-
-    pushd "${tmp_dir}"
+    pushd "${artifacts_dir}"
     gpg --no-tty --batch --yes --local-user "${BUILDBOT_GPG_KEY_ID}" --armor --detach-sign "cli_linux_amd64"
     gpg --no-tty --batch --yes --local-user "${BUILDBOT_GPG_KEY_ID}" --armor --detach-sign "pixie-px.${linux_arch}.deb"
     gpg --no-tty --batch --yes --local-user "${BUILDBOT_GPG_KEY_ID}" --armor --detach-sign "pixie-px.${linux_arch}.rpm"
-
-    gh release upload "${TAG_NAME}" --repo=pixie-io/pixie "cli_linux_amd64" "cli_linux_amd64.asc" "pixie-px.${linux_arch}.deb" "pixie-px.${linux_arch}.deb.asc" "pixie-px.${linux_arch}.rpm" "pixie-px.${linux_arch}.rpm.asc"
     popd
 }
 
@@ -129,13 +117,13 @@ public="True"
 bucket="pixie-dev-public"
 if [[ $release_tag == *"-"* ]]; then
   public="False"
-  bucket="pixie-prod-artifacts"
+  # Use the same bucket for RCs.
 fi
 output_path="gs://${bucket}/cli/${release_tag}"
 write_artifacts_to_gcs "${output_path}"
 # Check to see if it's production build. If so we should also write it to the latest directory.
 if [[ $public == "True" ]]; then
-    output_path="gs://pixie-dev-public/cli/latest"
+    output_path="gs://${bucket}/cli/latest"
     write_artifacts_to_gcs "${output_path}"
-    write_artifacts_to_gh
+    sign_artifacts
 fi

--- a/ci/cli_upload_signed.sh
+++ b/ci/cli_upload_signed.sh
@@ -25,11 +25,9 @@ set -ex
 
 printenv
 
+artifacts_dir="${ARTIFACTS_DIR:-?}"
 release_tag=${TAG_NAME##*/v}
-bucket="pixie-prod-artifacts"
-if [[ ! "$release_tag" == *"-"* ]]; then
-  bucket="pixie-dev-public"
-fi
+bucket="pixie-dev-public"
 
 gpg --no-tty --batch --yes --import "${BUILDBOT_GPG_KEY_FILE}"
 
@@ -40,10 +38,11 @@ do
 
   # Check to see if it's production build. If so we should also write it to the latest directory.
   if [[ ! "$release_tag" == *"-"* ]]; then
-    output_path="gs://pixie-dev-public/cli/latest"
+    output_path="gs://${bucket}/cli/latest"
     copy_artifact_to_gcs "$output_path" "cli_darwin_${arch}" "cli_darwin_${arch}"
 
     gpg --no-tty --batch --yes --local-user "${BUILDBOT_GPG_KEY_ID}" --armor --detach-sign "cli_darwin_${arch}"
-    gh release upload "${TAG_NAME}" --repo=pixie-io/pixie "cli_darwin_${arch}" "cli_darwin_${arch}.asc"
+    cp "cli_darwin_${arch}" "${artifacts_dir}"
+    cp "cli_darwin_${arch}.asc" "${artifacts_dir}"
   fi
 done


### PR DESCRIPTION
Summary: Adds a github action to build, sign, and push CLI releases. I decided to split it out into a separate workflow from the other releases because it requires multiple jobs. I may also move the other release actions into their own workflows also.

Type of change: /kind test-infra

Test Plan: Tested on my fork: https://github.com/JamesMBartlett/pixie/releases/tag/release%2Fcli%2Fv0.7.19
