### PR TITLE
[releases] Automatically create PR to update readme on vizier release.

### DIFF
--- a/.github/actions/update_readme_releases/action.yaml
+++ b/.github/actions/update_readme_releases/action.yaml
@@ -1,0 +1,74 @@
+---
+name: Update README
+description: Updates README with link to latest release.
+inputs:
+  component-name:
+    description: 'The name of the component to update release link for (eg. vizier, cli, operator, or cloud)'
+    required: true
+  release-url:
+    description: 'The URL of the GitHub release'
+    required: true
+  ref:
+    required: true
+  BUILDBOT_GPG_KEY_B64:
+    required: true
+  BUILDBOT_GPG_KEY_ID:
+    required: true
+  BUILDBOT_SSH_KEY_B64:
+    required: true
+  BUILDBOT_GH_API_TOKEN:
+    required: true
+runs:
+  using: "composite"
+  steps:
+  - name: Import GPG key
+    shell: bash
+    env:
+      BUILDBOT_GPG_KEY_B64: ${{ inputs.BUILDBOT_GPG_KEY_B64 }}
+      BUILDBOT_GPG_KEY_ID: ${{ inputs.BUILDBOT_GPG_KEY_ID }}
+    run: |
+      echo "${BUILDBOT_GPG_KEY_B64}" | base64 --decode | gpg --no-tty --batch --import
+      git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
+      git config --global commit.gpgsign true
+  - name: Import SSH key
+    shell: bash
+    env:
+      BUILDBOT_SSH_KEY_B64: ${{ inputs.BUILDBOT_SSH_KEY_B64 }}
+    run: |
+      echo "${BUILDBOT_SSH_KEY_B64}" | base64 --decode > /tmp/ssh.key
+      chmod 600 /tmp/ssh.key
+  - name: Setup git
+    shell: bash
+    env:
+      GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+    run: |
+      git config --global user.name 'pixie-io-buildbot'
+      git config --global user.email 'build@pixielabs.ai'
+      git remote add fork git@github.com:pixie-io-buildbot/pixie.git
+  - name: Update readme locally
+    shell: bash
+    env:
+      REF: ${{ inputs.ref }}
+      COMPONENT: ${{ inputs.component-name }}
+      URL: ${{ inputs.release-url }}
+    run: |
+      export VERSION="${REF#*/release/vizier/}"
+      ./ci/update_readme_with_latest_release.sh "${COMPONENT}" "${VERSION}" "${URL}"
+  - name: Create PR
+    shell: bash
+    env:
+      REF: ${{ inputs.ref }}
+      GH_TOKEN: ${{ inputs.BUILDBOT_GH_API_TOKEN }}
+      GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+    # yamllint disable rule:indentation
+    run: |
+      export VERSION="${REF#*/release/vizier/}"
+      export BRANCH="${VERSION}-update-readme"
+      git checkout -b "${BRANCH}"
+      git add README.md
+      git commit -s -m "$(cat pr_title)"
+      git push -f fork "${BRANCH}"
+      gh pr create --repo pixie-io/pixie \
+        --head "pixie-io-buildbot:${BRANCH}" \
+        --body "$(cat pr_body)" --title "$(cat pr_title)"
+    # yamllint enable rule:indentation

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -66,12 +66,15 @@ jobs:
     needs: build-release
     permissions:
       contents: write
+    outputs:
+      release-url: ${{ steps.release.outputs.url }}
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
     - name: Create Release
+      id: release
       env:
         REF: ${{ github.event.ref }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,4 +90,27 @@ jobs:
         gh release create "${TAG_NAME}" --title "Vizier ${TAG_NAME#release/vizier/}" \
           --notes $'Pixie Vizier Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" vizier-artifacts/*
+        url="$(gh release view "${TAG_NAME}" -q '.url' --json url)"
+        echo "url=${url}" >> $GITHUB_OUTPUT
       # yamllint enable rule:indentation
+  update-readme:
+    name: Update README with latest release
+    runs-on: ubuntu-latest
+    needs: create-github-release
+    permissions:
+      contents: read
+    # Only run one update readme job at a time.
+    concurrency: update-readme
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        ref: main
+    - uses: ./.github/actions/update_readme_releases
+      with:
+        component-name: "vizier"
+        release-url: ${{ needs.create-github-release.outputs.release-url }}
+        ref: ${{ github.event.ref }}
+        BUILDBOT_GH_API_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        BUILDBOT_SSH_KEY_B64: ${{ secrets.BUILDBOT_SSH_KEY_B64 }}

--- a/ci/update_readme_with_latest_release.sh
+++ b/ci/update_readme_with_latest_release.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -ex
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+    echo "Usage: $0 <artifact_type> <version> <url>"
+}
+
+if [ $# -lt 3 ]; then
+  usage
+  exit 1
+fi
+artifact_type="$1"
+version="$2"
+url="$3"
+
+readme_path="README.md"
+
+latest_release_comment="<!--${artifact_type}-latest-release-->"
+
+pretty_artifact_name() {
+    case "${artifact_type}" in
+        cli) echo "CLI";;
+        vizier) echo "Vizier";;
+        operator) echo "Operator";;
+        cloud) echo "Cloud";;
+    esac
+}
+
+latest_release_line() {
+  echo "- [$(pretty_artifact_name) ${version}](${url})${latest_release_comment}"
+}
+
+sed -i 's|.*'"${latest_release_comment}"'.*|'"$(latest_release_line)"'|' "${readme_path}"
+
+echo "[bot][releases] Update readme with link to latest ${artifact_type} release." > pr_title
+cat <<EOF > pr_body
+Summary: TSIA
+
+Type of change: /kind cleanup
+
+Test Plan: N/A
+EOF


### PR DESCRIPTION
Summary: Creates a PR from the pixie-io-buildbot account to update the README with the a link to the latest vizier release. The action will be reused for the other releases in future PRs.

Type of change: /kind cleanup

Test Plan: Tested on my fork, saw that the PR was created: https://github.com/JamesMBartlett/pixie/pull/15
