### PR TITLE
Run coverage build in a priviledged container

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -51,7 +51,8 @@ jobs:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
       volumes:
       - /etc/bazelrc:/etc/bazelrc
-      options: --cpus 16
+      # Needs to be priviledged to enable IPV6
+      options: --cpus 16 --privileged
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:


### PR DESCRIPTION
Summary: This is needed to enable IPV6.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Check coverage build on main after this lands.
