### PR TITLE
[build-and-test] Only run flakiness regression tests weekly

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -6,8 +6,8 @@ on:
     branches:
     - 'main'
   schedule:
-  # Run at 23:09 PST (07:09 UTC) every day. Github suggests not running actions on the hour.
-  - cron: '9 7 * * *'
+  # Run at 23:09 PST (07:09 UTC) every sunday. Github suggests not running actions on the hour.
+  - cron: '9 7 * * 0'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Summary: These regression tests are quite expensive to run, because it runs BPF tests across all kernels for 4 hours each. I don't really see much value in running it nightly, I think weekly should suffice.

Type of change: /kind test-infra.

Test Plan: N/A
