### PR TITLE
[releases] Create Github release for operator releases

### DIFF
--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -40,9 +40,44 @@ jobs:
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
+        export ARTIFACTS_DIR="$(pwd)/artifacts"
+        mkdir -p "${ARTIFACTS_DIR}"
         ./ci/save_version_info.sh
         ./ci/operator_build_release.sh
     - name: Update Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
       run: ./ci/update_artifact_manifest.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: operator-artifacts
+        path: artifacts/
+  create-github-release:
+    if: ${{ !contains(github.event.ref, '-') }}
+    name: Create Release on Github
+    runs-on: ubuntu-latest
+    needs: build-release
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - name: Create Release
+      env:
+        REF: ${{ github.event.ref }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: pixie-io
+        REPO: pixie
+      shell: bash
+      # yamllint disable rule:indentation
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        # actions/checkout doesn't get the tag annotation properly.
+        git fetch origin tag "${TAG_NAME}" -f
+        export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
+        gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
+          --notes $'Pixie Operator Release:\n'"${changelog}"
+        gh release upload "${TAG_NAME}" operator-artifacts/*
+      # yamllint enable rule:indentation

--- a/ci/operator_helm_build_release.sh
+++ b/ci/operator_helm_build_release.sh
@@ -33,6 +33,7 @@ parse_args() {
 
 parse_args "$@"
 tmp_dir="$(mktemp -d)"
+artifacts_dir="${ARTIFACTS_DIR:?}"
 
 helm_gcs_bucket="pixie-operator-charts"
 if [[ $VERSION == *"-"* ]]; then
@@ -80,6 +81,10 @@ helm package "${helm_path}2" -d "${tmp_dir}/${helm_gcs_bucket}"
 
 # Update the index file.
 helm repo index "${tmp_dir}/${helm_gcs_bucket}" --url "https://${helm_gcs_bucket}.storage.googleapis.com"
+
+cp "${tmp_dir}/${helm_gcs_bucket}/pixie-operator-chart-${VERSION}.tgz" "${artifacts_dir}/pixie-operator-chart-${VERSION}.tgz"
+sha256sum "${tmp_dir}/${helm_gcs_bucket}/pixie-operator-chart-${VERSION}.tgz" | awk '{print $1}' > sha
+cp sha "${artifacts_dir}/pixie-operator-chart-${VERSION}.tgz.sha256"
 
 # Upload the new index and tar to gcs by syncing. This will help keep the timestamps for pre-existing tars the same.
 gsutil rsync "${tmp_dir}/${helm_gcs_bucket}" "gs://${helm_gcs_bucket}"


### PR DESCRIPTION
Summary: Adds a github release for each operator non-RC release.

Type of change: /kind cleanup

Test Plan: Tested by forcing an RC to create a github release: https://github.com/pixie-io/pixie/releases/tag/release%2Foperator%2Fv0.1.1-pre-z4-1-test-operator-release.4
