### PR TITLE
Add `format_duration` pxl function to aid duration calculations

### DIFF
--- a/src/carnot/planner/objects/pixie_module.h
+++ b/src/carnot/planner/objects/pixie_module.h
@@ -200,6 +200,29 @@ class PixieModule : public QLObject {
   Returns:
     px.Time: The time value represented in the data.
   )doc";
+
+  inline static constexpr char kFormatDurationOpID[] = "format_duration";
+  inline static constexpr char kFormatDurationDocstring[] = R"doc(
+  Convert an integer in nanoseconds (-3,000,000,000) to a duration string ("-5m") while
+  preserving the sign. This function converts to whole milliseconds, seconds, minutes,
+  hours or days. This means it will round down to the nearest whole number time unit.
+
+  Examples:
+    # duration = "-5m"
+    duration = px.format_duration(-5 * 60 * 1000 * 1000 * 1000)
+    # duration = "5m" duration is rounded down to nearest whole minute.
+    duration = px.parse_duration(-5 * 60 * 1000 * 1000 * 1000 + 5)
+
+    # duration = "-5h"
+    duration = px.format_duration(-5 * 60 * 60 * 1000 * 1000 * 1000)
+
+  :topic: compile_time_fn
+
+  Args:
+    duration (int64): The duration in nanoseconds.
+  Returns:
+    string: The string representing the human readable duration (i.e. -5m, -10h).
+  )doc";
   inline static constexpr char kParseDurationOpID[] = "parse_duration";
   inline static constexpr char kParseDurationDocstring[] = R"doc(
   Parse a duration string to a duration in nanoseconds.

--- a/src/carnot/planner/objects/pixie_module_test.cc
+++ b/src/carnot/planner/objects/pixie_module_test.cc
@@ -291,6 +291,62 @@ TEST_F(PixieModuleTest, script_reference_test_with_args) {
   EXPECT_MATCH(args[5], ColumnNode("namespace_col"));
 }
 
+TEST_F(PixieModuleTest, format_duration) {
+  // Test positive.
+  {
+    ASSERT_OK_AND_ASSIGN(auto result, ParseExpression("px.format_duration(5 * 1000 * 1000)"));
+    ASSERT_TRUE(ExprObject::IsExprObject(result));
+    auto expr = static_cast<ExprObject*>(result.get());
+    ASSERT_MATCH(expr->expr(), String());
+    EXPECT_EQ(static_cast<StringIR*>(expr->expr())->str(), "5ms");
+  }
+
+  {
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         ParseExpression("px.format_duration(5 * 1000 * 1000 * 1000)"));
+    ASSERT_TRUE(ExprObject::IsExprObject(result));
+    auto expr = static_cast<ExprObject*>(result.get());
+    ASSERT_MATCH(expr->expr(), String());
+    EXPECT_EQ(static_cast<StringIR*>(expr->expr())->str(), "5s");
+  }
+
+  {
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         ParseExpression("px.format_duration(5 * 60 * 1000 * 1000 * 1000)"));
+    ASSERT_TRUE(ExprObject::IsExprObject(result));
+    auto expr = static_cast<ExprObject*>(result.get());
+    ASSERT_MATCH(expr->expr(), String());
+    EXPECT_EQ(static_cast<StringIR*>(expr->expr())->str(), "5m");
+  }
+
+  {
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         ParseExpression("px.format_duration(60 * 60 * 1000 * 1000 * 1000)"));
+    ASSERT_TRUE(ExprObject::IsExprObject(result));
+    auto expr = static_cast<ExprObject*>(result.get());
+    ASSERT_MATCH(expr->expr(), String());
+    EXPECT_EQ(static_cast<StringIR*>(expr->expr())->str(), "1h");
+  }
+
+  {
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         ParseExpression("px.format_duration(24 * 60 * 60 * 1000 * 1000 * 1000)"));
+    ASSERT_TRUE(ExprObject::IsExprObject(result));
+    auto expr = static_cast<ExprObject*>(result.get());
+    ASSERT_MATCH(expr->expr(), String());
+    EXPECT_EQ(static_cast<StringIR*>(expr->expr())->str(), "1d");
+  }
+  // Test negative value.
+  {
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         ParseExpression("px.format_duration(-5 * 60 * 1000 * 1000 * 1000)"));
+    ASSERT_TRUE(ExprObject::IsExprObject(result));
+    auto expr = static_cast<ExprObject*>(result.get());
+    ASSERT_MATCH(expr->expr(), String());
+    EXPECT_EQ(static_cast<StringIR*>(expr->expr())->str(), "-5m");
+  }
+}
+
 TEST_F(PixieModuleTest, parse_duration) {
   // Test positive.
   {


### PR DESCRIPTION
Summary: Add `format_duration` pxl function to aid duration calculations

While developing the `http_trace_id` pxl script in #1233, I had to perform some brittle math in order to parameterize the deep linked script ([source](https://github.com/pixie-io/pixie/blob/e6f7ad60905bf6a0b696cb74d2b91230017c764e/src/pxl_scripts/px/http_trace_id/script.pxl#L103-L111)). This function will simplify that logic and ensure that it works for all units (currently it would break if anything other than minutes were used).

Relevant Issues: N/A

Type of change: /kind new-pxl-script

Test Plan: Tests added for `format_duration` script pass

Changelog Message: Added the `format_duration` pxl function, which simplifies converting a duration integer to a string representation. This is useful for manipulating script time windows within pxl scripts (when deep linking pxl scripts via `px.script_reference`).