### PR TITLE
Fix dev cloud auth patch

### DIFF
--- a/k8s/cloud/dev/auth_deployment_patch.yaml
+++ b/k8s/cloud/dev/auth_deployment_patch.yaml
@@ -1,18 +1,23 @@
 ---
-- op: add
-  path: /spec/template/spec/containers/0/env
-  # yamllint disable rule:indentation
-  value: |
-    - name: PL_AUTH0_CLIENT_ID
-      valueFrom:
-        secretKeyRef:
-          name: cloud-auth0-secrets
-          key: auth0-client-id
-          optional: true
-    - name: PL_AUTH0_CLIENT_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: cloud-auth0-secrets
-          key: auth0-client-secret
-          optional: true
-  # yamllint enable rule:indentation
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: auth-server
+        env:
+        - name: PL_AUTH0_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: cloud-auth0-secrets
+              key: auth0-client-id
+              optional: true
+        - name: PL_AUTH0_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: cloud-auth0-secrets
+              key: auth0-client-secret
+              optional: true

--- a/k8s/cloud/dev/kustomization.yaml
+++ b/k8s/cloud/dev/kustomization.yaml
@@ -23,14 +23,10 @@ resources:
 - ../base
 - ../overlays/exposed_services_ilb
 - plugin_db_updater_job.yaml
-patches:
-- path: auth_deployment_patch.yaml
-  target:
-    kind: Deployment
-    labelSelector: name=auth-server
 patchesStrategicMerge:
 # bq_config is useful for testing, but we don't want dev clusters to typically send data to bq.
 # - bq_config.yaml
+- auth_deployment_patch.yaml
 - db_config.yaml
 - indexer_config.yaml
 - ory_service_config.yaml


### PR DESCRIPTION
Summary: The yaml patch was broken and the strategic patches are easier
to grok though a bit more verbose. So I changed the patch type and ensured
that it works when you skaffold a dev cloud.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Deployed a dev cloud
