### PR TITLE
[bpf tests] Remove timing dependence from dynamic_bpftrace_connector_bpf_test

### DIFF
--- a/src/stirling/testing/common.h
+++ b/src/stirling/testing/common.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
@@ -166,6 +167,18 @@ inline types::ColumnWrapperRecordBatch ExtractRecordsMatchingPID(DataTable* data
   }
   return res;
 }
+
+class Timeout {
+ public:
+  explicit Timeout(std::chrono::nanoseconds timeout = std::chrono::minutes{5})
+      : timeout_(timeout), start_(std::chrono::steady_clock::now()) {}
+
+  bool TimedOut() { return !((std::chrono::steady_clock::now() - start_) < timeout_); }
+
+ private:
+  std::chrono::nanoseconds timeout_;
+  std::chrono::time_point<std::chrono::steady_clock> start_;
+};
 
 }  // namespace testing
 }  // namespace stirling


### PR DESCRIPTION
Summary: Removes dependence on sleeps/timing from the dynamic_bpftrace bpf test, by adding loops with timeouts to wait for records to show up.

Relevant Issues: Fixes #1245.

Type of change: /kind cleanup

Test Plan: Along with #1278, ran `bazel test --config=qemu-bpf //src/stirling/source_connectors/dynamic_bpftrace:dynamic_bpftrace_connector_bpf_test --runs_per_test=50` without any failures.
