### PR TITLE
[build] Allow building non-PIE go executables without explicitly setting no-pie

### DIFF
--- a/bazel/cc_toolchains/clang/toolchain.BUILD
+++ b/bazel/cc_toolchains/clang/toolchain.BUILD
@@ -88,7 +88,7 @@ cc_toolchain_config(
         "-Wl,-z,relro,-z,now",
         "-Bexternal/{this_repo}/{toolchain_path}/bin",
         "-lm",
-    ] + (["-no-pie"] if {use_for_host_tools} else []),
+    ],
     opt_compile_flags = [
         "-g0",
         "-O2",

--- a/bazel/external/rules_go.patch
+++ b/bazel/external/rules_go.patch
@@ -12,3 +12,46 @@ index 11a8278f..7346aecd 100644
          ]
          env.update({
              "CGO_ENABLED": "1",
+diff --git a/go/tools/builders/link.go b/go/tools/builders/link.go
+index fcbea058..816c36fe 100644
+--- a/go/tools/builders/link.go
++++ b/go/tools/builders/link.go
+@@ -153,6 +153,23 @@ func link(args []string) error {
+ 	}
+ 
+ 	// add in the unprocess pass through options
++	isExtLinker := false
++	for i, arg := range toolArgs {
++		if isExtLinker {
++			isExtLinker = false
++			absPath, err := filepath.Abs(arg)
++			if err != nil {
++				continue
++			}
++			if isExecutable(absPath) {
++				// If the absolute path is an executable use that instead of the relative path.
++				toolArgs[i] = absPath
++			}
++		}
++		if arg == "-extld" {
++			isExtLinker = true
++		}
++	}
+ 	goargs = append(goargs, toolArgs...)
+ 	goargs = append(goargs, *main)
+ 	if err := goenv.runCommand(goargs); err != nil {
+@@ -167,3 +184,14 @@ func link(args []string) error {
+ 
+ 	return nil
+ }
++
++func isExecutable(p string) bool {
++	s, err := os.Stat(p)
++	if err != nil {
++		return false
++	}
++	if !s.IsDir() && (s.Mode()&0111) != 0 {
++		return true
++	}
++	return false
++}


### PR DESCRIPTION
Summary: The golang linker command accepts `-extld` to specify what external linker to use. If this option is a relative path, things mostly work. However, the [`linkerFlagSupported`](https://github.com/golang/go/blob/0d347544cbca0f42b160424f6bc2458ebcc7b3fc/src/cmd/link/internal/ld/lib.go#L1994) function doesn't work properly with the relative path, so some linker flags are not set. `rules_go` has a wrapper go binary that eventually calls out to `go tool link`. We circumvent the issue by making sure this wrapper binary uses an absolute path for `-extld` instead of a relative one.

Type of change: /kind cleanup

Test Plan: Tested that `//:pl_go_base_image` still builds properly with the new go upgrade (#1266).
