### PR TITLE
Add dimensional metrics to record applications that violate tls tracing assumptions (mismatched fds)

### DIFF
--- a/src/common/metrics/metrics.h
+++ b/src/common/metrics/metrics.h
@@ -30,6 +30,13 @@ prometheus::Registry& GetMetricsRegistry();
 // This function should only be called by testing code.
 void TestOnlyResetMetricsRegistry();
 
+// A convenience wrapper to return a counter with the specified name and help message when
+// dimensions aren't known at compile time. This should only be used when dimensional data is
+// very low cardinality.
+inline auto& BuildRawCounter(const std::string& name, const std::string& help_message) {
+  return prometheus::BuildCounter().Name(name).Help(help_message).Register(GetMetricsRegistry());
+}
+
 // A convenience wrapper to return a counter with the specified name and help message.
 inline auto& BuildCounter(const std::string& name, const std::string& help_message) {
   return prometheus::BuildCounter()

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -171,7 +171,6 @@ static __inline void set_conn_as_ssl(uint32_t tgid, int32_t fd) {
 static __inline void propagate_fd_to_user_space_call(uint64_t pid_tgid, int fd) {
   struct nested_syscall_fd_t* nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
   if (nested_syscall_fd_ptr != NULL) {
-    nested_syscall_fd_ptr->mismatched_fds = true;
     int current_fd = nested_syscall_fd_ptr->fd;
     if (current_fd == kInvalidFD) {
       nested_syscall_fd_ptr->fd = fd;

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -171,6 +171,7 @@ static __inline void set_conn_as_ssl(uint32_t tgid, int32_t fd) {
 static __inline void propagate_fd_to_user_space_call(uint64_t pid_tgid, int fd) {
   struct nested_syscall_fd_t* nested_syscall_fd_ptr = ssl_user_space_call_map.lookup(&pid_tgid);
   if (nested_syscall_fd_ptr != NULL) {
+    nested_syscall_fd_ptr->mismatched_fds = true;
     int current_fd = nested_syscall_fd_ptr->fd;
     if (current_fd == kInvalidFD) {
       nested_syscall_fd_ptr->fd = fd;

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/symaddrs.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/symaddrs.h
@@ -263,6 +263,12 @@ struct openssl_symaddrs_t {
   int32_t RBIO_num_offset;  // 0x30 (openssl 1.1.1) or 0x28 (openssl 1.1.0)
 };
 
+#define MAX_CMD_SIZE 32
+
+struct openssl_trace_state_debug_t {
+  char comm[MAX_CMD_SIZE];
+};
+
 // For reading file descriptor from a TLSWrap pointer.
 struct node_tlswrap_symaddrs_t {
   // Offset of StreamListener base class of TLSWrap class.

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -17,7 +17,6 @@
  */
 
 #include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
-#include <prometheus/text_serializer.h>
 
 #include <sys/sysinfo.h>
 #include <sys/types.h>
@@ -666,10 +665,6 @@ void SocketTraceConnector::CheckTracerState() {
           .Add({{"name", openssl_mismatched_fds_metric}, {"exe", debug.comm}})
           .Increment();
     }
-    auto& registry = GetMetricsRegistry();
-    auto metrics = registry.Collect();
-    auto metrics_text = prometheus::TextSerializer().Serialize(metrics);
-    LOG(WARNING) << absl::Substitute("with metric text: $0", metrics_text);
   }
   DCHECK_EQ(error_code, kOpenSSLTraceOk);
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -232,6 +232,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   ConnStats conn_stats_;
 
   std::unique_ptr<ebpf::BPFArrayTable<int>> openssl_trace_state_;
+  std::unique_ptr<ebpf::BPFHashTable<uint32_t, struct openssl_trace_state_debug_t>>
+      openssl_trace_state_debug_;
   prometheus::Counter& openssl_trace_mismatched_fds_counter_;
 
   absl::flat_hash_set<int> pids_to_trace_disable_;


### PR DESCRIPTION
Summary: Add dimensional metrics to record applications that violate tls tracing assumptions (mismatched fds)

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Verified that the metrics added do not clash with the non dimensional metrics. Please see https://github.com/pixie-io/pixie/commit/e83443a7ad555abe13d5d9bd0d28fc9084ffc427 for the code that was used to produce this output ([P363](https://phab.corp.pixielabs.ai/P363))