### PR TITLE
Add k8s manifests for the k8ssandra px cli demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -51,6 +51,39 @@ file describes the demo scenarios.
 
 4. Copy the yaml file to `pixie/demos/kafka`.
 
+## Updating the `px-k8ssandra` demo
+
+1. Clone `https://github.com/pixie-io/spring-petclinic-reactive`
+
+2. Build the k8s manifests with kustomize
+
+    ```shell
+    spring-petclinic-reactive-root-dir $ kustomize build . > petclinic.yaml
+    ```
+
+3. Clone `https://github.com/k8ssandra/k8ssandra-operator` and checkout the `v1.6.1` tag.
+
+
+4. Build the manifests needed to install the CRDs and k8ssandra control plane
+
+    ```shell
+    # Your kustomize version must be v4.5.7 or newer for these configs
+
+    k8ssandra-operator-root-dir $ cd config/crd
+    kustomize build . > crd.yaml
+
+    k8ssandra-operator-root-dir $ cd config/deployments/control-plane/cluster-scope
+    kustomize build . > k8ssandra-control-plane.yaml
+    ```
+
+5. Concatenate the yaml files in the order specified below and copy it into `pixie/demos/kafka`.
+
+    ```shell
+    cat crd.yaml k8ssandra-control-plane.yaml petclinic.yaml > demos/k8ssandra/k8ssandra.yaml
+    ```
+
+6. Replace all occurrences of the k8ssandra-operator namespace. At the time of this writing, the areas to search and replace include the namespace field for a given resource in addition to the cert-manager annotations (cert-manager.io/inject-ca-from). Note: there may be kustomize variables used for the cert-manager.io/inject-ca-from annotation, so ensure all usages reference the px-k8ssandra namespace.
+
 ## Updating the `px-finagle` demo
 
 1. Clone `https://github.com/pixie-io/finagle-helloworld`

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -45,7 +45,7 @@
     },
     "px-k8ssandra": {
         "description": "Microservice demo that spins up Cassandra and the Spring PetClinic demo app.",
-	"instructions": ["Use the px/cql_data script to view the Cassandra traffic flowing from the demo app."],
+	"instructions": ["Use the px/cql_data and px/http_data scripts to view the backend API and Cassandra traffic flowing from the demo app."],
 	"dependencies": {
             "cert-manager": true
         }


### PR DESCRIPTION
Summary: Add k8s manifests for k8ssandra px cli demo

Relevant Issues: #680

Type of change: /kind feature

Test Plan: Verify the demo works by deploying it as described below:
- [ ] Deploying the demo to minikube is successful: expected data is visible in the `px/cql_data` and `px/http_data` scripts and `px demo delete` is successful
<img width="1728" alt="Screenshot 2023-05-26 at 9 00 31 AM" src="https://github.com/pixie-io/pixie/assets/5855593/dc39410f-157d-47bb-8ced-5e2f29f6cbef">
<img width="1728" alt="Screenshot 2023-05-26 at 9 00 40 AM" src="https://github.com/pixie-io/pixie/assets/5855593/fc878c3d-e787-431d-b70f-51150f33b0f7">

Changelog Message:
```release-note
Add a k8ssandra demo to the `px` cli
```