### PR TITLE
[perf_tool] Add application overhead experiment

### DIFF
--- a/src/e2e_test/perf_tool/pkg/suites/metrics.go
+++ b/src/e2e_test/perf_tool/pkg/suites/metrics.go
@@ -113,6 +113,26 @@ func HTTPDataLossMetric(outputPeriod time.Duration) *pb.MetricSpec {
 	}
 }
 
+// ProtocolLoadtestPromMetrics adds metrics that scrapes prometheus metrics from the protocol loadtest server, collecting process data (cpu usage, rss, vsize).
+func ProtocolLoadtestPromMetrics(scrapePeriod time.Duration) *pb.MetricSpec {
+	return &pb.MetricSpec{
+		MetricType: &pb.MetricSpec_Prom{
+			Prom: &pb.PrometheusScrapeSpec{
+				Namespace:       "px-protocol-loadtest",
+				MatchLabelKey:   "name",
+				MatchLabelValue: "server",
+				Port:            8080,
+				ScrapePeriod:    types.DurationProto(scrapePeriod),
+				MetricNames: map[string]string{
+					"process_cpu_seconds_total":     "cpu_seconds_counter",
+					"process_resident_memory_bytes": "rss",
+					"process_virtual_memory_bytes":  "vsize",
+				},
+			},
+		},
+	}
+}
+
 func singleMetricOutputWithPodNodeName(col string, newName ...string) *pb.PxLScriptOutputSpec {
 	metricName := col
 	if len(newName) > 0 {

--- a/src/e2e_test/perf_tool/pkg/suites/suites.go
+++ b/src/e2e_test/perf_tool/pkg/suites/suites.go
@@ -40,11 +40,12 @@ func nightlyExperimentSuite() map[string]*pb.ExperimentSpec {
 	dur := 40 * time.Minute
 	httpNumConns := 100
 	exps := map[string]*pb.ExperimentSpec{
-		"http-loadtest/100/100":  HTTPLoadTestExperiment(httpNumConns, 100, defaultMetricPeriod, preDur, dur),
-		"http-loadtest/100/3000": HTTPLoadTestExperiment(httpNumConns, 3000, defaultMetricPeriod, preDur, dur),
-		"sock-shop":              SockShopExperiment(defaultMetricPeriod, preDur, dur),
-		"online-boutique":        OnlineBoutiqueExperiment(defaultMetricPeriod, preDur, dur),
-		"kafka":                  KafkaExperiment(defaultMetricPeriod, preDur, dur),
+		"http-loadtest/100/100":               HTTPLoadTestExperiment(httpNumConns, 100, defaultMetricPeriod, preDur, dur),
+		"http-loadtest/100/3000":              HTTPLoadTestExperiment(httpNumConns, 3000, defaultMetricPeriod, preDur, dur),
+		"sock-shop":                           SockShopExperiment(defaultMetricPeriod, preDur, dur),
+		"online-boutique":                     OnlineBoutiqueExperiment(defaultMetricPeriod, preDur, dur),
+		"kafka":                               KafkaExperiment(defaultMetricPeriod, preDur, dur),
+		"app-overhead/http-loadtest/100/3000": HTTPLoadApplicationOverheadExperiment(httpNumConns, 3000, defaultMetricPeriod),
 	}
 	for _, e := range exps {
 		addTags(e, "suite/nightly")

--- a/src/e2e_test/perf_tool/pkg/suites/workloads.go
+++ b/src/e2e_test/perf_tool/pkg/suites/workloads.go
@@ -86,7 +86,7 @@ data:
 `
 
 // HTTPLoadTestWorkload returns the WorkloadSpec to deploy a simple client/server http loadtest (see src/e2e_test/protocol_loadtest)
-func HTTPLoadTestWorkload(numConns int, targetRPS int) *pb.WorkloadSpec {
+func HTTPLoadTestWorkload(numConns int, targetRPS int, doPxLHealthCheck bool) *pb.WorkloadSpec {
 	return &pb.WorkloadSpec{
 		Name: "http_loadtest",
 		DeploySteps: []*pb.DeployStep{
@@ -114,7 +114,7 @@ func HTTPLoadTestWorkload(numConns int, targetRPS int) *pb.WorkloadSpec {
 				},
 			},
 		},
-		Healthchecks: HTTPHealthChecks("px-protocol-loadtest"),
+		Healthchecks: HTTPHealthChecks("px-protocol-loadtest", doPxLHealthCheck),
 	}
 }
 
@@ -138,7 +138,7 @@ func SockShopWorkload() *pb.WorkloadSpec {
 				},
 			},
 		},
-		Healthchecks: HTTPHealthChecks("px-sock-shop"),
+		Healthchecks: HTTPHealthChecks("px-sock-shop", true),
 	}
 }
 
@@ -162,7 +162,7 @@ func OnlineBoutiqueWorkload() *pb.WorkloadSpec {
 				},
 			},
 		},
-		Healthchecks: HTTPHealthChecks("px-online-boutique"),
+		Healthchecks: HTTPHealthChecks("px-online-boutique", true),
 	}
 }
 
@@ -186,7 +186,7 @@ func KafkaWorkload() *pb.WorkloadSpec {
 				},
 			},
 		},
-		Healthchecks: HTTPHealthChecks("px-kafka"),
+		Healthchecks: HTTPHealthChecks("px-kafka", true),
 	}
 }
 
@@ -218,22 +218,8 @@ func VizierHealthChecks() []*pb.HealthCheck {
 }
 
 // HTTPHealthChecks returns a healthcheck based on the existence of http_events in Pixie for a given namespace.
-func HTTPHealthChecks(namespace string) []*pb.HealthCheck {
-	t, err := template.New("").Parse(httpHealthCheckScript)
-	if err != nil {
-		log.WithError(err).Fatal("failed to parse HTTP healthcheck script")
-	}
-	buf := &strings.Builder{}
-	err = t.Execute(buf, &struct {
-		Namespace string
-	}{
-		Namespace: namespace,
-	})
-	if err != nil {
-		log.WithError(err).Fatal("failed to execute HTTP healthcheck template")
-	}
-
-	return []*pb.HealthCheck{
+func HTTPHealthChecks(namespace string, includePxL bool) []*pb.HealthCheck {
+	checks := []*pb.HealthCheck{
 		{
 			CheckType: &pb.HealthCheck_K8S{
 				K8S: &pb.K8SPodsReadyCheck{
@@ -241,13 +227,30 @@ func HTTPHealthChecks(namespace string) []*pb.HealthCheck {
 				},
 			},
 		},
-		{
+	}
+	if includePxL {
+		t, err := template.New("").Parse(httpHealthCheckScript)
+		if err != nil {
+			log.WithError(err).Fatal("failed to parse HTTP healthcheck script")
+		}
+		buf := &strings.Builder{}
+		err = t.Execute(buf, &struct {
+			Namespace string
+		}{
+			Namespace: namespace,
+		})
+		if err != nil {
+			log.WithError(err).Fatal("failed to execute HTTP healthcheck template")
+		}
+		checks = append(checks, &pb.HealthCheck{
 			CheckType: &pb.HealthCheck_PxL{
 				PxL: &pb.PxLHealthCheck{
 					Script:        buf.String(),
 					SuccessColumn: "success",
 				},
 			},
-		},
+		})
 	}
+
+	return checks
 }


### PR DESCRIPTION
Summary: Adds an experiment that runs an HTTP loadtest workload for 10 minutes collecting prometheus metrics on its CPU usage, RSS memory usage, etc. Then deploys Vizier and continues to run it for another 10 minutes. We can then compare the CPU usage with Vizier to the baseline, to measure Vizier's overhead on the application side.

Type of change: /kind test-infra.

Test Plan: Ran the application overhead experiment locally and it completed successfully.
