### PR TITLE
[perf_tool] Add experiment that runs the kafka demo

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/suites.go
+++ b/src/e2e_test/perf_tool/pkg/suites/suites.go
@@ -44,6 +44,7 @@ func nightlyExperimentSuite() map[string]*pb.ExperimentSpec {
 		"http-loadtest/100/3000": HTTPLoadTestExperiment(httpNumConns, 3000, defaultMetricPeriod, preDur, dur),
 		"sock-shop":              SockShopExperiment(defaultMetricPeriod, preDur, dur),
 		"online-boutique":        OnlineBoutiqueExperiment(defaultMetricPeriod, preDur, dur),
+		"kafka":                  KafkaExperiment(defaultMetricPeriod, preDur, dur),
 	}
 	for _, e := range exps {
 		addTags(e, "suite/nightly")

--- a/src/e2e_test/perf_tool/pkg/suites/workloads.go
+++ b/src/e2e_test/perf_tool/pkg/suites/workloads.go
@@ -166,6 +166,30 @@ func OnlineBoutiqueWorkload() *pb.WorkloadSpec {
 	}
 }
 
+// KafkaWorkload returns the WorkloadSpec to deploy the kafka demo.
+func KafkaWorkload() *pb.WorkloadSpec {
+	return &pb.WorkloadSpec{
+		Name: "px-kafka",
+		DeploySteps: []*pb.DeployStep{
+			{
+				DeployType: &pb.DeployStep_Px{
+					Px: &pb.PxCLIDeploy{
+						Args: []string{
+							"demo",
+							"deploy",
+							"px-kafka",
+						},
+						Namespaces: []string{
+							"px-kafka",
+						},
+					},
+				},
+			},
+		},
+		Healthchecks: HTTPHealthChecks("px-kafka"),
+	}
+}
+
 //go:embed scripts/healthcheck/vizier.pxl
 var vizierHealthCheckScript string
 


### PR DESCRIPTION
Summary: Adds a perf experiment that runs the `px-kafka` demo to the nightly suite.

Type of change: /kind test-infra

Test Plan: Currently, running a kafka experiment, and kafka deployed successfully. Will wait to make sure the experiment completes entirely sucessfully.
