### PR TITLE
Fix quantity parsing in configmgr service

### DIFF
--- a/src/cloud/config_manager/controllers/server.go
+++ b/src/cloud/config_manager/controllers/server.go
@@ -118,7 +118,11 @@ func AddDefaultTableStoreSize(pemMemoryRequest string, customPEMFlags map[string
 	if pemMemoryRequest == "" {
 		defaultTableStoreSizeMB = defaultUncappedTableStoreSizeMB
 	} else {
-		pemMemorySizeBytes := resource.MustParse(pemMemoryRequest)
+		pemMemorySizeBytes, err := resource.ParseQuantity(pemMemoryRequest)
+		if err != nil {
+			log.Errorf("Failed to parse quantity %s", pemMemoryRequest)
+			return
+		}
 		defaultTableStoreSizeBytes := defaultTableStorePercentage * float64(pemMemorySizeBytes.Value())
 		defaultTableStoreSizeMB = int(math.Floor(defaultTableStoreSizeBytes / bytesPerMiB))
 		if defaultTableStoreSizeMB == 0 {


### PR DESCRIPTION
Summary: Passing a quantity which cannot be parsed will lead to a crashloopbackoff.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Deploy to staging
