### PR TITLE
[k8s] Pin image digests

### DIFF
--- a/demos/finagle/finagle.yaml
+++ b/demos/finagle/finagle.yaml
@@ -53,7 +53,7 @@ spec:
       containers:
       - args:
         - client/run
-        image: gcr.io/pixie-prod/demos/finagle/hello:1.0
+        image: gcr.io/pixie-prod/demos/finagle/hello:1.0@sha256:85006a2eae6e86019d85e1e12915d9d21e4af85b80a24674dc2b7a2ef4e7dbff
         name: finagle-client
         resources: {}
       restartPolicy: Always
@@ -86,7 +86,7 @@ spec:
         io.kompose.service: finagle-server
     spec:
       containers:
-      - image: gcr.io/pixie-prod/demos/finagle/hello:1.0
+      - image: gcr.io/pixie-prod/demos/finagle/hello:1.0@sha256:85006a2eae6e86019d85e1e12915d9d21e4af85b80a24674dc2b7a2ef4e7dbff
         name: finagle-server
         ports:
         - containerPort: 9992

--- a/demos/kafka/kafka.yaml
+++ b/demos/kafka/kafka.yaml
@@ -165,7 +165,7 @@ spec:
         io.kompose.service: apache
     spec:
       containers:
-      - image: gcr.io/pixie-prod/demos/kafka/apache:1.0
+      - image: gcr.io/pixie-prod/demos/kafka/apache:1.0@sha256:d5d1602d4666f5422db47b4ea743e7a2be1b43392b2943fb763ef95757d986dc
         name: apache
         ports:
         - containerPort: 80
@@ -203,7 +203,7 @@ spec:
       - env:
         - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
           value: kafka-service:9092
-        image: gcr.io/pixie-prod/demos/kafka/invoicing:2.0
+        image: gcr.io/pixie-prod/demos/kafka/invoicing:2.0@sha256:bc49808a900b2b4fede7198a59eba64da204e75edee5909d7a735efb34debdab
         imagePullPolicy: Always
         name: invoicing
         resources: {}
@@ -212,7 +212,7 @@ spec:
         - sh
         - -c
         - sleep 10
-        image: alpine:3.6
+        image: alpine:3.6@sha256:66790a2b79e1ea3e1dabac43990c54aca5d1ddf268d9a5a0285e4167c8b24475
         name: wait-invoicing
       restartPolicy: Always
 status: {}
@@ -257,7 +257,7 @@ spec:
           value: "False"
         - name: JAVA_TOOL_OPTIONS
           value: "-XX:+PreserveFramePointer"
-        image: wurstmeister/kafka:2.12-2.5.0
+        image: wurstmeister/kafka:2.12-2.5.0@sha256:ed8058aa4ac11f2b08dd1e30bd5683f34d70ed773a0c77e51aa1de2bbcd9c2a8
         name: kafka
         ports:
         - containerPort: 9092
@@ -296,7 +296,7 @@ spec:
         - http://apache:8080
         command:
         - locust
-        image: gcr.io/pixie-prod/demos/kafka/load-test:1.0
+        image: gcr.io/pixie-prod/demos/kafka/load-test:1.0@sha256:43cb16a5493f84a6786900f011f49bd7d5b5fe55e85c92cee41b8f435da61416
         imagePullPolicy: Always
         name: load-test
 ---
@@ -330,7 +330,7 @@ spec:
       - env:
         - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
           value: kafka-service:9092
-        image: gcr.io/pixie-prod/demos/kafka/order:2.0
+        image: gcr.io/pixie-prod/demos/kafka/order:2.0@sha256:7338f1e5521bc02e3f59fc321c8412c24ed48b2944c126ec8e05b922df8aab20
         name: order
         resources: {}
       initContainers:
@@ -338,7 +338,7 @@ spec:
         - sh
         - -c
         - sleep 10
-        image: alpine:3.6
+        image: alpine:3.6@sha256:66790a2b79e1ea3e1dabac43990c54aca5d1ddf268d9a5a0285e4167c8b24475
         name: wait-order
       restartPolicy: Always
 status: {}
@@ -375,7 +375,7 @@ spec:
           value: dbpass
         - name: POSTGRES_USER
           value: dbuser
-        image: gcr.io/pixie-prod/demos/kafka/postgres:1.0
+        image: gcr.io/pixie-prod/demos/kafka/postgres:1.0@sha256:32ea3742beb88f7a893a89f86d15979baffc96d8fb1d9e93fada6fb474d3728f
         name: postgres
         resources: {}
       restartPolicy: Always
@@ -411,7 +411,7 @@ spec:
       - env:
         - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
           value: kafka-service:9092
-        image: gcr.io/pixie-prod/demos/kafka/shipping:2.0
+        image: gcr.io/pixie-prod/demos/kafka/shipping:2.0@sha256:d5b7a2dc93ed23a3e0e018002a5c184362f226559a92e1d6b0ee7e6a3c5d175a
         name: shipping
         resources: {}
       initContainers:
@@ -419,7 +419,7 @@ spec:
         - sh
         - -c
         - sleep 10
-        image: alpine:3.6
+        image: alpine:3.6@sha256:66790a2b79e1ea3e1dabac43990c54aca5d1ddf268d9a5a0285e4167c8b24475
         name: wait-shipping
       restartPolicy: Always
 status: {}
@@ -454,7 +454,7 @@ spec:
       - env:
         - name: ZOOKEEPER_CLIENT_PORT
           value: "2181"
-        image: gcr.io/pixie-prod/demos/kafka/zookeeper:2.0
+        image: gcr.io/pixie-prod/demos/kafka/zookeeper:2.0@sha256:7a7fd44a72104bfbd24a77844bad5fabc86485b036f988ea927d1780782a6680
         name: zookeeper
         ports:
         - containerPort: 2181

--- a/demos/online-boutique/online-boutique.yaml
+++ b/demos/online-boutique/online-boutique.yaml
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.6@sha256:700fc07f140b8be73212fff2b04938c49c4451dcd1044488438b9865aed7eece
         ports:
         - containerPort: 8080
         env:
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.6
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.6@sha256:cd6cb39b8397e193bddbb36be3599be949fa2ea617838910d2eacdddd4ef5437
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -141,7 +141,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.6@sha256:305488566cd703aa2d158b3097ca399f2340446ec0a0ec398d76bf4a4d7df22e
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -202,7 +202,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.6
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.6@sha256:54bc781a1791327799d793792c6f454342c8731d7f9737df336a8c97055883de
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -301,7 +301,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.6@sha256:476fcb22bf9aa231d771ea6b178014f070d97d233a5204aff29f8b45a01fc442
         ports:
         - containerPort: 50051
         env:
@@ -357,7 +357,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.6@sha256:a4b68f0a8d85c5a1e2476ac6804f9fdeb9610649aed2d0351416f711a82f3017
         ports:
         - containerPort: 3550
         env:
@@ -415,7 +415,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.6@sha256:eb0ac54c81a8f60ddba39921a4052dd6dfe88273805983c43d5283b446a584ee
         ports:
         - containerPort: 7070
         env:
@@ -488,7 +488,7 @@ spec:
           value: "frontend:80"
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.6@sha256:25548c590b038917536e381dd43d75af168e57b5ff4f5cf3374bb58b3ad4967e
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"
@@ -519,7 +519,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.6@sha256:1f6640ba9495a5097c3405cb9037bf0cb799c3cb3e301d9bf17b776bbf9e5cad
         ports:
         - name: grpc
           containerPort: 7000
@@ -575,7 +575,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.6@sha256:7e0b09aad2d8eb95979d1467311e74938768d55b875b0c5405317c3ee54e4d6c
         ports:
         - containerPort: 50051
         env:
@@ -632,7 +632,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:alpine
+        image: redis:alpine@sha256:da0cc759968a286f9fa8e3a0d8faca70e4dcf8ffc25fd290a041c59a9eb725c7
         ports:
         - containerPort: 6379
         readinessProbe:
@@ -687,7 +687,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/pixie-prod/demos/microservices-demo-app/adservice:1.0
+        image: gcr.io/pixie-prod/demos/microservices-demo-app/adservice:1.0@sha256:1f9fcf114f33c35cba4fd49c9bfc4c3b6dc17fd316b4f03aa0f9b3e1cbb4104d
         ports:
         - containerPort: 9555
         env:

--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: load-test
-        image: weaveworksdemos/load-test:0.1.1
+        image: weaveworksdemos/load-test:0.1.1@sha256:536d46f8c867e4ff4c3ed69848955b487f9bec060539c169f190fe522650e5cd
         command: ["locust"]
         # This runs locust in batch mode.
         # The following form runs locust in web mode.
@@ -28,7 +28,7 @@ spec:
 
       initContainers:
       - name: wait-sock-shop
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do

--- a/demos/sock-shop/sock-shop.yaml
+++ b/demos/sock-shop/sock-shop.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: carts-db
-        image: mongo:4
+        image: mongo:4@sha256:8665d6b3b8e022cceae38fda41f6f4b50eaf84380c930bcf9b3a78f220b9f75c
         ports:
         - name: mongo
           containerPort: 27017
@@ -160,7 +160,7 @@ spec:
     spec:
       containers:
       - name: catalogue-db
-        image: weaveworksdemos/catalogue-db:0.3.0
+        image: weaveworksdemos/catalogue-db:0.3.0@sha256:7ba74ec9adf88f6625b8d85d3323d1ee5232b39877e1590021ea485cf9457251
         env:
           - name: MYSQL_ROOT_PASSWORD
             value: fake_password
@@ -206,7 +206,7 @@ spec:
     spec:
       containers:
       - name: catalogue
-        image: weaveworksdemos/catalogue:0.3.5
+        image: weaveworksdemos/catalogue:0.3.5@sha256:0147a65b7116569439eefb1a6dbed455fe022464ef70e0c3cab75bc4a226b39b
         command: ["/app"]
         args:
         - -port=80
@@ -349,7 +349,7 @@ spec:
     spec:
       containers:
       - name: orders-db
-        image: mongo:4
+        image: mongo:4@sha256:8665d6b3b8e022cceae38fda41f6f4b50eaf84380c930bcf9b3a78f220b9f75c
         ports:
         - name: mongo
           containerPort: 27017
@@ -491,7 +491,7 @@ spec:
     spec:
       containers:
       - name: payment
-        image: weaveworksdemos/payment:0.4.3
+        image: weaveworksdemos/payment:0.4.3@sha256:5ab1c9877480a018d4dda10d6dfa382776e6bca9fc1c60bacbb80903fde8cfe0
         resources:
           limits:
             cpu: 100m
@@ -632,7 +632,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq
-        image: rabbitmq:3.6.8-management
+        image: rabbitmq:3.6.8-management@sha256:0297618bd60270f03665448b02b3b1110dfc51fae60a3c6804005169f0904dad
         ports:
         - containerPort: 15672
           name: management
@@ -697,7 +697,7 @@ spec:
     spec:
       containers:
       - name: session-db
-        image: redis:alpine
+        image: redis:alpine@sha256:da0cc759968a286f9fa8e3a0d8faca70e4dcf8ffc25fd290a041c59a9eb725c7
         ports:
         - name: redis
           containerPort: 6379
@@ -837,7 +837,7 @@ spec:
     spec:
       containers:
       - name: user-db
-        image: weaveworksdemos/user-db:0.3.0
+        image: weaveworksdemos/user-db:0.3.0@sha256:695bc22c11396c7ae747118c56e619f3b3295d9d4cbec999d30230b3f399a389
 
         ports:
         - name: mongo
@@ -895,7 +895,7 @@ spec:
     spec:
       containers:
       - name: user
-        image: weaveworksdemos/user:0.4.7
+        image: weaveworksdemos/user:0.4.7@sha256:2ffccc332963c89e035fea52201012208bf62df43a55fe461ad6598a5c757ab7
         resources:
           limits:
             cpu: 300m

--- a/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
@@ -61,7 +61,7 @@ spec:
           # yamllint disable-line rule:line-length
           value: postgres://$(PL_POSTGRES_USERNAME):$(PL_POSTGRES_PASSWORD)@$(PL_POSTGRES_HOSTNAME):$(PL_POSTGRES_PORT)/$(PL_POSTGRES_DB)?sslmode=disable&max_conns=20&max_idle_conns=4
         imagePullPolicy: IfNotPresent
-        image: oryd/hydra:v1.9.2-sqlite
+        image: oryd/hydra:v1.9.2-sqlite@sha256:61771c706934e1ffd66f86700a28a294ce4ed150fbf30cc131710924271a5871
         volumeMounts:
         - mountPath: /etc/config/hydra
           name: config
@@ -77,7 +77,7 @@ spec:
       containers:
       - name: server
         imagePullPolicy: IfNotPresent
-        image: oryd/hydra:v1.9.2-sqlite
+        image: oryd/hydra:v1.9.2-sqlite@sha256:61771c706934e1ffd66f86700a28a294ce4ed150fbf30cc131710924271a5871
         args:
         - serve
         - -c
@@ -153,7 +153,7 @@ spec:
             type: RuntimeDefault
       - name: client-create-or-update
         imagePullPolicy: IfNotPresent
-        image: oryd/hydra:v1.9.2-alpine
+        image: oryd/hydra:v1.9.2-alpine@sha256:faa6ca02e77e0a08f66bfa7470a5e06d80e6e68c9c35410c65a4ea7b501aea61
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://localhost:4445/health/ready";

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -49,7 +49,7 @@ spec:
           # yamllint disable-line rule:line-length
           value: postgres://$(PL_POSTGRES_USERNAME):$(PL_POSTGRES_PASSWORD)@$(PL_POSTGRES_HOSTNAME):$(PL_POSTGRES_PORT)/$(PL_POSTGRES_DB)?sslmode=disable&max_conns=20&max_idle_conns=4
         imagePullPolicy: IfNotPresent
-        image: oryd/kratos:v0.10.1
+        image: oryd/kratos:v0.10.1@sha256:fdcfac3da3b64e619af553451607e1ab00160e59860bb19ec145cdc6f6f9c41d
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
@@ -135,7 +135,7 @@ spec:
         - name: SELFSERVICE_FLOWS_ERROR_UI_URL
           value: https://$(PL_WORK_DOMAIN)/auth/password/error
         imagePullPolicy: IfNotPresent
-        image: oryd/kratos:v0.10.1
+        image: oryd/kratos:v0.10.1@sha256:fdcfac3da3b64e619af553451607e1ab00160e59860bb19ec145cdc6f6f9c41d
         ports:
         - containerPort: 4433
         - containerPort: 4434
@@ -156,7 +156,8 @@ spec:
             type: RuntimeDefault
       - name: admin-create-if-not-exists
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="${ADMIN_URL}/admin/health/ready";

--- a/k8s/cloud/base/proxy_deployment.yaml
+++ b/k8s/cloud/base/proxy_deployment.yaml
@@ -96,7 +96,7 @@ spec:
             type: RuntimeDefault
       - name: envoy
         imagePullPolicy: IfNotPresent
-        image: envoyproxy/envoy:v1.12.2
+        image: envoyproxy/envoy:v1.12.2@sha256:b36ee021fc4d285de7861dbaee01e7437ce1d63814ead6ae3e4dfcad4a951b2e
         command: ["envoy"]
         args: ["-c", "/etc/envoy.yaml", "--service-cluster", "$(POD_NAME)"]
         env:

--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: postgres-wait
-        image: postgres:14-alpine
+        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         # yamllint disable rule:indentation
         command: ['sh', '-c',
           'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do

--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -56,7 +56,8 @@ spec:
               key: PL_PLUGIN_SERVICE
         - name: PL_PLUGIN_REPO
           value: "pixie-io/pixie-plugin"
-      - image: b.gcr.io/cloudsql-docker/gce-proxy:1.14
+      # yamllint disable-line rule:line-length
+      - image: b.gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         name: cloudsql-proxy
         command: ["/bin/sh", "-c"]
         envFrom:

--- a/k8s/cloud/prod/db_sidecar.yaml
+++ b/k8s/cloud/prod/db_sidecar.yaml
@@ -8,7 +8,8 @@ spec:
     spec:
       containers:
       - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        # yamllint disable-line rule:line-length
+        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         command: ["/cloud_sql_proxy",
                   "-instances=pixie-prod:us-west1:pixie-cloud-prod-db-pg13=tcp:5432",
                   "-ip_address_types=PRIVATE",

--- a/k8s/cloud/public/base/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/base/plugin_db_updater_job.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: postgres-wait
-        image: postgres:14-alpine
+        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         # yamllint disable rule:indentation
         command: ['sh', '-c',
           'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do

--- a/k8s/cloud/staging/db_sidecar.yaml
+++ b/k8s/cloud/staging/db_sidecar.yaml
@@ -8,7 +8,8 @@ spec:
     spec:
       containers:
       - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        # yamllint disable-line rule:line-length
+        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         command: ["/cloud_sql_proxy",
                   "-instances=pixie-prod:us-west1:pixie-cloud-staging-db-pg13=tcp:5432",
                   "-ip_address_types=PRIVATE",

--- a/k8s/cloud/testing/db_sidecar.yaml
+++ b/k8s/cloud/testing/db_sidecar.yaml
@@ -8,7 +8,8 @@ spec:
     spec:
       containers:
       - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        # yamllint disable-line rule:line-length
+        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         command: ["/cloud_sql_proxy",
                   "-instances=pl-pixies:us-west1:pixie-cloud-testing-db-pg13=tcp:5432",
                   "-ip_address_types=PRIVATE",

--- a/k8s/cloud_deps/base/elastic/cluster/elastic_cluster.yaml
+++ b/k8s/cloud_deps/base/elastic/cluster/elastic_cluster.yaml
@@ -4,7 +4,8 @@ kind: Elasticsearch
 metadata:
   name: pl-elastic
 spec:
-  image: gcr.io/pixie-oss/pixie-dev-public/elasticsearch:7.6.0-patched1
+  # yamllint disable-line rule:line-length
+  image: gcr.io/pixie-oss/pixie-dev-public/elasticsearch:7.6.0-patched1@sha256:f734909115be9dba66736c4b7356fd52da58b1ffdb895ba74cb5c2fca2b133dd
   version: 7.6.0
   nodeSets:
   - name: master

--- a/k8s/cloud_deps/base/elastic/operator/elastic_operator.yaml
+++ b/k8s/cloud_deps/base/elastic/operator/elastic_operator.yaml
@@ -4834,7 +4834,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-        - image: "docker.elastic.co/eck/eck-operator:1.8.0"
+        - image: "docker.elastic.co/eck/eck-operator:1.8.0@sha256:61d809705b3d65710d12e78a7e76cc2ff195fbd3bb3986d4df2fb80ebd29956a"
           imagePullPolicy: IfNotPresent
           name: manager
           args:

--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -157,7 +157,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: pl-nats
-        image: nats:2.9.0-alpine3.16
+        image: nats:2.9.0-alpine3.16@sha256:369d96bfb77439b67c975045e9d15ba37999e691094361ff6c447a9e78b7b67c
         ports:
         - containerPort: 4222
           name: client

--- a/k8s/cloud_deps/dev/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/dev/postgres/postgres_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres:14-alpine
+        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         ports:
         - containerPort: 5432
         env:

--- a/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres:14-alpine
+        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         ports:
         - containerPort: 5432
         env:

--- a/k8s/cloud_monitoring/base/gke_prometheus_operator.yaml
+++ b/k8s/cloud_monitoring/base/gke_prometheus_operator.yaml
@@ -165,7 +165,8 @@ spec:
       serviceAccountName: operator
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.3.1-gke.0
+        # yamllint disable-line rule:line-length
+        image: gke.gcr.io/prometheus-engine/operator:v0.3.1-gke.0@sha256:0985e01d7955b6ca3b0d1d6790187c66b146d53caa552a879f34e587d1bc01d4
         args:
         - "--public-namespace=gmp-public"
         - "--priority-class=gmp-critical"

--- a/k8s/cloud_monitoring/prod/new_relic.yaml
+++ b/k8s/cloud_monitoring/prod/new_relic.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: newrelic-logging
-          image: "newrelic/newrelic-fluentbit-output:1.10.0"
+          image: "newrelic/newrelic-fluentbit-output:1.10.0@sha256:e64b37e642f233f20abd1655ace5655d419d4ca34e14d6c84a59506c14d1bd74"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ENDPOINT
@@ -223,7 +223,7 @@ spec:
       serviceAccount: default
       containers:
       - name: nri-metadata-injection
-        image: "newrelic/k8s-metadata-injection:1.6.0"
+        image: "newrelic/k8s-metadata-injection:1.6.0@sha256:729d02c7720f96e5870cf026d616b6a82420d537b5a9f9aaccc8a5decc81a794"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: clusterName
@@ -283,7 +283,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infrastructure
-          image: "newrelic/infrastructure-k8s:2.8.1"
+          image: "newrelic/infrastructure-k8s:2.8.1@sha256:9fcbd9c856abfd9a16386889533e6f3a72d0145b2771ec397f6aa9fff42c6c81"
           imagePullPolicy: "IfNotPresent"
           securityContext:
             privileged: true
@@ -639,7 +639,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -850,7 +850,7 @@ spec:
         - --collectors=volumeattachments
         - --telemetry-port=8081
         imagePullPolicy: IfNotPresent
-        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8"
+        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8@sha256:47d3a12d9da6699a9d95df8aaff235305229ef08203fae3fc1f1d47b2a409f89"
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -894,7 +894,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
           imagePullPolicy: IfNotPresent
           args:
             - patch
@@ -1109,7 +1109,7 @@ spec:
       serviceAccountName: nri-prometheus
       containers:
       - name: nri-prometheus
-        image: newrelic/nri-prometheus:2.10.0
+        image: newrelic/nri-prometheus:2.10.0@sha256:80f7cae8804870b4f24aa2db178b1621cafc3b2531ae5a7bf7afe9c266a4610d
         args:
           - "--configfile=/etc/nri-prometheus/config.yaml"
         ports:
@@ -1185,7 +1185,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kube-events
-          image: newrelic/nri-kube-events:1.6.0
+          image: newrelic/nri-kube-events:1.6.0@sha256:9c3f26f763190c3cff90b7e73d864b4aa9ddad6b17c1855969b0abfd4c34b436
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -1196,7 +1196,7 @@ spec:
             - name: config-volume
               mountPath: /app/config
         - name: infra-agent
-          image: newrelic/k8s-events-forwarder:1.20.5
+          image: newrelic/k8s-events-forwarder:1.20.5@sha256:f62fcf22ffc9fd5f25034346137b836af5085fa790c3f69177a13280c68d9e97
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/k8s/cloud_monitoring/staging/new_relic.yaml
+++ b/k8s/cloud_monitoring/staging/new_relic.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: newrelic-logging
-          image: "newrelic/newrelic-fluentbit-output:1.10.0"
+          image: "newrelic/newrelic-fluentbit-output:1.10.0@sha256:e64b37e642f233f20abd1655ace5655d419d4ca34e14d6c84a59506c14d1bd74"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ENDPOINT
@@ -223,7 +223,7 @@ spec:
       serviceAccount: default
       containers:
       - name: nri-metadata-injection
-        image: "newrelic/k8s-metadata-injection:1.6.0"
+        image: "newrelic/k8s-metadata-injection:1.6.0@sha256:729d02c7720f96e5870cf026d616b6a82420d537b5a9f9aaccc8a5decc81a794"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: clusterName
@@ -283,7 +283,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infrastructure
-          image: "newrelic/infrastructure-k8s:2.8.1"
+          image: "newrelic/infrastructure-k8s:2.8.1@sha256:9fcbd9c856abfd9a16386889533e6f3a72d0145b2771ec397f6aa9fff42c6c81"
           imagePullPolicy: "IfNotPresent"
           securityContext:
             privileged: true
@@ -639,7 +639,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -850,7 +850,7 @@ spec:
         - --collectors=volumeattachments
         - --telemetry-port=8081
         imagePullPolicy: IfNotPresent
-        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8"
+        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8@sha256:47d3a12d9da6699a9d95df8aaff235305229ef08203fae3fc1f1d47b2a409f89"
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -894,7 +894,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
           imagePullPolicy: IfNotPresent
           args:
             - patch
@@ -1109,7 +1109,7 @@ spec:
       serviceAccountName: nri-prometheus
       containers:
       - name: nri-prometheus
-        image: newrelic/nri-prometheus:2.10.0
+        image: newrelic/nri-prometheus:2.10.0@sha256:80f7cae8804870b4f24aa2db178b1621cafc3b2531ae5a7bf7afe9c266a4610d
         args:
           - "--configfile=/etc/nri-prometheus/config.yaml"
         ports:
@@ -1185,7 +1185,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kube-events
-          image: newrelic/nri-kube-events:1.6.0
+          image: newrelic/nri-kube-events:1.6.0@sha256:9c3f26f763190c3cff90b7e73d864b4aa9ddad6b17c1855969b0abfd4c34b436
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -1196,7 +1196,7 @@ spec:
             - name: config-volume
               mountPath: /app/config
         - name: infra-agent
-          image: newrelic/k8s-events-forwarder:1.20.5
+          image: newrelic/k8s-events-forwarder:1.20.5@sha256:f62fcf22ffc9fd5f25034346137b836af5085fa790c3f69177a13280c68d9e97
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/k8s/cloud_monitoring/testing/new_relic.yaml
+++ b/k8s/cloud_monitoring/testing/new_relic.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: newrelic-logging
-          image: "newrelic/newrelic-fluentbit-output:1.10.0"
+          image: "newrelic/newrelic-fluentbit-output:1.10.0@sha256:e64b37e642f233f20abd1655ace5655d419d4ca34e14d6c84a59506c14d1bd74"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ENDPOINT
@@ -223,7 +223,7 @@ spec:
       serviceAccount: default
       containers:
       - name: nri-metadata-injection
-        image: "newrelic/k8s-metadata-injection:1.6.0"
+        image: "newrelic/k8s-metadata-injection:1.6.0@sha256:729d02c7720f96e5870cf026d616b6a82420d537b5a9f9aaccc8a5decc81a794"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: clusterName
@@ -283,7 +283,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infrastructure
-          image: "newrelic/infrastructure-k8s:2.8.1"
+          image: "newrelic/infrastructure-k8s:2.8.1@sha256:9fcbd9c856abfd9a16386889533e6f3a72d0145b2771ec397f6aa9fff42c6c81"
           imagePullPolicy: "IfNotPresent"
           securityContext:
             privileged: true
@@ -639,7 +639,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -850,7 +850,7 @@ spec:
         - --collectors=volumeattachments
         - --telemetry-port=8081
         imagePullPolicy: IfNotPresent
-        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8"
+        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8@sha256:47d3a12d9da6699a9d95df8aaff235305229ef08203fae3fc1f1d47b2a409f89"
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -894,7 +894,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
           imagePullPolicy: IfNotPresent
           args:
             - patch
@@ -1109,7 +1109,7 @@ spec:
       serviceAccountName: nri-prometheus
       containers:
       - name: nri-prometheus
-        image: newrelic/nri-prometheus:2.10.0
+        image: newrelic/nri-prometheus:2.10.0@sha256:80f7cae8804870b4f24aa2db178b1621cafc3b2531ae5a7bf7afe9c266a4610d
         args:
           - "--configfile=/etc/nri-prometheus/config.yaml"
         ports:
@@ -1185,7 +1185,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kube-events
-          image: newrelic/nri-kube-events:1.6.0
+          image: newrelic/nri-kube-events:1.6.0@sha256:9c3f26f763190c3cff90b7e73d864b4aa9ddad6b17c1855969b0abfd4c34b436
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
@@ -1196,7 +1196,7 @@ spec:
             - name: config-volume
               mountPath: /app/config
         - name: infra-agent
-          image: newrelic/k8s-events-forwarder:1.20.5
+          image: newrelic/k8s-events-forwarder:1.20.5@sha256:f62fcf22ffc9fd5f25034346137b836af5085fa790c3f69177a13280c68d9e97
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/k8s/clusters/prod/db_reader.yaml
+++ b/k8s/clusters/prod/db_reader.yaml
@@ -14,7 +14,7 @@ spec:
         name: db-reader
     spec:
       containers:
-      - image: postgres:14-alpine
+      - image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         imagePullPolicy: IfNotPresent
         name: psql
         command: ["bash"]
@@ -28,7 +28,8 @@ spec:
         - -instances=pixie-prod:us-west1:pixie-cloud-prod-db-pg13=tcp:5432
         - -ip_address_types=PRIVATE
         - -credential_file=/secrets/cloudsql/db_service_account.json
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        # yamllint disable-line rule:line-length
+        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         imagePullPolicy: IfNotPresent
         name: cloudsql-proxy
         resources: {}

--- a/k8s/clusters/staging/db_reader.yaml
+++ b/k8s/clusters/staging/db_reader.yaml
@@ -14,7 +14,7 @@ spec:
         name: db-reader
     spec:
       containers:
-      - image: postgres:14-alpine
+      - image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         imagePullPolicy: IfNotPresent
         name: psql
         command: ["bash"]
@@ -28,7 +28,8 @@ spec:
         - -instances=pixie-prod:us-west1:pixie-cloud-staging-db-pg13=tcp:5432
         - -ip_address_types=PRIVATE
         - -credential_file=/secrets/cloudsql/db_service_account.json
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        # yamllint disable-line rule:line-length
+        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         imagePullPolicy: IfNotPresent
         name: cloudsql-proxy
         resources: {}

--- a/k8s/clusters/testing/db_reader.yaml
+++ b/k8s/clusters/testing/db_reader.yaml
@@ -14,7 +14,7 @@ spec:
         name: db-reader
     spec:
       containers:
-      - image: postgres:14-alpine
+      - image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
         imagePullPolicy: IfNotPresent
         name: psql
         command: ["bash"]
@@ -28,7 +28,8 @@ spec:
         - -instances=pl-pixies:us-west1:pixie-cloud-testing-db-pg13=tcp:5432
         - -ip_address_types=PRIVATE
         - -credential_file=/secrets/cloudsql/db_service_account.json
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14
+        # yamllint disable-line rule:line-length
+        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
         imagePullPolicy: IfNotPresent
         name: cloudsql-proxy
         resources: {}

--- a/k8s/devinfra/jenkins-oss/values.yaml
+++ b/k8s/devinfra/jenkins-oss/values.yaml
@@ -577,7 +577,7 @@ controller:
   # Optionally specify additional init-containers
   customInitContainers: []
   # - name: custom-init
-  #   image: "alpine:3.7"
+  #   image: "alpine:3.7@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10"
   #   imagePullPolicy: IfNotPresent
   #   command: ["/bin/sh", "-c", "ls"]
   #   volumeMounts:
@@ -592,7 +592,7 @@ controller:
       # http://<jenkins_url>/reload-configuration-as-code endpoint to reapply config when changes to the
       # configScripts are detected.
       enabled: true
-      image: kiwigrid/k8s-sidecar:1.15.0
+      image: kiwigrid/k8s-sidecar:1.15.0@sha256:abc3060bfe232788886f279530f8afe02614ef590ae59d9d58f637df770bcffc
       imagePullPolicy: IfNotPresent
       resources:
         {}
@@ -632,7 +632,8 @@ controller:
     ##
     ## Note: To use it you should go to https://smee.io/new and update the url to the generete one.
     # - name: smee
-    #   image: docker.io/twalter/smee-client:1.0.2
+    # yamllint disable-line rule:line-length
+    #   image: docker.io/twalter/smee-client:1.0.2@sha256:cd7abc0156a96a92c75edb6b7f06eb2f8abaaeb8d160040d5636492328e2fc66
     #   args: ["--port", "{{ .Values.controller.servicePort }}", \
     #          "--path", "/github-webhook/", "--url", "https://smee.io/new"]
     #   resources:
@@ -973,7 +974,7 @@ agent:
   #      serviceAccount: jenkins
   #      containers:
   #        - name: python
-  #          image: python:3
+  #          image: python:3@sha256:f7382f4f9dbc51183c72d621b9c196c1565f713a1fe40c119d215c961fa22815
   #          command: "/bin/sh -c"
   #          args: "cat"
   #          ttyEnabled: true

--- a/k8s/devinfra/prow/prow_setup_starter.yaml
+++ b/k8s/devinfra/prow/prow_setup_starter.yaml
@@ -136,7 +136,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/hook:v20221011-5d4db25b24@sha256:f021c155e77664d0a09a5650df3b18d4d3f8f5e79c2b4b1485cabe3727cbb7e7
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -226,7 +226,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/sinker:v20221011-5d4db25b24@sha256:6e52e2a43c0fb1babe08cdee42f23a3ec6115cc8ad8ab86bf96568be1b45fa2f
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -265,7 +265,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/deck:v20221011-5d4db25b24@sha256:5abf75ef4705617d556f989e2e3593f42cb1e71d790e4bef0e676a234d88a936
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -362,7 +362,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/horologium:v20221011-5d4db25b24@sha256:9cff5fa5754ab0d8adfe07368816eb97861aa33a6dee83141e987c12a26803c3
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -397,7 +397,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/tide:v20221011-5d4db25b24@sha256:5b6499763fca06f5a026f8437178db949ce954445887c5e663d7ebcd17b6f7b7
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -528,7 +528,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/status-reconciler:v20221011-5d4db25b24@sha256:ae1061a7fcd2c9892312baef45847f72bba693fece043c2fef95dc692a96380d
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -920,7 +920,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/ghproxy:v20221011-5d4db25b24@sha256:5bb79645bda90ef094e65ce11747beec2dfadbe57d48acb9cc38309353036f8d
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -989,7 +989,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/prow-controller-manager:v20221011-5d4db25b24@sha256:1c527b5ee1000024dbe8cfb55cea80334e02fcbeb30eb36e634a31fd1ad250b6
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1124,7 +1124,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20221011-5d4db25b24
+        image: gcr.io/k8s-prow/crier:v20221011-5d4db25b24@sha256:91d8ea8210a1d836b4872002d7eba19c17d2b40bffabecdd52e722f1611ea37c
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/k8s/grafana_demo/grafana-deployment.yaml
+++ b/k8s/grafana_demo/grafana-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       initContainers:
       # downloads plugin from pixie Github.
       - name: init-grafana
-        image: busybox:1.28
+        image: busybox:1.28@sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47
         volumeMounts:
         - mountPath: /var/lib/grafana
           name: grafana-storage
@@ -85,7 +85,7 @@ spec:
         # yamllint enable rule:indentation
       containers:
       - name: grafana
-        image: grafana/grafana:7.5.16
+        image: grafana/grafana:7.5.16@sha256:9b7b1d9a1deadbe6fed74416d58db47f8af31b5cee214cfb659f89e6dda3f716
         imagePullPolicy: IfNotPresent
         env:
         # uncomment when plugin is posted on grafana plugins page

--- a/k8s/slackin/deployment.yaml
+++ b/k8s/slackin/deployment.yaml
@@ -14,7 +14,8 @@ spec:
     spec:
       containers:
       - name: slackin-server
-        image: gcr.io/pixie-oss/pixie-prod/slackin/slackin-server:20201222_1
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-prod/slackin/slackin-server:20201222_1@sha256:cd7b02475021e13f44595e3a9ad136a9727eb10e277c9f6b99bf7efdc6debefa
         ports:
         - containerPort: 58000
         readinessProbe:

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -33,7 +33,8 @@ spec:
                 - linux
       initContainers:
       - name: qb-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";

--- a/k8s/vizier/base/patch_sentry.yaml
+++ b/k8s/vizier/base/patch_sentry.yaml
@@ -8,7 +8,8 @@ spec:
     spec:
       initContainers:
       - name: cc-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/readyz";

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -37,7 +37,8 @@ spec:
                 - linux
       initContainers:
       - name: mds-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -35,7 +35,8 @@ spec:
       serviceAccountName: cloud-conn-service-account
       initContainers:
       - name: nats-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -38,7 +38,8 @@ spec:
                 - linux
       initContainers:
       - name: nats-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
@@ -57,7 +58,8 @@ spec:
         - name: PROTOCOL
           value: "http"
       - name: etcd-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           ETCD_PATH="${PL_MD_ETCD_SERVER}";

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -44,7 +44,8 @@ spec:
         effect: NoSchedule
       initContainers:
       - name: qb-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c',
           '

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -41,7 +41,8 @@ spec:
       serviceAccountName: metadata-service-account
       initContainers:
       - name: nats-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -14,7 +14,8 @@ spec:
     spec:
       initContainers:
       - name: qb-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";

--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -111,7 +111,8 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: pl-nats
-        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:multiarch-2.8.4-alpine3.15
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:multiarch-2.8.4-alpine3.15@sha256:988010f74b61749cfb82c28b50b47d26d0b972860ce6e9325a5afcde97713da2
         ports:
         - containerPort: 4222
           name: client

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -19,7 +19,8 @@ spec:
     spec:
       initContainers:
       - name: wait-for-publisher
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://jetstream-publisher.${NS}.svc.cluster.local:8080/metrics";

--- a/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
@@ -28,7 +28,8 @@ spec:
     spec:
       initContainers:
       - name: server-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       initContainers:
       - name: server-wait
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0
+        # yamllint disable-line rule:line-length
+        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:indentation rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://${SERVICE_NAME}:${SERVICE_PORT}/";


### PR DESCRIPTION
Summary: Pins all of the non-latest images in kubernetes manifests to their digests.
<details>
<summary>Script</summary>

```
#!/bin/bash -e

while IFS="~" read -r file line image;
do
  image="$(echo "${image}" | grep -Po '(?<=image: ).*')"
  if unquoted_image="$(echo "${image}" | grep -Po '(?<=").*(?=")')"; then
    image="${unquoted_image}"
  fi
  if echo "${image}" | grep "[{}]" &> /dev/null; then
    # Ignore templated images
    continue;
  fi
  if echo "${image}" | grep ":latest$" &> /dev/null; then
    # Ignore images with latest tag
    continue;
  fi
  if echo "${image}" | grep "gcr.io/pixie-prod/cloud/plugin/load_db" &> /dev/null; then
    # Ignore load_db
    continue;
  fi
  digest="$(crane digest "${image}")"
  image_with_digest="${image}@${digest}" 
  sed -i "${line}s|${image}|${image_with_digest}|" ${file} 
done < <(rg 'image:[^:]*:[^@]*$' -t yaml --line-number --field-match-separator="~")
```

</details>

Type of change: /kind cleanup

Test Plan: Tested a couple of the manifests to make sure they still work with pinned digests. Also tested that `crane` returns the correct digest for multiarch images.
