### PR TITLE
Fix a test flake in `socket_trace_bpf_test`.

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
@@ -50,8 +50,8 @@ using ::px::system::TCPSocket;
 using ::px::system::UDPSocket;
 using ::px::system::UnixSocket;
 using ::px::types::ColumnWrapperRecordBatch;
-using ::testing::HasSubstr;
 using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::StrEq;
 
 constexpr std::string_view kHTTPReqMsg1 =
@@ -589,10 +589,9 @@ TEST_F(SocketTraceBPFTest, SendFile) {
 
   ASSERT_THAT(records, RecordBatchSizeIs(2));
 
-  const absl::flat_hash_set<std::string> responses {
-    records[kHTTPRespBodyIdx]->Get<types::StringValue>(0),
-    records[kHTTPRespBodyIdx]->Get<types::StringValue>(1)
-  };
+  const absl::flat_hash_set<std::string> responses{
+      records[kHTTPRespBodyIdx]->Get<types::StringValue>(0),
+      records[kHTTPRespBodyIdx]->Get<types::StringValue>(1)};
 
   const std::string kHTTPRespMsgContentAsFiller(kHTTPRespMsgContent.size(), 0);
   EXPECT_THAT(responses, Contains(kHTTPRespMsgContentAsFiller));

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
@@ -51,6 +51,7 @@ using ::px::system::UDPSocket;
 using ::px::system::UnixSocket;
 using ::px::types::ColumnWrapperRecordBatch;
 using ::testing::HasSubstr;
+using ::testing::Contains;
 using ::testing::StrEq;
 
 constexpr std::string_view kHTTPReqMsg1 =
@@ -588,13 +589,14 @@ TEST_F(SocketTraceBPFTest, SendFile) {
 
   ASSERT_THAT(records, RecordBatchSizeIs(2));
 
-  // Time ordering by response means that we should get server entry first, then client entry.
-  std::string server_body = records[kHTTPRespBodyIdx]->Get<types::StringValue>(0);
-  std::string client_body = records[kHTTPRespBodyIdx]->Get<types::StringValue>(1);
+  const absl::flat_hash_set<std::string> responses {
+    records[kHTTPRespBodyIdx]->Get<types::StringValue>(0),
+    records[kHTTPRespBodyIdx]->Get<types::StringValue>(1)
+  };
 
   const std::string kHTTPRespMsgContentAsFiller(kHTTPRespMsgContent.size(), 0);
-  EXPECT_EQ(server_body, kHTTPRespMsgContentAsFiller);
-  EXPECT_EQ(client_body, kHTTPRespMsgContent);
+  EXPECT_THAT(responses, Contains(kHTTPRespMsgContentAsFiller));
+  EXPECT_THAT(responses, Contains(kHTTPRespMsgContent));
 }
 
 using NullRemoteAddrTest = testing::SocketTraceBPFTestFixture</* TClientSideTracing */ false>;


### PR DESCRIPTION
Summary: In the prior impl. of test case `socket_trace_bpf_test`, there was a possible test flake based on capturing eBPF perf buffer data out of order. Because the test case started two threads, depending on which CPU owned which thread and when the perf buffers were populated, we could see the test expectations out of order (even though logically that was not what happened). We fix this test flake by removing the expectation of seeing the results in order.

Type of change: /kind bug fix

Test Plan: Tested locally, ran socket_trace_bpf_test with --runs_per_test 16 and did not observe this specific test flake any more.
