### PR TITLE
[cli] Fix ContainsAny call

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -136,6 +136,10 @@
       "type": "golangci-lint",
       "include": [
         "(\\.go$)"
+      ],
+      "flags": [
+        "--timeout=5m0s",
+        "--out-format=checkstyle"
       ]
     },
     "golint": {

--- a/src/api/go/pxapi/client.go
+++ b/src/api/go/pxapi/client.go
@@ -86,7 +86,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 }
 
 func (c *Client) init(ctx context.Context) error {
-	isInternal := strings.ContainsAny(c.cloudAddr, "cluster.local")
+	isInternal := strings.Contains(c.cloudAddr, "cluster.local")
 
 	tlsConfig := &tls.Config{InsecureSkipVerify: isInternal}
 	creds := credentials.NewTLS(tlsConfig)

--- a/src/pixie_cli/pkg/update/cli.go
+++ b/src/pixie_cli/pkg/update/cli.go
@@ -43,7 +43,7 @@ import (
 )
 
 func newATClient(cloudAddr string) (cloudpb.ArtifactTrackerClient, error) {
-	isInternal := strings.ContainsAny(cloudAddr, "cluster.local")
+	isInternal := strings.Contains(cloudAddr, "cluster.local")
 
 	dialOpts, err := services.GetGRPCClientDialOptsServerSideTLS(isInternal)
 	if err != nil {

--- a/src/pixie_cli/pkg/utils/cloud.go
+++ b/src/pixie_cli/pkg/utils/cloud.go
@@ -28,7 +28,7 @@ import (
 
 // GetCloudClientConnection gets the GRPC connection based on the cloud addr.
 func GetCloudClientConnection(cloudAddr string) (*grpc.ClientConn, error) {
-	isInternal := strings.ContainsAny(cloudAddr, "cluster.local")
+	isInternal := strings.Contains(cloudAddr, "cluster.local")
 
 	dialOpts, err := services.GetGRPCClientDialOptsServerSideTLS(isInternal)
 	if err != nil {

--- a/src/pixie_cli/pkg/vizier/client.go
+++ b/src/pixie_cli/pkg/vizier/client.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newVizierClusterInfoClient(cloudAddr string) (cloudpb.VizierClusterInfoClient, error) {
-	isInternal := strings.ContainsAny(cloudAddr, "cluster.local")
+	isInternal := strings.Contains(cloudAddr, "cluster.local")
 
 	dialOpts, err := services.GetGRPCClientDialOptsServerSideTLS(isInternal)
 	if err != nil {

--- a/src/pixie_cli/pkg/vizier/connector.go
+++ b/src/pixie_cli/pkg/vizier/connector.go
@@ -102,7 +102,7 @@ func (c *Connector) connect(addr string) error {
 		<-ch
 		cancel()
 	}()
-	isInternal := strings.ContainsAny(addr, "cluster.local")
+	isInternal := strings.Contains(addr, "cluster.local")
 
 	dialOpts, err := services.GetGRPCClientDialOptsServerSideTLS(isInternal)
 	if err != nil {

--- a/src/utils/pixie_updater/main.go
+++ b/src/utils/pixie_updater/main.go
@@ -57,7 +57,7 @@ func init() {
 }
 
 func getCloudClientConnection(cloudAddr string) (*grpc.ClientConn, error) {
-	isInternal := strings.ContainsAny(cloudAddr, "cluster.local")
+	isInternal := strings.Contains(cloudAddr, "cluster.local")
 
 	dialOpts, err := services.GetGRPCClientDialOptsServerSideTLS(isInternal)
 	if err != nil {

--- a/src/vizier/services/cloud_connector/bridge/vzconn_client.go
+++ b/src/vizier/services/cloud_connector/bridge/vzconn_client.go
@@ -64,7 +64,7 @@ func NewVZConnClient(vzOperator VizierOperatorInfo) (vzconnpb.VZConnServiceClien
 		cloudAddr = viper.GetString("cloud_addr")
 	}
 
-	isInternal := strings.ContainsAny(cloudAddr, ".svc.cluster.local")
+	isInternal := strings.Contains(cloudAddr, ".svc.cluster.local")
 
 	dialOpts, err := services.GetGRPCClientDialOptsServerSideTLS(isInternal)
 	if err != nil {


### PR DESCRIPTION
Summary: The CLI was checking for cluster local addresses using `strings.ContainsAny` but this is incorrect. This PR replaces it with `strings.Contains`.

Type of change: /kind cleanup

Test Plan: Ran `px run` to make sure it can still connect to a vizier.
