### PR TITLE
[build] Remove GH_API_KEY from action env for default builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,8 +2,11 @@
 
 # Use strict action env to prevent leaks of env vars.
 build --incompatible_strict_action_env
-# Passthrough GH_API_KEY from the environment.
-build --action_env=GH_API_KEY
+
+# Only pass through GH_API_KEY for stamped builds.
+# This is still not ideal as it still busts the cache of stamped builds.
+build:stamp --stamp
+build:stamp --action_env=GH_API_KEY
 
 # Doesn't rely on a localjdk which is default. This removes the need for a JAVA_HOME
 # on the build machine and also makes JAVA builds hermetic.

--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -38,7 +38,7 @@ darwin_arm64_binary=$(bazel cquery -c opt //src/pixie_cli:px_darwin_arm64 --outp
 bazel run -c opt //src/utils/artifacts/versions_gen:versions_gen -- \
       --repo_path "${repo_path}" --artifact_name cli --versions_file "${versions_file}"
 
-bazel build -c opt --stamp //src/pixie_cli:px_darwin_amd64 //src/pixie_cli:px_darwin_arm64 //src/pixie_cli:px
+bazel build -c opt --config=stamp //src/pixie_cli:px_darwin_amd64 //src/pixie_cli:px_darwin_arm64 //src/pixie_cli:px
 
 # Avoid dealing with bazel's symlinks by copying binaries into a temp dir.
 binary_dir="$(mktemp -d)"
@@ -50,7 +50,7 @@ cp "${darwin_arm64_binary}" "${binary_dir}"
 darwin_arm64_binary="${binary_dir}/$(basename "${darwin_arm64_binary}")"
 
 # Create and push docker image.
-bazel run -c opt --stamp //src/pixie_cli:push_px_image
+bazel run -c opt --config=stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
     # Create rpm package.

--- a/ci/cloud_build_release.sh
+++ b/ci/cloud_build_release.sh
@@ -53,7 +53,7 @@ echo "The image tag is: ${image_tag}"
 
 # We are building the OSS images/YAMLs. In this case, we only want to push the images but not deploy the YAMLs.
 if [[ "$PUBLIC" == "true" ]]; then
-  bazel run --stamp -c opt --action_env=GOOGLE_APPLICATION_CREDENTIALS --//k8s:image_version="${image_tag}" \
+  bazel run --config=stamp -c opt --action_env=GOOGLE_APPLICATION_CREDENTIALS --//k8s:image_version="${image_tag}" \
       --//k8s:build_type=public //k8s/cloud:cloud_images_push
 
   bazel build //tools/licenses:all_licenses --action_env=GOOGLE_APPLICATION_CREDENTIALS
@@ -85,16 +85,16 @@ if [[ "$PUBLIC" == "true" ]]; then
   exit 0
 fi
 
-bazel run --stamp -c opt --action_env=GOOGLE_APPLICATION_CREDENTIALS --//k8s:image_version="${image_tag}" \
+bazel run --config=stamp -c opt --action_env=GOOGLE_APPLICATION_CREDENTIALS --//k8s:image_version="${image_tag}" \
     --//k8s:build_type=proprietary //k8s/cloud:cloud_images_push
 
 yaml_path="${repo_path}/bazel-bin/k8s/cloud/pixie_staging_cloud.yaml"
 # Build prod YAMLs.
 if [[ "$RELEASE" == "true" ]]; then
   yaml_path="${repo_path}/bazel-bin/k8s/cloud/pixie_prod_cloud.yaml"
-  bazel build --stamp -c opt --//k8s:image_version="${image_tag}" //k8s/cloud:pixie_prod_cloud
+  bazel build --config=stamp -c opt --//k8s:image_version="${image_tag}" //k8s/cloud:pixie_prod_cloud
 else # Build staging YAMLs.
-  bazel build --stamp -c opt --//k8s:image_version="${image_tag}" //k8s/cloud:pixie_staging_cloud
+  bazel build --config=stamp -c opt --//k8s:image_version="${image_tag}" //k8s/cloud:pixie_staging_cloud
 fi
 
 kubectl apply -f "$yaml_path"

--- a/ci/image_utils.sh
+++ b/ci/image_utils.sh
@@ -23,9 +23,9 @@ push_images_for_arch() {
   build_type="$4"
   bazel_args="$5"
 
-  bazel run --stamp -c opt --//k8s:image_version="${release_tag}-${arch}" \
+  bazel run --config=stamp -c opt --//k8s:image_version="${release_tag}-${arch}" \
       --config="${arch}_sysroot" \
-      --stamp "${build_type}" "${image_rule}" "${bazel_args}" > /dev/null
+      --config=stamp "${build_type}" "${image_rule}" "${bazel_args}" > /dev/null
 }
 
 push_multiarch_image() {
@@ -55,6 +55,6 @@ push_all_multiarch_images() {
   while read -r image;
   do
     push_multiarch_image "${image}"
-  done < <(bazel run --stamp -c opt --//k8s:image_version="${release_tag}" \
-          --stamp "${build_type}" "${image_list_rule}" "${bazel_args}")
+  done < <(bazel run --config=stamp -c opt --//k8s:image_version="${release_tag}" \
+          --config=stamp "${build_type}" "${image_list_rule}" "${bazel_args}")
 }

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -45,8 +45,8 @@ latest_output_path="gs://${bucket}/vizier/latest"
 
 push_all_multiarch_images "//k8s/vizier:vizier_images_push" "//k8s/vizier:list_image_bundle" "${release_tag}" "${build_type}" "${extra_bazel_args[@]}"
 
-bazel build --stamp -c opt --//k8s:image_version="${release_tag}" \
-    --stamp "${build_type}" //k8s/vizier:vizier_yamls "${extra_bazel_args[@]}"
+bazel build --config=stamp -c opt --//k8s:image_version="${release_tag}" \
+    --config=stamp "${build_type}" //k8s/vizier:vizier_yamls "${extra_bazel_args[@]}"
 
 output_path="gs://${bucket}/vizier/${release_tag}"
 yamls_tar="${repo_path}/bazel-bin/k8s/vizier/vizier_yamls.tar"

--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -113,7 +113,7 @@ profiles:
     path: /build/artifacts/context=./bazel/args
     value:
     - --compilation_mode=opt
-    - --stamp
+    - --config=stamp
     - --action_env=GOOGLE_APPLICATION_CREDENTIALS
   - op: replace
     path: /manifests/kustomize/paths
@@ -127,7 +127,7 @@ profiles:
     path: /build/artifacts/context=./bazel/args
     value:
     - --compilation_mode=opt
-    - --stamp
+    - --config=stamp
     - --action_env=GOOGLE_APPLICATION_CREDENTIALS
   - op: replace
     path: /manifests/kustomize/paths
@@ -141,7 +141,7 @@ profiles:
     path: /build/artifacts/context=./bazel/args
     value:
     - --compilation_mode=opt
-    - --stamp
+    - --config=stamp
     - --action_env=GOOGLE_APPLICATION_CREDENTIALS
   - op: replace
     path: /manifests/kustomize/paths

--- a/src/stirling/k8s/run_stirling_wrapper_on_k8s.sh
+++ b/src/stirling/k8s/run_stirling_wrapper_on_k8s.sh
@@ -79,8 +79,8 @@ echo "Building and pushing stirling_wrapper image"
 echo "-------------------------------------------"
 
 bazel build -c "$COMPILATION_MODE" //src/stirling/binaries:stirling_wrapper_image
-# --stamp is needed to assign the image tag from username.
-bazel run -c "$COMPILATION_MODE" --stamp //src/stirling/binaries:push_stirling_wrapper_image
+# --config=stamp is needed to assign the image tag from username.
+bazel run -c "$COMPILATION_MODE" --config=stamp //src/stirling/binaries:push_stirling_wrapper_image
 
 echo ""
 echo "-------------------------------------------"

--- a/src/stirling/scripts/run_go_grpc_app_on_k8s.sh
+++ b/src/stirling/scripts/run_go_grpc_app_on_k8s.sh
@@ -16,8 +16,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-bazel run --stamp src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client:push_image
-bazel run --stamp src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server:push_image
+bazel run --config=stamp src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client:push_image
+bazel run --config=stamp src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server:push_image
 
 namespace_name="px-go-grpc"
 

--- a/src/stirling/scripts/run_go_http_app_on_k8s.sh
+++ b/src/stirling/scripts/run_go_http_app_on_k8s.sh
@@ -19,8 +19,8 @@
 pixie_root=$(git rev-parse --show-toplevel)
 http_app_dir=src/stirling/source_connectors/socket_tracer/protocols/http/testing
 
-bazel run --stamp //src/stirling/source_connectors/socket_tracer/protocols/http/testing/go_http_client:push_image
-bazel run --stamp //src/stirling/source_connectors/socket_tracer/protocols/http/testing/go_http_server:push_image
+bazel run --config=stamp //src/stirling/source_connectors/socket_tracer/protocols/http/testing/go_http_client:push_image
+bazel run --config=stamp //src/stirling/source_connectors/socket_tracer/protocols/http/testing/go_http_server:push_image
 
 ns="px-go-http"
 

--- a/src/stirling/testing/demo_apps/go_http/README.md
+++ b/src/stirling/testing/demo_apps/go_http/README.md
@@ -1,10 +1,10 @@
 # HTTP client & server applications
 
-To push container image to GCR, run `:push_image` target with `--stamp`:
+To push container image to GCR, run `:push_image` target with `--config=stamp`:
 
 ```
-bazel run --stamp //src/stirling/testing/demo_apps/go_http/go_http_client:push_image
-bazel run --stamp //src/stirling/testing/demo_apps/go_http/go_http_server:push_image
+bazel run --config=stamp //src/stirling/testing/demo_apps/go_http/go_http_client:push_image
+bazel run --config=stamp //src/stirling/testing/demo_apps/go_http/go_http_server:push_image
 ```
 
 To deploy the client & server onto a Kubernetes cluster:


### PR DESCRIPTION
Summary: `GH_API_KEY` being in the action env significantly reduces the performance of the cache. This PR improves that somewhat by removing in from the action env for default builds. However, it's still in the action env for stamped builds, so those will still have bad cache properties.

Type of change: /kind cleanup

Test Plan: Ran `bazel build //tools/licenses:all_licenses --config=stamp` and it worked without missing licenses.
