### PR TITLE
Move graph widget controls into titlebar

### DIFF
--- a/src/ui/src/containers/live-widgets/graph/graph-base.tsx
+++ b/src/ui/src/containers/live-widgets/graph/graph-base.tsx
@@ -28,11 +28,17 @@ import { createStyles, makeStyles } from '@mui/styles';
 import { Network } from 'vis-network/standalone';
 
 import { buildClass } from 'app/components';
-import { WithChildren } from 'app/utils/react-boilerplate';
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
-    width: '100%',
+    // Bust out of the extra padding from the <Paper/> container
+    width: `calc(100% + ${theme.spacing(1.5)})`,
+    margin: theme.spacing(-0.75),
+    marginTop: 0,
+    borderBottomLeftRadius: 'inherit',
+    borderBottomRightRadius: 'inherit',
+
+    // Layout
     flex: 1,
     minHeight: 0,
     display: 'flex',
@@ -45,6 +51,8 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     height: '100%',
     minHeight: 0,
     border: '1px solid transparent',
+    borderBottomLeftRadius: 'inherit',
+    borderBottomRightRadius: 'inherit',
     '&$focus': { borderColor: theme.palette.foreground.grey2 },
     '& > .vis-active': { boxShadow: 'none' },
   },
@@ -55,11 +63,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
       padding: theme.spacing(0.375), // 3px
     },
   },
-  zoomButton: {
-    opacity: 0,
-    transition: 'opacity 0.25s linear',
-    '&$focus': { opacity: 1 },
-  },
+  zoomButton: {},
   focus: {/* Blank entry so the rule above has something to reference */},
 }), { name: 'Graph' });
 
@@ -67,17 +71,20 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 const MIN_ZOOM = 0.075;
 const MAX_ZOOM = 10;
 
-export interface GraphBaseProps extends WithChildren {
+export interface GraphBaseProps {
   network: Network;
   visRootRef: React.MutableRefObject<HTMLDivElement>;
   showZoomButtons?: boolean;
+  setExternalControls?: React.RefCallback<React.ReactNode>;
+  additionalButtons?: React.ReactNode;
 }
 
 export const GraphBase = React.memo<GraphBaseProps>(({
   network,
   visRootRef,
   showZoomButtons = false,
-  children: additionalButtons,
+  setExternalControls,
+  additionalButtons,
 }) => {
   const [focused, setFocused] = React.useState(false);
 
@@ -178,36 +185,51 @@ export const GraphBase = React.memo<GraphBaseProps>(({
   }, [focused, clickWrapper]);
 
   const classes = useStyles();
+
+  const controls = React.useMemo(() => (
+    <>
+      {showZoomButtons && (
+        <>
+          <Tooltip title='Zoom Out'>
+            <IconButton
+              className={buildClass(classes.zoomButton, focused && classes.focus)}
+              size='small'
+              onClick={zoomOut}
+              disabled={zoomLevel <= MIN_ZOOM}
+            >
+              <ZoomOutIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title='Zoom In'>
+            <IconButton
+              className={buildClass(classes.zoomButton, focused && classes.focus)}
+              size='small'
+              onClick={zoomIn}
+              disabled={zoomLevel >= MAX_ZOOM}
+            >
+              <ZoomInIcon />
+            </IconButton>
+          </Tooltip>
+        </>
+      )}
+      {additionalButtons}
+    </>
+  ), [additionalButtons, classes.focus, classes.zoomButton, focused, showZoomButtons, zoomIn, zoomLevel, zoomOut]);
+
+  React.useEffect(() => {
+    if (setExternalControls) {
+      setExternalControls(controls);
+    }
+  }, [controls, setExternalControls]);
+
   return (
     <div className={classes.root}>
       <div className={buildClass(classes.clickWrapper, focused && classes.focus)} ref={clickWrapperRef} />
-      <div className={classes.buttonContainer}>
-        {showZoomButtons && (
-          <>
-            <Tooltip title='Zoom Out'>
-              <IconButton
-                className={buildClass(classes.zoomButton, focused && classes.focus)}
-                size='small'
-                onClick={zoomOut}
-                disabled={zoomLevel <= MIN_ZOOM}
-              >
-                <ZoomOutIcon />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title='Zoom In'>
-              <IconButton
-                className={buildClass(classes.zoomButton, focused && classes.focus)}
-                size='small'
-                onClick={zoomIn}
-                disabled={zoomLevel >= MAX_ZOOM}
-              >
-                <ZoomInIcon />
-              </IconButton>
-            </Tooltip>
-          </>
-        )}
-        {additionalButtons}
-      </div>
+      {!setExternalControls && (
+        <div className={classes.buttonContainer}>
+          {controls}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/ui/src/containers/live-widgets/graph/graph-base.tsx
+++ b/src/ui/src/containers/live-widgets/graph/graph-base.tsx
@@ -63,6 +63,11 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
       padding: theme.spacing(0.375), // 3px
     },
   },
+  buttonSeparator: {
+    display: 'inline-flex',
+    width: theme.spacing(2),
+    userSelect: 'none',
+  },
   zoomButton: {},
   focus: {/* Blank entry so the rule above has something to reference */},
 }), { name: 'Graph' });
@@ -210,11 +215,15 @@ export const GraphBase = React.memo<GraphBaseProps>(({
               <ZoomInIcon />
             </IconButton>
           </Tooltip>
+          {additionalButtons && <div className={classes.buttonSeparator} />}
         </>
       )}
       {additionalButtons}
     </>
-  ), [additionalButtons, classes.focus, classes.zoomButton, focused, showZoomButtons, zoomIn, zoomLevel, zoomOut]);
+  ), [
+    additionalButtons, focused, showZoomButtons, zoomIn, zoomLevel, zoomOut,
+    classes.focus, classes.zoomButton, classes.buttonSeparator,
+  ]);
 
   React.useEffect(() => {
     if (setExternalControls) {

--- a/src/ui/src/containers/live-widgets/graph/graph.tsx
+++ b/src/ui/src/containers/live-widgets/graph/graph.tsx
@@ -82,6 +82,7 @@ interface GraphProps {
   edgeHoverInfo?: ColInfo[];
   edgeLength?: number;
   enableDefaultHierarchy?: boolean;
+  setExternalControls?: React.RefCallback<React.ReactNode>;
 }
 
 interface GraphData {
@@ -96,6 +97,7 @@ interface GraphWidgetProps {
   data: any[];
   relation: Relation;
   propagatedArgs?: Arguments;
+  setExternalControls?: React.RefCallback<React.ReactNode>;
 }
 
 const INVALID_NODE_TYPES = [
@@ -126,6 +128,7 @@ function getColorForEdge(col: ColInfo, val: number, thresholds: EdgeThresholds):
 export const Graph = React.memo<GraphProps>(({
   dot, toCol, fromCol, data, propagatedArgs, edgeWeightColumn,
   nodeWeightColumn, edgeColorColumn, edgeThresholds, edgeHoverInfo, edgeLength, enableDefaultHierarchy,
+  setExternalControls,
 }) => {
   const theme = useTheme();
 
@@ -265,21 +268,29 @@ export const Graph = React.memo<GraphProps>(({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graph, doubleClickCallback, hierarchyEnabled]);
 
+  const controls = React.useMemo(() => (
+    <Button
+      size='small'
+      onClick={toggleHierarchy}
+    >
+      {hierarchyEnabled ? 'Disable hierarchy' : 'Enable hierarchy'}
+    </Button>
+  ), [hierarchyEnabled, toggleHierarchy]);
+
   return (
-    <GraphBase network={network} visRootRef={ref} showZoomButtons={true}>
-      <Button
-        size='small'
-        onClick={toggleHierarchy}
-      >
-        {hierarchyEnabled ? 'Disable hierarchy' : 'Enable hierarchy'}
-      </Button>
-    </GraphBase>
+    <GraphBase
+      network={network}
+      visRootRef={ref}
+      showZoomButtons={true}
+      setExternalControls={setExternalControls}
+      additionalButtons={controls}
+    />
   );
 });
 Graph.displayName = 'Graph';
 
 export const GraphWidget = React.memo<GraphWidgetProps>(({
-  display, data, relation, propagatedArgs,
+  display, data, relation, propagatedArgs, setExternalControls,
 }) => {
   if (display.dotColumn && data.length > 0) {
     return (
@@ -316,6 +327,7 @@ export const GraphWidget = React.memo<GraphWidgetProps>(({
           edgeColorColumn={colorColInfo}
           propagatedArgs={propagatedArgs}
           edgeHoverInfo={edgeHoverInfo}
+          setExternalControls={setExternalControls}
         />
       );
     }

--- a/src/ui/src/containers/live-widgets/graph/request-graph.tsx
+++ b/src/ui/src/containers/live-widgets/graph/request-graph.tsx
@@ -50,6 +50,7 @@ interface RequestGraphProps {
   data: any[];
   relation: Relation;
   propagatedArgs?: Arguments;
+  setExternalControls?: React.RefCallback<React.ReactNode>;
 }
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
@@ -59,7 +60,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 }), { name: 'RequestGraphWidget' });
 
 export const RequestGraphWidget = React.memo<RequestGraphProps>(({
-  data, relation, display, propagatedArgs,
+  data, relation, display, propagatedArgs, setExternalControls,
 }) => {
   const { selectedClusterName } = React.useContext(ClusterContext);
   const { embedState } = React.useContext(LiveRouteContext);
@@ -176,8 +177,9 @@ export const RequestGraphWidget = React.memo<RequestGraphProps>(({
   }, [network, doubleClickCallback]);
 
   const classes = useStyles();
-  return (
-    <GraphBase network={network} visRootRef={ref} showZoomButtons={true}>
+
+  const controls = React.useMemo(() => (
+    <>
       <Tooltip title={colorByLatency ? 'Colored by latency' : 'Colored by Error Rate'}>
         <IconButton
           size='small'
@@ -205,7 +207,19 @@ export const RequestGraphWidget = React.memo<RequestGraphProps>(({
           <WorkspacesIcon />
         </IconButton>
       </Tooltip>
-    </GraphBase>
+    </>
+    // toggleColor depends on graphMgr, which depends on stuff that can change every frame.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [classes.enabled, clusteredMode, colorByLatency, hierarchyEnabled, toggleHierarchy, toggleMode]);
+
+  return (
+    <GraphBase
+      network={network}
+      visRootRef={ref}
+      showZoomButtons={true}
+      setExternalControls={setExternalControls}
+      additionalButtons={controls}
+    />
   );
 });
 RequestGraphWidget.displayName = 'RequestGraphWidget';

--- a/src/ui/src/containers/live/canvas.tsx
+++ b/src/ui/src/containers/live/canvas.tsx
@@ -148,6 +148,13 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     height: '100%',
   },
   vegaWidget: {
+    // Bust out of the extra padding from the <Paper/> container
+    width: `calc(100% + ${theme.spacing(1.5)})`,
+    margin: theme.spacing(-0.75),
+    marginTop: 0,
+    borderBottomLeftRadius: 'inherit',
+    borderBottomRightRadius: 'inherit',
+
     flex: 1,
     display: 'flex',
     border: '1px solid transparent',
@@ -224,6 +231,13 @@ const WidgetDisplay: React.FC<{
   const [affix, setAffix] = React.useState<React.ReactNode>(null);
   const affixRef = React.useCallback((el: React.ReactNode) => { setAffix(el); }, []);
 
+  // Needs to be memoized to avoid making graphs re-render every single frame
+  const parsedTable = React.useMemo(
+    () => table ? dataFromProto(table.relation, table.batches) : [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [table?.relation, table?.batches],
+  );
+
   // Before we do any other processing, check if we have the chart that exist entirely in the vis spec with no data
   if (display[DISPLAY_TYPE_KEY] === TEXT_CHART_DISPLAY_TYPE) {
     return (
@@ -257,17 +271,16 @@ const WidgetDisplay: React.FC<{
     );
   }
 
-  const parsedTable = dataFromProto(table.relation, table.batches);
-
   if (display[DISPLAY_TYPE_KEY] === GRAPH_DISPLAY_TYPE) {
     return (
       <div className={classes.graphContainer}>
-        <WidgetTitlebar title={widgetName} />
+        <WidgetTitlebar title={widgetName} affix={affix} />
         <GraphWidget
           display={display as GraphDisplay}
           data={parsedTable}
           relation={table.relation}
           propagatedArgs={propagatedArgs}
+          setExternalControls={affixRef}
         />
       </div>
     );
@@ -276,12 +289,13 @@ const WidgetDisplay: React.FC<{
   if (display[DISPLAY_TYPE_KEY] === REQUEST_GRAPH_DISPLAY_TYPE) {
     return (
       <>
-        <WidgetTitlebar title={widgetName} />
+        <WidgetTitlebar title={widgetName} affix={affix} />
         <RequestGraphWidget
           display={display as RequestGraphDisplay}
           data={parsedTable}
           relation={table.relation}
           propagatedArgs={propagatedArgs}
+          setExternalControls={affixRef}
         />
       </>
     );


### PR DESCRIPTION
Summary: TSIA. Affects network graphs, request graphs, and flamegraphs.
Also presses the edges of these graphs to the edge of their container to use the full available space.
<img width="495" alt="image" src="https://user-images.githubusercontent.com/314133/236042675-efd55b2e-3201-4ca7-b207-595a744ee61e.png">

Relevant Issues: #1174

Test Plan: Run `px/cluster` and `px/perf_flamegraph`.
The outermost borders of graphs in both should be pushed to the edges of their containers.
The extra buttons (including zoom buttons) for the request graph should be in the titlebar now, and still function.

Type of change: /kind feature
