### PR TITLE
Auto-select Command Palette input on open

### DIFF
--- a/src/ui/src/components/command-palette/command-text-field.tsx
+++ b/src/ui/src/components/command-palette/command-text-field.tsx
@@ -270,7 +270,7 @@ export const CommandTextField = React.memo<CommandTextFieldProps>(({
     setTimeout(() => {
       inputEl?.focus();
       const l = inputEl?.value.length ?? 0;
-      inputEl?.setSelectionRange(l, l);
+      inputEl?.setSelectionRange(0, l);
       onInputScroll();
     });
   }, [inputEl, onInputScroll]);


### PR DESCRIPTION
Summary: Selects the text that it pre-fills immediately. Before, it would only put the caret at the end.
This lets you start typing immediately.

Test Plan: Open the command palette.

Type of change: /kind bug
