### PR TITLE
Update `perf_profiler_bpf_test` to use `UnitConnector`.

### DIFF
--- a/src/stirling/core/unit_connector.h
+++ b/src/stirling/core/unit_connector.h
@@ -111,6 +111,22 @@ class UnitConnector {
     return Status::OK();
   }
 
+  Status ResetConnectorContext(absl::flat_hash_set<md::UPID> upids) {
+    // Stop transferring data.
+    PX_RETURN_IF_ERROR(StopTransferDataThread());
+    if (upids.size() == 0) {
+      // The upids set is empty: trace all processes and use automatic context refresh.
+      ctx_ = std::make_unique<EverythingLocalContext>();
+    } else {
+      // The upids set is non-empty: we will trace only processes identified by that set.
+      ctx_ = std::make_unique<StandaloneContext>(upids);
+    }
+    // Restart.
+    PX_RETURN_IF_ERROR(StartTransferDataThread());
+
+    return Status::OK();
+  }
+
   Status Init(absl::flat_hash_set<md::UPID> upids = {}) {
     if (upids.size() == 0) {
       // Enter this branch if Init() is called with no arguments (i.e. with a default empty set).

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -51,6 +51,7 @@ pl_cc_test(
         "//src/stirling/source_connectors/perf_profiler/testing/cc:profiler_test_app_fib",
         "//src/stirling/source_connectors/perf_profiler/testing/go:profiler_test_app_sqrt_go",
         "//src/stirling/source_connectors/perf_profiler/testing/java:graal-vm-aot-test",
+        "//src/stirling/source_connectors/perf_profiler/testing/java:profiler_test",
     ],
     defines = ['JDK_IMAGE_NAMES=\\"%s\\"' % ",".join(jdk_image_names)],
     env = {"QEMU_CPU_COUNT": "4"},

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -231,7 +231,7 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
       test_run_time_ = std::chrono::seconds{FLAGS_stirling_profiler_table_update_period_seconds};
     }
   }
-  
+
   void PopulateObservedStackTraces(const std::vector<size_t>& target_row_idxs) {
     auto stack_traces_column = columns_[kStackTraceStackTraceStrIdx];
     auto counts_column = columns_[kStackTraceCountIdx];
@@ -505,7 +505,7 @@ TEST_F(FastPerfProfileBPFTest, PerfProfilerJavaArtifactsCleanupTest) {
   std::set<int> pids_with_java_symbols;
   {
     Timeout timer;
-    while( !timer.TimedOut() && pids_with_java_symbols.size() < kNumSubProcs) {
+    while (!timer.TimedOut() && pids_with_java_symbols.size() < kNumSubProcs) {
       ASSERT_OK(source_.Flush());
       auto s = source_.ConsumeRecords(kProfilerTableNum);
       if (s.ok()) {
@@ -552,8 +552,8 @@ TEST_F(FastPerfProfileBPFTest, PerfProfilerJavaArtifactsCleanupTest) {
 
   // Need to pass in an invalid upid set to prevent picking up the default context that
   // accepts all pids.
-  const md::UPID invalid_upid = { 0, 0, 0 };
-  const absl::flat_hash_set<md::UPID> invalid_upid_set = { invalid_upid };
+  const md::UPID invalid_upid = {0, 0, 0};
+  const absl::flat_hash_set<md::UPID> invalid_upid_set = {invalid_upid};
   ASSERT_OK(source_.ResetConnectorContext(invalid_upid_set));
 
   // Now that the sub-processes are gone, iterate over the previously found artifact paths.
@@ -588,7 +588,7 @@ TEST_F(FastPerfProfileBPFTest, TestOutOfContext) {
 
   // The "out of context" test needs to handle init., param. setup, and start each individually,
   //  so that it can pass in an empty set of upids rather than the subprocess upids.
-  const md::UPID invalid_upid = { 0, 0, 0 };
+  const md::UPID invalid_upid = {0, 0, 0};
   const absl::flat_hash_set<md::UPID> invalid_upid_set = {invalid_upid};
   ASSERT_OK(source_.Init(invalid_upid_set));
   ASSERT_OK(source_.Start());

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -232,10 +232,6 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     }
   }
   
-  // void TearDown() override {
-  //   PX_UNUSED(source_.Stop());
-  // }
-
   void PopulateObservedStackTraces(const std::vector<size_t>& target_row_idxs) {
     auto stack_traces_column = columns_[kStackTraceStackTraceStrIdx];
     auto counts_column = columns_[kStackTraceCountIdx];

--- a/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profiler_bpf_test.cc
@@ -22,6 +22,7 @@
 
 #include <sys/sysinfo.h>
 
+#include <absl/strings/match.h>
 #include <absl/strings/substitute.h>
 #include <gtest/gtest.h>
 
@@ -30,6 +31,7 @@
 #include "src/common/fs/fs_wrapper.h"
 #include "src/common/testing/test_utils/container_runner.h"
 #include "src/stirling/core/connector_context.h"
+#include "src/stirling/core/unit_connector.h"
 #include "src/stirling/source_connectors/perf_profiler/java/attach.h"
 #include "src/stirling/source_connectors/perf_profiler/perf_profile_connector.h"
 #include "src/stirling/source_connectors/perf_profiler/stack_traces_table.h"
@@ -54,11 +56,8 @@ using ::px::stirling::testing::FindRecordIdxMatchesPIDs;
 using ::px::testing::BazelRunfilePath;
 using ::px::testing::PathExists;
 using ::testing::Each;
-using ::testing::Gt;
 using ::testing::Not;
-using ::testing::Pair;
 using ::testing::SizeIs;
-using ::testing::UnorderedElementsAre;
 
 namespace {
 // BazelXXTestAppPath() are helpers to build & return the bazelified path to
@@ -210,37 +209,41 @@ class ContainerSubProcesses final : public PerfProfilerTestSubProcesses {
   std::vector<std::unique_ptr<ContainerRunner>> sub_processes_;
 };
 
+template <bool FastTest>
 class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path> {
- public:
-  PerfProfileBPFTest()
-      : test_run_time_(FLAGS_test_run_time), data_table_(/*id*/ 0, kStackTraceTable) {}
-
  protected:
   void SetUp() override {
     FLAGS_stirling_profiler_java_symbols = true;
     FLAGS_number_attach_attempts_per_iteration = kNumSubProcs;
-    FLAGS_stirling_profiler_table_update_period_seconds = 1;
-    FLAGS_stirling_profiler_stack_trace_sample_period_ms = 7;
 
-    source_ = PerfProfileConnector::Create("perf_profile_connector");
-    ASSERT_OK(source_->Init());
-    source_->set_data_tables({&data_table_});
+    if constexpr (FastTest) {
+      // Increase frequency of TransferData().
+      FLAGS_stirling_profiler_table_update_period_seconds = 1;
 
-    // Immediately start the transfer data thread to continue draining perf buffers,
-    // i.e. to prevent dropping perf buffer entries.
-    StartTransferDataThread();
+      // Increase frequency at which we sample stack traces in underlying eBPF probe.
+      FLAGS_stirling_profiler_stack_trace_sample_period_ms = 7;
+
+      // Shorten the test run time.
+      test_run_time_ = std::chrono::seconds{FLAGS_test_run_time};
+    } else {
+      // Accept perf profiler defaults for freq. of TransferData() and stack trace sampling.
+      // Set test run time long enough to capture one iter. of TransferData().
+      test_run_time_ = std::chrono::seconds{FLAGS_stirling_profiler_table_update_period_seconds};
+    }
   }
-
-  void TearDown() override { ASSERT_OK(source_->Stop()); }
+  
+  // void TearDown() override {
+  //   PX_UNUSED(source_.Stop());
+  // }
 
   void PopulateObservedStackTraces(const std::vector<size_t>& target_row_idxs) {
-    // Sanity check; column pointers should be populated already.
-    ASSERT_TRUE(column_ptrs_populated_);
+    auto stack_traces_column = columns_[kStackTraceStackTraceStrIdx];
+    auto counts_column = columns_[kStackTraceCountIdx];
 
     for (const auto row_idx : target_row_idxs) {
       // Build the histogram of observed stack traces here.
-      const std::string stack_trace_str = stack_traces_column_->Get<types::StringValue>(row_idx);
-      const int64_t count = counts_column_->Get<types::Int64Value>(row_idx).val;
+      const std::string stack_trace_str = stack_traces_column->Get<types::StringValue>(row_idx);
+      const int64_t count = counts_column->Get<types::Int64Value>(row_idx).val;
       histo_[stack_trace_str] += count;
     }
 
@@ -257,33 +260,32 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
   }
 
   void PopulateCumulativeSum(const std::vector<size_t>& target_row_idxs) {
-    ASSERT_TRUE(column_ptrs_populated_);
-    ASSERT_EQ(cumulative_sum_, 0);
+    cumulative_sum_ = 0;
+    auto counts_column = columns_[kStackTraceCountIdx];
 
     for (const auto row_idx : target_row_idxs) {
-      const int64_t count = counts_column_->Get<types::Int64Value>(row_idx).val;
+      const int64_t count = counts_column->Get<types::Int64Value>(row_idx).val;
       cumulative_sum_ += count;
       ASSERT_GT(count, 0);
     }
   }
 
-  void CheckExpectedSampleRate(const ssize_t num_subprocesses,
-                               const std::chrono::duration<double> t_elapsed) {
-    const uint64_t table_period_ms = source_->SamplingPeriod().count();
-    const uint64_t bpf_period_ms = source_->StackTraceSamplingPeriod().count();
+  void CheckExpectedSampleRate(const ssize_t num_subprocesses) {
+    const uint64_t table_period_ms = source_.RawPtr()->SamplingPeriod().count();
+    const uint64_t bpf_period_ms = source_.RawPtr()->StackTraceSamplingPeriod().count();
     const double expected_rate = 1000.0 / static_cast<double>(bpf_period_ms);
-    const double expected_num_samples = num_subprocesses * t_elapsed.count() * expected_rate;
+    const double expected_num_samples = num_subprocesses * t_elapsed_.count() * expected_rate;
     const uint64_t expected_num_sample_lower = uint64_t(0.9 * expected_num_samples);
     const uint64_t expected_num_sample_upper = uint64_t(1.1 * expected_num_samples);
     const double observedNumSamples = static_cast<double>(cumulative_sum_);
-    const double observed_rate = observedNumSamples / t_elapsed.count() / num_subprocesses;
+    const double observed_rate = observedNumSamples / t_elapsed_.count() / num_subprocesses;
 
     LOG(INFO) << absl::StrFormat("Table sampling period: %d [ms].", table_period_ms);
     LOG(INFO) << absl::StrFormat("BPF sampling period: %d [ms].", bpf_period_ms);
     LOG(INFO) << absl::StrFormat("Number of processes: %d.", num_subprocesses);
     LOG(INFO) << absl::StrFormat("expected num samples: %d.", uint64_t(expected_num_samples));
     LOG(INFO) << absl::StrFormat("total samples: %d.", cumulative_sum_);
-    LOG(INFO) << absl::StrFormat("elapsed time: %.1f [sec].", t_elapsed.count());
+    LOG(INFO) << absl::StrFormat("elapsed time: %.1f [sec].", t_elapsed_.count());
     LOG(INFO) << absl::StrFormat("expected sample rate: %.2f [Hz].", expected_rate);
     LOG(INFO) << absl::StrFormat("observed sample rate: %.2f [Hz].", observed_rate);
 
@@ -292,7 +294,7 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     // For this test, use an upper & lower bound with 10% allowed error band.
     const std::string err_msg = absl::StrFormat(
         "num sub-processes: %d, time: %.2f [sec.], rate: %.2f [Hz], observed_rate: %.2f [Hz]",
-        num_subprocesses, t_elapsed.count(), expected_rate, observed_rate);
+        num_subprocesses, t_elapsed_.count(), expected_rate, observed_rate);
     EXPECT_GT(cumulative_sum_, expected_num_sample_lower) << err_msg;
     EXPECT_LT(cumulative_sum_, expected_num_sample_upper) << err_msg;
   }
@@ -317,13 +319,11 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     EXPECT_GT(ratio, 2.0 - kRatioMargin);
     EXPECT_LT(ratio, 2.0 + kRatioMargin);
 
-    EXPECT_EQ(source_->stats().Get(PerfProfileConnector::StatKey::kLossHistoEvent), 0);
+    EXPECT_EQ(source_.RawPtr()->stats().Get(PerfProfileConnector::StatKey::kLossHistoEvent), 0);
   }
 
   void ConsumeRecords() {
-    const std::vector<TaggedRecordBatch> tablets = data_table_.ConsumeRecords();
-    ASSERT_NOT_EMPTY_AND_GET_RECORDS(columns_, tablets);
-    PopulateColumnPtrs(columns_);
+    ASSERT_OK_AND_ASSIGN(columns_, source_.ConsumeRecords(kProfilerTableNum));
     auto target_row_idxs =
         FindRecordIdxMatchesPIDs(columns_, kStackTraceUPIDIdx, sub_processes_->pids());
 
@@ -331,74 +331,22 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
     PopulateObservedStackTraces(target_row_idxs);
   }
 
-  void PopulateColumnPtrs(const types::ColumnWrapperRecordBatch& columns) {
-    trace_ids_column_ = columns[kStackTraceStackTraceIDIdx];
-    stack_traces_column_ = columns[kStackTraceStackTraceStrIdx];
-    counts_column_ = columns[kStackTraceCountIdx];
-    column_ptrs_populated_ = true;
-  }
+  Status RunTest() {
+    PX_RETURN_IF_ERROR(source_.Init(sub_processes_->upids()));
+    PX_RETURN_IF_ERROR(source_.Start());
 
-  void RefreshContext(const absl::flat_hash_set<md::UPID>& upids) {
-    absl::base_internal::SpinLockHolder lock(&perf_profiler_state_lock_);
-    ctx_ = std::make_unique<StandaloneContext>(upids);
-  }
-
-  void StartTransferDataThread() {
-    ASSERT_TRUE(source_ != nullptr);
-
-    sampling_period_ = source_->SamplingPeriod();
-    ASSERT_LT(sampling_period_, test_run_time_);
-
-    // Create an initial empty context for use by the transfer data thread.
-    const absl::flat_hash_set<md::UPID> empty_upid_set;
-    ctx_ = std::make_unique<StandaloneContext>(empty_upid_set);
-
-    transfer_data_thread_ = std::thread([this]() {
-      transfer_enable_ = true;
-      while (transfer_enable_) {
-        {
-          absl::base_internal::SpinLockHolder lock(&perf_profiler_state_lock_);
-          source_->TransferData(ctx_.get());
-        }
-        std::this_thread::sleep_for(sampling_period_);
-      }
-    });
-  }
-
-  void StopTransferDataThread() {
-    CHECK(transfer_data_thread_.joinable());
-    transfer_enable_ = false;
-    transfer_data_thread_.join();
-    source_->TransferData(ctx_.get());
-  }
-
-  std::chrono::duration<double> RunTest() {
     const auto start_time = std::chrono::steady_clock::now();
-
-    // While we sleep (here), the transfer data thread is running.
-    // In that thread, TransferData() is invoked periodically.
     std::this_thread::sleep_for(test_run_time_);
-    StopTransferDataThread();
 
-    // We return the amount of time that we ran the test; it will be used to compute
-    // the observed sample rate and the expected number of samples.
-    return std::chrono::steady_clock::now() - start_time;
+    PX_RETURN_IF_ERROR(source_.Stop());
+
+    const auto end_time = std::chrono::steady_clock::now();
+    t_elapsed_ = std::chrono::duration_cast<std::chrono::duration<double>>(end_time - start_time);
+
+    return Status::OK();
   }
 
-  const std::chrono::seconds test_run_time_;
-  std::chrono::milliseconds sampling_period_;
-  std::atomic<bool> transfer_enable_ = false;
-  std::thread transfer_data_thread_;
-  absl::base_internal::SpinLock perf_profiler_state_lock_;
-  std::unique_ptr<PerfProfileConnector> source_;
   std::unique_ptr<PerfProfilerTestSubProcesses> sub_processes_;
-  std::unique_ptr<StandaloneContext> ctx_;
-  DataTable data_table_;
-
-  bool column_ptrs_populated_ = false;
-  std::shared_ptr<types::ColumnWrapper> trace_ids_column_;
-  std::shared_ptr<types::ColumnWrapper> stack_traces_column_;
-  std::shared_ptr<types::ColumnWrapper> counts_column_;
 
   uint64_t cumulative_sum_ = 0;
   absl::flat_hash_map<std::string, uint64_t> histo_;
@@ -408,9 +356,23 @@ class PerfProfileBPFTest : public ::testing::TestWithParam<std::filesystem::path
   // To reduce variance in results, we add more run-time or add sub-processes:
   static constexpr uint64_t kNumSubProcs = 4;
   static constexpr double kRatioMargin = 0.5;
+
+  static constexpr uint32_t kProfilerTableNum = 0;
+
+  // Target test run time. Used by RunTest().
+  std::chrono::seconds test_run_time_;
+
+  // Elapsed test run time. Set by RunTest().
+  std::chrono::duration<double> t_elapsed_;
+
+  UnitConnector<PerfProfileConnector> source_;
 };
 
-TEST_F(PerfProfileBPFTest, PerfProfilerGoTest) {
+class FastPerfProfileBPFTest : public PerfProfileBPFTest</* FastTest */ true> {};
+
+class SlowPerfProfileBPFTest : public PerfProfileBPFTest</* FastTest */ false> {};
+
+TEST_F(SlowPerfProfileBPFTest, PerfProfilerGoTest) {
   const std::filesystem::path bazel_app_path = BazelGoTestAppPath("profiler_test_app_sqrt_go");
   ASSERT_TRUE(fs::Exists(bazel_app_path)) << absl::StrFormat("Missing: %s.", bazel_app_path);
 
@@ -423,19 +385,19 @@ TEST_F(PerfProfileBPFTest, PerfProfilerGoTest) {
   // Start target apps & create the connector context using the sub-process upids.
   sub_processes_ = std::make_unique<CPUPinnedSubProcesses>(bazel_app_path);
   ASSERT_NO_FATAL_FAILURE(sub_processes_->StartAll());
-  RefreshContext(sub_processes_->upids());
 
-  // Allow target apps to run, and periodically call transfer data on perf profile connector.
-  const std::chrono::duration<double> t_elapsed = RunTest();
+  // Bring up (and later stop) the perf profile source connector, setup test params,
+  // and allow target apps to run for the allotted time.
+  ASSERT_OK(RunTest());
 
   // Pull the data from the perf profile connector into this test case.
   ASSERT_NO_FATAL_FAILURE(ConsumeRecords());
 
-  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs, t_elapsed));
+  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs));
   ASSERT_NO_FATAL_FAILURE(CheckExpectedProfile(histo_, key1x, key2x));
 }
 
-TEST_F(PerfProfileBPFTest, PerfProfilerCppTest) {
+TEST_F(FastPerfProfileBPFTest, PerfProfilerCppTest) {
   const std::filesystem::path bazel_app_path = BazelCCTestAppPath("profiler_test_app_fib");
   ASSERT_TRUE(fs::Exists(bazel_app_path)) << absl::StrFormat("Missing: %s.", bazel_app_path);
 
@@ -446,20 +408,20 @@ TEST_F(PerfProfileBPFTest, PerfProfilerCppTest) {
   // Start target apps & create the connector context using the sub-process upids.
   sub_processes_ = std::make_unique<CPUPinnedSubProcesses>(bazel_app_path);
   ASSERT_NO_FATAL_FAILURE(sub_processes_->StartAll());
-  RefreshContext(sub_processes_->upids());
 
-  // Allow target apps to run, and periodically call transfer data on perf profile connector.
-  const std::chrono::duration<double> t_elapsed = RunTest();
+  // Bring up (and later stop) the perf profile source connector, setup test params,
+  // and allow target apps to run for the allotted time.
+  ASSERT_OK(RunTest());
 
   // Pull the data from the perf profile connector into this test case.
   ASSERT_NO_FATAL_FAILURE(ConsumeRecords());
 
   const auto leaf_histo = KeepNLeafSyms(3, histo_);
-  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs, t_elapsed));
+  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs));
   ASSERT_NO_FATAL_FAILURE(CheckExpectedProfile(leaf_histo, key1x, key2x));
 }
 
-TEST_F(PerfProfileBPFTest, GraalVM_AOT_Test) {
+TEST_F(FastPerfProfileBPFTest, GraalVM_AOT_Test) {
   const std::string app_path = "ProfilerTest";
   const std::filesystem::path bazel_app_path = BazelJavaTestAppPath(app_path);
   ASSERT_TRUE(fs::Exists(bazel_app_path)) << absl::StrFormat("Missing: %s.", bazel_app_path);
@@ -472,20 +434,20 @@ TEST_F(PerfProfileBPFTest, GraalVM_AOT_Test) {
   // Start target apps & create the connector context using the sub-process upids.
   sub_processes_ = std::make_unique<CPUPinnedSubProcesses>(bazel_app_path);
   ASSERT_NO_FATAL_FAILURE(sub_processes_->StartAll());
-  RefreshContext(sub_processes_->upids());
 
-  // Allow target apps to run, and periodically call transfer data on perf profile connector.
-  const std::chrono::duration<double> t_elapsed = RunTest();
+  // Bring up (and later stop) the perf profile source connector, setup test params,
+  // and allow target apps to run for the allotted time.
+  ASSERT_OK(RunTest());
 
   // Pull the data from the perf profile connector into this test case.
   ASSERT_NO_FATAL_FAILURE(ConsumeRecords());
 
   const auto leaf_histo = KeepNLeafSyms(1, histo_);
-  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs, t_elapsed));
+  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs));
   ASSERT_NO_FATAL_FAILURE(CheckExpectedProfile(leaf_histo, key1x, key2x));
 }
 
-TEST_P(PerfProfileBPFTest, PerfProfilerJavaTest) {
+TEST_P(FastPerfProfileBPFTest, PerfProfilerJavaTest) {
   constexpr std::string_view kContainerNamePfx = "java";
   const std::filesystem::path image_tar_path = GetParam();
   ASSERT_TRUE(fs::Exists(image_tar_path)) << absl::StrFormat("Missing: %s.", image_tar_path);
@@ -498,54 +460,129 @@ TEST_P(PerfProfileBPFTest, PerfProfilerJavaTest) {
   // Start target apps & create the connector context using the sub-process upids.
   sub_processes_ = std::make_unique<ContainerSubProcesses>(image_tar_path, kContainerNamePfx);
   ASSERT_NO_FATAL_FAILURE(sub_processes_->StartAll());
-  RefreshContext(sub_processes_->upids());
 
-  // Allow target apps to run, and periodically call transfer data on perf profile connector.
-  RunTest();
+  // Bring up (and later stop) the perf profile source connector, setup test params,
+  // and allow target apps to run for the allotted time.
+  ASSERT_OK(RunTest());
 
   // Pull the data from the perf profile connector into this test case.
   ASSERT_NO_FATAL_FAILURE(ConsumeRecords());
 
   const auto leaf_histo = KeepNLeafSyms(1, histo_);
   ASSERT_NO_FATAL_FAILURE(CheckExpectedProfile(leaf_histo, key1x, key2x));
+  ASSERT_NO_FATAL_FAILURE(CheckExpectedSampleRate(kNumSubProcs));
+}
 
-  // Now we will test agent cleanup, specifically whether the aritfacts directory is removed.
-  // We will construct a list of artifacts paths that we expect,
-  // then kill all the subprocesses,
-  // and expect that all the artifacts paths are (as a result) removed.
-  std::vector<std::filesystem::path> artifacts_paths;
+using ::px::stirling::testing::Timeout;
 
-  // Consruct the names of the artifacts paths and expect that they exist.
-  for (const auto& upid : sub_processes_->struct_upids()) {
-    const auto artifacts_path = java::StirlingArtifactsPath(upid);
-    EXPECT_TRUE(fs::Exists(artifacts_path));
-    if (fs::Exists(artifacts_path)) {
-      artifacts_paths.push_back(artifacts_path);
+TEST_F(FastPerfProfileBPFTest, PerfProfilerJavaArtifactsCleanupTest) {
+  const std::filesystem::path bazel_app_path = BazelJavaTestAppPath("profiler_test");
+  ASSERT_TRUE(fs::Exists(bazel_app_path)) << absl::StrFormat("Missing: %s.", bazel_app_path);
+
+  sub_processes_ = std::make_unique<CPUPinnedSubProcesses>(bazel_app_path);
+  ASSERT_NO_FATAL_FAILURE(sub_processes_->StartAll());
+
+  for (const auto pid : sub_processes_->pids()) {
+    LOG(WARNING) << "Started sub-process: " << pid << ".";
+  }
+
+  ASSERT_OK(source_.Init(sub_processes_->upids()));
+  ASSERT_OK(source_.Start());
+
+  std::set<std::filesystem::path> artifacts_paths;
+
+  {
+    Timeout timer;
+    while (!timer.TimedOut() && artifacts_paths.size() < kNumSubProcs) {
+      for (const auto& upid : sub_processes_->struct_upids()) {
+        const auto artifacts_path = java::StirlingArtifactsPath(upid);
+        if (fs::Exists(artifacts_path) && artifacts_paths.count(artifacts_path) == 0) {
+          artifacts_paths.insert(artifacts_path);
+        }
+      }
     }
   }
   EXPECT_THAT(artifacts_paths, SizeIs(kNumSubProcs));
 
+  // Wait to see a Java symbol from each sub-process, i.e. so that we know the symbolization
+  // artifact was created and populated.
+  std::set<int> pids_with_java_symbols;
+  {
+    Timeout timer;
+    while( !timer.TimedOut() && pids_with_java_symbols.size() < kNumSubProcs) {
+      ASSERT_OK(source_.Flush());
+      auto s = source_.ConsumeRecords(kProfilerTableNum);
+      if (s.ok()) {
+        columns_ = s.ConsumeValueOrDie();
+        auto stack_traces_column = columns_[kStackTraceStackTraceStrIdx];
+        for (const auto pid : sub_processes_->pids()) {
+          if (pids_with_java_symbols.find(pid) != pids_with_java_symbols.end()) {
+            // Already found, ok to continue.
+            continue;
+          }
+
+          // This returns a list of each symbol in all the stack traces for a given pid.
+          auto AllSymbolsForPid = [&](const int pid) {
+            std::vector<std::string> stack_traces;
+
+            const auto rows_idxs = FindRecordIdxMatchesPIDs(columns_, kStackTraceUPIDIdx, {pid});
+            for (const auto row_idx : rows_idxs) {
+              const auto stack_trace = stack_traces_column->Get<types::StringValue>(row_idx);
+              stack_traces.push_back(stack_trace);
+            }
+            const std::string all_symbols = absl::StrJoin(stack_traces, ";");
+            const std::vector<std::string_view> symbols = absl::StrSplit(all_symbols, ";");
+            return symbols;
+          };
+
+          // Iterate over all the symbols for this pid to look for a Java symbol.
+          for (const auto symbol : AllSymbolsForPid(pid)) {
+            if (absl::StartsWith(symbol, "[j]")) {
+              // The Java symbolizer found a Java symbol for this process.
+              pids_with_java_symbols.insert(pid);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // We expect that we found a Java symbol for each sub-process.
+  EXPECT_THAT(pids_with_java_symbols, SizeIs(kNumSubProcs));
+
   // Kill the subprocs.
   sub_processes_->KillAll();
 
-  // Inside of PerfProfileConnector, we need the list of deleted upids to match our original
-  // list of upids based on our subprocs.
-  // For that to happen, here, we reset the context so that it has no UPIDs.
-  // The ProcTracker (inside of PerfProfileConnector) will take the difference
-  // between the previous list of upids (our subprocs) and the current list of upids (empty)
-  // to find a list of deleted upids.
-  const absl::flat_hash_set<md::UPID> empty_upid_set;
-  RefreshContext(empty_upid_set);
+  // Need to pass in an invalid upid set to prevent picking up the default context that
+  // accepts all pids.
+  const md::UPID invalid_upid = { 0, 0, 0 };
+  const absl::flat_hash_set<md::UPID> invalid_upid_set = { invalid_upid };
+  ASSERT_OK(source_.ResetConnectorContext(invalid_upid_set));
 
-  // Run transfer data so that cleanup is kicked off in the perf profile source connector.
-  // The deleted upids list that is inferred will match our original upid list.
-  source_->TransferData(ctx_.get());
+  // Now that the sub-processes are gone, iterate over the previously found artifact paths.
+  // If the artifact path can no longer be found, we remove it from the set.
+  {
+    Timeout timer;
+    std::set<std::filesystem::path> removed_artifacts_paths;
+    while (!timer.TimedOut() && artifacts_paths.size() > 0) {
+      for (const auto& artifacts_path : artifacts_paths) {
+        if (!fs::Exists(artifacts_path)) {
+          artifacts_paths.erase(artifacts_path);
+          break;
+        }
+      }
+    }
+  }
 
-  // Expect that that the artifacts paths have been removed.
-  EXPECT_THAT(artifacts_paths, Each(Not(PathExists())));
+  // This is the main event:
+  // we expect that the profiler cleans up each artifact.
+  EXPECT_THAT(artifacts_paths, SizeIs(0));
+
+  ASSERT_OK(source_.Stop());
 }
 
-TEST_F(PerfProfileBPFTest, TestOutOfContext) {
+TEST_F(FastPerfProfileBPFTest, TestOutOfContext) {
   const std::filesystem::path bazel_app_path = BazelCCTestAppPath("profiler_test_app_fib");
   ASSERT_TRUE(fs::Exists(bazel_app_path)) << absl::StrFormat("Missing: %s.", bazel_app_path);
 
@@ -553,11 +590,17 @@ TEST_F(PerfProfileBPFTest, TestOutOfContext) {
   sub_processes_ = std::make_unique<CPUPinnedSubProcesses>(bazel_app_path);
   ASSERT_NO_FATAL_FAILURE(sub_processes_->StartAll());
 
-  // Use an empty connector context.
-  ctx_ = std::make_unique<StandaloneContext>(absl::flat_hash_set<md::UPID>());
+  // The "out of context" test needs to handle init., param. setup, and start each individually,
+  //  so that it can pass in an empty set of upids rather than the subprocess upids.
+  const md::UPID invalid_upid = { 0, 0, 0 };
+  const absl::flat_hash_set<md::UPID> invalid_upid_set = {invalid_upid};
+  ASSERT_OK(source_.Init(invalid_upid_set));
+  ASSERT_OK(source_.Start());
 
   // Allow target apps to run, and periodically call transfer data on perf profile connector.
-  RunTest();
+  std::this_thread::sleep_for(test_run_time_);
+
+  ASSERT_OK(source_.Stop());
 
   // Pull the data from the perf profile connector into this test case.
   ASSERT_NO_FATAL_FAILURE(ConsumeRecords());
@@ -573,7 +616,7 @@ std::vector<std::filesystem::path> GetJavaImagePaths() {
   return image_paths;
 }
 
-INSTANTIATE_TEST_SUITE_P(PerfProfileJavaTests, PerfProfileBPFTest,
+INSTANTIATE_TEST_SUITE_P(PerfProfileJavaTests, FastPerfProfileBPFTest,
                          ::testing::ValuesIn(GetJavaImagePaths()));
 
 }  // namespace stirling


### PR DESCRIPTION
Summary: we convert `perf_profiler_bpf_test` to use `UnitConnector` to share code across different tests and binaries.

We also refactor the Java test case to separately test the expectation that Java symbolization artifacts are removed after processes stop. The main Java test case then conforms to the pattern established for Go and cpp.

We also update some of the helper functions in the test to tidy up the common test cases.

Type of change: /kind cleanup

Test Plan: existing tests & runs per test.
- [x] `bazel test //src/stirling/source_connectors/perf_profiler/... --config bpf --runs_per_test 16` ([all tests passed](https://phab.corp.pixielabs.ai/P372)).