### PR TITLE
[etcd_metadata] Add tolerations to metadata deployment

### DIFF
--- a/k8s/vizier/etcd_metadata/aarch64/daemonset.yaml
+++ b/k8s/vizier/etcd_metadata/aarch64/daemonset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/aarch64/deployment.yaml
+++ b/k8s/vizier/etcd_metadata/aarch64/deployment.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/aarch64/job.yaml
+++ b/k8s/vizier/etcd_metadata/aarch64/job.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/aarch64/kustomization.yaml
+++ b/k8s/vizier/etcd_metadata/aarch64/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../pem
+patches:
+- path: deployment.yaml
+  target:
+    kind: Deployment
+- path: job.yaml
+  target:
+    kind: Job
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet

--- a/k8s/vizier/etcd_metadata/aarch64/statefulset.yaml
+++ b/k8s/vizier/etcd_metadata/aarch64/statefulset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -125,3 +125,20 @@ spec:
       - name: certs
         secret:
           secretName: service-tls-certs
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/x86/daemonset.yaml
+++ b/k8s/vizier/etcd_metadata/x86/daemonset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/x86/deployment.yaml
+++ b/k8s/vizier/etcd_metadata/x86/deployment.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/x86/job.yaml
+++ b/k8s/vizier/etcd_metadata/x86/job.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/k8s/vizier/etcd_metadata/x86/kustomization.yaml
+++ b/k8s/vizier/etcd_metadata/x86/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../pem
+patches:
+- path: deployment.yaml
+  target:
+    kind: Deployment
+- path: job.yaml
+  target:
+    kind: Job
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet

--- a/k8s/vizier/etcd_metadata/x86/statefulset.yaml
+++ b/k8s/vizier/etcd_metadata/x86/statefulset.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoSchedule"
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "amd64"
+        effect: "NoExecute"

--- a/skaffold/skaffold_vizier.yaml
+++ b/skaffold/skaffold_vizier.yaml
@@ -107,7 +107,27 @@ profiles:
   - op: replace
     path: /manifests/kustomize/paths
     value:
-    - k8s/vizier/etcd_metadata
+    - k8s/vizier/etcd_metadata/x86
+- name: etcd_x86_64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=x86_64_sysroot
+  - op: replace
+    path: /manifests/kustomize/paths
+    value:
+    - k8s/vizier/etcd_metadata/x86
+- name: etcd_aarch64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=aarch64_sysroot
+  - op: replace
+    path: /manifests/kustomize/paths
+    value:
+    - k8s/vizier/etcd_metadata/aarch64
 - name: aarch64_sysroot
   patches:
   - op: add


### PR DESCRIPTION
Summary: Adds tolerations for arm64 and amd64 taints to the etcd_metadata deployment.

Relevant Issues: #893

Type of change: /kind cleanup

Test Plan: Tested that the metadata deployment works on arm tainted nodes now.
