### PR TITLE
Enable metadata service to track the events from a subset of namespaces

### DIFF
--- a/src/vizier/services/metadata/BUILD.bazel
+++ b/src/vizier/services/metadata/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "@com_github_spf13_viper//:viper",
         "@io_etcd_go_etcd_client_pkg_v3//transport",
         "@io_etcd_go_etcd_client_v3//:client",
+        "@io_k8s_api//core/v1:core",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller.go
+++ b/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller.go
@@ -60,11 +60,11 @@ func NewController(namespaces []string, updateCh chan *K8sResourceMessage) (*Con
 	if err != nil {
 		return nil, err
 	}
-	return NewControllerWithClientSet(updateCh, clientset)
+	return NewControllerWithClientSet(namespaces, updateCh, clientset)
 }
 
 // NewControllerWithClientSet creates a new Controller using the given Clientset.
-func NewControllerWithClientSet(updateCh chan *K8sResourceMessage, clientset kubernetes.Interface) (*Controller, error) {
+func NewControllerWithClientSet(namespaces []string, updateCh chan *K8sResourceMessage, clientset kubernetes.Interface) (*Controller, error) {
 	quitCh := make(chan struct{})
 
 	// Create a watcher for each resource.

--- a/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller.go
+++ b/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller.go
@@ -48,7 +48,7 @@ type watcher interface {
 }
 
 // NewController creates a new Controller.
-func NewController(updateCh chan *K8sResourceMessage) (*Controller, error) {
+func NewController(namespaces []string, updateCh chan *K8sResourceMessage) (*Controller, error) {
 	// There is a specific config for services running in the cluster.
 	kubeConfig, err := rest.InClusterConfig()
 	if err != nil {
@@ -72,13 +72,13 @@ func NewControllerWithClientSet(updateCh chan *K8sResourceMessage, clientset kub
 	// for example, nodes and namespaces must be synced before pods, since nodes/namespaces
 	// contain pods.
 	watchers := []watcher{
-		nodeWatcher("nodes", updateCh, clientset),
-		namespaceWatcher("namespaces", updateCh, clientset),
-		podWatcher("pods", updateCh, clientset),
-		endpointsWatcher("endpoints", updateCh, clientset),
-		serviceWatcher("services", updateCh, clientset),
-		replicaSetWatcher("replicasets", updateCh, clientset),
-		deploymentWatcher("deployments", updateCh, clientset),
+		nodeWatcher("nodes", namespaces, updateCh, clientset),
+		namespaceWatcher("namespaces", namespaces, updateCh, clientset),
+		podWatcher("pods", namespaces, updateCh, clientset),
+		endpointsWatcher("endpoints", namespaces, updateCh, clientset),
+		serviceWatcher("services", namespaces, updateCh, clientset),
+		replicaSetWatcher("replicasets", namespaces, updateCh, clientset),
+		deploymentWatcher("deployments", namespaces, updateCh, clientset),
 	}
 
 	mc := &Controller{quitCh: quitCh, updateCh: updateCh, watchers: watchers}

--- a/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller_test.go
+++ b/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller_test.go
@@ -914,7 +914,7 @@ func TestControllerWithNotWatchedNameSpaces(t *testing.T) {
 				&pod{
 					p: &v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "myunwatchedpod",
+							Name: "mynotwatchedpod",
 						},
 						Spec: v1.PodSpec{
 							Hostname: "hostname",
@@ -922,6 +922,15 @@ func TestControllerWithNotWatchedNameSpaces(t *testing.T) {
 					},
 					ns: "dontwatchme",
 					t:  create,
+				},
+				&pod{
+					p: &v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mynotwatchedpod",
+						},
+					},
+					ns: "dontwatchme",
+					t:  del,
 				},
 			},
 			expectedUpdates: []*k8smeta.K8sResourceMessage{
@@ -942,6 +951,399 @@ func TestControllerWithNotWatchedNameSpaces(t *testing.T) {
 									Conditions:        []*metadatapb.PodCondition{},
 									ContainerStatuses: []*metadatapb.ContainerStatus{},
 								},
+							},
+						},
+					},
+					EventType: watch.Added,
+				},
+			},
+		},
+		{
+			name: "simple endpoint",
+			updates: []resourceUpdate{
+				&endpoints{
+					e: &v1.Endpoints{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mynotwatchedendpoint",
+						},
+						Subsets: []v1.EndpointSubset{
+							{
+								Addresses: []v1.EndpointAddress{
+									{
+										IP:       "127.0.0.1",
+										Hostname: "hostname",
+									},
+								},
+								NotReadyAddresses: []v1.EndpointAddress{
+									{
+										IP:       "127.0.0.2",
+										Hostname: "notready",
+									},
+								},
+								Ports: []v1.EndpointPort{
+									{
+										Name:     "endpointport",
+										Protocol: v1.ProtocolTCP,
+										Port:     8081,
+									},
+								},
+							},
+						},
+					},
+					ns: "dontwatchme",
+					t:  create,
+				},
+				&endpoints{
+					e: &v1.Endpoints{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myendpoint",
+						},
+						Subsets: []v1.EndpointSubset{
+							{
+								Addresses: []v1.EndpointAddress{
+									{
+										IP:       "127.0.0.1",
+										Hostname: "hostname",
+									},
+								},
+								NotReadyAddresses: []v1.EndpointAddress{
+									{
+										IP:       "127.0.0.2",
+										Hostname: "notready",
+									},
+								},
+								Ports: []v1.EndpointPort{
+									{
+										Name:     "endpointport",
+										Protocol: v1.ProtocolTCP,
+										Port:     8081,
+									},
+								},
+							},
+						},
+					},
+					ns: "test",
+					t:  create,
+				},
+			},
+			expectedUpdates: []*k8smeta.K8sResourceMessage{
+				{
+					ObjectType: "endpoints",
+					Object: &storepb.K8SResource{
+						Resource: &storepb.K8SResource_Endpoints{
+							Endpoints: &metadatapb.Endpoints{
+								Metadata: &metadatapb.ObjectMetadata{
+									Name:            "myendpoint",
+									Namespace:       "test",
+									OwnerReferences: []*metadatapb.OwnerReference{},
+								},
+								Subsets: []*metadatapb.EndpointSubset{
+									{
+										Addresses: []*metadatapb.EndpointAddress{
+											{
+												IP:       "127.0.0.1",
+												Hostname: "hostname",
+											},
+										},
+										NotReadyAddresses: []*metadatapb.EndpointAddress{
+											{
+												IP:       "127.0.0.2",
+												Hostname: "notready",
+											},
+										},
+										Ports: []*metadatapb.EndpointPort{
+											{
+												Name:     "endpointport",
+												Port:     8081,
+												Protocol: metadatapb.TCP,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					EventType: watch.Added,
+				},
+			},
+		},
+		{
+			name: "simple service",
+			updates: []resourceUpdate{
+				&service{
+					s: &v1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mynotwatchedservice",
+						},
+						Spec: v1.ServiceSpec{
+							Ports: []v1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: v1.ProtocolTCP,
+									Port:     8080,
+								},
+							},
+						},
+					},
+					ns: "dontwatchme",
+					t:  create,
+				},
+				&service{
+					s: &v1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myservice",
+						},
+						Spec: v1.ServiceSpec{
+							Ports: []v1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: v1.ProtocolTCP,
+									Port:     8080,
+								},
+							},
+						},
+					},
+					ns: "test",
+					t:  create,
+				},
+			},
+			expectedUpdates: []*k8smeta.K8sResourceMessage{
+				{
+					ObjectType: "services",
+					Object: &storepb.K8SResource{
+						Resource: &storepb.K8SResource_Service{
+							Service: &metadatapb.Service{
+								Metadata: &metadatapb.ObjectMetadata{
+									Name:            "myservice",
+									Namespace:       "test",
+									OwnerReferences: []*metadatapb.OwnerReference{},
+								},
+								Spec: &metadatapb.ServiceSpec{
+									Ports: []*metadatapb.ServicePort{
+										{
+											Name:     "myport",
+											Protocol: metadatapb.TCP,
+											Port:     8080,
+										},
+									},
+								},
+							},
+						},
+					},
+					EventType: watch.Added,
+				},
+			},
+		},
+		{
+			name: "simple replicaset",
+			updates: []resourceUpdate{
+				&replicaSet{
+					rs: &appsv1.ReplicaSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mynotwatchedrs",
+						},
+						Spec: appsv1.ReplicaSetSpec{
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "mypod",
+								},
+								Spec: v1.PodSpec{
+									Hostname: "hostname",
+								},
+							},
+							Selector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "test",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"test2"},
+									},
+								},
+							},
+						},
+					},
+					ns: "dontwatchme",
+					t:  create,
+				},
+				&replicaSet{
+					rs: &appsv1.ReplicaSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrs",
+						},
+						Spec: appsv1.ReplicaSetSpec{
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "mypod",
+								},
+								Spec: v1.PodSpec{
+									Hostname: "hostname",
+								},
+							},
+							Selector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "test",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"test2"},
+									},
+								},
+							},
+						},
+					},
+					ns: "test",
+					t:  create,
+				},
+			},
+			expectedUpdates: []*k8smeta.K8sResourceMessage{
+				{
+					ObjectType: "replicasets",
+					Object: &storepb.K8SResource{
+						Resource: &storepb.K8SResource_ReplicaSet{
+							ReplicaSet: &metadatapb.ReplicaSet{
+								Metadata: &metadatapb.ObjectMetadata{
+									Name:            "myrs",
+									Namespace:       "test",
+									OwnerReferences: []*metadatapb.OwnerReference{},
+								},
+								Spec: &metadatapb.ReplicaSetSpec{
+									Replicas: 1,
+									Template: &metadatapb.PodTemplateSpec{
+										Metadata: &metadatapb.ObjectMetadata{
+											Name:            "mypod",
+											OwnerReferences: []*metadatapb.OwnerReference{},
+										},
+										Spec: &metadatapb.PodSpec{
+											Hostname: "hostname",
+										},
+									},
+									Selector: &metadatapb.LabelSelector{
+										MatchExpressions: []*metadatapb.LabelSelectorRequirement{
+											{
+												Key:      "test",
+												Operator: "In",
+												Values:   []string{"test2"},
+											},
+										},
+									},
+								},
+								Status: &metadatapb.ReplicaSetStatus{
+									Conditions: []*metadatapb.ReplicaSetCondition{},
+								},
+							},
+						},
+					},
+					EventType: watch.Added,
+				},
+			},
+		},
+		{
+			name: "simple deployment",
+			updates: []resourceUpdate{
+				&deployment{
+					d: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mynotwatcheddeployment",
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "mypod",
+								},
+								Spec: v1.PodSpec{
+									Hostname: "hostname",
+								},
+							},
+							Selector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "test",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"test2"},
+									},
+								},
+							},
+							Strategy: appsv1.DeploymentStrategy{
+								Type: appsv1.RecreateDeploymentStrategyType,
+							},
+							RevisionHistoryLimit:    int32ptr(1),
+							ProgressDeadlineSeconds: int32ptr(1),
+						},
+					},
+					ns: "dontwatchme",
+					t:  create,
+				},
+				&deployment{
+					d: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mydeployment",
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "mypod",
+								},
+								Spec: v1.PodSpec{
+									Hostname: "hostname",
+								},
+							},
+							Selector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "test",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"test2"},
+									},
+								},
+							},
+							Strategy: appsv1.DeploymentStrategy{
+								Type: appsv1.RecreateDeploymentStrategyType,
+							},
+							RevisionHistoryLimit:    int32ptr(1),
+							ProgressDeadlineSeconds: int32ptr(1),
+						},
+					},
+					ns: "test",
+					t:  create,
+				},
+			},
+			expectedUpdates: []*k8smeta.K8sResourceMessage{
+				{
+					ObjectType: "deployments",
+					Object: &storepb.K8SResource{
+						Resource: &storepb.K8SResource_Deployment{
+							Deployment: &metadatapb.Deployment{
+								Metadata: &metadatapb.ObjectMetadata{
+									Name:            "mydeployment",
+									Namespace:       "test",
+									OwnerReferences: []*metadatapb.OwnerReference{},
+								},
+								Spec: &metadatapb.DeploymentSpec{
+									Replicas: 0,
+									Template: &metadatapb.PodTemplateSpec{
+										Metadata: &metadatapb.ObjectMetadata{
+											Name:            "mypod",
+											OwnerReferences: []*metadatapb.OwnerReference{},
+										},
+										Spec: &metadatapb.PodSpec{
+											Hostname: "hostname",
+										},
+									},
+									Selector: &metadatapb.LabelSelector{
+										MatchExpressions: []*metadatapb.LabelSelectorRequirement{
+											{
+												Key:      "test",
+												Operator: "In",
+												Values:   []string{"test2"},
+											},
+										},
+									},
+									Strategy: &metadatapb.DeploymentStrategy{
+										Type: metadatapb.DEPLOYMENT_STRATEGY_RECREATE,
+									},
+									RevisionHistoryLimit:    1,
+									ProgressDeadlineSeconds: 1,
+								},
+								Status: &metadatapb.DeploymentStatus{},
 							},
 						},
 					},
@@ -1019,7 +1421,7 @@ func TestControllerWithNotWatchedNameSpaces(t *testing.T) {
 			}
 
 			assert.Equal(t, 1, len(updates))
-			ns := updates[0].Object.GetPod().GetMetadata().GetNamespace()
+			ns := getNameSpaceFromResourceMessage(updates[0], tc.expectedUpdates[0].ObjectType)
 			assert.Equal(t, "test", ns)
 		})
 	}
@@ -1031,6 +1433,23 @@ func TestController_InClusterConfig(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "unable to load in-cluster configuration")
 	assert.Nil(t, controller)
+}
+
+func getNameSpaceFromResourceMessage(rm *k8smeta.K8sResourceMessage, resourceType string) string {
+	switch resourceType {
+	case "pods":
+		return rm.Object.GetPod().GetMetadata().GetNamespace()
+	case "deployments":
+		return rm.Object.GetDeployment().GetMetadata().GetNamespace()
+	case "endpoints":
+		return rm.Object.GetEndpoints().GetMetadata().GetNamespace()
+	case "services":
+		return rm.Object.GetService().GetMetadata().GetNamespace()
+	case "replicasets":
+		return rm.Object.GetReplicaSet().GetMetadata().GetNamespace()
+	default:
+		return ""
+	}
 }
 
 func zeroTimestamps(updates []*k8smeta.K8sResourceMessage) []*k8smeta.K8sResourceMessage {

--- a/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller_test.go
+++ b/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_controller_test.go
@@ -838,7 +838,7 @@ func TestController(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			controller, err := k8smeta.NewControllerWithClientSet(updateCh, client)
+			controller, err := k8smeta.NewControllerWithClientSet([]string{v1.NamespaceAll}, updateCh, client)
 			require.NoError(t, err)
 			defer controller.Stop()
 
@@ -891,7 +891,7 @@ func TestController(t *testing.T) {
 
 func TestController_InClusterConfig(t *testing.T) {
 	updateCh := make(chan *k8smeta.K8sResourceMessage)
-	controller, err := k8smeta.NewController(updateCh)
+	controller, err := k8smeta.NewController([]string{v1.NamespaceAll}, updateCh)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "unable to load in-cluster configuration")
 	assert.Nil(t, controller)

--- a/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_utils.go
+++ b/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_utils.go
@@ -35,11 +35,11 @@ import (
 )
 
 type informerWatcher struct {
-	convert func(obj interface{}) *K8sResourceMessage
-	objType string
-	ch      chan *K8sResourceMessage
-	inf     cache.SharedIndexInformer
-	init    func() error
+	convert   func(obj interface{}) *K8sResourceMessage
+	objType   string
+	ch        chan *K8sResourceMessage
+	init      func() error
+	informers []cache.SharedIndexInformer
 }
 
 func (i *informerWatcher) send(msg *K8sResourceMessage, et watch.EventType) {
@@ -51,27 +51,30 @@ func (i *informerWatcher) send(msg *K8sResourceMessage, et watch.EventType) {
 
 // StartWatcher starts a watcher.
 func (i *informerWatcher) StartWatcher(quitCh chan struct{}) {
-	_, _ = i.inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			msg := i.convert(obj)
-			if msg != nil {
-				i.send(msg, watch.Added)
-			}
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			msg := i.convert(newObj)
-			if msg != nil {
-				i.send(msg, watch.Modified)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			msg := i.convert(obj)
-			if msg != nil {
-				i.send(msg, watch.Deleted)
-			}
-		},
-	})
-	i.inf.Run(quitCh)
+	for _, inf := range i.informers {
+		_, _ = inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				msg := i.convert(obj)
+				if msg != nil {
+					i.send(msg, watch.Added)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				msg := i.convert(newObj)
+				if msg != nil {
+					i.send(msg, watch.Modified)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				msg := i.convert(obj)
+				if msg != nil {
+					i.send(msg, watch.Deleted)
+				}
+			},
+		})
+		inf.Run(quitCh)
+	}
+
 }
 
 // InitWatcher initializes a watcher, for example to perform a list.
@@ -82,14 +85,17 @@ func (i *informerWatcher) InitWatcher() error {
 	return nil
 }
 
-func podWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
-
+func podWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
 	iw := &informerWatcher{
 		convert: podConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Core().V1().Pods().Informer(),
+	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Core().V1().Pods().Informer()
+		iw.informers = append(iw.informers, inf)
 	}
 
 	init := func() error {
@@ -114,43 +120,65 @@ func podWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernet
 	return iw
 }
 
-func serviceWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
-	return &informerWatcher{
+func serviceWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
+	iw := &informerWatcher{
 		convert: serviceConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Core().V1().Services().Informer(),
 	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Core().V1().Services().Informer()
+		iw.informers = append(iw.informers, inf)
+	}
+
+	return iw
 }
 
-func namespaceWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
-	return &informerWatcher{
+func namespaceWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
+	iw := &informerWatcher{
 		convert: namespaceConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Core().V1().Namespaces().Informer(),
 	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Core().V1().Namespaces().Informer()
+		iw.informers = append(iw.informers, inf)
+	}
+
+	return iw
 }
 
-func endpointsWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
-	return &informerWatcher{
+func endpointsWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
+	iw := &informerWatcher{
 		convert: endpointsConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Core().V1().Endpoints().Informer(),
 	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Core().V1().Endpoints().Informer()
+		iw.informers = append(iw.informers, inf)
+	}
+
+	return iw
 }
 
-func nodeWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
+func nodeWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
 	iw := &informerWatcher{
 		convert: nodeConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Core().V1().Nodes().Informer(),
+	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Core().V1().Nodes().Informer()
+		iw.informers = append(iw.informers, inf)
 	}
 
 	init := func() error {
@@ -175,24 +203,36 @@ func nodeWatcher(resource string, ch chan *K8sResourceMessage, clientset kuberne
 	return iw
 }
 
-func replicaSetWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
-	return &informerWatcher{
+func replicaSetWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
+	iw := &informerWatcher{
 		convert: replicaSetConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Apps().V1().ReplicaSets().Informer(),
 	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Apps().V1().ReplicaSets().Informer()
+		iw.informers = append(iw.informers, inf)
+	}
+
+	return iw
 }
 
-func deploymentWatcher(resource string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
-	factory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
-	return &informerWatcher{
+func deploymentWatcher(resource string, namespaces []string, ch chan *K8sResourceMessage, clientset kubernetes.Interface) *informerWatcher {
+	iw := &informerWatcher{
 		convert: deploymentConverter,
 		objType: resource,
 		ch:      ch,
-		inf:     factory.Apps().V1().Deployments().Informer(),
 	}
+
+	for _, ns := range namespaces {
+		factory := informers.NewSharedInformerFactoryWithOptions(clientset, 12*time.Hour, informers.WithNamespace(ns))
+		inf := factory.Apps().V1().Deployments().Informer()
+		iw.informers = append(iw.informers, inf)
+	}
+
+	return iw
 }
 
 func podConverter(obj interface{}) *K8sResourceMessage {

--- a/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_utils.go
+++ b/src/vizier/services/metadata/controllers/k8smeta/k8s_metadata_utils.go
@@ -75,7 +75,6 @@ func (i *informerWatcher) StartWatcher(quitCh chan struct{}) {
 		})
 		inf.Run(quitCh)
 	}
-
 }
 
 // InitWatcher initializes a watcher, for example to perform a list.

--- a/src/vizier/services/metadata/metadata_server.go
+++ b/src/vizier/services/metadata/metadata_server.go
@@ -36,7 +36,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 
 	version "px.dev/pixie/src/shared/goversion"
 	"px.dev/pixie/src/shared/services"
@@ -159,7 +159,6 @@ func etcdTLSConfig() (*tls.Config, error) {
 }
 
 func main() {
-	namespaces := []string{v1.NamespaceAll}
 	services.SetupService("metadata", 50400)
 	services.SetupSSLClientFlags()
 	services.PostFlagSetupAndParse()
@@ -237,6 +236,10 @@ func main() {
 	updateCh := make(chan *k8smeta.K8sResourceMessage)
 	mdh := k8smeta.NewHandler(updateCh, k8sMds, k8sMds, nc)
 
+	namespaces := []string{v1.NamespaceAll}
+	if viper.IsSet("METADATA_NAMESPACES") {
+		namespaces = strings.Split(viper.GetString("METADATA_NAMESPACES"), ",")
+	}
 	k8sMc, err := k8smeta.NewController(namespaces, updateCh)
 	defer k8sMc.Stop()
 

--- a/src/vizier/services/metadata/metadata_server.go
+++ b/src/vizier/services/metadata/metadata_server.go
@@ -36,6 +36,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	version "px.dev/pixie/src/shared/goversion"
 	"px.dev/pixie/src/shared/services"
@@ -158,6 +159,7 @@ func etcdTLSConfig() (*tls.Config, error) {
 }
 
 func main() {
+	namespaces := []string{v1.NamespaceAll}
 	services.SetupService("metadata", 50400)
 	services.SetupSSLClientFlags()
 	services.PostFlagSetupAndParse()
@@ -235,7 +237,7 @@ func main() {
 	updateCh := make(chan *k8smeta.K8sResourceMessage)
 	mdh := k8smeta.NewHandler(updateCh, k8sMds, k8sMds, nc)
 
-	k8sMc, err := k8smeta.NewController(updateCh)
+	k8sMc, err := k8smeta.NewController(namespaces, updateCh)
 	defer k8sMc.Stop()
 
 	ads := agent.NewDatastore(dataStore, 24*time.Hour)

--- a/src/vizier/services/metadata/metadata_server.go
+++ b/src/vizier/services/metadata/metadata_server.go
@@ -82,7 +82,6 @@ func init() {
 	// So instead just map PL_ETCD_OPERATOR_ENABLED to use_etcd_operator to make it work.
 	// TODO: We should clean this up in the future and make these flags consistent.
 	viper.BindEnv("use_etcd_operator", "PL_ETCD_OPERATOR_ENABLED")
-	viper.BindEnv("metadata_namespaces")
 }
 
 func mustInitEtcdDatastore() (*etcd.DataStore, func()) {


### PR DESCRIPTION
Summary: Enable metadata service to track the events from a subset of namespaces when desired, instead of tracking the events from the entire cluster.

Relevant Issues: #1364

Type of change: /kind feature

Test Plan: Added unit tests for the new behaviour. @JamesMBartlett tested by skaffolding a dev vizier version to a cluster both with and without `metadata_namespaces` selected, and both behaved as expected.
