### PR TITLE
Fix test data used in CQL parser tests

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/parse_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/parse_test.cc
@@ -103,8 +103,8 @@ TEST_F(CQLParserTest, BadOpcode) {
 }
 
 TEST_F(CQLParserTest, LengthTooLarge) {
-  // Length is 0x01000000
-  constexpr uint8_t kBadLengthFrame[] = {0x04, 0x00, 0x00, 0x06, 0xff, 0x01,
+  // Length is 0x020000000
+  constexpr uint8_t kBadLengthFrame[] = {0x04, 0x00, 0x00, 0x06, 0x07, 0x20,
                                          0x00, 0x00, 0x00, 0x00, 0x00};
 
   std::string_view frame_view =
@@ -119,7 +119,7 @@ TEST_F(CQLParserTest, LengthTooLarge) {
 
 TEST_F(CQLParserTest, LengthNegative) {
   // Length is 0xf0000000
-  constexpr uint8_t kBadLengthFrame[] = {0x04, 0x00, 0x00, 0x06, 0xff, 0xf0,
+  constexpr uint8_t kBadLengthFrame[] = {0x04, 0x00, 0x00, 0x06, 0x07, 0xf0,
                                          0x00, 0x00, 0x00, 0x00, 0x00};
 
   std::string_view frame_view =
@@ -134,7 +134,7 @@ TEST_F(CQLParserTest, LengthNegative) {
 
 TEST_F(CQLParserTest, VersionTooOld) {
   // Version is set to 2.
-  constexpr uint8_t kBadLengthFrame[] = {0x02, 0x00, 0x00, 0x06, 0xff, 0x00,
+  constexpr uint8_t kBadLengthFrame[] = {0x02, 0x00, 0x00, 0x06, 0x07, 0x00,
                                          0x00, 0x00, 0x02, 0x00, 0x00};
 
   std::string_view frame_view =
@@ -149,7 +149,7 @@ TEST_F(CQLParserTest, VersionTooOld) {
 
 TEST_F(CQLParserTest, VersionTooNew) {
   // Version is set to 5.
-  constexpr uint8_t kBadLengthFrame[] = {0x05, 0x00, 0x00, 0x06, 0xff, 0x00,
+  constexpr uint8_t kBadLengthFrame[] = {0x05, 0x00, 0x00, 0x06, 0x07, 0x00,
                                          0x00, 0x00, 0x02, 0x00, 0x00};
 
   std::string_view frame_view =


### PR DESCRIPTION
Summary: Fix test data used in CQL parser tests

The CQL protocol defines that messages have a [256 MiB size limit](https://github.com/apache/cassandra/blob/fad1f7457032544ab6a7b40c5d38ecb8b25899bb/doc/native_protocol_v3.spec#LL199C24-L199C24). The CQL parser test cases used a 16 MiB message size (0x1000000) rather than one that was greater than 256 MiB. The inconsistencies in this test were identified as I've been investigating #1375.

Relevant Issues: #1375

Type of change: /kind test-infra

Test Plan: Verified with gdb that each test case returns the `kInvalid` from its specific branch and existing tests pass