### PR TITLE
[releases] Don't create github releases for cloud RCs

### DIFF
--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -50,7 +50,7 @@ jobs:
         name: cloud-artifacts
         path: artifacts/
   create-github-release:
-    if: ${{ contains(github.event.ref, '-') }}
+    if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github
     runs-on: ubuntu-latest
     needs: build-release


### PR DESCRIPTION
Summary: There was a slight bug that slipped through which meant GitHub releases were only being created for cloud RCs instead of only for full releases.

Type of change: /kind cleanup

Test Plan: N/A
