### PR TITLE
Enable IPV6 in github actions for coverage build

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -66,6 +66,8 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
+        # Github actions container runner creates a docker network without IPv6 support. We enable it manually.
+        sysctl -w net.ipv6.conf.lo.disable_ipv6=0
         ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r pixie-io/pixie
   generate-matrix:
     needs: get-dev-image


### PR DESCRIPTION
Summary: This should fix the tcp_socket_test that is failing for
coverage builds.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check coverage run on main after this lands.
