### PR TITLE
[grpc_trace_bpf_test] Fix test teardown to avoid segfault

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/grpc_trace_bpf_test.cc
@@ -119,12 +119,14 @@ struct TestParams {
   bool use_https;
 };
 
-class GRPCTraceTest : public testing::SocketTraceBPFTestFixture</* TClientSideTracing */ false>,
-                      public ::testing::WithParamInterface<TestParams> {
+using TestFixture = testing::SocketTraceBPFTestFixture</* TClientSideTracing */ false>;
+
+class GRPCTraceTest : public TestFixture, public ::testing::WithParamInterface<TestParams> {
  protected:
   GRPCTraceTest() {}
 
   void TearDown() override {
+    TestFixture::TearDown();
     server_.s_.Kill();
     CHECK_EQ(9, server_.s_.Wait()) << "Server should have been killed.";
   }


### PR DESCRIPTION
Summary: Under qemu, there was a segfault occuring in the `grpc_trace_bpf_test`. The segfault occured because `SocketTraceBPFTestFixture` was destroyed (and subsequently `SocketTraceConnector` was also destroyed) without a call to `SocketTraceConnector::Stop` which meant the uprobe deploy threads could still be active after destruction of `SocketTraceConnector` and `UProbeManager` leading to attempts to dereference null pointers.

Type of change: /kind cleanup.

Test Plan: The segfault was consistent under qemu, and after this change it no longer happens. The test is still somewhat flaky about (1 in 20), but not because of segfaults.
