### PR TITLE
[indexer] Use `esutils.ManagedIndex` to create elastic index

### DIFF
--- a/k8s/cloud/base/indexer_config.yaml
+++ b/k8s/cloud/base/indexer_config.yaml
@@ -4,5 +4,7 @@ kind: ConfigMap
 metadata:
   name: pl-indexer-config
 data:
-  PL_MD_INDEX_NAME: md_entities_8
+  PL_MD_INDEX_NAME: md_entities_9
   PL_MD_INDEX_REPLICAS: "4"
+  PL_MD_INDEX_MAX_AGE: "3d"
+  PL_MD_INDEX_DELETE_AFTER: "3d"

--- a/k8s/cloud/dev/indexer_config.yaml
+++ b/k8s/cloud/dev/indexer_config.yaml
@@ -4,5 +4,4 @@ kind: ConfigMap
 metadata:
   name: pl-indexer-config
 data:
-  PL_MD_INDEX_NAME: md_entities_8
   PL_MD_INDEX_REPLICAS: "1"

--- a/k8s/cloud/staging/indexer_config.yaml
+++ b/k8s/cloud/staging/indexer_config.yaml
@@ -4,5 +4,4 @@ kind: ConfigMap
 metadata:
   name: pl-indexer-config
 data:
-  PL_MD_INDEX_NAME: md_entities_8
   PL_MD_INDEX_REPLICAS: "2"

--- a/k8s/cloud/testing/indexer_config.yaml
+++ b/k8s/cloud/testing/indexer_config.yaml
@@ -4,5 +4,4 @@ kind: ConfigMap
 metadata:
   name: pl-indexer-config
 data:
-  PL_MD_INDEX_NAME: md_entities_8
   PL_MD_INDEX_REPLICAS: "2"

--- a/src/cloud/autocomplete/suggester_test.go
+++ b/src/cloud/autocomplete/suggester_test.go
@@ -166,7 +166,7 @@ func TestMain(m *testing.M) {
 	elasticClient = es
 
 	// Set up elastic indexes.
-	err = md.InitializeMapping(es, indexName, 1)
+	err = md.InitializeMapping(es, indexName, 1, "30d", "30d")
 	if err != nil {
 		cleanup()
 		log.Fatal(err)

--- a/src/cloud/indexer/indexer_server.go
+++ b/src/cloud/indexer/indexer_server.go
@@ -50,6 +50,8 @@ func init() {
 	pflag.String("domain_name", "dev.withpixie.dev", "The domain name of Pixie Cloud")
 
 	pflag.String("md_index_name", "", "The elastic index name for metadata.")
+	pflag.String("md_index_max_age", "", "The amount of time before rolling over the elastic index as a string, eg '30d'")
+	pflag.String("md_index_delete_after", "", "The amount of time after rollover to delete old elastic indices, as a string, eg '30d'")
 	pflag.Int("md_index_replicas", 4, "The number of replicas to setup for the metadata index.")
 }
 
@@ -121,7 +123,16 @@ func main() {
 	}
 	replicas := viper.GetInt("md_index_replicas")
 
-	err = md.InitializeMapping(es, indexName, replicas)
+	maxAge := viper.GetString("md_index_max_age")
+	if maxAge == "" {
+		log.Fatal("Must specify a max age for the elastic index.")
+	}
+	deleteAfter := viper.GetString("md_index_delete_after")
+	if deleteAfter == "" {
+		log.Fatal("Must specify a delete after time for the rolled over elastic indices.")
+	}
+
+	err = md.InitializeMapping(es, indexName, replicas, maxAge, deleteAfter)
 	if err != nil {
 		log.WithError(err).Fatal("Could not initialize elastic mapping")
 	}

--- a/src/cloud/indexer/md/BUILD.bazel
+++ b/src/cloud/indexer/md/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     importpath = "px.dev/pixie/src/cloud/indexer/md",
     visibility = ["//src/cloud:__subpackages__"],
     deps = [
+        "//src/cloud/shared/esutils",
         "//src/shared/k8s/metadatapb:metadata_pl_go_proto",
         "//src/shared/services/msgbus",
         "@com_github_gofrs_uuid//:uuid",

--- a/src/cloud/indexer/md/md_test.go
+++ b/src/cloud/indexer/md/md_test.go
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 	vzID = uuid.Must(uuid.NewV4())
 	orgID = uuid.Must(uuid.NewV4())
 
-	err = md.InitializeMapping(es, indexName, 1)
+	err = md.InitializeMapping(es, indexName, 1, "30d", "30d")
 	if err != nil {
 		cleanup()
 		log.WithError(err).Fatal("Could not initialize indexes in elastic")

--- a/src/cloud/shared/esutils/ilm_policy.go
+++ b/src/cloud/shared/esutils/ilm_policy.go
@@ -27,17 +27,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// DefaultMaxIndexSize is the default size to allow the index to grow to before rollover.
-	DefaultMaxIndexSize = "50gb"
-	// DefaultTimeBeforeDelete is the default amount of time after rollover, to wait before deleting an index.
-	DefaultTimeBeforeDelete = "0d"
-)
-
-func strPtr(s string) *string {
-	return &s
-}
-
 type esILMPolicy struct {
 	Policy map[string]interface{} `json:"policy"`
 }
@@ -59,7 +48,7 @@ func NewILMPolicy(es *elastic.Client, policyName string) *ILMPolicy {
 			Policy: make(map[string]interface{}),
 		},
 	}
-	return p.Rollover(strPtr(DefaultMaxIndexSize), nil, nil).DeleteAfter(DefaultTimeBeforeDelete)
+	return p
 }
 
 func (p *ILMPolicy) mapForPhase(phaseName string) map[string]interface{} {

--- a/src/cloud/shared/esutils/index_test.go
+++ b/src/cloud/shared/esutils/index_test.go
@@ -279,7 +279,7 @@ func TestIndexMigrate(t *testing.T) {
 			{
 				"settings": {
 					"index": {
-						"number_of_shards": 2
+						"number_of_shards": "2"
 					}
 				}
 			}
@@ -296,7 +296,7 @@ func TestIndexMigrate(t *testing.T) {
 				{
 					"settings": {
 						"index": {
-							"number_of_shards": 1
+							"number_of_shards": "1"
 						}
 					}
 				}
@@ -313,7 +313,7 @@ func TestIndexMigrate(t *testing.T) {
 			{
 				"settings": {
 					"index": {
-						"number_of_shards": 2,
+						"number_of_shards": "2",
 						"blocks": {
 							"write": "true",
 							"read": "false"
@@ -326,7 +326,7 @@ func TestIndexMigrate(t *testing.T) {
 			{
 				"settings": {
 					"index": {
-						"number_of_shards": 2	,
+						"number_of_shards": "2",
 						"blocks": {
 							"write": "true",
 							"read": "false"
@@ -351,7 +351,7 @@ func TestIndexMigrate(t *testing.T) {
 				{
 					"settings": {
 						"index": {
-							"number_of_shards": 2,
+							"number_of_shards": "2",
 							"blocks": {
 								"write": "false",
 								"read": "true"

--- a/src/cloud/shared/esutils/managed_index.go
+++ b/src/cloud/shared/esutils/managed_index.go
@@ -91,6 +91,14 @@ func (m *ManagedIndex) MaxIndexSize(maxSize string) *ManagedIndex {
 	return m
 }
 
+// MaxIndexAge sets how long the index will live until its rolled over.
+// Rolled over indices can still be accessed until the Delete condition is reached.
+// It should be specified as a string, eg. "30d".
+func (m *ManagedIndex) MaxIndexAge(maxAge string) *ManagedIndex {
+	m.policy.Rollover(nil, nil, &maxAge)
+	return m
+}
+
 // TimeBeforeDelete sets the amount of time that should be waited after rollover, before deleting the index.
 // The time should be specified as a string with unit, eg. "1d".
 func (m *ManagedIndex) TimeBeforeDelete(timeBeforeDelete string) *ManagedIndex {

--- a/src/cloud/shared/esutils/managed_index_test.go
+++ b/src/cloud/shared/esutils/managed_index_test.go
@@ -80,7 +80,7 @@ func TestManagedIndexMigrate(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := esutils.NewManagedIndex(elasticClient, tc.managedIndName).Migrate(context.Background())
+			err := esutils.NewManagedIndex(elasticClient, tc.managedIndName).MaxIndexSize("1gb").TimeBeforeDelete("10d").Migrate(context.Background())
 			if tc.expectErr {
 				require.NotNil(t, err)
 				assert.Equal(t, tc.errMsg, err.Error())


### PR DESCRIPTION
Summary: The `ManagedIndex` creates an elastic ILM policy which causes elastic to rollover the indices after the given period of time, and then delete rolled-over indices after another given period of time. Its currently setup to rollover indices after 3 days and then delete the rolled over indices after another 3 days. Since we refresh metadata every 12hours this should be plenty of leeway. This PR also fixes a couple of bugs with the way `esutils` handles updating settings when the requested index already exists.

Type of change: /kind cleanup

Test Plan: Tested on dev cloud
- [x] Deployed to dev cloud and made sure I could see pods/nodes/etc in the command palette.
- [x] Bounced the indexer server and made sure it came up properly and that I could still see metadata in the command palette after.
- [x] Set the max age and delete after to 10m, saw the rollover and subsequent delete occur as expected. After the initial rollover, all the metadata could still be seen in the command palette. After the delete, the old metadata was gone, but if I bounced a pod in my cluster I could see the new pod in the command palette.
