### PR TITLE
[protocol_loadtest] Add prometheus process metrics instrumentation.

### DIFF
--- a/src/e2e_test/protocol_loadtest/http/BUILD.bazel
+++ b/src/e2e_test/protocol_loadtest/http/BUILD.bazel
@@ -24,5 +24,10 @@ go_library(
     visibility = [
         "//src/e2e_test:__subpackages__",
     ],
-    deps = ["//src/e2e_test/util"],
+    deps = [
+        "//src/e2e_test/util",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/collectors",
+        "@com_github_prometheus_client_golang//prometheus/promhttp",
+    ],
 )

--- a/src/e2e_test/protocol_loadtest/http/http.go
+++ b/src/e2e_test/protocol_loadtest/http/http.go
@@ -27,6 +27,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"px.dev/pixie/src/e2e_test/util"
 )
 
@@ -208,6 +212,10 @@ func setupHTTPServer(port string) {
 
 // RunHTTPServers sets up and runs the SSL and non-SSL HTTP server with the provided parameters.
 func RunHTTPServers(tlsConfig *tls.Config, port, sslPort string) {
+	r := prometheus.NewRegistry()
+	r.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	http.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
+
 	http.HandleFunc("/", chunkMiddleware(gzipMiddleware(basicHandler)))
 	// SSL port is optional
 	if sslPort != "" && tlsConfig != nil {


### PR DESCRIPTION
Summary: Adds prometheus instrumentation to the protocol_loadtest server. We will use this instrumentation to measure CPU/rss/etc before and after we deploy vizier, to measure vizier's overhead on the application.

Type of change: /kind test-infra

Test Plan: Tested that I get prometheus process metrics at the `/metrics` endpoint of the protocol loadtest server.
