### PR TITLE
[README] Update latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Pixie is a community-driven project; we welcome your contribution! For code cont
 ## Latest Releases
 We version separate components of Pixie separately, so what Github shows as the "latest" release will only be the latest for one of the components.
 We maintain links to the latest releases for all components here:
-- [CLI v0.8.0](https://github.com/pixie-io/pixie/releases/tag/release/cli/v0.8.0)<!--cli-latest-release-->
+- [CLI v0.8.1](https://github.com/pixie-io/pixie/releases/tag/release/cli/v0.8.1)<!--cli-latest-release-->
 - [Cloud v0.1.1](https://github.com/pixie-io/pixie/releases/tag/release/cloud/v0.1.1) <!--cloud-latest-release-->
-- [Vizier v0.13.4](https://github.com/pixie-io/pixie/releases/tag/release/vizier/v0.13.4)<!--vizier-latest-release-->
-<!--operator-latest-release-->
+- [Vizier v0.13.5](https://github.com/pixie-io/pixie/releases/tag/release/vizier/v0.13.5)<!--vizier-latest-release-->
+- [Operator v0.1.1](https://github.com/pixie-io/pixie/releases/tag/release/operator/v0.1.1)<!--operator-latest-release-->
 
 ## Changelog
 


### PR DESCRIPTION
Summary: Update links to latest releases in readme. Until #1366 lands we have to keep doing this manually.

Type of change: /kind cleanup

Test Plan: N/A
