### PR TITLE
[pxapi] Allow streaming queries to reconnect if stream ends without trailers

### DIFF
--- a/src/api/go/pxapi/results.go
+++ b/src/api/go/pxapi/results.go
@@ -151,6 +151,9 @@ func isTransientGRPCError(err error) bool {
 	if s.Code() == codes.Internal && strings.Contains(s.Message(), "RST_STREAM") {
 		return true
 	}
+	if s.Code() == codes.Internal && strings.Contains(s.Message(), "server closed the stream without sending trailers") {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
Summary: The `perf-eval` github action was often failing because the data loss streaming pxl script would fail with error "server closed the stream without sending trailers". It seems like this happens similarly to `RST_STREAM` when someone on the TCP chain decides to give up on the connection. This diff allows the script to try to reconnect if this error occurs. I tested the perf eval using these changes and it no longer errors with the above error.

Type of change: /kind cleanup

Test Plan: Tested a perf eval with a streaming query and saw that it successfully completed without running into any "server closed the stream ..." errors.
