### PR TITLE
[perf_tool] Exit early on errors in metric recorders

### DIFF
--- a/src/e2e_test/perf_tool/pkg/metrics/recorder.go
+++ b/src/e2e_test/perf_tool/pkg/metrics/recorder.go
@@ -19,25 +19,30 @@
 package metrics
 
 import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+
 	"px.dev/pixie/src/e2e_test/perf_tool/experimentpb"
 	"px.dev/pixie/src/e2e_test/perf_tool/pkg/pixie"
 )
 
 // Recorder is an interface for all metric recorders.
 type Recorder interface {
-	Start() error
-	Close() error
+	Start(ctx context.Context) error
+	Close()
 }
 
 // NewMetricsRecorder creates a new Recorder for the given MetricSpec.
 // Currently, only supports PxL script recorders.
-func NewMetricsRecorder(pxCtx *pixie.Context, spec *experimentpb.MetricSpec, resultCh chan<- *ResultRow) Recorder {
+func NewMetricsRecorder(pxCtx *pixie.Context, spec *experimentpb.MetricSpec, eg *errgroup.Group, resultCh chan<- *ResultRow) Recorder {
 	switch spec.MetricType.(type) {
 	case *experimentpb.MetricSpec_PxL:
 		return &pxlScriptRecorderImpl{
 			pxCtx: pxCtx,
 			spec:  spec.GetPxL(),
 
+			eg:       eg,
 			resultCh: resultCh,
 		}
 	}


### PR DESCRIPTION
Summary: Errors often occur in the metric recorders when a cluster goes unhealthy or a query fails for other reasons. Previously, these errors would only be surfaced after the experiment finished running. This PR adds a channel to send the errors to, so that the errors are caught as soon as they happen and the experiment can be abandoned earlier.

Type of change: /kind test-infra

Test Plan: Tested that sending an error to the error channel leads to the experiment being aborted early.
