### PR TITLE
Remove unused extra bazel args

### DIFF
--- a/ci/image_utils.sh
+++ b/ci/image_utils.sh
@@ -21,11 +21,10 @@ push_images_for_arch() {
   image_rule="$2"
   release_tag="$3"
   build_type="$4"
-  bazel_args="$5"
 
   bazel run --config=stamp -c opt --//k8s:image_version="${release_tag}-${arch}" \
       --config="${arch}_sysroot" \
-      --config=stamp "${build_type}" "${image_rule}" "${bazel_args}" > /dev/null
+      --config=stamp "${build_type}" "${image_rule}" > /dev/null
 }
 
 push_multiarch_image() {
@@ -47,14 +46,13 @@ push_all_multiarch_images() {
   image_list_rule="$2"
   release_tag="$3"
   build_type="$4"
-  bazel_args="$5"
 
-  push_images_for_arch "x86_64" "${image_rule}" "${release_tag}" "${build_type}" "${bazel_args}"
-  push_images_for_arch "aarch64" "${image_rule}" "${release_tag}" "${build_type}" "${bazel_args}"
+  push_images_for_arch "x86_64" "${image_rule}" "${release_tag}" "${build_type}"
+  push_images_for_arch "aarch64" "${image_rule}" "${release_tag}" "${build_type}"
 
   while read -r image;
   do
     push_multiarch_image "${image}"
   done < <(bazel run --config=stamp -c opt --//k8s:image_version="${release_tag}" \
-          --config=stamp "${build_type}" "${image_list_rule}" "${bazel_args}")
+          --config=stamp "${build_type}" "${image_list_rule}")
 }

--- a/ci/operator_build_release.sh
+++ b/ci/operator_build_release.sh
@@ -43,7 +43,6 @@ bucket="pixie-dev-public"
 # The previous version should be the 2nd item in the tags. Since this is a release build,
 # the first item in the tag is the current release.
 prev_tag=$(echo "$tags" | sed -n '2 p')
-extra_bazel_args=()
 if [[ $release_tag == *"-"* ]]; then
   build_type="--//k8s:build_type=dev"
   image_path="gcr.io/pixie-oss/pixie-dev/operator/operator_image:${release_tag}"
@@ -56,7 +55,7 @@ if [[ $release_tag == *"-"* ]]; then
   prev_tag=$(echo "$tags" | sed -n '1 p')
 fi
 
-push_all_multiarch_images "//k8s/operator:operator_images_push" "//k8s/operator:list_image_bundle" "${release_tag}" "${build_type}" "${extra_bazel_args[@]}"
+push_all_multiarch_images "//k8s/operator:operator_images_push" "//k8s/operator:list_image_bundle" "${release_tag}" "${build_type}"
 
 # Build operator bundle for OLM.
 tmp_dir="$(mktemp -d)"

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -35,7 +35,6 @@ bazel run -c opt //src/utils/artifacts/versions_gen:versions_gen -- \
 
 build_type="--//k8s:build_type=public"
 bucket="pixie-dev-public"
-extra_bazel_args=()
 if [[ $release_tag == *"-"* ]]; then
   build_type="--//k8s:build_type=dev"
   # Use the same bucket as above for RCs
@@ -44,10 +43,10 @@ fi
 output_path="gs://${bucket}/vizier/${release_tag}"
 latest_output_path="gs://${bucket}/vizier/latest"
 
-push_all_multiarch_images "//k8s/vizier:vizier_images_push" "//k8s/vizier:list_image_bundle" "${release_tag}" "${build_type}" "${extra_bazel_args[@]}"
+push_all_multiarch_images "//k8s/vizier:vizier_images_push" "//k8s/vizier:list_image_bundle" "${release_tag}" "${build_type}"
 
 bazel build --config=stamp -c opt --//k8s:image_version="${release_tag}" \
-    --config=stamp "${build_type}" //k8s/vizier:vizier_yamls "${extra_bazel_args[@]}"
+    --config=stamp "${build_type}" //k8s/vizier:vizier_yamls
 
 output_path="gs://${bucket}/vizier/${release_tag}"
 yamls_tar="${repo_path}/bazel-bin/k8s/vizier/vizier_yamls.tar"


### PR DESCRIPTION
Summary: These args were used to define image registries. Now we use
config flags to do the same and the args are unset/unused.

Type of change: /kind cleanup

Test Plan: Unused args, release scripts should continue to work.
