### PR TITLE
[perf_tool] Cleanup comment from #1273

### DIFF
--- a/src/e2e_test/perf_tool/pkg/metrics/prometheus_recorder.go
+++ b/src/e2e_test/perf_tool/pkg/metrics/prometheus_recorder.go
@@ -87,6 +87,7 @@ func (r *prometheusRecorderImpl) run() error {
 		return err
 	}
 	t := time.NewTicker(d)
+	defer t.Stop()
 	for {
 		select {
 		case <-r.stopCh:


### PR DESCRIPTION
Summary: Comment on #1273 came through after it was already merged. This PR adds a defer `ticker.Stop()` to address that comment.

Type of change: /kind cleanup

Test Plan: N/A
