### PR TITLE
Remove update to BPF map not used in status quo tls tracing

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c
@@ -147,11 +147,6 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
   void* ssl = (void*)PT_REGS_PARM1(ctx);
   update_node_ssl_tls_wrap_map(ssl);
 
-  struct nested_syscall_fd_t nested_syscall_fd = {
-      .fd = kInvalidFD,
-  };
-  ssl_user_space_call_map.update(&id, &nested_syscall_fd);
-
   char* buf = (char*)PT_REGS_PARM2(ctx);
   int32_t fd = get_fd(tgid, ssl);
 
@@ -191,11 +186,6 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
 
   void* ssl = (void*)PT_REGS_PARM1(ctx);
   update_node_ssl_tls_wrap_map(ssl);
-
-  struct nested_syscall_fd_t nested_syscall_fd = {
-      .fd = kInvalidFD,
-  };
-  ssl_user_space_call_map.update(&id, &nested_syscall_fd);
 
   char* buf = (char*)PT_REGS_PARM2(ctx);
   int32_t fd = get_fd(tgid, ssl);


### PR DESCRIPTION
Summary: Remove update to BPF map not used in status quo tls tracing

In order to vet the new style of tls tracing, we introduced a mechanism for detecting mismatched fds (#1161). This instrumented all of our tls tracing when it was first developed. When the new method of tls tracing was introduced, we removed the mismatched fd detection from the status quo tls tracing (#1123), however, this BPF map update was missed in that refactor (#1123).

Relevant Issues: #692

Type of change: /kind bug

Test Plan: Existing tests pass