### PR TITLE
Reduce privileges required to install Vizier

### DIFF
--- a/k8s/vizier/base/metadata_role.yaml
+++ b/k8s/vizier/base/metadata_role.yaml
@@ -11,18 +11,24 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - "apps"
   resources:
   - pods
   - services
   - endpoints
   - namespaces
-  - replicasets
-  - deployments
   verbs:
   - "watch"
   - "get"
   - "list"
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - watch
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -72,7 +78,10 @@ rules:
   - ""
   resources:
   - endpoints
-  verbs: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/k8s/vizier/bootstrap/cert_provisioner_job.yaml
+++ b/k8s/vizier/bootstrap/cert_provisioner_job.yaml
@@ -8,7 +8,7 @@ spec:
     metadata:
       name: cert-provisioner-job
     spec:
-      serviceAccountName: pl-updater-service-account
+      serviceAccountName: pl-cert-provisioner-service-account
       containers:
       - name: provisioner
         image: gcr.io/pixie-oss/pixie-dev/vizier/cert_provisioner_image:latest

--- a/k8s/vizier/bootstrap/cert_provisioner_role.yaml
+++ b/k8s/vizier/bootstrap/cert_provisioner_role.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pl-cert-provisioner-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pl-cert-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pl-cert-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pl-cert-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: pl-cert-provisioner-service-account
+  namespace: pl

--- a/k8s/vizier/bootstrap/cloud_connector_role.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_role.yaml
@@ -58,16 +58,38 @@ rules:
   resources:
   - jobs
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
-  - px.dev
   resources:
   - secrets
   - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - px.dev
+  resources:
   - viziers
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/k8s/vizier/bootstrap/kustomization.yaml
+++ b/k8s/vizier/bootstrap/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
 - cloud_connector_service.yaml
 - updater_role.yaml
 - cloud_connector_role.yaml
+- cert_provisioner_role.yaml
 - cert_provisioner_job.yaml
 - vizier_crd_role.yaml

--- a/k8s/vizier/bootstrap/updater_role.yaml
+++ b/k8s/vizier/bootstrap/updater_role.yaml
@@ -5,63 +5,67 @@ metadata:
   name: pl-updater-service-account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: pl-updater-cluster-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: pl-updater-role
-subjects:
-- kind: ServiceAccount
-  name: pl-updater-service-account
-  namespace: pl
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: pl-updater-cluster-role
-rules:
-# Allow actions on Kubernetes objects
-- apiGroups:
-  - rbac.authorization.k8s.io
-  - etcd.database.coreos.com
-  - nats.io
-  resources:
-  - clusterroles
-  - clusterrolebindings
-  - persistentvolumes
-  - etcdclusters
-  - natsclusters
-  verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: pl-updater-role
 rules:
 - apiGroups:
   - ""
-  - apps
-  - rbac.authorization.k8s.io
-  - extensions
-  - batch
-  - policy
   resources:
   - configmaps
   - secrets
   - pods
   - services
+  - persistentvolumes
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   - daemonsets
-  - persistentvolumes
-  - roles
-  - rolebindings
-  - serviceaccounts
   - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
   - cronjobs
   - jobs
-  verbs: ["*"]
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/utils/template_generator/vizier_yamls/vizier_yamls.go
+++ b/src/utils/template_generator/vizier_yamls/vizier_yamls.go
@@ -365,6 +365,12 @@ func generateVzYAMLs(yamlMap map[string]string) ([]*yamls.YAMLFile, error) {
 			TemplateValue:   fmt.Sprintf(".%s.svc", nsTmpl),
 		},
 		{
+			TemplateMatcher: yamls.GenerateResourceNameMatcherFn("pl-cert-provisioner-binding"),
+			Patch:           `{ "subjects": [{ "name": "pl-cert-provisioner-service-account", "namespace": "__PX_SUBJECT_NAMESPACE__", "kind": "ServiceAccount" }] }`,
+			Placeholder:     "__PX_SUBJECT_NAMESPACE__",
+			TemplateValue:   nsTmpl,
+		},
+		{
 			TemplateMatcher: yamls.GenerateResourceNameMatcherFn("pl-updater-binding"),
 			Patch:           `{ "subjects": [{ "name": "pl-updater-service-account", "namespace": "__PX_SUBJECT_NAMESPACE__", "kind": "ServiceAccount" }] }`,
 			Placeholder:     "__PX_SUBJECT_NAMESPACE__",


### PR DESCRIPTION
Summary: Cleans up RBAC rules for Vizier in order to reduce the privileges required to install it.  Removes `pl-updater` service account and its RBAC, which included non-functional `ClusterRole` and `ClusterRoleBinding` and doesn't appear to be used by the current operator-based upgrade workflow.

Type of change: /kind cleanup

Test Plan: Tested new yamls on a local minikube using `skaffold` as suggested in DEVELOPMENT.md, deleted `proxy-tls-certs` manually and re-ran the cert-provisioner-job successfully.  Tested change to vizier_yaml.go by running the template generator against a local build of the base yaml tar, observed that the new binding's subject namespace is templated as expected.

Fixes: #634 and #1353