### PR TITLE
Add TLS verify to NATS

### DIFF
--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -32,6 +32,7 @@ data:
       cert_file: "/etc/nats-server-tls-certs/server.crt",
       key_file: "/etc/nats-server-tls-certs/server.key",
       timeout: 3
+      verify: true
     }
   # yamllint enable rule:indentation
 ---


### PR DESCRIPTION
Summary: We were already using TLS for our NATS communications. This option adds validation for the client certificate.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Create a Vizier RC and deploy it to a cluster. Ensure that everything continues running as expected.

Changelog Message:
```release-note
Add TLS verification to NATS.
```
