### PR TITLE
Add a UDA for converting profiling data to pprof protobuf format.

### DIFF
--- a/src/carnot/funcs/builtins/BUILD.bazel
+++ b/src/carnot/funcs/builtins/BUILD.bazel
@@ -35,6 +35,7 @@ pl_cc_library(
         "//src/carnot/exec/ml:cc_library",
         "//src/carnot/funcs/builtins/sql_parsing:cc_library",
         "//src/carnot/udf:cc_library",
+        "//src/shared/pprof:cc_library",
         "@com_github_derrickburns_tdigest//:tdigest",
         "@com_github_google_sentencepiece//:libsentencepiece",
         "@com_github_grpc_grpc//:grpc++",
@@ -204,5 +205,15 @@ pl_cc_test(
         ":cc_library",
         "//src/carnot/udf:udf_testutils",
         "@com_github_grpc_grpc//:grpc++",
+    ],
+)
+
+pl_cc_test(
+    name = "pprof_ops_test",
+    srcs = ["pprof_ops_test.cc"],
+    deps = [
+        ":cc_library",
+        "//src/carnot/udf:udf_testutils",
+        "//src/shared/pprof:cc_library",
     ],
 )

--- a/src/carnot/funcs/builtins/builtins.cc
+++ b/src/carnot/funcs/builtins/builtins.cc
@@ -24,6 +24,7 @@
 #include "src/carnot/funcs/builtins/math_sketches.h"
 #include "src/carnot/funcs/builtins/ml_ops.h"
 #include "src/carnot/funcs/builtins/pii_ops.h"
+#include "src/carnot/funcs/builtins/pprof_ops.h"
 #include "src/carnot/funcs/builtins/regex_ops.h"
 #include "src/carnot/funcs/builtins/request_path_ops.h"
 #include "src/carnot/funcs/builtins/sql_ops.h"
@@ -51,6 +52,7 @@ void RegisterBuiltinsOrDie(udf::Registry* registry) {
   RegisterPIIOpsOrDie(registry);
   RegisterURIOpsOrDie(registry);
   RegisterUtilOpsOrDie(registry);
+  RegisterPProfOpsOrDie(registry);
 }
 
 }  // namespace builtins

--- a/src/carnot/funcs/builtins/pprof_ops.cc
+++ b/src/carnot/funcs/builtins/pprof_ops.cc
@@ -16,23 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#pragma once
+#include "src/carnot/funcs/builtins/pprof_ops.h"
 
-#include <string>
-
-#include <absl/container/flat_hash_map.h>
-
-#include "proto/profile.pb.h"
+#include "src/carnot/udf/registry.h"
+#include "src/common/base/base.h"
 
 namespace px {
-namespace shared {
+namespace carnot {
+namespace builtins {
 
-using PProfProfile = ::perftools::profiles::Profile;
-using PProfHisto = absl::flat_hash_map<std::string, uint64_t>;
+void RegisterPProfOpsOrDie(udf::Registry* registry) {
+  CHECK(registry != nullptr);
 
-// https://github.com/google/pprof/blob/main/proto/profile.proto
-PProfProfile CreatePProfProfile(const uint32_t period_ms, const PProfHisto& histo);
-PProfHisto DeserializePProfProfile(const PProfProfile& pprof);
+  registry->RegisterOrDie<CreatePProfRowAggregate>("pprof");
+}
 
-}  // namespace shared
+}  // namespace builtins
+}  // namespace carnot
 }  // namespace px

--- a/src/carnot/funcs/builtins/pprof_ops.h
+++ b/src/carnot/funcs/builtins/pprof_ops.h
@@ -87,10 +87,10 @@ class CreatePProfRowAggregate : public udf::UDA {
     return output;
   }
 
-  Status Deserialize(FunctionContext*, const StringValue& upstream_pprof_str) {
-    // Parse upstream data into a pprof proto object.
+  Status Deserialize(FunctionContext*, const StringValue& pprof_str) {
+    // Parse serialized input a pprof proto object.
     PProfProfile pprof;
-    if (!pprof.ParseFromString(upstream_pprof_str)) {
+    if (!pprof.ParseFromString(pprof_str)) {
       return error::Internal("Could not parse input string into a pprof proto.");
     }
 

--- a/src/carnot/funcs/builtins/pprof_ops.h
+++ b/src/carnot/funcs/builtins/pprof_ops.h
@@ -97,10 +97,10 @@ class CreatePProfRowAggregate : public udf::UDA {
     UpdateOrCheckSamplingPeriod(pprof.period() / 1000 / 1000);
 
     // Deserialize into a map from stack_trace string to count.
-    const auto upstream_histo = ::px::shared::DeserializePProfProfile(pprof);
+    const auto merge_histo = ::px::shared::DeserializePProfProfile(pprof);
 
     // Incorporate the deserialized result into our histo_.
-    for (const auto& [stack_trace, count] : upstream_histo) {
+    for (const auto& [stack_trace, count] : merge_histo) {
       histo_[stack_trace] += count;
     }
     return Status::OK();

--- a/src/carnot/funcs/builtins/pprof_ops.h
+++ b/src/carnot/funcs/builtins/pprof_ops.h
@@ -38,8 +38,11 @@ class CreatePProfRowAggregate : public udf::UDA {
     return udf::UDADocBuilder("Convert perf profiling data to pprof format.")
         .Details("Converts perf profiling stack traces into pprof format.")
         .Example(
-            R"example(df = px.DataFrame(table='stack_traces.beta', start_time='-1m')
-df = df.agg(pprof=('stack_trace', 'count', px.pprof)))example")
+            R"example(stack_traces = px.DataFrame(table='stack_traces.beta', start_time='-1m')
+sample_period = px.GetProfilerSamplingPeriodMS()
+stack_traces.asid = px.asid()
+df = stack_traces.merge(sample_period, how='inner', left_on=['asid'], right_on=['asid'])df = df.groupby(['profiler_sampling_period_ms'])
+df = df.agg(pprof=('stack_trace', 'count', 'profiler_sampling_period_ms', px.pprof)))example")
         .Arg("stack_trace", "Stack trace string.")
         .Arg("count", "Count of the stack trace string.")
         .Arg("profiler_period_ms", "Profiler stack trace sampling period in ms.")

--- a/src/carnot/funcs/builtins/pprof_ops.h
+++ b/src/carnot/funcs/builtins/pprof_ops.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <absl/container/flat_hash_map.h>
+
+#include <string>
+
+#include "src/carnot/udf/registry.h"
+#include "src/carnot/udf/udf.h"
+#include "src/shared/pprof/pprof.h"
+
+namespace px {
+namespace carnot {
+namespace builtins {
+
+using px::shared::PProfProfile;
+
+class CreatePProfRowAggregate : public udf::UDA {
+ public:
+  static udf::UDADocBuilder Doc() {
+    return udf::UDADocBuilder("Convert perf profiling data to pprof format.")
+        .Details("Converts perf profiling stack traces into pprof format.")
+        .Example(
+            R"example(df = px.DataFrame(table='stack_traces.beta', start_time='-1m')
+df = df.agg(pprof=('stack_trace', 'count', px.pprof)))example")
+        .Arg("stack_trace", "Stack trace string.")
+        .Arg("count", "Count of the stack trace string.")
+        .Arg("profiler_period_ms", "Profiler stack trace sampling period in ms.")
+        .Returns("A single row that aggregates all the stack traces and counts into pprof format.");
+  }
+
+  void Update(FunctionContext*, const StringValue stack_trace, const Int64Value count,
+              const Int64Value profiler_period_ms) {
+    histo_[stack_trace] += count.val;
+
+    // Initialize profiler_period_ms_.
+    if (profiler_period_ms_ == -1) {
+      profiler_period_ms_ = profiler_period_ms.val;
+    }
+
+    // If any inconsistent profiler period is observed, set the error flag.
+    if (profiler_period_ms_ != profiler_period_ms.val) {
+      multiple_profiler_periods_found_ = true;
+    }
+  }
+
+  void Merge(FunctionContext*, const CreatePProfRowAggregate& other) {
+    for (const auto& [stack_trace, count] : other.histo_) {
+      histo_[stack_trace] += count;
+    }
+    if (profiler_period_ms_ != other.profiler_period_ms_) {
+      multiple_profiler_periods_found_ = true;
+    }
+  }
+
+  StringValue Serialize(FunctionContext*) {
+    if (multiple_profiler_periods_found_) {
+      return "Protobuf `SerializeToString` failed, multiple profiling periods found.";
+    }
+
+    const auto pprof = px::shared::CreatePProfProfile(profiler_period_ms_, histo_);
+    std::string output;
+    const bool ok = pprof.SerializeToString(&output);
+    if (!ok) {
+      return "Protobuf `SerializeToString` failed.";
+    }
+    return output;
+  }
+
+  Status Deserialize(FunctionContext*, const StringValue& upstream_pprof_str) {
+    // Parse upstream data into a pprof proto object.
+    PProfProfile pprof;
+    if (!pprof.ParseFromString(upstream_pprof_str)) {
+      return error::Internal("Could not parse input string into a pprof proto.");
+    }
+
+    if (profiler_period_ms_ == -1) {
+      // Initialize profiler_period_ms_ from the upstream pprof.
+      profiler_period_ms_ = pprof.period() / 1000 / 1000;
+    } else {
+      // Verify consistency of profiler_period_ms_ with the upstream pprof.
+      const int64_t profiler_period_ns = profiler_period_ms_ * 1000 * 1000;
+      if (profiler_period_ns != pprof.period()) {
+        multiple_profiler_periods_found_ = true;
+      }
+    }
+
+    // Deserialize into a map from stack_trace string to count.
+    const auto upstream_histo = ::px::shared::DeserializePProfProfile(pprof);
+
+    // Incorporate the deserialized result into our histo_.
+    for (const auto& [stack_trace, count] : upstream_histo) {
+      histo_[stack_trace] += count;
+    }
+    return Status::OK();
+  }
+
+  StringValue Finalize(FunctionContext* ctx) { return Serialize(ctx); }
+
+ protected:
+  absl::flat_hash_map<std::string, uint64_t> histo_;
+  int32_t profiler_period_ms_ = -1;
+  bool multiple_profiler_periods_found_ = false;
+};
+
+void RegisterPProfOpsOrDie(udf::Registry* registry);
+
+}  // namespace builtins
+}  // namespace carnot
+}  // namespace px

--- a/src/carnot/funcs/builtins/pprof_ops.h
+++ b/src/carnot/funcs/builtins/pprof_ops.h
@@ -38,11 +38,20 @@ class CreatePProfRowAggregate : public udf::UDA {
     return udf::UDADocBuilder("Convert perf profiling data to pprof format.")
         .Details("Converts perf profiling stack traces into pprof format.")
         .Example(
-            R"example(stack_traces = px.DataFrame(table='stack_traces.beta', start_time='-1m')
-sample_period = px.GetProfilerSamplingPeriodMS()
-stack_traces.asid = px.asid()
-df = stack_traces.merge(sample_period, how='inner', left_on=['asid'], right_on=['asid'])df = df.groupby(['profiler_sampling_period_ms'])
-df = df.agg(pprof=('stack_trace', 'count', 'profiler_sampling_period_ms', px.pprof)))example")
+            R"doc(
+        | # Get the stack traces, the underlying data we want; populate an ASID column
+        | # to join with profiler sampling period (see next).
+        | stack_traces = px.DataFrame(table='stack_traces.beta', start_time='-1m')
+        | stack_traces.asid = px.asid()
+        |
+        | # Get the profiler sampling period for all deployed PEMs, then merge to stack traces on ASID.
+        | sample_period = px.GetProfilerSamplingPeriodMS()
+        | df = stack_traces.merge(sample_period, how='inner', left_on=['asid'], right_on=['asid'])
+        |
+        | # The pprof UDA requires that each underlying dataset have the same sampling period.
+        | # Thus, group by sampling period (normally this results in just one group).
+        | df = df.groupby(['profiler_sampling_period_ms']).agg(pprof=('stack_trace', 'count', 'profiler_sampling_period_ms', px.pprof))
+        )doc")
         .Arg("stack_trace", "Stack trace string.")
         .Arg("count", "Count of the stack trace string.")
         .Arg("profiler_period_ms", "Profiler stack trace sampling period in ms.")

--- a/src/carnot/funcs/builtins/pprof_ops_test.cc
+++ b/src/carnot/funcs/builtins/pprof_ops_test.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/carnot/funcs/builtins/pprof_ops.h"
+
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <vector>
+
+#include "src/carnot/udf/test_utils.h"
+#include "src/shared/pprof/pprof.h"
+
+namespace px {
+namespace carnot {
+namespace builtins {
+
+using px::shared::DeserializePProfProfile;
+using px::shared::PProfProfile;
+
+namespace {
+constexpr int64_t profiler_period_ms = 11;
+}
+
+TEST(PProf, profiling_rows_to_pprof_test) {
+  // Raw stack trace string and count input data.
+  // Note, there are duplicated stack traces.
+  const std::vector<std::pair<std::string, uint64_t>> input = {
+      {"foo;bar;baz", 1},
+      {"foo;bar;baz", 2},
+      {"foo;bar;qux", 3},
+      {"foo;bar", 4},
+      {"foo;bar", 5},
+      {"main;compute;map;reduce", 6},
+      {"main;compute;map;reduce", 7},
+      {"main;compute;map;reduce", 8},
+  };
+
+  // The expected output as a histogram (string=>count map).
+  const absl::flat_hash_map<std::string, uint64_t> expected = {
+      {"foo;bar;baz", 1 + 2},
+      {"foo;bar;qux", 3},
+      {"foo;bar", 4 + 5},
+      {"main;compute;map;reduce", 6 + 7 + 8},
+  };
+
+  // Create our UDA tester.
+  auto pprof_uda_tester = udf::UDATester<CreatePProfRowAggregate>();
+
+  // Feed the input to the tester.
+  for (const auto& [stack_trace, count] : input) {
+    pprof_uda_tester.ForInput(stack_trace, count, profiler_period_ms);
+  }
+
+  // Get the result.
+  const std::string result = pprof_uda_tester.Result();
+
+  // Parse the result.
+  PProfProfile pprof;
+  EXPECT_TRUE(pprof.ParseFromString(result));
+
+  // Deserialize the parsed pprof into a histo.
+  const auto actual = DeserializePProfProfile(pprof);
+
+  // Expect the deserialized result to be equal to our expected value.
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(PProf, pprof_merge_test) {
+  // Raw stack trace string and count input data.
+  // Note, there are duplicated stack traces.
+  const std::vector<std::pair<std::string, uint64_t>> input_a = {
+      {"foo;bar;baz", 1},
+      {"foo;bar;qux", 2},
+      {"main;compute;map;reduce", 3},
+  };
+  const std::vector<std::pair<std::string, uint64_t>> input_b = {
+      {"foo;bar;baz", 5},
+      {"foo;bar;baz", 5},
+      {"foo;bar;qux", 10},
+      {"foo;bar;qux", 10},
+      {"main;compute;map;reduce", 15},
+      {"main;compute;map;reduce", 15},
+  };
+
+  // The expected output as a histogram (string=>count map).
+  const absl::flat_hash_map<std::string, uint64_t> expected = {
+      {"foo;bar;baz", 11},
+      {"foo;bar;qux", 22},
+      {"main;compute;map;reduce", 33},
+  };
+
+  auto pprof_uda_tester_a = udf::UDATester<CreatePProfRowAggregate>();
+  auto pprof_uda_tester_b = udf::UDATester<CreatePProfRowAggregate>();
+  auto pprof_uda_tester_merge = udf::UDATester<CreatePProfRowAggregate>();
+
+  // Feed the A inputs to the tester_a.
+  for (const auto& [stack_trace, count] : input_a) {
+    pprof_uda_tester_a.ForInput(stack_trace, count, profiler_period_ms);
+  }
+
+  // Feed the B inputs to the tester_b.
+  for (const auto& [stack_trace, count] : input_b) {
+    pprof_uda_tester_b.ForInput(stack_trace, count, profiler_period_ms);
+  }
+
+  // Merge A & B UDAs into the final "merge" UDA.
+  EXPECT_OK(pprof_uda_tester_merge.Deserialize(pprof_uda_tester_a.Serialize()));
+  EXPECT_OK(pprof_uda_tester_merge.Deserialize(pprof_uda_tester_b.Serialize()));
+
+  // Get the result.
+  const std::string result = pprof_uda_tester_merge.Result();
+
+  // Parse the result.
+  PProfProfile pprof;
+  EXPECT_TRUE(pprof.ParseFromString(result));
+
+  // Deserialize the parsed pprof into a histo.
+  const auto actual = DeserializePProfProfile(pprof);
+
+  // Expect the deserialized result to be equal to our expected value.
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(PProf, uda_fails_with_multiple_sample_periods) {
+  // Create our UDA tester.
+  auto pprof_uda_tester = udf::UDATester<CreatePProfRowAggregate>();
+
+  // Input two stack traces, but with different profiling sample periods.
+  pprof_uda_tester.ForInput("foo;bar;baz", 1, profiler_period_ms);
+  pprof_uda_tester.ForInput("foo;bar;qux", 2, profiler_period_ms + 1);
+
+  // Get the result.
+  const std::string result = pprof_uda_tester.Result();
+
+  // Parse the result: this should fail because we used multiple sample periods above.
+  PProfProfile pprof;
+  EXPECT_FALSE(pprof.ParseFromString(result));
+}
+
+}  // namespace builtins
+}  // namespace carnot
+}  // namespace px


### PR DESCRIPTION
Summary: We add a new UDA that converts profiling data to pprof protobuf format.

Long term, we see this as useful in several scenarios:
1. For OTel export (it seems likely that OTel will add profiling data and include pprof as a supported wire format).
2. For general purpose download, e.g. a user wants to directly download profiling data in pprof format.

Type of change: /kind feature

Test Plan: Added a new test `pprof_test` into `src/carnot/funcs/builtins`. The new test covers both the UDA and its underlying serialize and deserialize methods found in `src/shared/pprof`.