### PR TITLE
[carnot] Optimize compiler to execute UDFs for unary operations

### DIFF
--- a/src/carnot/planner/compiler/ast_visitor.h
+++ b/src/carnot/planner/compiler/ast_visitor.h
@@ -417,7 +417,7 @@ class ASTVisitorImpl : public ASTVisitor {
    * @param node
    * @return StatusOr<ExpressionIR*> the IR representation of the number.
    */
-  StatusOr<QLObjectPtr> ProcessNumber(const pypa::AstNumberPtr& node, bool negate = false);
+  StatusOr<QLObjectPtr> ProcessNumber(const pypa::AstNumberPtr& node);
 
   /**
    * @brief Processes a str ast ptr into an IR node.

--- a/src/carnot/planner/compiler/ast_visitor.h
+++ b/src/carnot/planner/compiler/ast_visitor.h
@@ -417,7 +417,7 @@ class ASTVisitorImpl : public ASTVisitor {
    * @param node
    * @return StatusOr<ExpressionIR*> the IR representation of the number.
    */
-  StatusOr<QLObjectPtr> ProcessNumber(const pypa::AstNumberPtr& node);
+  StatusOr<QLObjectPtr> ProcessNumber(const pypa::AstNumberPtr& node, bool negate = false);
 
   /**
    * @brief Processes a str ast ptr into an IR node.

--- a/src/carnot/planner/compiler/ast_visitor_expression_test.cc
+++ b/src/carnot/planner/compiler/ast_visitor_expression_test.cc
@@ -117,6 +117,51 @@ TEST_F(ASTExpressionTest, Integer) {
   EXPECT_EQ(static_cast<IntIR*>(expr)->val(), 1);
 }
 
+TEST_F(ASTExpressionTest, NegativeInteger) {
+  auto parse_result = parser.Parse("-1", /* parse_doc_strings */ false);
+  auto visitor_result =
+      ast_visitor->ProcessSingleExpressionModule(parse_result.ConsumeValueOrDie());
+
+  ASSERT_OK(visitor_result);
+
+  auto obj = visitor_result.ConsumeValueOrDie();
+  ASSERT_TRUE(ExprObject::IsExprObject(obj));
+  auto expr = static_cast<ExprObject*>(obj.get())->expr();
+
+  ASSERT_MATCH(expr, Int());
+  EXPECT_EQ(static_cast<IntIR*>(expr)->val(), -1);
+}
+
+TEST_F(ASTExpressionTest, NegativeFloat) {
+  auto parse_result = parser.Parse("-1.0", /* parse_doc_strings */ false);
+  auto visitor_result =
+      ast_visitor->ProcessSingleExpressionModule(parse_result.ConsumeValueOrDie());
+
+  ASSERT_OK(visitor_result);
+
+  auto obj = visitor_result.ConsumeValueOrDie();
+  ASSERT_TRUE(ExprObject::IsExprObject(obj));
+  auto expr = static_cast<ExprObject*>(obj.get())->expr();
+
+  ASSERT_MATCH(expr, Float());
+  EXPECT_EQ(static_cast<FloatIR*>(expr)->val(), -1);
+}
+
+TEST_F(ASTExpressionTest, NegativeLong) {
+  auto parse_result = parser.Parse("-2305843009213693952", /* parse_doc_strings */ false);
+  auto visitor_result =
+      ast_visitor->ProcessSingleExpressionModule(parse_result.ConsumeValueOrDie());
+
+  ASSERT_OK(visitor_result);
+
+  auto obj = visitor_result.ConsumeValueOrDie();
+  ASSERT_TRUE(ExprObject::IsExprObject(obj));
+  auto expr = static_cast<ExprObject*>(obj.get())->expr();
+
+  ASSERT_MATCH(expr, Int());
+  EXPECT_EQ(static_cast<IntIR*>(expr)->val(), -2305843009213693952);
+}
+
 TEST_F(ASTExpressionTest, PLModule) {
   auto parse_result = parser.Parse("px.mean", /* parse_doc_strings */ false);
   auto visitor_result =

--- a/src/carnot/planner/compiler/ast_visitor_expression_test.cc
+++ b/src/carnot/planner/compiler/ast_visitor_expression_test.cc
@@ -162,6 +162,21 @@ TEST_F(ASTExpressionTest, NegativeLong) {
   EXPECT_EQ(static_cast<IntIR*>(expr)->val(), -2305843009213693952);
 }
 
+TEST_F(ASTExpressionTest, InvertInteger) {
+  auto parse_result = parser.Parse("~1", /* parse_doc_strings */ false);
+  auto visitor_result =
+      ast_visitor->ProcessSingleExpressionModule(parse_result.ConsumeValueOrDie());
+
+  ASSERT_OK(visitor_result);
+
+  auto obj = visitor_result.ConsumeValueOrDie();
+  ASSERT_TRUE(ExprObject::IsExprObject(obj));
+  auto expr = static_cast<ExprObject*>(obj.get())->expr();
+
+  ASSERT_MATCH(expr, Int());
+  EXPECT_EQ(static_cast<IntIR*>(expr)->val(), -2);
+}
+
 TEST_F(ASTExpressionTest, PLModule) {
   auto parse_result = parser.Parse("px.mean", /* parse_doc_strings */ false);
   auto visitor_result =

--- a/src/carnot/planner/compiler/ast_visitor_test.cc
+++ b/src/carnot/planner/compiler/ast_visitor_test.cc
@@ -1852,6 +1852,18 @@ TEST_F(ASTVisitorTest, exec_funcs_list_arg_syntax_error) {
   EXPECT_THAT(graph_or_s.status(), HasCompilerError("Failed to parse arg"));
 }
 
+TEST_F(ASTVisitorTest, unary_ops_execute_underlying_udf_funcs) {
+  std::string keep_duplicates_expr = R"pxl(import px
+df = px.DataFrame('http_events')
+df.test = -(10 * -2)
+px.display(df)
+)pxl";
+
+  ASSERT_OK_AND_ASSIGN(auto graph, CompileGraph(keep_duplicates_expr, {}));
+  auto int_node = graph->FindNodesThatMatch(Int(20));
+  ASSERT_EQ(int_node.size(), 1);
+}
+
 // The function definition Module.
 constexpr char kFuncsUtilsModule[] = R"pxl(
 import px

--- a/src/carnot/planner/parser/symbol_table.h
+++ b/src/carnot/planner/parser/symbol_table.h
@@ -41,7 +41,7 @@ namespace planner {
 
 /**
  * @brief Symbol Table is an abstraction used to access any table structure.
- * The two main virtualn functions to implement are HasSymbol and GetSymbol.
+ * The two main virtual functions to implement are HasSymbol and GetSymbol.
  *
  * AddSymbol is deliberately left out from the interface because there is a case
  * where we would like to store QLObjectPtrs but can't create a circular dependency in the system to


### PR DESCRIPTION
Summary: [carnot] Optimize compiler to execute UDFs for unary operations

This optimization is needed to handle negative integer arguments to a new pxl function I'm working on in #1256 (`format_duration`). This function will simplify the brittle math performed in the `http_trace_id` script that doubles a pxl script time window upon deep linking ([source](https://github.com/pixie-io/pixie/blob/e6f7ad60905bf6a0b696cb74d2b91230017c764e/src/pxl_scripts/px/http_trace_id/script.pxl#L103-L111)).

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: New tests added pass and PR to add `format_duration` works with negative numbers now
- [x] Prevents the following error in my PR to add a `format_duration` function ([P361](https://phab.corp.pixielabs.ai/P361))
- [x] Verify that the `ast_visitor` test added fails if unary UDFs are not optimized ([P362](https://phab.corp.pixielabs.ai/P362))