### PR TITLE
[gitattributes] Fix github syntax highlighting for PxL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,4 @@
 go_deps.bzl -diff linguist-generated=true
 src/ui/.yarn/releases/** -diff linguist-generated=true
 src/ui/.yarn/plugins/** -diff linguist-generated=true
-*.pxl linguist-language=python
+*.pxl linguist-language=Python


### PR DESCRIPTION
Summary: TSIA

Type of change: /kind cleanup.

Test Plan: Tested on my fork that syntax highlighting works with this change.
