### PR TITLE
Update prometheus scrape configs

### DIFF
--- a/k8s/cloud/base/indexer_deployment.yaml
+++ b/k8s/cloud/base/indexer_deployment.yaml
@@ -16,8 +16,8 @@ spec:
         monitoring.gke.io/scrape: 'true'
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '51800'
-        prometheus.io/scheme: 'https'
+        prometheus.io/port: '51801'
+        prometheus.io/scheme: 'http'
     spec:
       containers:
       - name: indexer-server

--- a/k8s/cloud/base/metrics_deployment.yaml
+++ b/k8s/cloud/base/metrics_deployment.yaml
@@ -14,8 +14,8 @@ spec:
         monitoring.gke.io/scrape: 'true'
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '50800'
-        prometheus.io/scheme: 'https'
+        prometheus.io/port: '50801'
+        prometheus.io/scheme: 'http'
     spec:
       containers:
       - name: metrics-server

--- a/k8s/cloud/base/vzconn_deployment.yaml
+++ b/k8s/cloud/base/vzconn_deployment.yaml
@@ -14,8 +14,8 @@ spec:
         monitoring.gke.io/scrape: 'true'
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '51600'
-        prometheus.io/scheme: 'https'
+        prometheus.io/port: '51601'
+        prometheus.io/scheme: 'http'
     spec:
       containers:
       - name: vzconn-server

--- a/k8s/cloud/base/vzmgr_deployment.yaml
+++ b/k8s/cloud/base/vzmgr_deployment.yaml
@@ -16,8 +16,8 @@ spec:
         monitoring.gke.io/scrape: 'true'
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '51800'
-        prometheus.io/scheme: 'https'
+        prometheus.io/port: '51801'
+        prometheus.io/scheme: 'http'
     spec:
       containers:
       - name: vzmgr-server


### PR DESCRIPTION
Summary: We updated the ports and scheme for prometheus metrics in
953d82850969ff04772203e78671032e70381e5e but failed to update the scrape
configs. This updates the configs so that these metrics continue to be
captured by monitoring.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Updated a deployment manually with the fixed config, saw the metrics
being scraped.
