### PR TITLE
[releases] GPG sign release artifacts

### DIFF
--- a/.github/actions/sign_artifacts/action.yaml
+++ b/.github/actions/sign_artifacts/action.yaml
@@ -1,0 +1,40 @@
+---
+name: sign-artifacts
+description: Sign all artifacts in the given directory using the provided GPG key.
+inputs:
+  artifacts-dir:
+    description: 'Directory with artifacts to sign'
+    required: true
+  skip-shas:
+    description: 'Whether to skip signing of sha256 files'
+    default: 'true'
+  BUILDBOT_GPG_KEY_ID:
+    description: 'GPG key ID of key to sign with'
+    required: true
+  BUILDBOT_GPG_KEY_B64:
+    description: 'GPG private key base64 encoded'
+    required: true
+runs:
+  using: "composite"
+  steps:
+  - name: Import GPG key
+    shell: bash
+    env:
+      BUILDBOT_GPG_KEY_B64: ${{ inputs.BUILDBOT_GPG_KEY_B64 }}
+    run: |
+      echo "${BUILDBOT_GPG_KEY_B64}" | base64 --decode | gpg --no-tty --batch --import
+  - name: Sign Artifacts
+    shell: bash
+    env:
+      ARTIFACTS_DIR: ${{ inputs.artifacts-dir }}
+      SKIP_SHAS: ${{ inputs.skip-shas }}
+      BUILDBOT_GPG_KEY_ID: ${{ inputs.BUILDBOT_GPG_KEY_ID }}
+    # yamllint disable rule:indentation
+    run: |
+      for artifact in "${ARTIFACTS_DIR}/"*; do
+        if [[ "${SKIP_SHAS}" == "true" ]] && [[ "${artifact}" == *".sha256" ]]; then
+          continue
+        fi
+        gpg --no-tty --batch --yes --local-user "${BUILDBOT_GPG_KEY_ID}" --armor --detach-sign "${artifact}"
+      done
+    # yamllint enable rule:indentation

--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -45,6 +45,12 @@ jobs:
         mkdir -p "${ARTIFACTS_DIR}"
         ./ci/save_version_info.sh
         ./ci/cloud_build_release.sh
+    - name: Sign Artifacts
+      uses: ./.github/actions/sign_artifacts
+      with:
+        artifacts-dir: artifacts
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: cloud-artifacts

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -48,6 +48,12 @@ jobs:
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
       run: ./ci/update_artifact_manifest.sh
+    - name: Sign Artifacts
+      uses: ./.github/actions/sign_artifacts
+      with:
+        artifacts-dir: artifacts
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: operator-artifacts

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -55,6 +55,12 @@ jobs:
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
       run: ./ci/update_artifact_manifest.sh
+    - name: Sign Artifacts
+      uses: ./.github/actions/sign_artifacts
+      with:
+        artifacts-dir: artifacts
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: vizier-artifacts


### PR DESCRIPTION
Summary: GPG sign release artifacts for vizier, operator and cloud releases. Eventually we should refactor the CLI release to use the same signing method, but I'm going to leave it as is for now. Not sure whether we should sign the `.sha256` files, since it seems a bit weird to do, but it might be the case that the CLO monitor check requires it. In any case, I made it a flag that's easy to change, so if we do want to sign sha files we can flip the flag.

Type of change: /kind cleanup

Test Plan: Tested on my fork, saw releases with `.asc` signature files: [vizier](https://github.com/JamesMBartlett/pixie/releases/tag/release%2Fvizier%2Fv0.13.6-pre-test-sign-release-artifacts.2), [operator](https://github.com/JamesMBartlett/pixie/releases/tag/release%2Foperator%2Fv0.1.2-pre-test-sign-release-artifacts.1), [cloud](https://github.com/JamesMBartlett/pixie/releases/tag/release%2Fcloud%2Fv0.1.2-pre-test-sign-release-artifacts.3)
