### PR TITLE
Improve api_svc logs

### DIFF
--- a/src/cloud/api/ptproxy/request_proxyer.go
+++ b/src/cloud/api/ptproxy/request_proxyer.go
@@ -279,31 +279,31 @@ func (p *requestProxyer) processNatsMsg(msg *nats.Msg) error {
 	case *cvmsgspb.V2CAPIStreamResponse_ExecResp:
 		err = p.srv.SendMsg(parsed.ExecResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send message")
+			log.WithError(err).Error("Failed to send ExecResp message")
 			return err
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_HcResp:
 		err = p.srv.SendMsg(parsed.HcResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send message")
+			log.WithError(err).Error("Failed to send HcResp message")
 			return err
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_GenerateOTelScriptResp:
 		err = p.srv.SendMsg(parsed.GenerateOTelScriptResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send message")
+			log.WithError(err).Error("Failed to send GenerateOTelScriptResp message")
 			return err
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_DebugLogResp:
 		err = p.srv.SendMsg(parsed.DebugLogResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send message")
+			log.WithError(err).Error("Failed to send DebugLogResp message")
 			return err
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_DebugPodsResp:
 		err = p.srv.SendMsg(parsed.DebugPodsResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send message")
+			log.WithError(err).Error("Failed to send DebugPodsResp message")
 			return err
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_Status:

--- a/src/shared/services/logging.go
+++ b/src/shared/services/logging.go
@@ -59,7 +59,7 @@ func HTTPLoggingMiddleware(next http.Handler) http.Handler {
 		}
 
 		switch {
-		case lw.Status() != http.StatusOK:
+		case lw.Status() != http.StatusOK && lw.Status() != 0:
 			log.WithTime(start).WithFields(logFields).Info("HTTP Request")
 		case r.URL.String() == "/healthz":
 			log.WithTime(start).WithFields(logFields).Trace("HTTP Request")

--- a/src/shared/services/server/grpc_server.go
+++ b/src/shared/services/server/grpc_server.go
@@ -105,13 +105,21 @@ func createGRPCAuthFunc(env env.Env, opts *GRPCServerOptions) func(context.Conte
 	}
 }
 
+func CodeToLevel(code codes.Code) log.Level {
+	if code == codes.Unavailable {
+		return log.DebugLevel
+	}
+
+	return grpc_logrus.DefaultClientCodeToLevel(code)
+}
+
 // CreateGRPCServer creates a GRPC server with default middleware for our services.
 func CreateGRPCServer(env env.Env, serverOpts *GRPCServerOptions) *grpc.Server {
 	logrusOpts := []grpc_logrus.Option{
 		grpc_logrus.WithDurationField(func(duration time.Duration) (string, interface{}) {
 			return "time", duration
 		}),
-		grpc_logrus.WithLevels(grpc_logrus.DefaultClientCodeToLevel),
+		grpc_logrus.WithLevels(CodeToLevel),
 	}
 	opts := []grpc.ServerOption{}
 	if !serverOpts.DisableMiddleware {


### PR DESCRIPTION
Summary: This does two things, reduce the logging from grpc code
`Unavailable` and http StatusCode `Unknown` to reduce log spam
and also identify which message type errored in the request proxyer.

This should help us narrow down any API svc issues.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Ensure that everything builds and check logs upon deploy.
