### PR TITLE
[build-and-test] Remove custom name from matrix checks.

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -86,11 +86,10 @@ jobs:
       - /etc/bazelrc:/etc/bazelrc
       - /var/run/docker.sock:/var/run/docker.sock
       options: --privileged
-    if: needs.generate-matrix.outputs.matrix
+    if: ${{ needs.generate-matrix.outputs.matrix && (toJson(fromJson(needs.generate-matrix.outputs.matrix)) != '[]') }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       fail-fast: false
-    name: ${{ matrix.name }}
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
     - name: Add pwd to git safe dir


### PR DESCRIPTION
Summary: When there are no matrix configs to run, without this change, a check is added with an ugly ${{ matrix.name }}. This PR removes the custom naming, which removes the ugly ${{matrix.name}}

Type of change: /kind cleanup

Test Plan: Testing with this PR, since there shouldn't be any matrix configs to run.
