### PR TITLE
[build-and-test] Fix passing of github context to matrix.sh

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -65,8 +65,7 @@ jobs:
       id: set-matrix
       shell: bash
       run: |
-        echo '${{ toJSON(github) }}' > github.json
-        matrix="$(./ci/github/matrix.sh github.json)"
+        matrix="$(./ci/github/matrix.sh '${{ github.event_name }}')"
         echo "Build & Test matrix: ${matrix}"
         echo "matrix=${matrix}" >> $GITHUB_OUTPUT
     - name: Upload Target Files


### PR DESCRIPTION
Summary: Passing the full github context to `matrix.sh` was unreliable, instead just pass the things we need.

Type of change: /kind test-infra

Test Plan: Testing with this PR, also rebasing #1316 which previously failed to make sure it doesn't anymore.
