### PR TITLE
Tidy up & fix `EverythingLocalContext`.

### DIFF
--- a/src/stirling/core/connector_context.cc
+++ b/src/stirling/core/connector_context.cc
@@ -98,9 +98,8 @@ absl::flat_hash_set<md::UPID> ListUPIDs(const std::filesystem::path& proc_path, 
 SystemWideStandaloneContext::SystemWideStandaloneContext(const std::filesystem::path& proc_path)
     : StandaloneContext(ListUPIDs(proc_path, /*asid*/ 0), proc_path) {}
 
-const absl::flat_hash_set<md::UPID>& EverythingLocalContext::GetUPIDs() const {
+void EverythingLocalContext::RefreshUPIDList() {
   upids_ = ListUPIDs(::px::system::ProcPath(), GetASID());
-  return upids_;
 }
 
 }  // namespace stirling

--- a/src/stirling/core/connector_context.h
+++ b/src/stirling/core/connector_context.h
@@ -111,7 +111,8 @@ class AgentContext : public ConnectorContext {
 
   std::vector<CIDRBlock> GetClusterCIDRs() override;
 
-  virtual void RefreshUPIDList() override {};
+  virtual void RefreshUPIDList() override{};
+
  private:
   std::shared_ptr<const md::AgentMetadataState> agent_metadata_state_;
 };
@@ -144,7 +145,8 @@ class StandaloneContext : public ConnectorContext {
 
   Status SetClusterCIDR(std::string_view cidr_str);
 
-  virtual void RefreshUPIDList() override {};
+  virtual void RefreshUPIDList() override{};
+
  protected:
   absl::flat_hash_set<md::UPID> upids_;
   absl::flat_hash_map<md::UPID, md::PIDInfoUPtr> upid_pidinfo_map_;

--- a/src/stirling/core/connector_context.h
+++ b/src/stirling/core/connector_context.h
@@ -72,6 +72,8 @@ class ConnectorContext {
    * tracing.
    */
   virtual std::vector<CIDRBlock> GetClusterCIDRs() = 0;
+
+  virtual void RefreshUPIDList() = 0;
 };
 
 /**
@@ -109,6 +111,7 @@ class AgentContext : public ConnectorContext {
 
   std::vector<CIDRBlock> GetClusterCIDRs() override;
 
+  virtual void RefreshUPIDList() override {};
  private:
   std::shared_ptr<const md::AgentMetadataState> agent_metadata_state_;
 };
@@ -141,6 +144,7 @@ class StandaloneContext : public ConnectorContext {
 
   Status SetClusterCIDR(std::string_view cidr_str);
 
+  virtual void RefreshUPIDList() override {};
  protected:
   absl::flat_hash_set<md::UPID> upids_;
   absl::flat_hash_map<md::UPID, md::PIDInfoUPtr> upid_pidinfo_map_;
@@ -165,8 +169,7 @@ class SystemWideStandaloneContext : public StandaloneContext {
 class EverythingLocalContext : public SystemWideStandaloneContext {
  public:
   bool UPIDIsInContext(const md::UPID& /*upid*/) const override { return true; }
-  const absl::flat_hash_set<md::UPID>& GetUPIDs() const override;
-  mutable absl::flat_hash_set<md::UPID> upids_;
+  virtual void RefreshUPIDList() override;
 };
 
 }  // namespace stirling

--- a/src/stirling/core/connector_context.h
+++ b/src/stirling/core/connector_context.h
@@ -111,7 +111,7 @@ class AgentContext : public ConnectorContext {
 
   std::vector<CIDRBlock> GetClusterCIDRs() override;
 
-  virtual void RefreshUPIDList() override{};
+  void RefreshUPIDList() override{};
 
  private:
   std::shared_ptr<const md::AgentMetadataState> agent_metadata_state_;
@@ -145,7 +145,7 @@ class StandaloneContext : public ConnectorContext {
 
   Status SetClusterCIDR(std::string_view cidr_str);
 
-  virtual void RefreshUPIDList() override{};
+  void RefreshUPIDList() override{};
 
  protected:
   absl::flat_hash_set<md::UPID> upids_;
@@ -171,7 +171,7 @@ class SystemWideStandaloneContext : public StandaloneContext {
 class EverythingLocalContext : public SystemWideStandaloneContext {
  public:
   bool UPIDIsInContext(const md::UPID& /*upid*/) const override { return true; }
-  virtual void RefreshUPIDList() override;
+  void RefreshUPIDList() override;
 };
 
 }  // namespace stirling


### PR DESCRIPTION
Summary: In the previous impl. of `EverythingLocalContext`, we masked a base class instance of `upids_`. We fix that in this patch, and align usage of the `EverythingLocalContext` to better match the existing work in `socket_trace_bpf_test_fixture.h`.

Type of change: /kind cleanup

Test Plan: Tested locally with the next diff and along with work to de-flake socket tracer tests.