### PR TITLE
[perf_tool] Add experiment running online boutique

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/suites.go
+++ b/src/e2e_test/perf_tool/pkg/suites/suites.go
@@ -43,6 +43,7 @@ func nightlyExperimentSuite() map[string]*pb.ExperimentSpec {
 		"http-loadtest/100/100":  HTTPLoadTestExperiment(httpNumConns, 100, defaultMetricPeriod, preDur, dur),
 		"http-loadtest/100/3000": HTTPLoadTestExperiment(httpNumConns, 3000, defaultMetricPeriod, preDur, dur),
 		"sock-shop":              SockShopExperiment(defaultMetricPeriod, preDur, dur),
+		"online-boutique":        OnlineBoutiqueExperiment(defaultMetricPeriod, preDur, dur),
 	}
 	for _, e := range exps {
 		addTags(e, "suite/nightly")

--- a/src/e2e_test/perf_tool/pkg/suites/workloads.go
+++ b/src/e2e_test/perf_tool/pkg/suites/workloads.go
@@ -142,6 +142,30 @@ func SockShopWorkload() *pb.WorkloadSpec {
 	}
 }
 
+// OnlineBoutiqueWorkload returns the WorkloadSpec to deploy online boutique.
+func OnlineBoutiqueWorkload() *pb.WorkloadSpec {
+	return &pb.WorkloadSpec{
+		Name: "px-online-boutique",
+		DeploySteps: []*pb.DeployStep{
+			{
+				DeployType: &pb.DeployStep_Px{
+					Px: &pb.PxCLIDeploy{
+						Args: []string{
+							"demo",
+							"deploy",
+							"px-online-boutique",
+						},
+						Namespaces: []string{
+							"px-online-boutique",
+						},
+					},
+				},
+			},
+		},
+		Healthchecks: HTTPHealthChecks("px-online-boutique"),
+	}
+}
+
 //go:embed scripts/healthcheck/vizier.pxl
 var vizierHealthCheckScript string
 


### PR DESCRIPTION
Summary: Adds a new experiment to the nightly perf suite that runs online boutique as the workload.

Type of change: /kind test-infra.

Test Plan: Ran the online boutique experiment locally, saw that it completed succesfully.
