### PR TITLE
[qemu] Add interactive runner using ssh

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -131,8 +131,8 @@ test:qemu-bpf --test_tag_filters=requires_bpf,-disabled,-no_qemu
 build:gcc --copt -Wno-error=sign-compare
 build:gcc --copt -Wno-error=stringop-truncation
 build:gcc --copt -Wno-error=maybe-uninitialized
-build:gcc --build_tag_filters=-no_gcc
-build:gcc --test_tag_filters=-no_gcc,-requires_root,-requires_bpf,-disabled
+build:gcc --build_tag_filters=-no_gcc,-qemu_interactive
+build:gcc --test_tag_filters=-no_gcc,-requires_root,-requires_bpf,-disabled,-qemu_interactive
 build:gcc --//bazel/cc_toolchains:compiler=gcc
 test:gcc --config=tmp-sandbox
 

--- a/bazel/pl_build_system.bzl
+++ b/bazel/pl_build_system.bzl
@@ -21,6 +21,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_context", "go_library", "go_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:defs.bzl", "py_test")
+load("//bazel:toolchain_transitions.bzl", "qemu_interactive_runner")
 
 pl_supported_go_sdk_versions = ["1.16", "1.17", "1.18", "1.19", "1.20"]
 
@@ -476,3 +477,27 @@ def pl_py_test(**kwargs):
 def pl_sh_test(**kwargs):
     _add_test_runner(kwargs)
     native.sh_test(**kwargs)
+
+def pl_cc_bpf_test(**kwargs):
+    pl_cc_test(**kwargs)
+    qemu_interactive_runner(
+        name = kwargs["name"] + "_qemu_interactive",
+        test = ":" + kwargs["name"],
+        tags = [
+            "manual",
+            "qemu_interactive",
+        ],
+        testonly = True,
+    )
+
+def pl_sh_bpf_test(**kwargs):
+    pl_sh_test(**kwargs)
+    qemu_interactive_runner(
+        name = kwargs["name"] + "_qemu_interactive",
+        test = ":" + kwargs["name"],
+        tags = [
+            "manual",
+            "qemu_interactive",
+        ],
+        testonly = True,
+    )

--- a/bazel/test_runners/qemu_with_kernel/BUILD.bazel
+++ b/bazel/test_runners/qemu_with_kernel/BUILD.bazel
@@ -16,7 +16,10 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:pl_qemu_kernels.bzl", "kernel_flag_name", "qemu_image_to_deps")
+load("//bazel:toolchain_transitions.bzl", "qemu_interactive_runner")
 load("//bazel/test_runners/qemu_with_kernel:runner.bzl", "qemu_with_kernel_test_runner")
+
+exports_files(["interactive_runner.sh"])
 
 kernel_image_deps = qemu_image_to_deps()
 
@@ -39,5 +42,14 @@ kernel_select_list = {kernel_flag_name(version): dep for version, dep in kernel_
 qemu_with_kernel_test_runner(
     name = "runner",
     kernel_image = select(kernel_select_list),
+    visibility = ["//visibility:public"],
+)
+
+qemu_interactive_runner(
+    name = "run_interactive",
+    tags = [
+        "manual",
+        "qemu_interactive",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/test_runners/qemu_with_kernel/interactive_runner.sh
+++ b/bazel/test_runners/qemu_with_kernel/interactive_runner.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S -i /bin/bash
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# shellcheck shell=bash
+
+execroot="$(realpath "${PWD%%/execroot/px/*}/execroot")"
+# Make OLDPWD look like what bazel's test setup does.
+export OLDPWD="${execroot}/px"
+export RUNFILES_DIR="$PWD"
+export INTERACTIVE_MODE="true"
+
+# shellcheck disable=SC2288
+%qemu_runner_path% %test_path%

--- a/bazel/test_runners/qemu_with_kernel/run_qemu.sh
+++ b/bazel/test_runners/qemu_with_kernel/run_qemu.sh
@@ -84,7 +84,7 @@ flags+=(-netdev "user,id=net0,hostfwd=tcp::0-:22")
 flags+=(-monitor "unix:${MONITOR_SOCK},server,nowait")
 
 retval=0
-qemu-system-x86_64 "${flags[@]}" || retval=$?
+exec qemu-system-x86_64 "${flags[@]}" || retval=$?
 
 if [[ "${retval}" -gt 0 ]]; then
     if [[ "${retval}" -lt 128 ]]; then

--- a/bazel/toolchain_transitions.bzl
+++ b/bazel/toolchain_transitions.bzl
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@com_github_fmeum_rules_meta//meta:defs.bzl", "meta")
+load("//bazel/test_runners/qemu_with_kernel:runner.bzl", "qemu_with_kernel_interactive_runner")
 
 cc_static_musl_binary = meta.wrap_with_transition(
     native.cc_binary,
@@ -37,6 +38,14 @@ cc_clang_binary = meta.wrap_with_transition(
     native.cc_binary,
     {
         "@//bazel/cc_toolchains:compiler": meta.replace_with("clang"),
+    },
+    executable = True,
+)
+
+qemu_interactive_runner = meta.wrap_with_transition(
+    qemu_with_kernel_interactive_runner,
+    {
+        "@//bazel/cc_toolchains:libc_version": meta.replace_with("glibc2_36"),
     },
     executable = True,
 )

--- a/src/stirling/bpf_tools/BUILD.bazel
+++ b/src/stirling/bpf_tools/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -60,7 +60,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bcc_wrapper_bpf_test",
     srcs = ["bcc_wrapper_bpf_test.cc"],
     tags = [
@@ -74,7 +74,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bcc_symbolizer_bpf_test",
     srcs = ["bcc_symbolizer_bpf_test.cc"],
     tags = [
@@ -87,7 +87,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bpftrace_wrapper_bpf_test",
     srcs = ["bpftrace_wrapper_bpf_test.cc"],
     tags = [
@@ -100,7 +100,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "task_struct_resolver_bpf_test",
     srcs = ["task_struct_resolver_bpf_test.cc"],
     tags = [
@@ -116,7 +116,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "uprobe_extra_trigger_bpf_test",
     srcs = ["uprobe_extra_trigger_bpf_test.cc"],
     tags = [

--- a/src/stirling/e2e_tests/BUILD.bazel
+++ b/src/stirling/e2e_tests/BUILD.bazel
@@ -14,12 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_test", "pl_sh_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_test", "pl_sh_bpf_test", "pl_sh_test")
 load("//src/stirling/source_connectors/perf_profiler/testing:testing.bzl", "agent_libs", "agent_libs_arg")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stirling_bpf_test",
     timeout = "moderate",
     srcs = ["stirling_bpf_test.cc"],
@@ -33,7 +33,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "bpf_map_leak_bpf_test",
     timeout = "moderate",
     srcs = ["bpf_map_leak_bpf_test.cc"],
@@ -64,7 +64,7 @@ pl_cc_test(
     ],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_kprobe_leak_bpf_test",
     srcs = ["stirling_wrapper_kprobe_leak_bpf_test.sh"],
     args = [
@@ -84,7 +84,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_bpf_test",
     srcs = ["stirling_wrapper_bpf_test.sh"],
     args = [
@@ -110,7 +110,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_bpftrace_bpf_test",
     srcs = ["stirling_wrapper_bpftrace_bpf_test.sh"],
     args = [
@@ -134,7 +134,7 @@ pl_sh_test(
     ],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_container_bpf_test",
     srcs = ["stirling_wrapper_container_bpf_test.sh"],
     args = [
@@ -163,7 +163,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_perf_bpf_test",
     srcs = ["stirling_perf_bpf_test.sh"],
     args = [
@@ -188,7 +188,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "stirling_wrapper_jvm_stats_bpf_test",
     srcs = ["stirling_wrapper_jvm_stats_bpf_test.sh"],
     args = [
@@ -230,7 +230,7 @@ pl_sh_test(
     deps = ["//src/stirling/scripts:sh_library"],
 )
 
-pl_sh_test(
+pl_sh_bpf_test(
     name = "probe_cleaner_bpf_test",
     srcs = ["probe_cleaner_bpf_test.sh"],
     args = [

--- a/src/stirling/obj_tools/BUILD.bazel
+++ b/src/stirling/obj_tools/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -102,7 +102,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "elf_reader_symbolizer_bpf_test",
     srcs = ["elf_reader_symbolizer_bpf_test.cc"],
     tags = [

--- a/src/stirling/source_connectors/cpu_stat_bpftrace/BUILD.bazel
+++ b/src/stirling/source_connectors/cpu_stat_bpftrace/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -34,7 +34,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "cpu_stat_bpftrace_connector_bpf_test",
     timeout = "long",
     srcs = ["cpu_stat_bpftrace_connector_bpf_test.cc"],

--- a/src/stirling/source_connectors/dynamic_bpftrace/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_bpftrace/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -34,7 +34,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dynamic_bpftrace_connector_bpf_test",
     srcs = ["dynamic_bpftrace_connector_bpf_test.cc"],
     data = [

--- a/src/stirling/source_connectors/dynamic_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_tracer/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -43,7 +43,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dynamic_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dynamic_trace_bpf_test.cc"],
@@ -63,7 +63,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stirling_dt_bpf_test",
     timeout = "long",
     srcs = ["stirling_dt_bpf_test.cc"],

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 load("//src/stirling/source_connectors/perf_profiler/testing:testing.bzl", "agent_libs", "jdk_names", "px_jattach", "stirling_profiler_java_args")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
@@ -41,7 +41,7 @@ jdk_image_names = ["%s-java-profiler-test-image" % jdk_name for jdk_name in jdk_
 
 image_tars = ["//src/stirling/source_connectors/perf_profiler/testing/java:%s-java-profiler-test-image.tar" % jdk_name for jdk_name in jdk_names]
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "perf_profiler_bpf_test",
     timeout = "long",
     srcs = ["perf_profiler_bpf_test.cc"],
@@ -70,7 +70,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stringifier_bpf_test",
     srcs = ["stringifier_bpf_test.cc"],
     tags = [

--- a/src/stirling/source_connectors/proc_exit/BUILD.bazel
+++ b/src/stirling/source_connectors/proc_exit/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__pkg__"])
 
@@ -36,7 +36,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "proc_exit_trace_bpf_test",
     srcs = ["proc_exit_trace_bpf_test.cc"],
     data = ["//src/stirling/source_connectors/proc_exit/testing:sleep"],

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -171,7 +171,7 @@ pl_cc_binary(
 # BPF Tests
 ###############################################################################
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "socket_trace_bpf_test",
     timeout = "long",
     srcs = ["socket_trace_bpf_test.cc"],
@@ -188,7 +188,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "conn_stats_bpf_test",
     timeout = "moderate",
     srcs = ["conn_stats_bpf_test.cc"],
@@ -208,7 +208,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "http_trace_bpf_test",
     timeout = "moderate",
     srcs = ["http_trace_bpf_test.cc"],
@@ -229,7 +229,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "mux_trace_bpf_test",
     timeout = "moderate",
     srcs = ["mux_trace_bpf_test.cc"],
@@ -249,7 +249,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "mysql_trace_bpf_test",
     timeout = "moderate",
     srcs = ["mysql_trace_bpf_test.cc"],
@@ -273,7 +273,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "cql_trace_bpf_test",
     timeout = "moderate",
     srcs = [
@@ -294,7 +294,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "pgsql_trace_bpf_test",
     timeout = "moderate",
     srcs = [
@@ -316,7 +316,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "grpc_trace_bpf_test",
     timeout = "moderate",
     srcs = ["grpc_trace_bpf_test.cc"],
@@ -353,7 +353,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "http2_trace_bpf_test",
     timeout = "moderate",
     srcs = ["http2_trace_bpf_test.cc"],
@@ -376,7 +376,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dns_trace_bpf_test",
     timeout = "moderate",
     srcs = [
@@ -397,7 +397,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "redis_trace_bpf_test",
     timeout = "long",
     srcs = ["redis_trace_bpf_test.cc"],
@@ -416,7 +416,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "nats_trace_bpf_test",
     timeout = "long",
     srcs = ["nats_trace_bpf_test.cc"],
@@ -433,7 +433,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "kafka_trace_bpf_test",
     timeout = "moderate",
     srcs = ["kafka_trace_bpf_test.cc"],
@@ -451,7 +451,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "openssl_trace_bpf_test",
     timeout = "long",
     srcs = ["openssl_trace_bpf_test.cc"],
@@ -474,7 +474,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "netty_tls_trace_bpf_test",
     timeout = "long",
     srcs = ["netty_tls_trace_bpf_test.cc"],
@@ -493,7 +493,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "dyn_lib_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dyn_lib_trace_bpf_test.cc"],
@@ -512,7 +512,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "go_tls_trace_bpf_test",
     timeout = "moderate",
     srcs = ["go_tls_trace_bpf_test.cc"],
@@ -533,7 +533,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "amqp_trace_bpf_test",
     timeout = "moderate",
     srcs = ["amqp_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/stirling_error/BUILD.bazel
+++ b/src/stirling/source_connectors/stirling_error/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 load("//src/stirling/source_connectors/perf_profiler/testing:testing.bzl", "agent_libs", "px_jattach", "stirling_profiler_java_args")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
@@ -35,7 +35,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "stirling_error_bpf_test",
     timeout = "moderate",
     srcs = ["stirling_error_bpf_test.cc"],

--- a/src/stirling/source_connectors/tcp_stats/BUILD.bazel
+++ b/src/stirling/source_connectors/tcp_stats/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -35,7 +35,7 @@ pl_cc_library(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "tcp_stats_bpf_test",
     timeout = "long",
     srcs = ["tcp_stats_bpf_test.cc"],

--- a/src/stirling/utils/BUILD.bazel
+++ b/src/stirling/utils/BUILD.bazel
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:pl_build_system.bzl", "pl_cc_library", "pl_cc_test")
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
@@ -127,7 +127,7 @@ pl_cc_test(
     ],
 )
 
-pl_cc_test(
+pl_cc_bpf_test(
     name = "detect_application_bpf_test",
     timeout = "moderate",
     srcs = ["detect_application_bpf_test.cc"],


### PR DESCRIPTION
Summary: Adds a way to get a shell inside qemu using SSH. To run the interactive qemu session without any test runfiles, run: `bazel run //bazel/test_runners/qemu_with_kernel:run_interactive`.
To run with a test's runfiles, run `bazel run //<path/to/test>_qemu_interactive`, eg. `bazel run //src/stirling/obj_tools:elf_reader_symbolizer_bpf_test_qemu_interactive`. Note it won't work if you add `--config=qemu-bpf` because of the way bazel's `run_under` flag works, so just leave out the `--config`.

Type of change: /kind test-infra.

Test Plan: Tested that the interactive runner opens a shell with the expected runfiles. Also tested that closing the shell at any point doesn't leave zombie qemu processes.
