### PR TITLE
Add http_trace_id pxl script for viewing http spans that contain a trace id

### DIFF
--- a/src/pxl_scripts/px/http_trace_id/script.pxl
+++ b/src/pxl_scripts/px/http_trace_id/script.pxl
@@ -23,7 +23,7 @@ be viewed.
 import px
 
 
-def http_trace_data(start_time: str, trace_id_filter: str):
+def http_trace_data(start_time: str, trace_header_name: str, trace_id_filter: str):
 
     df = px.DataFrame(table='http_events', start_time=start_time)
 
@@ -33,12 +33,16 @@ def http_trace_data(start_time: str, trace_id_filter: str):
     df = add_source_dest_columns(df)
     df = add_source_dest_links(df, start_time)
 
-    # Determine the trace_id from the traceparent http header and filter out
-    # requests that don't include a trace id.
-    df.traceparent_id = px.pluck(df.req_headers, 'traceparent')
-    df.trace_id = px.replace(
-        r"[A-Za-z0-9]+\-([A-Za-z0-9]+)\-[A-Za-z0-9]+\-[A-Za-z0-9]+",
-        df.traceparent_id, "\\1")
+    # Determine the trace_id from the {trace_header_name} http header. Otel's trace
+    # header (traceparent) includes more than the trace id and requires further
+    # parsing, while others (X-B3-Trace-Id) the value can be used wholesale.
+    df.trace_id = px.pluck(df.req_headers, trace_header_name)
+    df.trace_id = px.select(
+        trace_header_name != 'traceparent', df.trace_id, px.replace(
+            r"[A-Za-z0-9]+\-([A-Za-z0-9]+)\-[A-Za-z0-9]+\-[A-Za-z0-9]+",
+            df.trace_id, "\\1"))
+
+    # Filter out requests that don't include a trace id.
     df = df[df.trace_id != ""]
 
     df = add_trace_id_link(df, start_time)
@@ -103,7 +107,7 @@ def add_trace_id_link(df, start_time: str):
     # the sort order of the table visualization (descending time), this
     # wouldn't be a concern.
     extended_start = 2 * px.parse_duration(start_time)
-    nanos_per_min = 60000000000
+    nanos_per_min = 60 * 1000 * 1000 * 1000
     extended_start_time = px.itoa(px.floor(extended_start / nanos_per_min)) + 'm'
 
     df.trace_id_link = px.script_reference(df.trace_id, 'px/http_trace_id', {

--- a/src/pxl_scripts/px/http_trace_id/script.pxl
+++ b/src/pxl_scripts/px/http_trace_id/script.pxl
@@ -1,0 +1,147 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+''' HTTP Trace Id Tracer
+
+This script traces all HTTP/HTTP2 data on the cluster that includes an Otel traceparent http header.
+In addition, it allows filtering by trace id so all of the spans contained within that trace can
+be viewed.
+'''
+import px
+
+
+def http_trace_data(start_time: str, trace_id_filter: str):
+
+    df = px.DataFrame(table='http_events', start_time=start_time)
+
+    # Add context.
+    df.node = df.ctx['node']
+    df.pid = px.upid_to_pid(df.upid)
+    df = add_source_dest_columns(df)
+    df = add_source_dest_links(df, start_time)
+
+    # Determine the trace_id from the traceparent http header and filter out
+    # requests that don't include a trace id.
+    df.traceparent_id = px.pluck(df.req_headers, 'traceparent')
+    df.trace_id = px.replace(
+        "[A-Za-z0-9]+\-([A-Za-z0-9]+)\-[A-Za-z0-9]+\-[A-Za-z0-9]+",  # noqa: W605
+        df.traceparent_id, "\\1")
+    df = df[df.trace_id != ""]
+
+    df = add_trace_id_link(df, start_time)
+
+    # This filter seems to sometimes work depending on how many results are returned
+    # I believe there is some default applied.
+    df = df[px.contains(df.trace_id, trace_id_filter)]
+
+    # Order columns.
+    df = df['time_', 'trace_id', 'source', 'destination', 'latency', 'major_version', 'req_path',
+            'req_method', 'req_headers', 'req_body', 'req_body_size', 'resp_status',
+            'resp_message', 'resp_headers', 'resp_body', 'resp_body_size']
+
+    return df
+
+
+def add_source_dest_columns(df):
+    ''' Add source and destination columns for the HTTP request.
+
+    HTTP requests are traced server-side (trace_role==2), unless the server is
+    outside of the cluster in which case the request is traced client-side (trace_role==1).
+
+    When trace_role==2, the HTTP request source is the remote_addr column
+    and destination is the pod column. When trace_role==1, the HTTP request
+    source is the pod column and the destination is the remote_addr column.
+
+    Input DataFrame must contain trace_role, upid, remote_addr columns.
+    '''
+    df.pod = df.ctx['pod']
+    df.namespace = df.ctx['namespace']
+
+    # If remote_addr is a pod, get its name. If not, use IP address.
+    df.ra_pod = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
+    df.is_ra_pod = df.ra_pod != ''
+    df.ra_name = px.select(df.is_ra_pod, df.ra_pod, df.remote_addr)
+
+    df.is_server_tracing = df.trace_role == 2
+    df.is_source_pod_type = px.select(df.is_server_tracing, df.is_ra_pod, True)
+    df.is_dest_pod_type = px.select(df.is_server_tracing, True, df.is_ra_pod)
+
+    # Set source and destination based on trace_role.
+    df.source = px.select(df.is_server_tracing, df.ra_name, df.pod)
+    df.destination = px.select(df.is_server_tracing, df.pod, df.ra_name)
+
+    # Filter out messages with empty source / destination.
+    df = df[df.source != '']
+    df = df[df.destination != '']
+
+    df = df.drop(['ra_pod', 'is_ra_pod', 'ra_name', 'is_server_tracing'])
+
+    return df
+
+
+def add_trace_id_link(df, start_time: str):
+    '''Modifies the trace_id column to provide a deeplink in the UI to a filtered
+    view of just the requests related to that trace id. This function assumes that
+    any data frames that have empty trace ids have been filtered prior.
+    '''
+
+    df.trace_id_link = px.script_reference(df.trace_id, 'px/http_trace_id', {
+        'start_time': start_time,
+        'trace_id_filter': df.trace_id,
+    })
+    df.trace_id = df.trace_id_link
+
+    df = df.drop(['trace_id_link'])
+
+    return df
+
+
+def add_source_dest_links(df, start_time: str):
+    ''' Modifies the source and destination columns to display deeplinks in the UI.
+    Clicking on a pod name in either column will run the px/pod script for that pod.
+    Clicking on an IP address, will run the px/ip script showing all network connections
+    to/from that IP address.
+
+    Input DataFrame must contain source, destination, is_source_pod_type,
+    is_dest_pod_type, and namespace columns.
+    '''
+
+    # Source linking. If source is a pod, link to px/pod. If an IP addr, link to px/net_flow_graph.
+    df.src_pod_link = px.script_reference(df.source, 'px/pod', {
+        'start_time': start_time,
+        'pod': df.source
+    })
+    df.src_link = px.script_reference(df.source, 'px/ip', {
+        'start_time': start_time,
+        'ip': df.source,
+    })
+    df.source = px.select(df.is_source_pod_type, df.src_pod_link, df.src_link)
+
+    # If destination is a pod, link to px/pod. If an IP addr, link to px/net_flow_graph.
+    df.dest_pod_link = px.script_reference(df.destination, 'px/pod', {
+        'start_time': start_time,
+        'pod': df.destination
+    })
+    df.dest_link = px.script_reference(df.destination, 'px/ip', {
+        'start_time': start_time,
+        'ip': df.destination,
+    })
+    df.destination = px.select(df.is_dest_pod_type, df.dest_pod_link, df.dest_link)
+
+    df = df.drop(['src_pod_link', 'src_link', 'is_source_pod_type', 'dest_pod_link',
+                  'dest_link', 'is_dest_pod_type'])
+
+    return df

--- a/src/pxl_scripts/px/http_trace_id/script.pxl
+++ b/src/pxl_scripts/px/http_trace_id/script.pxl
@@ -98,8 +98,18 @@ def add_trace_id_link(df, start_time: str):
     any data frames that have empty trace ids have been filtered prior.
     '''
 
+    # Until PxL has support for performing the inverse of px.parse_duration,
+    # compute 2x the original start_time manually. The goal is to avoid allowing
+    # a user to load the script with a specified trace id when the requests involved
+    # have aged out of the original start_time window. If PxL supported specifying
+    # the sort order of the table visualization (descending time), this
+    # wouldn't be a concern.
+    extended_start = 2 * px.parse_duration(start_time)
+    nanos_per_min = 60000000000
+    extended_start_time = px.itoa(px.floor(extended_start / nanos_per_min)) + 'm'
+
     df.trace_id_link = px.script_reference(df.trace_id, 'px/http_trace_id', {
-        'start_time': start_time,
+        'start_time': extended_start_time,
         'trace_id_filter': df.trace_id,
     })
     df.trace_id = df.trace_id_link

--- a/src/pxl_scripts/px/http_trace_id/script.pxl
+++ b/src/pxl_scripts/px/http_trace_id/script.pxl
@@ -37,7 +37,7 @@ def http_trace_data(start_time: str, trace_id_filter: str):
     # requests that don't include a trace id.
     df.traceparent_id = px.pluck(df.req_headers, 'traceparent')
     df.trace_id = px.replace(
-        "[A-Za-z0-9]+\-([A-Za-z0-9]+)\-[A-Za-z0-9]+\-[A-Za-z0-9]+",  # noqa: W605
+        r"[A-Za-z0-9]+\-([A-Za-z0-9]+)\-[A-Za-z0-9]+\-[A-Za-z0-9]+",
         df.traceparent_id, "\\1")
     df = df[df.trace_id != ""]
 

--- a/src/pxl_scripts/px/http_trace_id/script.pxl
+++ b/src/pxl_scripts/px/http_trace_id/script.pxl
@@ -43,8 +43,6 @@ def http_trace_data(start_time: str, trace_id_filter: str):
 
     df = add_trace_id_link(df, start_time)
 
-    # This filter seems to sometimes work depending on how many results are returned
-    # I believe there is some default applied.
     df = df[px.contains(df.trace_id, trace_id_filter)]
 
     # Order columns.

--- a/src/pxl_scripts/px/http_trace_id/vis.json
+++ b/src/pxl_scripts/px/http_trace_id/vis.json
@@ -1,0 +1,49 @@
+{
+    "variables": [
+        {
+            "name": "start_time",
+            "type": "PX_STRING",
+            "description": "The start time of the window in time units before now.",
+            "defaultValue": "-1h"
+        },
+        {
+            "name": "trace_id_filter",
+            "type": "PX_STRING",
+            "description": "Otel trace id.",
+            "defaultValue": ""
+        }
+    ],
+    "globalFuncs": [
+        {
+            "outputName": "http_trace_data",
+            "func": {
+                "name": "http_trace_data",
+                "args": [
+                    {
+                        "name": "start_time",
+                        "variable": "start_time"
+                    },
+                    {
+                        "name": "trace_id_filter",
+                        "variable": "trace_id_filter"
+                    }
+                ]
+            }
+        }
+    ],
+    "widgets": [
+        {
+            "name": "Table",
+            "position": {
+                "x": 0,
+                "y": 0,
+                "w": 12,
+                "h": 4
+            },
+            "globalFuncOutputName": "http_trace_data",
+            "displaySpec": {
+                "@type": "types.px.dev/px.vispb.Table"
+            }
+        }
+    ]
+}

--- a/src/pxl_scripts/px/http_trace_id/vis.json
+++ b/src/pxl_scripts/px/http_trace_id/vis.json
@@ -4,7 +4,7 @@
             "name": "start_time",
             "type": "PX_STRING",
             "description": "The start time of the window in time units before now.",
-            "defaultValue": "-1h"
+            "defaultValue": "-30m"
         },
         {
             "name": "trace_id_filter",

--- a/src/pxl_scripts/px/http_trace_id/vis.json
+++ b/src/pxl_scripts/px/http_trace_id/vis.json
@@ -7,9 +7,15 @@
             "defaultValue": "-30m"
         },
         {
+            "name": "trace_header_name",
+            "type": "PX_STRING",
+            "description": "The HTTP header that contains the distributed trace id. Defaults to Otel's traceparent header",
+            "defaultValue": "traceparent"
+        },
+        {
             "name": "trace_id_filter",
             "type": "PX_STRING",
-            "description": "Otel trace id.",
+            "description": "Trace id.",
             "defaultValue": ""
         }
     ],
@@ -22,6 +28,10 @@
                     {
                         "name": "start_time",
                         "variable": "start_time"
+                    },
+                    {
+                        "name": "trace_header_name",
+                        "variable": "trace_header_name"
                     },
                     {
                         "name": "trace_id_filter",


### PR DESCRIPTION
Summary: Add http_trace_id pxl script for viewing http spans that contain a trace id

Many people at Kubecon asked if Pixie could view distributed traces. While our UI doesn't natively support a distributed trace visualization, pxl scripts are flexible enough to display requests that include trace ids in addition to filtering http requests to only those with a given trace id.

Relevant Issues: N/A

Type of change: /kind new-pxl-script

Test Plan: Developed this script within Pixie's scratch pad interface and verified the following
- [x] The script displays all http requests that include a trace id when no parameters are applied

<img width="1728" alt="Screen Shot 2023-04-26 at 2 46 42 PM" src="https://user-images.githubusercontent.com/5855593/234710181-8a4a63ca-91d6-4b0d-a8ce-08ba4ba41a69.png">

- [x] The script displays http requests for a given trace id when `trace_id_filter` is used

<img width="1728" alt="Screen Shot 2023-04-26 at 2 46 20 PM" src="https://user-images.githubusercontent.com/5855593/234710237-13c0b203-6d3d-4b22-9592-06712a2c59fa.png">


- [x] The logic that doubles the start_time when the deep link is followed works for default time range
<img width="1728" alt="Screen Shot 2023-04-26 at 2 46 31 PM" src="https://user-images.githubusercontent.com/5855593/234710284-a48bbc97-416a-4bc9-b108-fe5169ed536b.png">

- [ ] Verified that the script's deeplinking to itself works (clicking on a trace id should reload the dashboard with the given trace) -- not sure if I can test this until the pxl script bundle is uploaded.