### PR TITLE
Add `pprof` as an external repo.

### DIFF
--- a/bazel/external/pprof.BUILD
+++ b/bazel/external/pprof.BUILD
@@ -1,0 +1,31 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "pprof_proto",
+    srcs = [
+        "proto/profile.proto",
+    ],
+)
+
+cc_proto_library(
+    name = "pprof_proto_cc",
+    deps = [":pprof_proto"],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,6 +167,7 @@ def _cc_deps():
     _bazel_repo("com_github_opentelemetry_proto", build_file = "//bazel/external:opentelemetry.BUILD")
     _bazel_repo("com_github_uriparser_uriparser", build_file = "//bazel/external:uriparser.BUILD")
     _bazel_repo("com_github_libbpf_libbpf", build_file = "//bazel/external:libbpf.BUILD")
+    _bazel_repo("com_github_google_pprof", build_file = "//bazel/external:pprof.BUILD")
 
     # Uncomment these to develop bcc and/or bpftrace locally. Should also comment out the corresponding _bazel_repo lines.
     # _local_repo("com_github_iovisor_bcc", build_file = "//bazel/external/local_dev:bcc.BUILD")

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -36,6 +36,12 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/boringssl/" +
                 "archive/7b00d84b025dff0c392c2df5ee8aa6d3c63ad539.tar.gz"],
     ),
+    # Used by the perf profiler to create pprof proto output.
+    com_github_google_pprof = dict(
+        urls = ["https://github.com/google/pprof/archive/905365eefe3e5dc92b363189b7e5dbceba5cac82.tar.gz"],
+        strip_prefix = "pprof-905365eefe3e5dc92b363189b7e5dbceba5cac82",
+        sha256 = "9c618bbe4643a88753745e5a9f45449127934c3a15d32de6e75c494b8fa09d56",
+    ),
     com_github_antlr_antlr4 = dict(
         urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.11.1.tar.gz"],
         strip_prefix = "antlr4-4.11.1",


### PR DESCRIPTION
Summary: We add Google `pprof` as an external repository to support upcoming export of perf profiling in `pprof` format.

Type of change: /kind feature

Test Plan: Tested locally in a separate branch. At the moment, this additional bazel repo is not used.