### PR TITLE
In `SocketTraceConnector`, ensure that uprobe deployment thread is joined before dtor.

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -175,7 +175,7 @@ SocketTraceConnector::SocketTraceConnector(std::string_view source_name)
   InitProtocolTransferSpecs();
 }
 
-SocketTraceConnector()::~SocketTraceConnector() {
+SocketTraceConnector::~SocketTraceConnector() {
   if (uprobe_deployment_thread_.joinable()) {
     uprobe_deployment_thread_.join();
   }

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -114,6 +114,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
     return std::unique_ptr<SourceConnector>(new SocketTraceConnector(name));
   }
 
+  ~SocketTraceConnector();
+
   Status InitImpl() override;
   Status StopImpl() override;
   void InitContextImpl(ConnectorContext* ctx) override;
@@ -179,8 +181,6 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   static void HandleGrpcCCloseDataLoss(void* cb_cookie, uint64_t lost);
 
   explicit SocketTraceConnector(std::string_view source_name);
-
-  ~SocketTraceConnector();
 
   Status InitBPF();
   auto InitPerfBufferSpecs();

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -180,6 +180,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
 
   explicit SocketTraceConnector(std::string_view source_name);
 
+  ~SocketTraceConnector();
+
   Status InitBPF();
   auto InitPerfBufferSpecs();
   void InitProtocolTransferSpecs();
@@ -237,6 +239,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   absl::flat_hash_set<int> pids_to_trace_disable_;
 
   std::function<std::chrono::steady_clock::time_point()> now_fn_ = std::chrono::steady_clock::now;
+
+  std::thread uprobe_deployment_thread_;
 
   struct TransferSpec {
     // TODO(yzhao): Enabling protocol is essentially equivalent to subscribing to DataTable. They


### PR DESCRIPTION
Summary: In `SocketTraceConnector`, we ensure that if a uprobe deployment thread was created, it is joined before calling the destructor. This change is motivated by observing test flakiness for `socket_trace_bpf_test` which would sometimes segfault in test case `SocketTraceServerSideBPFTest.StatsDisabledTracker`. For some reason, that test was (with some probability) able to create the exact behavior that is being fixed here.

Type of change: /kind bug fix

Test Plan: Tested locally, ran `socket_trace_bpf_test` with `--runs_per_test 8` and did not observe this specific test flake any more.
