### PR TITLE
Add bounds checking to prevent bogus ELF bytecode parsing from causing allocation errors

### DIFF
--- a/src/stirling/obj_tools/elf_reader.cc
+++ b/src/stirling/obj_tools/elf_reader.cc
@@ -617,7 +617,7 @@ StatusOr<utils::u8string> ElfReader::SymbolByteCode(std::string_view section,
   // To protect against our ELF parsing logic locating bogus memory, set a bound on
   // how large of a string we will allocate. SymbolByteCode's main use case is to determine
   // return instructions for the crypto/tls.(*Conn).Write and crypto/tls.(*Conn).Read Go functions.
-  // These symbols' are roughly 2 KiB and were used to inform the threshold below. We apply
+  // These symbols are roughly 2 KiB and were used to inform the threshold below. We apply
   // an additional 100x multiplier for additional headroom.
   // See https://github.com/pixie-io/pixie/issues/1111 for more details.
   if (symbol.size > 100 * 2048) {

--- a/src/stirling/obj_tools/elf_reader.cc
+++ b/src/stirling/obj_tools/elf_reader.cc
@@ -622,7 +622,7 @@ StatusOr<utils::u8string> ElfReader::SymbolByteCode(std::string_view section,
   // See https://github.com/pixie-io/pixie/issues/1111 for more details.
   if (symbol.size > 100 * 2048) {
     return error::Internal(
-        "ELF symbol=$0 bytecode detected as size=$0 bytes. Refusing to preallocate that much "
+        "ELF symbol=$0 bytecode detected as size=$1 bytes. Refusing to preallocate that much "
         "memory",
         symbol.name, symbol.size);
   }


### PR DESCRIPTION
Summary: Add bounds checking to prevent bogus ELF bytecode parsing from causing allocation errors

#1111 documents a case where attempting to deploy Go uprobes to a particular application results in `std::bad_alloc` errors. The specific application that caused this behavior was a go 1.13 binary built using include GOOS=linux GOARCH=386 CGO_ENABLED=0.

The bytecode threshold was determined by inspecting Go's `crypto/tls.(*Conn).Write` and `crypto/tls.(*Conn).Read` symbol sizes with an additional 100x multiplier applied (see Test plan for more details).

Relevant Issues: #1111

Type of change: /kind bug

Test Plan: Created a [test program](https://github.com/pixie-io/pixie/commit/51bef3c04331d13e635532bf0dc9d23e082044fa) to isolate the ELF and DWARF parsing code to reproduce the crash and validated the following:
- [x] Verified that the test program no longer throws a `std::bad_alloc` error ([P369](https://phab.corp.pixielabs.ai/P369))
- [x] Searched for other usages of `px::utils::u8string` to determine if other usages needed to be protected
- [x] Verified that Go's `crypto/tls.(*Conn).Write` and `crypto/tls.(*Conn).Read` symbol bytecode is ~2 KiB in size ([P370](https://phab.corp.pixielabs.ai/P370)).

Changelog Message: Add bounds checking to prevent a situation where certain Go binaries can cause Pixie to crash with a memory allocation error.