### PR TITLE
[qemu] Interactive qemu runner

### DIFF
--- a/bazel/cc_toolchains/sysroots/sysroots.bzl
+++ b/bazel/cc_toolchains/sysroots/sysroots.bzl
@@ -34,9 +34,9 @@ SYSROOT_LOCATIONS = dict(
         urls = ["https://storage.googleapis.com/pixie-dev-public/sysroots/pl6/sysroot-amd64-test.tar.gz"],
     ),
     sysroot_x86_64_glibc2_36_debug = dict(
-        sha256 = "5639c73b5afd7c16bbdcbfcbd54262ea232283a5f5b4852e51c77062dea62f2e",
+        sha256 = "1430be9aa4290060c45f2afddeef59460746ccea91435605ce3d6fe907f6a558",
         strip_prefix = "",
-        urls = ["https://storage.googleapis.com/pixie-dev-public/sysroots/pl6/sysroot-amd64-debug.tar.gz"],
+        urls = ["https://storage.googleapis.com/pixie-dev-public/sysroots/pl7/sysroot-amd64-debug.tar.gz"],
     ),
     sysroot_aarch64_glibc2_36_runtime = dict(
         sha256 = "48ea0856326974dca562db5a4e7ef09befef50fdb7a13698966e06393a3b090c",

--- a/bazel/pl_build_system.bzl
+++ b/bazel/pl_build_system.bzl
@@ -21,6 +21,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_library", "go_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:defs.bzl", "py_test")
+load("//bazel:toolchain_transitions.bzl", "qemu_interactive_runner")
 
 pl_supported_go_sdk_versions = ["1.16", "1.17", "1.18", "1.19", "1.20"]
 
@@ -476,3 +477,25 @@ def pl_py_test(**kwargs):
 def pl_sh_test(**kwargs):
     _add_test_runner(kwargs)
     native.sh_test(**kwargs)
+
+def pl_cc_bpf_test(**kwargs):
+    pl_cc_test(**kwargs)
+    qemu_interactive_runner(
+        name = kwargs["name"] + "_qemu_interactive",
+        data = [
+            ":" + kwargs["name"],
+        ],
+        tags = ["manual"],
+        testonly = True,
+    )
+
+def pl_sh_bpf_test(**kwargs):
+    pl_sh_test(**kwargs)
+    qemu_interactive_runner(
+        name = kwargs["name"] + "_qemu_interactive",
+        data = [
+            ":" + kwargs["name"],
+        ],
+        tags = ["manual"],
+        testonly = True,
+    )

--- a/bazel/test_runners/qemu_with_kernel/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/BUILD.bazel
@@ -16,7 +16,10 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:pl_qemu_kernels.bzl", "kernel_flag_name", "qemu_image_to_deps")
+load("//bazel:toolchain_transitions.bzl", "qemu_interactive_runner")
 load("//bazel/test_runners/qemu_with_kernel:runner.bzl", "qemu_with_kernel_test_runner")
+
+exports_files(["interactive_runner.sh"])
 
 kernel_image_deps = qemu_image_to_deps()
 
@@ -39,5 +42,10 @@ kernel_select_list = {kernel_flag_name(version): dep for version, dep in kernel_
 qemu_with_kernel_test_runner(
     name = "runner",
     kernel_image = select(kernel_select_list),
+    visibility = ["//visibility:public"],
+)
+
+qemu_interactive_runner(
+    name = "run_interactive",
     visibility = ["//visibility:public"],
 )

--- a/bazel/test_runners/qemu_with_kernel/init
+++ b/bazel/test_runners/qemu_with_kernel/init
@@ -75,6 +75,9 @@ function mount_system_dirs() {
 
   mkdir -p /dev/shm
   mount -t tmpfs tmpfs /dev/shm
+
+  mkdir -p /dev/pts
+  mount -t devpts devpts /dev/pts
 }
 
 function mount_test_fs() {

--- a/bazel/test_runners/qemu_with_kernel/interactive_runner.sh
+++ b/bazel/test_runners/qemu_with_kernel/interactive_runner.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env -S -i /bin/bash
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# shellcheck shell=bash
+
+get_free_port() {
+  read -r l u < /proc/sys/net/ipv4/ip_local_port_range
+  for port in $(seq "${l}" "${u}"); do
+    if ! (echo "" 2>/dev/null > "/dev/tcp/127.0.0.1/${port}"); then
+      echo "${port}"
+      break
+    fi
+  done
+}
+
+export OLDPWD="$PWD"
+export RUNFILES_DIR="$PWD"
+export INTERACTIVE_MODE="true"
+SSH_PORT="$(get_free_port)"
+export SSH_PORT
+
+priv_key="${RUNFILES_DIR}/qemu_guest_ssh_key"
+pub_key="${priv_key}.pub"
+rm "${priv_key}" &> /dev/null || true
+rm "${pub_key}" &> /dev/null || true
+ssh-keygen -f "${priv_key}" -N '' -b 1024 &>/dev/null
+
+export SSH_PUB_KEY="${pub_key}"
+
+log="$PWD/interactive_qemu.log"
+# shellcheck disable=SC2288
+%qemu_runner_path% &> "${log}" &
+qemu_pid="$!"
+
+script_pid="$$"
+
+cleanup() {
+  set +e
+  echo "Killing QEMU"
+  kill "${qemu_pid}"
+  while kill -0 "${qemu_pid}" 2>/dev/null; do
+    sleep 1
+  done
+  exit
+}
+
+trap cleanup SIGINT
+
+echo "QEMU logs redirected to ${log}"
+while ! ssh -t -i "${priv_key}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p "${SSH_PORT}" root@localhost 'cd /test_fs; bash -l'; do
+  sleep 1
+done
+
+cleanup

--- a/bazel/test_runners/qemu_with_kernel/run_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/run_qemu.sh
@@ -76,16 +76,23 @@ flags+=(-append "console=ttyS0 root=/dev/sda")
 # Disable graphics mode.
 flags+=(-nographic)
 
+if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
+  flags+=(-device "virtio-net-pci,netdev=net0")
+  flags+=(-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:${SSH_PORT}")
+fi
+
 retval=0
-qemu-system-x86_64 "${flags[@]}" || retval=$?
+exec qemu-system-x86_64 "${flags[@]}" || retval=$?
 
 if [[ "${retval}" -gt 0 ]]; then
     if [[ "${retval}" -lt 128 ]]; then
-	echo "QEMU failed to launch with status code: ${retval}"
+	    echo "QEMU failed to launch with status code: ${retval}"
     else
-	retval="$(echo "($retval-128-1)/2" | bc)"
-	echo "Test failed with status: ${retval}"
+	    retval="$(echo "($retval-128-1)/2" | bc)"
     fi
+fi
+if [[ "${retval}" -ne 0 ]];  then
+  echo "Test failed with status: ${retval}"
 fi
 
 exit "${retval}"

--- a/bazel/toolchain_transitions.bzl
+++ b/bazel/toolchain_transitions.bzl
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@com_github_fmeum_rules_meta//meta:defs.bzl", "meta")
+load("//bazel/test_runners/qemu_with_kernel:runner.bzl", "qemu_with_kernel_interactive_runner")
 
 cc_static_musl_binary = meta.wrap_with_transition(
     native.cc_binary,
@@ -37,6 +38,15 @@ cc_clang_binary = meta.wrap_with_transition(
     native.cc_binary,
     {
         "@//bazel/cc_toolchains:compiler": meta.replace_with("clang"),
+    },
+    executable = True,
+)
+
+qemu_interactive_runner = meta.wrap_with_transition(
+    qemu_with_kernel_interactive_runner,
+    {
+        "@//bazel/cc_toolchains/sysroots:debug_sysroot": meta.replace_with(True),
+        "@//bazel/cc_toolchains:libc_version": meta.replace_with("glibc2_36"),
     },
     executable = True,
 )

--- a/src/stirling/bpf_tools/BUILD.bazel
+++ b/src/stirling/bpf_tools/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -60,7 +60,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bcc_wrapper_bpf_test",
     srcs = ["bcc_wrapper_bpf_test.cc"],
     tags = [
@@ -74,7 +74,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bcc_symbolizer_bpf_test",
     srcs = ["bcc_symbolizer_bpf_test.cc"],
     tags = [
@@ -87,7 +87,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bpftrace_wrapper_bpf_test",
     srcs = ["bpftrace_wrapper_bpf_test.cc"],
     tags = [
@@ -100,7 +100,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "task_struct_resolver_bpf_test",
     srcs = ["task_struct_resolver_bpf_test.cc"],
     tags = [
@@ -116,7 +116,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "uprobe_extra_trigger_bpf_test",
     srcs = ["uprobe_extra_trigger_bpf_test.cc"],
     tags = [

--- a/src/stirling/e2e_tests/BUILD.bazel
+++ b/src/stirling/e2e_tests/BUILD.bazel
@@ -14,12 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_test", "pl_sh_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_test", "pl_sh_bpf_test", "pl_sh_test")
 load("//src/stirling/source_connectors/perf_profiler/testing:testing.bzl", "agent_libs", "agent_libs_arg")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stirling_bpf_test",
     timeout = "moderate",
     srcs = ["stirling_bpf_test.cc"],
@@ -33,7 +33,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bpf_map_leak_bpf_test",
     timeout = "moderate",
     srcs = ["bpf_map_leak_bpf_test.cc"],
@@ -64,7 +64,7 @@ pl_cc_test(
     ],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_kprobe_leak_bpf_test",
     srcs = ["stirling_wrapper_kprobe_leak_bpf_test.sh"],
     args = [
@@ -84,7 +84,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_bpf_test",
     srcs = ["stirling_wrapper_bpf_test.sh"],
     args = [
@@ -110,7 +110,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_bpftrace_bpf_test",
     srcs = ["stirling_wrapper_bpftrace_bpf_test.sh"],
     args = [
@@ -134,7 +134,7 @@ pl_sh_test(
     ],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_container_bpf_test",
     srcs = ["stirling_wrapper_container_bpf_test.sh"],
     args = [
@@ -163,7 +163,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_perf_bpf_test",
     srcs = ["stirling_perf_bpf_test.sh"],
     args = [
@@ -188,7 +188,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_jvm_stats_bpf_test",
     srcs = ["stirling_wrapper_jvm_stats_bpf_test.sh"],
     args = [
@@ -230,7 +230,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "probe_cleaner_bpf_test",
     srcs = ["probe_cleaner_bpf_test.sh"],
     args = [

--- a/src/stirling/obj_tools/BUILD.bazel
+++ b/src/stirling/obj_tools/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -102,7 +102,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "elf_reader_symbolizer_bpf_test",
     srcs = ["elf_reader_symbolizer_bpf_test.cc"],
     tags = [

--- a/src/stirling/source_connectors/cpu_stat_bpftrace/BUILD.bazel
+++ b/src/stirling/source_connectors/cpu_stat_bpftrace/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -34,7 +34,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "cpu_stat_bpftrace_connector_bpf_test",
     timeout = "long",
     srcs = ["cpu_stat_bpftrace_connector_bpf_test.cc"],

--- a/src/stirling/source_connectors/dynamic_bpftrace/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_bpftrace/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -34,7 +34,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dynamic_bpftrace_connector_bpf_test",
     srcs = ["dynamic_bpftrace_connector_bpf_test.cc"],
     data = [

--- a/src/stirling/source_connectors/dynamic_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_tracer/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -43,7 +43,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dynamic_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dynamic_trace_bpf_test.cc"],
@@ -63,7 +63,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stirling_dt_bpf_test",
     timeout = "long",
     srcs = ["stirling_dt_bpf_test.cc"],

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 load("//src/stirling/source_connectors/perf_profiler/testing:testing.bzl", "agent_libs", "jdk_names", "px_jattach", "stirling_profiler_java_args")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
@@ -41,7 +41,7 @@ jdk_image_names = ["%s-java-profiler-test-image" % jdk_name for jdk_name in jdk_
 
 image_tars = ["//src/stirling/source_connectors/perf_profiler/testing/java:%s-java-profiler-test-image.tar" % jdk_name for jdk_name in jdk_names]
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "perf_profiler_bpf_test",
     timeout = "long",
     srcs = ["perf_profiler_bpf_test.cc"],
@@ -70,7 +70,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stringifier_bpf_test",
     srcs = ["stringifier_bpf_test.cc"],
     tags = [

--- a/src/stirling/source_connectors/proc_exit/BUILD.bazel
+++ b/src/stirling/source_connectors/proc_exit/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__pkg__"])
 
@@ -36,7 +36,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "proc_exit_trace_bpf_test",
     srcs = ["proc_exit_trace_bpf_test.cc"],
     data = ["//src/stirling/source_connectors/proc_exit/testing:sleep"],

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -171,7 +171,7 @@ pl_cc_binary(
 # BPF Tests
 ###############################################################################
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "socket_trace_bpf_test",
     timeout = "long",
     srcs = ["socket_trace_bpf_test.cc"],
@@ -188,7 +188,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "conn_stats_bpf_test",
     timeout = "moderate",
     srcs = ["conn_stats_bpf_test.cc"],
@@ -208,7 +208,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "http_trace_bpf_test",
     timeout = "moderate",
     srcs = ["http_trace_bpf_test.cc"],
@@ -229,7 +229,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "mux_trace_bpf_test",
     timeout = "moderate",
     srcs = ["mux_trace_bpf_test.cc"],
@@ -249,7 +249,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "mysql_trace_bpf_test",
     timeout = "moderate",
     srcs = ["mysql_trace_bpf_test.cc"],
@@ -273,7 +273,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "cql_trace_bpf_test",
     timeout = "moderate",
     srcs = [
@@ -294,7 +294,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "pgsql_trace_bpf_test",
     timeout = "moderate",
     srcs = [
@@ -316,7 +316,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "grpc_trace_bpf_test",
     timeout = "moderate",
     srcs = ["grpc_trace_bpf_test.cc"],
@@ -353,7 +353,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "http2_trace_bpf_test",
     timeout = "moderate",
     srcs = ["http2_trace_bpf_test.cc"],
@@ -376,7 +376,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dns_trace_bpf_test",
     timeout = "moderate",
     srcs = [
@@ -397,7 +397,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "redis_trace_bpf_test",
     timeout = "long",
     srcs = ["redis_trace_bpf_test.cc"],
@@ -416,7 +416,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "nats_trace_bpf_test",
     timeout = "long",
     srcs = ["nats_trace_bpf_test.cc"],
@@ -433,7 +433,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "kafka_trace_bpf_test",
     timeout = "moderate",
     srcs = ["kafka_trace_bpf_test.cc"],
@@ -451,7 +451,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "openssl_trace_bpf_test",
     timeout = "long",
     srcs = ["openssl_trace_bpf_test.cc"],
@@ -474,7 +474,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "netty_tls_trace_bpf_test",
     timeout = "long",
     srcs = ["netty_tls_trace_bpf_test.cc"],
@@ -493,7 +493,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dyn_lib_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dyn_lib_trace_bpf_test.cc"],
@@ -512,7 +512,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "go_tls_trace_bpf_test",
     timeout = "moderate",
     srcs = ["go_tls_trace_bpf_test.cc"],
@@ -533,7 +533,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "amqp_trace_bpf_test",
     timeout = "moderate",
     srcs = ["amqp_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/stirling_error/BUILD.bazel
+++ b/src/stirling/source_connectors/stirling_error/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 load("//src/stirling/source_connectors/perf_profiler/testing:testing.bzl", "agent_libs", "px_jattach", "stirling_profiler_java_args")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
@@ -35,7 +35,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stirling_error_bpf_test",
     timeout = "moderate",
     srcs = ["stirling_error_bpf_test.cc"],

--- a/src/stirling/source_connectors/tcp_stats/BUILD.bazel
+++ b/src/stirling/source_connectors/tcp_stats/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -35,7 +35,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "tcp_stats_bpf_test",
     timeout = "long",
     srcs = ["tcp_stats_bpf_test.cc"],

--- a/src/stirling/utils/BUILD.bazel
+++ b/src/stirling/utils/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -127,7 +127,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "detect_application_bpf_test",
     timeout = "moderate",
     srcs = ["detect_application_bpf_test.cc"],

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -50,7 +50,7 @@ GRAALVM_ARCHIVE_FNAME := graalvm-native-image-22.3.0.tar.gz
 GRAALVM_ARCHIVE_GS_PATH := gs://pixie-dev-public/graalvm-native-image-22.3.0-$(GRAALVM_IMAGE_VERSION).tar.gz
 
 ## Sysroot parameters
-SYSROOT_REV := pl6
+SYSROOT_REV := pl7
 SYSROOT_BUILD_DIR := $(BUILD_DIR)/sysroots
 SYSROOT_ARCHITECTURES := amd64 arm64
 SYSROOT_VARIANTS := runtime build test

--- a/tools/docker/sysroot_creator/package_groups/debug.yaml
+++ b/tools/docker/sysroot_creator/package_groups/debug.yaml
@@ -3,5 +3,6 @@ include:
 - gdb
 - llvm-15
 - lldb-15
+- openssh-server
 path_excludes:
 - usr/lib/llvm-15/build


### PR DESCRIPTION
Summary: Adds a rule that creates an executable that will run qemu in interactive mode. QEMU will be launched, and then ssh'd into so that you get a normal shell instead of a serial console. You can run `bazel run //bazel/test_runners/qemu_with_kernel:run_interactive` to get a blank qemu without any test runfiles. Alternatively, you can run `bazel run //<path/to/bpf/test>_qemu_interactive` for any bpf test to get a qemu environment that has the test and its runfiles, eg `bazel run //src/stirling/e2e_tests:probe_cleaner_bpf_test_qemu_interactive`. Note that you don't specify `--config=qemu-bpf`, because of how bazel's `--run_under` works, that config flag wont work.

Type of change: /kind test-infra

Test Plan: Tested a couple of different bpf tests in the interactive qemu and they all worked. Also tested that qemu isn't zombied when you exit.
