### PR TITLE
[qemu-bpf] Remove OVMF bios

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/run_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/run_qemu.sh
@@ -76,13 +76,6 @@ flags+=(-append "console=ttyS0 root=/dev/sda")
 # Disable graphics mode.
 flags+=(-nographic)
 
-# Change to the OVMF bios if it exists.
-# This fixes issues with terminal/screen cocrruption after running qemu.
-ovmf_bios=/usr/share/ovmf/OVMF.fd
-if [[ -e "${ovmf_bios}" ]]; then
-  flags+=(-bios "${ovmf_bios}")
-fi
-
 retval=0
 qemu-system-x86_64 "${flags[@]}" || retval=$?
 


### PR DESCRIPTION
Summary: OVMF bios seems to cause kernel hangs when running enough tests concurrently. Don't have time to debug it at the moment, so for now let's just put up with the control characters from SeaBIOS.

Type of change: /kind test-infra.

Test Plan: Tested that running multiple tests concurrently under qemu doesn't hang anymore.
