### PR TITLE
More improvements to error handling

### DIFF
--- a/src/cloud/api/ptproxy/request_proxyer.go
+++ b/src/cloud/api/ptproxy/request_proxyer.go
@@ -264,13 +264,13 @@ func (p *requestProxyer) processNatsMsg(msg *nats.Msg) error {
 	v2c := cvmsgspb.V2CMessage{}
 	err := v2c.Unmarshal(msg.Data)
 	if err != nil {
-		return fmt.Errorf("Failed to unmarshall response: %w", err)
+		return fmt.Errorf("Failed to unmarshall v2cMessage: %w", err)
 	}
 
 	resp := cvmsgspb.V2CAPIStreamResponse{}
 	err = types.UnmarshalAny(v2c.Msg, &resp)
 	if err != nil {
-		return fmt.Errorf("Failed to unmarshall response: %w", err)
+		return fmt.Errorf("Failed to unmarshall v2cAPIStreamResponse: %w", err)
 	}
 
 	switch parsed := resp.Msg.(type) {

--- a/src/cloud/api/ptproxy/request_proxyer.go
+++ b/src/cloud/api/ptproxy/request_proxyer.go
@@ -264,47 +264,40 @@ func (p *requestProxyer) processNatsMsg(msg *nats.Msg) error {
 	v2c := cvmsgspb.V2CMessage{}
 	err := v2c.Unmarshal(msg.Data)
 	if err != nil {
-		log.WithError(err).Error("Failed to unmarshall response, bailing...")
-		return err
+		return fmt.Errorf("Failed to unmarshall response: %w", err)
 	}
 
 	resp := cvmsgspb.V2CAPIStreamResponse{}
 	err = types.UnmarshalAny(v2c.Msg, &resp)
 	if err != nil {
-		log.WithError(err).Error("Failed to unmarshall response, bailing...")
-		return err
+		return fmt.Errorf("Failed to unmarshall response: %w", err)
 	}
 
 	switch parsed := resp.Msg.(type) {
 	case *cvmsgspb.V2CAPIStreamResponse_ExecResp:
 		err = p.srv.SendMsg(parsed.ExecResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send ExecResp message")
-			return err
+			return fmt.Errorf("Failed to send ExecResp message: %w", err)
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_HcResp:
 		err = p.srv.SendMsg(parsed.HcResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send HcResp message")
-			return err
+			return fmt.Errorf("Failed to send HcResp message: %w", err)
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_GenerateOTelScriptResp:
 		err = p.srv.SendMsg(parsed.GenerateOTelScriptResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send GenerateOTelScriptResp message")
-			return err
+			return fmt.Errorf("Failed to send GenerateOTelScriptResp message: %w", err)
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_DebugLogResp:
 		err = p.srv.SendMsg(parsed.DebugLogResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send DebugLogResp message")
-			return err
+			return fmt.Errorf("Failed to send DebugLogResp message: %w", err)
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_DebugPodsResp:
 		err = p.srv.SendMsg(parsed.DebugPodsResp)
 		if err != nil {
-			log.WithError(err).Error("Failed to send DebugPodsResp message")
-			return err
+			return fmt.Errorf("Failed to send DebugPodsResp message: %w", err)
 		}
 	case *cvmsgspb.V2CAPIStreamResponse_Status:
 		// Status message come when the stream is closed.


### PR DESCRIPTION
Summary: Make `processNatsMsg` wrap and return an error but not log it
since the caller already logs it.
Update grpc middleware to ignore Context Canceled errors.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check logs and sentry after deploying.
