### PR TITLE
[bpf tests] Remove timing dependence from stirling_error_bpf_test

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/test_runner_inside_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/test_runner_inside_qemu.sh
@@ -35,6 +35,8 @@ if [[ -n "${GTEST_TMP_DIR}" ]]; then
     mkdir -p "${GTEST_TMP_DIR}"
 fi
 
+export TESTING_UNDER_QEMU=true
+
 # Actually run the test and capture the return value.
 retval=0
 "${test_exec_path:?}" || retval=$?

--- a/src/stirling/testing/overloads.h
+++ b/src/stirling/testing/overloads.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <absl/strings/substitute.h>
+#include <magic_enum.hpp>
+
+#include "src/stirling/utils/monitor.h"
+
+namespace px {
+namespace stirling {
+
+inline bool operator==(const SourceStatusRecord& a, const SourceStatusRecord& b) {
+  return (a.source_connector == b.source_connector) && (a.status == b.status) &&
+         (a.error == b.error) && (a.context == b.context);
+}
+
+inline void PrintTo(const SourceStatusRecord& r, std::ostream* os) {
+  *os << absl::Substitute(
+      "SourceStatusRecord{timestamp_ns: $0, source_connector: $1, status: $2, error: $3, "
+      "context: $4}",
+      r.timestamp_ns, r.source_connector, magic_enum::enum_name(r.status), r.error, r.context);
+}
+
+inline bool operator==(const ProbeStatusRecord& a, const ProbeStatusRecord& b) {
+  return (a.source_connector == b.source_connector) && (a.tracepoint == b.tracepoint) &&
+         (a.status == b.status) && (a.error == b.error) && (a.info == b.info);
+}
+
+inline void PrintTo(const ProbeStatusRecord& r, std::ostream* os) {
+  *os << absl::Substitute(
+      "ProbeStatusRecord{timestamp_ns: $0, source_connector: $1, tracepoint: $2, status: "
+      "$3, error: $4, "
+      "info: $5}",
+      r.timestamp_ns, r.source_connector, r.tracepoint, magic_enum::enum_name(r.status), r.error,
+      r.info);
+}
+
+}  // namespace stirling
+}  // namespace px


### PR DESCRIPTION
Summary: `stirling_error_bpf_test` relied a lot on timing in order to make its assertions. This removes all timing dependence, and instead waits for the expectations or timesout.

Type of change: /kind test-infra

Test Plan: Ran `bazel test --config=qemu-bpf //src/stirling/source_connectors/stirling_error:stirling_error_bpf_test --runs_per_test=50` without a single failure.
