### PR TITLE
Refine `px demo delete` logic for more complex demo applications

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -70,9 +70,15 @@ file describes the demo scenarios.
     # Your kustomize version must be v4.5.7 or newer for these configs
 
     k8ssandra-operator-root-dir $ cd config/crd
+    # Edit config/crd/kustomization.yaml to append the following:
+    # commonLabels:
+    #   pixie-demo: px-k8ssandra
     kustomize build . > crd.yaml
 
     k8ssandra-operator-root-dir $ cd config/deployments/control-plane/cluster-scope
+    # Edit config/deployments/control-plane/cluster-scope/kustomization.yaml to append the following:
+    # commonLabels:
+    #   pixie-demo: px-k8ssandra
     kustomize build . > k8ssandra-control-plane.yaml
     ```
 


### PR DESCRIPTION
Summary: We are working on adding the px-k8ssandra demo in our demo apps. However, this demo app is more complex. It requires cluster-scoped resources such as mutating webhooks, and proper cleanup requires the K8ssandraCluster to be deleted first or else things will hang.
We can control the delete process through labels. Adding labels to the demo resources allow us to target cluster-scoped resources that wouldn't be deleted from just deleting the namespace. We can use an additional label for resources that need to be cleaned up first.

Relevant Issues: #680

Type of change: /kind cleanup

Test Plan: Deploy px-k8ssandra demo app and delete. Make sure resources all get cleaned up and delete runs without error. Also make sure delete still works on existing demo-apps, such as px-sock-shop.

Changelog Message:
```release-note
Enhanced `px demo` to support more complex applications which require CRDs
```
