### PR TITLE
Fix coverage build

### DIFF
--- a/src/stirling/source_connectors/tcp_stats/tcp_stats_bpf_test.cc
+++ b/src/stirling/source_connectors/tcp_stats/tcp_stats_bpf_test.cc
@@ -101,6 +101,8 @@ TEST_F(TcpTraceTest, Capture) {
 
   std::vector<TcpStatsRecord> expected = {
       {
+          .local_addr = "",
+          .local_port = 0,
           .remote_addr = "127.0.0.1",
           .remote_port = 12345,
           .tx = 6,


### PR DESCRIPTION
Summary: This missing initializers for `local_addr` and `local_port` cause
GCC to error with `error=missing-field-initializers`. This causes our
GCC+Coverage build to fail.
These fields aren't currently used in the test assertions, but are present
for a future use case. So just set them to some default values to fix the
build under GCC.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Built the `tcp_stats_bpf_test` under the GCC + coverage
config. It builds successfully now.
