### PR TITLE
Upgrade nats for cloud and adjust lively/ready/startup probes

### DIFF
--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -107,6 +107,7 @@ spec:
     matchLabels:
       name: pl-nats
   replicas: 5
+  podManagementPolicy: Parallel
   serviceName: pl-nats
   volumeClaimTemplates:
   - metadata:
@@ -157,7 +158,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: pl-nats
-        image: nats:2.9.0-alpine3.16@sha256:369d96bfb77439b67c975045e9d15ba37999e691094361ff6c447a9e78b7b67c
+        image: nats:2.9.16-alpine3.17@sha256:887f0193c5b72b66ff4795b807f3e9e324c34ffafbce612e54b2be8140a06de1
         ports:
         - containerPort: 4222
           name: client
@@ -203,17 +204,29 @@ spec:
         #
         livenessProbe:
           httpGet:
-            path: /
+            path: /healthz?js-enabled-only=true
             port: 8222
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /
+            path: /healthz?js-server-only=true
             port: 8222
           initialDelaySeconds: 10
           timeoutSeconds: 5
-          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8222
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 90
 
         # Gracefully stop NATS Server on pod deletion or image upgrade.
         #


### PR DESCRIPTION
Summary: Upgrade nats to the latest patch version. This version includes many performance improvements for JetStream.
Also update startup, readiness and liveliness probes. These probes follow the same pattern that the [upstream](https://github.com/nats-io/k8s/blob/e0eda12d6062b9f049a7c34b4c9da9f50cb24f64/helm/charts/nats/values.yaml#L48-L106) default helm configs for NATS use.
Note that to use the readiness probes, we also need `podManagementPolicy: Parallel` since the pods won't mark themselves as ready until RAFT is established but we need quorum and all pods to be up to do so.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Deployed dev cloud with these changes.