### PR TITLE
Add k8ssandra demo support to CLI

### DIFF
--- a/demos/BUILD.bazel
+++ b/demos/BUILD.bazel
@@ -45,11 +45,19 @@ pkg_tar(
     strip_prefix = "online-boutique",
 )
 
+pkg_tar(
+    name = "px-k8ssandra",
+    srcs = glob(["k8ssandra/*"]),
+    extension = "tar.gz",
+    strip_prefix = "k8ssandra",
+)
+
 ARCHIVES = [
     ":px-finagle",
     ":px-kafka",
     ":px-sock-shop",
     ":px-online-boutique",
+    ":px-k8ssandra",
 ]
 
 demo_upload(

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -42,5 +42,9 @@
             "Mux tracing is only enabled on newer kernels (>= 5.2) by default.",
             "Make sure your system meets these requirements before deploying."
         ]
+    },
+    "px-k8ssandra": {
+        "description": "tmp", 
+	"instructions": ["tmp"] 
     }
 }

--- a/src/pixie_cli/pkg/cmd/BUILD.bazel
+++ b/src/pixie_cli/pkg/cmd/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "@com_github_alecthomas_chroma//quick",
         "@com_github_blang_semver//:semver",
         "@com_github_bmatcuk_doublestar//:doublestar",
+        "@com_github_cenkalti_backoff_v4//:backoff",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_fatih_color//:color",
         "@com_github_gofrs_uuid//:uuid",

--- a/src/utils/shared/k8s/apply.go
+++ b/src/utils/shared/k8s/apply.go
@@ -248,9 +248,6 @@ func ApplyResources(clientset kubernetes.Interface, config *rest.Config, resourc
 		_, err = createRes.Create(context.Background(), resource.Object, metav1.CreateOptions{})
 		if err != nil {
 			if !k8serrors.IsAlreadyExists(err) {
-				log.Info(resource.Object)
-				log.WithError(err).Info("NOT ALREADY EXISTS")
-
 				return err
 			} else if (k8sRes == "clusterroles" || k8sRes == "cronjobs") || allowUpdate {
 				// TODO(michelle,vihang,philkuz) Update() fails on services and PVCs that are already running on the

--- a/src/utils/shared/k8s/apply.go
+++ b/src/utils/shared/k8s/apply.go
@@ -193,7 +193,6 @@ func ApplyResources(clientset kubernetes.Interface, config *rest.Config, resourc
 
 	apiGroupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
 	if err != nil {
-		log.WithError(err).Info("API GROUP")
 		return err
 	}
 	rm := restmapper.NewDiscoveryRESTMapper(apiGroupResources)
@@ -201,8 +200,6 @@ func ApplyResources(clientset kubernetes.Interface, config *rest.Config, resourc
 	for _, resource := range resources {
 		mapping, err := rm.RESTMapping(resource.GVK.GroupKind(), resource.GVK.Version)
 		if err != nil {
-			log.WithError(err).Info("REST MAPPING")
-
 			return err
 		}
 
@@ -226,8 +223,6 @@ func ApplyResources(clientset kubernetes.Interface, config *rest.Config, resourc
 		}
 		dynamicClient, err := dynamic.NewForConfig(restconfig)
 		if err != nil {
-			log.WithError(err).Info("DYNAMIC CLIENT")
-
 			return err
 		}
 


### PR DESCRIPTION
Summary:
We want to add a K8ssandra demo to our list of demos. A few changes needed to be made to ensure the demo can be deployed properly:
- We should check for cert-manager as a required dep. We decided not to deploy this with the demo, since deploying 2 cert-managers can break things. If we deploy cert-manager for the user, there's a bit of bookkeeping we'd need to do if the user runs `px demo delete` to decide whether or not we should also clean up cert-manager. Instead, we'll leave this up to the user for the time-being.
- The demo deploys some CRDs. This can lead to race conditions if deploying everything in the manifest at once. To handle this, added a retry in the deploy block.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Push to dev demo manifest, `px demo deploy` with and without cert-manager installed.
