### PR TITLE
Sign images using cosign

### DIFF
--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -38,6 +38,8 @@ jobs:
         BUILD_NUMBER: ${{ github.run_attempt }}
         JOB_NAME: ${{ github.job }}
         GH_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+        COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+        COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -37,6 +37,8 @@ jobs:
         REF: ${{ github.event.ref }}
         BUILD_NUMBER: ${{ github.run_attempt }}
         JOB_NAME: ${{ github.job }}
+        COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+        COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -37,6 +37,8 @@ jobs:
         REF: ${{ github.event.ref }}
         BUILD_NUMBER: ${{ github.run_attempt }}
         JOB_NAME: ${{ github.job }}
+        COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+        COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"

--- a/ci/cloud_build_release.sh
+++ b/ci/cloud_build_release.sh
@@ -35,6 +35,13 @@ echo "The image tag is: ${release_tag}"
 bazel run --config=stamp -c opt --action_env=GOOGLE_APPLICATION_CREDENTIALS --//k8s:image_version="${release_tag}" \
     --//k8s:build_type=public //k8s/cloud:cloud_images_push
 
+while read -r image;
+do
+  image_digest=$(crane digest "${image}")
+  cosign sign --key env://COSIGN_PRIVATE_KEY --yes -r "${image}@${image_digest}"
+done < <(bazel run --config=stamp -c opt --action_env=GOOGLE_APPLICATION_CREDENTIALS --//k8s:image_version="${release_tag}" \
+    --//k8s:build_type=public //k8s/cloud:list_image_bundle)
+
 all_licenses_opts=("//tools/licenses:all_licenses" "--action_env=GOOGLE_APPLICATION_CREDENTIALS" "--remote_download_outputs=toplevel")
 all_licenses_path="$(bazel cquery "${all_licenses_opts[@]}"  --output starlark --starlark:expr "target.files.to_list()[0].path" 2> /dev/null)"
 bazel build "${all_licenses_opts[@]}"


### PR DESCRIPTION
Summary: This uses cosign to sign all of our images.

Type of change: /kind cleanup

Test Plan: Created RCs for operator, cloud, and vizier. Verified that they were all signed as expected.