### PR TITLE
Release changelogs should read release-notes from commit messages

### DIFF
--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -115,7 +115,6 @@ function update_pre {
 function generate_changelog {
     prev_tag=$1
     bazel_target=$2
-    prev_tag="release/vizier/v0.12.10"
 
     bug_changelog=''
     feature_changelog=''
@@ -182,15 +181,15 @@ function generate_changelog {
     done
 
     # Format changelog.
-    changelog="##Changes by Kind\n"
+    changelog="## Changes by Kind\n"
     if [[ -n $feature_changelog ]]; then
-    changelog="${changelog}###New Features\n${feature_changelog}"
+    changelog="${changelog}\n### New Features\n${feature_changelog}"
     fi
     if [[ -n $bug_changelog ]]; then
-    changelog="${changelog}###Bug Fixes\n${bug_changelog}"
+    changelog="${changelog}\n### Bug Fixes\n${bug_changelog}"
     fi
     if [[ -n $cleanup_changelog ]]; then
-    changelog="${changelog}###Cleanup\n${cleanup_changelog}"
+    changelog="${changelog}\n### Cleanup\n${cleanup_changelog}"
     fi
 
     echo -e "$changelog"
@@ -251,10 +250,11 @@ if [ "$RELEASE" != "true" ]; then
 fi
 
 changelog=$(generate_changelog "$prev_tag" "$BAZEL_TARGET")
-echo -e "$changelog" > test.log
-# new_tag="release/$ARTIFACT_TYPE/v"$new_version_str
-# git tag -a "$new_tag" -m "$(echo -e "$changelog")"
 
-# if [ "$PUSH" = "true" ]; then
-#  git push origin "$new_tag"
-# fi
+new_tag="release/$ARTIFACT_TYPE/v"$new_version_str
+echo -e "$changelog"
+git tag -a "$new_tag" -m "$changelog" --cleanup=whitespace
+
+if [ "$PUSH" = "true" ]; then
+ git push origin "$new_tag"
+fi

--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -256,5 +256,5 @@ echo -e "$changelog"
 git tag -a "$new_tag" -m "$changelog" --cleanup=whitespace
 
 if [ "$PUSH" = "true" ]; then
- git push origin "$new_tag"
+   git push origin "$new_tag"
 fi

--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Copyright 2018- The Pixie Authors.
 #
@@ -141,39 +141,34 @@ function generate_changelog {
 
                 # Get the type of change (cleanup|bug|feature).
                 typeRe='Type of change: /kind ([A-Za-z]+)'
-                if [[ $log =~ $typeRe ]]
-                then
-                changeType=${BASH_REMATCH[1]}
+                if [[ $log =~ $typeRe ]]; then
+                    changeType=${BASH_REMATCH[1]}
                 fi
 
                 # Get release notes.
-                # shellcheck disable=SC2016
-                # The backticks make shellcheck think that the string should be evaluatable.
-                notesRe='```release-note\s((\S|\s)*)```'
-                if [[ $log =~ $notesRe ]]
-                then
-                releaseNote=${BASH_REMATCH[1]}
+                notesRe="\`\`\`release-note\s((\S|\s)*)\`\`\`"
+                if [[ $log =~ $notesRe ]]; then
+                    releaseNote=${BASH_REMATCH[1]}
                 fi
 
-                if [[ -n $releaseNote ]]
-                then
-                case $changeType in
-                "cleanup")
-                # shellcheck disable=SC2086
-                # Double-quoting adds an extra newline.
-                cleanup_changelog="${cleanup_changelog}- $(echo -e $releaseNote)\n"
-                ;;
-                "bug")
-                # shellcheck disable=SC2086
-                bug_changelog="${bug_changelog}- $(echo -e $releaseNote)\n"
-                ;;
-                "feature")
-                # shellcheck disable=SC2086
-                feature_changelog="${feature_changelog}- $(echo -e $releaseNote)\n"
-                ;;
-                *)
-                ;;
-                esac
+                if [[ -n $releaseNote ]]; then
+                    case $changeType in
+                    "cleanup")
+                        # shellcheck disable=SC2086
+                        # Double-quoting adds an extra newline.
+                        cleanup_changelog="${cleanup_changelog}- $(echo -e $releaseNote)\n"
+                        ;;
+                    "bug")
+                        # shellcheck disable=SC2086
+                        bug_changelog="${bug_changelog}- $(echo -e $releaseNote)\n"
+                        ;;
+                    "feature")
+                        # shellcheck disable=SC2086
+                        feature_changelog="${feature_changelog}- $(echo -e $releaseNote)\n"
+                        ;;
+                    *)
+                        ;;
+                    esac
                 fi
                 break
             fi
@@ -181,15 +176,15 @@ function generate_changelog {
     done
 
     # Format changelog.
-    changelog="## Changes by Kind\n"
+    changelog=""
     if [[ -n $feature_changelog ]]; then
-    changelog="${changelog}\n### New Features\n${feature_changelog}"
+        changelog="${changelog}### New Features\n${feature_changelog}\n"
     fi
     if [[ -n $bug_changelog ]]; then
-    changelog="${changelog}\n### Bug Fixes\n${bug_changelog}"
+        changelog="${changelog}### Bug Fixes\n${bug_changelog}\n"
     fi
     if [[ -n $cleanup_changelog ]]; then
-    changelog="${changelog}\n### Cleanup\n${cleanup_changelog}"
+        changelog="${changelog}### Cleanup\n${cleanup_changelog}\n"
     fi
 
     echo -e "$changelog"
@@ -252,9 +247,9 @@ fi
 changelog=$(generate_changelog "$prev_tag" "$BAZEL_TARGET")
 
 new_tag="release/$ARTIFACT_TYPE/v"$new_version_str
-echo -e "$changelog"
+
 git tag -a "$new_tag" -m "$changelog" --cleanup=whitespace
 
 if [ "$PUSH" = "true" ]; then
-   git push origin "$new_tag"
+    git push origin "$new_tag"
 fi


### PR DESCRIPTION
Summary: The current process for writing changelogs is manual. You manually compile the changelogs and pipe it to the `create_release_tag` script to be used as the tag's message.
We've now standardized our commit message formats, so we can parse commits to determine the type of commit + if it has any release notes to include. This PR updates `create_release_tag` so that it:
1. Finds all commits which touch a dependency of the artifact being released.
2. Parses the commit message to find the kind of commit (bug, feature request, cleanup).
3. Parses the commit message to get the release notes, if any.
4. Takes the commits and compiles it into a markdown-formatted changelog.

Here's an example changelog (there were no changelog updates since the last release so I set it to gather changelogs from a much earlier prev version):
```
tag release/vizier/v0.13.1-pre-changelog5.1
Tagger: Michelle Nguyen <michellenguyen@pixielabs.ai>

##Changes by Kind

###New Features
- New chart type: gauge
- New chart type: pie
- New chart type: Text. Literally just the text you type in the Vis spec, nothing more.
- New chart type: Stat. Shows a label, metric, and units for that metric.

###Bug Fixes
- Fixes a bug where postgres requests could be dropped causing missing protocol traces
update changelog generation

```

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Ran `create_release_tag`. See example output above.
