### PR TITLE
Update the FDResolver stdin test to pass when resolution returns a file or pipe

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/fd_resolver_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/fd_resolver_test.cc
@@ -28,6 +28,9 @@
 namespace px {
 namespace stirling {
 
+using testing::AnyOf;
+using testing::StartsWith;
+
 class FDResolverTest : public ::testing::Test {
  protected:
   void SetUp() { proc_parser_ = std::make_unique<system::ProcParser>(); }
@@ -64,8 +67,8 @@ TEST_F(FDResolverTest, ResolveStdin) {
   // FD link captured during established time window.
   fd_link = resolver.InferFDLink(t);
   EXPECT_TRUE(fd_link.has_value());
-  // Value should be a path.
-  EXPECT_TRUE(absl::StartsWith(*fd_link, "/"));
+  // Value should be a path or a pipe
+  EXPECT_THAT(*fd_link, AnyOf(StartsWith("/"), StartsWith("pipe")));
 
   // Resolver can't conclude anything for outside the time window.
   fd_link = resolver.InferFDLink(std::chrono::steady_clock::now());


### PR DESCRIPTION
Summary: Update the FDResolver stdin test to pass when resolution returns a file or pipe

This test was failing when run under bazel remote execution. The source of the error was due to the FDResolver returning a string like `pipe:[15235525]`. This updates the test assertion to handle the pipe and file path case.

Relevant Issues: N/A

Type of change: /kind test-infra

Test Plan: Hard coded `pipe:[15235525]` as the return value and verified the test passes