### PR TITLE
[build] Disable PIE for building host tools

### DIFF
--- a/bazel/cc_toolchains/clang/toolchain.BUILD
+++ b/bazel/cc_toolchains/clang/toolchain.BUILD
@@ -88,7 +88,7 @@ cc_toolchain_config(
         "-Wl,-z,relro,-z,now",
         "-Bexternal/{this_repo}/{toolchain_path}/bin",
         "-lm",
-    ],
+    ] + (["-no-pie"] if {use_for_host_tools} else []),
     opt_compile_flags = [
         "-g0",
         "-O2",


### PR DESCRIPTION
Summary: `rules_docker` requires building some go binaries to be used as tools in later build steps. Since our compiler defaults to using PIE, and golang doesn't realize it defaults to using PIE, the resultant golang PIE executable is invalid. This disables PIE for host tools on the clang side, circumventing this issue.

Type of change: /kind cleanup

Test Plan: Built `//:pl_go_base_iamge` with the new golang version without issue.
