### PR TITLE
Upgrade pyshark to fix security vulnerability and fix `amqp_code_gen` missing pip dep

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/BUILD.bazel
@@ -59,5 +59,6 @@ py_binary(
         ":amqp_code_gen",
         requirement("fire"),
         requirement("pyshark"),
+        requirement("dill"),
     ],
 )

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/requirements.bazel.txt
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/requirements.bazel.txt
@@ -8,6 +8,10 @@ appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
     # via pyshark
+dill==0.3.6 \
+    --hash=sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0 \
+    --hash=sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373
+    # via -r requirements.txt
 fire==0.4.0 \
     --hash=sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62
     # via -r requirements.txt
@@ -133,17 +137,13 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via pyshark
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via pyshark
 pyparsing==3.0.9 \
     --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
     --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
     # via packaging
-pyshark==0.5.3 \
-    --hash=sha256:41bc2781066715a00198a00074bf659222822cbe74f36ea88663386aa7d9aa2b \
-    --hash=sha256:41f015d803d648a1e655d7dba8a7635129dc0403bb887b3c9bdef1d6b09d9882
+pyshark==0.6 \
+    --hash=sha256:98e8a1ebdcbfbb6e8defd0c96736ea51bf8234339f980b15dd3545f87f5146d4 \
+    --hash=sha256:a424d83e0ca6224a96bbe30cd3f89d5491654d783faaaf90adaf45867a0bcb17
     # via -r requirements.txt
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -151,4 +151,6 @@ six==1.16.0 \
     # via fire
 termcolor==1.1.0 \
     --hash=sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b
-    # via fire
+    # via
+    #   fire
+    #   pyshark

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/requirements.txt
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/requirements.txt
@@ -1,3 +1,4 @@
 fire==0.4.0
 Jinja2==3.1.2
-pyshark==0.5.3
+pyshark==0.6
+dill==0.3.6


### PR DESCRIPTION
Summary: Upgrade pyshark to fix security vulnerability and fix amqp_code_gen missing pip dep

This upgrades the pyshark package to address [this dependabot](https://github.com/ddelnano/pixie/security/dependabot/4) vulnerability. When trying to test that the amqp code generation still works, I noticed that the `dill` dependency is not specified and so our scripts have been broken on main for some time.

```
$ bazel run //src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator:amqp_test_code_gen -- parse_packet

Traceback (most recent call last):
  File "/home/ddelnano/.cache/bazel/_bazel_ddelnano/fa8604ca46879b9b1ffd44d337c531f3/execroot/px/bazel-out/k8-fastbuild/bin/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/amqp_test_code_gen.runfiles/px/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/amqp_test_code_gen.py", line 26, in <module>
    import dill
ModuleNotFoundError: No module named 'dill'
```

I was unable to verify that the amqp code generation works fully end to end because it relies on a amqp pcap file that I can't seem to find. The amqp pcap files used in stirling's protocol inference code doesn't include all of the amqp frame types necessary to run the script. I've created #1238 to follow up with fixing that.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Verified that the `dill` dependency fix no longer results in a missing module error