### PR TITLE
Enable TLS tracing for applications using dynamically linked OpenSSL v3

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -14,29 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_bpf_test", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/stirling:__subpackages__"])
-
-# TODO(ddelnano): Remove once new tls tracing implementation is
-# the default and we are ready to enable tracing of openssl v3.
-bool_flag(
-    name = "enable_openssl_v3_testing_flag",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "enable_openssl_v3_testing",
-    flag_values = {
-        ":enable_openssl_v3_testing_flag": "True",
-    },
-)
-
-enable_openssl_v3_tracing_defines = select({
-    ":enable_openssl_v3_testing": ["ENABLE_OPENSSL_V3_TRACING"],
-    "//conditions:default": [],
-})
 
 pl_cc_library(
     name = "cc_library",
@@ -48,7 +28,6 @@ pl_cc_library(
         ],
     ),
     hdrs = glob(["*.h"]),
-    defines = enable_openssl_v3_tracing_defines,
     deps = [
         "//src/common/exec:cc_library",
         "//src/common/grpcutils:cc_library",
@@ -455,7 +434,6 @@ pl_cc_bpf_test(
     name = "openssl_trace_bpf_test",
     timeout = "long",
     srcs = ["openssl_trace_bpf_test.cc"],
-    defines = enable_openssl_v3_tracing_defines,
     flaky = True,
     shard_count = 2,
     tags = [

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -166,15 +166,8 @@ typedef ::testing::Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1
                          Node12_3_1ContainerWrapper, Node14_18_1AlpineContainerWrapper>
     OpenSSLServerImplementations;
 
-// TODO(ddelnano): Remove once new tls tracing implementation is
-// the default and we are ready to enable tracing of openssl v3.
-#ifdef ENABLE_OPENSSL_V3_TRACING
 typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper, NginxOpenSSL_3_0_7_ContainerWrapper>
     OpenSSLServerNestedSyscallFDImplementations;
-#else
-typedef ::testing::Types<NginxOpenSSL_1_1_1_ContainerWrapper>
-    OpenSSLServerNestedSyscallFDImplementations;
-#endif
 
 template <typename T>
 using OpenSSLTraceTest = BaseOpenSSLTraceTest<T, false>;

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -149,7 +149,7 @@ DEFINE_uint64(max_body_bytes, gflags::Uint64FromEnv("PL_STIRLING_MAX_BODY_BYTES"
 
 DEFINE_bool(
     access_tls_socket_fd_via_syscall,
-    gflags::BoolFromEnv("PL_ACCESS_TLS_SOCKET_FD_VIA_SYSCALL", false),
+    gflags::BoolFromEnv("PL_ACCESS_TLS_SOCKET_FD_VIA_SYSCALL", true),
     "If true, stirling will identify a socket's fd based on the underlying syscall (read, write, "
     "etc) while a user space tls function call occurs. When false, stirling attempts to access the "
     "socket fd by walking user space data structures which may be brittle.");

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -344,7 +344,7 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
       return error::Internal("libcrypto not found [path = $0]", container_libcrypto.string());
     }
 
-    if (!FLAGS_access_tls_socket_fd_via_syscall) {
+    if (!FLAGS_access_tls_socket_fd_via_syscall || libssl == kLibNettyTcnativePrefix) {
       auto fptr_manager = std::make_unique<obj_tools::RawFptrManager>(container_libcrypto);
 
       PX_RETURN_IF_ERROR(UpdateOpenSSLSymAddrs(fptr_manager.get(), container_libcrypto, pid));
@@ -361,7 +361,7 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
 
       // TODO(ddelnano): Remove this conditional logic once the new tls tracing
       // implementation is the default.
-      if (FLAGS_access_tls_socket_fd_via_syscall) {
+      if (FLAGS_access_tls_socket_fd_via_syscall && libssl != kLibNettyTcnativePrefix) {
         spec.probe_fn = absl::Substitute("$0_syscall_fd_access", spec.probe_fn);
       }
       PX_RETURN_IF_ERROR(LogAndAttachUProbe(spec));

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -285,21 +285,17 @@ struct SSLLibMatcher {
   HostPathForPIDPathSearchType search_type;
 };
 
-// TODO(ddelnano): Remove the ENABLE_OPENSSL_V3_TRACING ifdef once this
-// code this could should be enabled outside of test use cases
 static constexpr const auto kLibSSLMatchers = MakeArray<SSLLibMatcher>({
     SSLLibMatcher{
         .libssl = "libssl.so.1.1",
         .libcrypto = "libcrypto.so.1.1",
         .search_type = HostPathForPIDPathSearchType::kSearchTypeEndsWith,
     },
-#ifdef ENABLE_OPENSSL_V3_TRACING
     SSLLibMatcher{
         .libssl = "libssl.so.3",
         .libcrypto = "libcrypto.so.3",
         .search_type = HostPathForPIDPathSearchType::kSearchTypeEndsWith,
     },
-#endif
     SSLLibMatcher{
         .libssl = kLibNettyTcnativePrefix,
         .libcrypto = kLibNettyTcnativePrefix,
@@ -313,6 +309,12 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
   for (auto ssl_library_match : kLibSSLMatchers) {
     const auto libssl = ssl_library_match.libssl;
     const auto libcrypto = ssl_library_match.libcrypto;
+
+    // TODO(ddelnano): The legacy tls tracing implementation does not support OpenSSL v3.
+    // Remove this once that implementation is removed in addition to the feature toggle.
+    if (!FLAGS_access_tls_socket_fd_via_syscall && absl::EndsWith(libssl, "so.3")) {
+      continue;
+    }
 
     const std::vector<std::string_view> lib_names = {libssl, libcrypto};
     const auto search_type = ssl_library_match.search_type;


### PR DESCRIPTION
Summary: Enable TLS tracing for applications using dynamically linked OpenSSL v3

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Existing tests provide the necessary coverage

Changelog Message:
```release-note
TLS tracing now supports applications using OpenSSL v3
```