### PR TITLE
[releases] Automatically create PR to update readme on releases.

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -143,7 +143,7 @@ jobs:
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         OWNER: pixie-io
         REPO: pixie
       shell: bash

--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -64,7 +64,7 @@ jobs:
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         OWNER: pixie-io
         REPO: pixie
       shell: bash

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         OWNER: pixie-io
         REPO: pixie
       shell: bash

--- a/.github/workflows/release_update_readme.yaml
+++ b/.github/workflows/release_update_readme.yaml
@@ -1,0 +1,67 @@
+---
+name: update-readme-on-release
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        ref: main
+    - name: Import GPG key
+      shell: bash
+      env:
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+      run: |
+        echo "${BUILDBOT_GPG_KEY_B64}" | base64 --decode | gpg --no-tty --batch --import
+        git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
+        git config --global commit.gpgsign true
+    - name: Import SSH key
+      shell: bash
+      env:
+        BUILDBOT_SSH_KEY_B64: ${{ secrets.BUILDBOT_SSH_KEY_B64 }}
+      run: |
+        echo "${BUILDBOT_SSH_KEY_B64}" | base64 --decode > /tmp/ssh.key
+        chmod 600 /tmp/ssh.key
+    - name: Setup git
+      shell: bash
+      env:
+        GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+      run: |
+        git config --global user.name 'pixie-io-buildbot'
+        git config --global user.email 'build@pixielabs.ai'
+        git remote add fork git@github.com:pixie-io-buildbot/pixie.git
+    - name: Update readme locally
+      shell: bash
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
+        URL: ${{ github.event.release.html_url }}
+      run: |
+        export COMPONENT="$(echo "${TAG_NAME}" | cut -d'/' -f2)"
+        export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
+        ./ci/update_readme_with_latest_release.sh "${COMPONENT}" "${VERSION}" "${URL}"
+    - name: Create PR
+      shell: bash
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
+        GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+      # yamllint disable rule:indentation
+      run: |
+        export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
+        export BRANCH="${VERSION}-update-readme"
+        git checkout -b "${BRANCH}"
+        git add README.md
+        git commit -s -m "$(cat pr_title)"
+        git push -f fork "${BRANCH}"
+        gh pr create --repo pixie-io/pixie \
+          --head "pixie-io-buildbot:${BRANCH}" \
+          --body "$(cat pr_body)" --title "$(cat pr_title)"
+      # yamllint enable rule:indentation

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         OWNER: pixie-io
         REPO: pixie
       shell: bash

--- a/ci/update_readme_with_latest_release.sh
+++ b/ci/update_readme_with_latest_release.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+    echo "Usage: $0 <artifact_type> <version> <url>"
+}
+
+if [ $# -lt 3 ]; then
+  usage
+  exit 1
+fi
+artifact_type="$1"
+version="$2"
+url="$3"
+
+readme_path="README.md"
+
+latest_release_comment="<!--${artifact_type}-latest-release-->"
+
+pretty_artifact_name() {
+    case "${artifact_type}" in
+        cli) echo "CLI";;
+        vizier) echo "Vizier";;
+        operator) echo "Operator";;
+        cloud) echo "Cloud";;
+    esac
+}
+
+latest_release_line() {
+  echo "- [$(pretty_artifact_name) ${version}](${url})${latest_release_comment}"
+}
+
+sed -i 's|.*'"${latest_release_comment}"'.*|'"$(latest_release_line)"'|' "${readme_path}"
+
+echo "[bot][releases] Update readme with link to latest ${artifact_type} release." > pr_title
+cat <<EOF > pr_body
+Summary: TSIA
+
+Type of change: /kind cleanup
+
+Test Plan: N/A
+EOF


### PR DESCRIPTION
Summary: Adds a github workflow to create a PR to update the release links in the README. Note that github won't recursively run workflows, so all of the release workflows need to use the pixie-io-buildbot token to create the releases instead of the default github action token.

Type of change: /kind cleanup

Test Plan: Tested on my fork, saw that the PR gets created as expected: https://github.com/JamesMBartlett/pixie/pull/18.
