### PR TITLE
[action-runners] Use a single container for dind and runner

### DIFF
--- a/k8s/devinfra/action-runners/runners/base/deployment.yaml
+++ b/k8s/devinfra/action-runners/runners/base/deployment.yaml
@@ -6,11 +6,10 @@ metadata:
 spec:
   template:
     spec:
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
       repository: pixie-io/pixie
-      resources:
-        requests:
-          cpu: 16000m
-      dockerVolumeMounts:
+      volumeMounts:
       - mountPath: /etc/docker/daemon.json
         subPath: daemon.json
         name: dockerd-config

--- a/k8s/devinfra/action-runners/runners/kvm/deployment.yaml
+++ b/k8s/devinfra/action-runners/runners/kvm/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      resources:
+        requests:
+          cpu: 46000m
       labels:
       - kvm
       nodeSelector:

--- a/k8s/devinfra/action-runners/runners/nokvm/deployment.yaml
+++ b/k8s/devinfra/action-runners/runners/nokvm/deployment.yaml
@@ -6,5 +6,8 @@ metadata:
 spec:
   template:
     spec:
+      resources:
+        requests:
+          cpu: 16000m
       labels:
       - nokvm


### PR DESCRIPTION
Summary: The cpu requests were only being applied to the runner container and not the dind container, but the cpu usage was in the dind container. I think this was leading to some CPU throttling. This PR avoids the issue by using a single container for the runner and the docker daemon. This PR also increases the CPU allocation for KVM runners.

Type of change: /kind test-infra

Test Plan: Deployed the new configs to dev infra, running a bpf build&test seems to be somewhat faster.
