### PR TITLE
Remove `no_qemu` tag for tcp_stats_bpf_test

### DIFF
--- a/src/stirling/source_connectors/tcp_stats/BUILD.bazel
+++ b/src/stirling/source_connectors/tcp_stats/BUILD.bazel
@@ -40,7 +40,6 @@ pl_cc_bpf_test(
     timeout = "long",
     srcs = ["tcp_stats_bpf_test.cc"],
     tags = [
-        "no_qemu",
         "requires_bpf",
     ],
     deps = [


### PR DESCRIPTION
Summary: Remove `no_qemu` tag for tcp_stats_bpf_test

The long lived PR for adding our CI jobs to GitHub actions finished up just as the qemu incompatibility was addressed. We can now opt this test into qemu testing.

Relevant Issues: N/A

Type of change: /kind buf

Test Plan: Verified in #1308 that this test works with qemu