### PR TITLE
[releases] Create github release for vizier releases

### DIFF
--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -40,6 +40,8 @@ jobs:
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
+        export ARTIFACTS_DIR="$(pwd)/artifacts"
+        mkdir -p "${ARTIFACTS_DIR}"
         ./ci/save_version_info.sh
         ./ci/vizier_build_release.sh
     - name: Build & Export Docs
@@ -53,3 +55,36 @@ jobs:
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
       run: ./ci/update_artifact_manifest.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: vizier-artifacts
+        path: artifacts/
+  create-github-release:
+    if: ${{ !contains(github.event.ref, '-') }}
+    name: Create Release on Github
+    runs-on: ubuntu-latest
+    needs: build-release
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - name: Create Release
+      env:
+        REF: ${{ github.event.ref }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: pixie-io
+        REPO: pixie
+      shell: bash
+      # yamllint disable rule:indentation
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        # actions/checkout doesn't get the tag annotation properly.
+        git fetch origin tag "${TAG_NAME}" -f
+        export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
+        gh release create "${TAG_NAME}" --title "Vizier ${TAG_NAME#release/vizier/}" \
+          --notes $'Pixie Vizier Release:\n'"${changelog}"
+        gh release upload "${TAG_NAME}" vizier-artifacts/*
+      # yamllint enable rule:indentation

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -20,6 +20,7 @@ set -ex
 
 printenv
 
+artifacts_dir="${ARTIFACTS_DIR:?}"
 versions_file="$(realpath "${VERSIONS_FILE:?}")"
 repo_path=$(pwd)
 release_tag=${TAG_NAME##*/v}
@@ -54,6 +55,9 @@ yamls_tar="${repo_path}/bazel-bin/k8s/vizier/vizier_yamls.tar"
 sha256sum "${yamls_tar}" | awk '{print $1}' > sha
 gsutil cp "${yamls_tar}" "${output_path}/vizier_yamls.tar"
 gsutil cp sha "${output_path}/vizier_yamls.tar.sha256"
+
+cp "${yamls_tar}" "${artifacts_dir}/vizier_yamls.tar"
+cp sha "${artifacts_dir}/vizier_yamls.tar.sha256"
 
 # Upload templated YAMLs.
 tmp_dir="$(mktemp -d)"


### PR DESCRIPTION
Summary: Creates a github release in the github releases tab for any non-RC vizier releases. Adds `vizier_yamls.tar` and `vizier_yamls.tar.sha256` as artifacts.

Type of change: /kind cleanup

Test Plan: Tested with an RC that I forced to create a github release https://github.com/pixie-io/pixie/releases/tag/release%2Fvizier%2Fv0.13.2-pre-vizier-github-release4.5.
