### PR TITLE
Fix highlight CSS in autocomplete dropdowns

### DIFF
--- a/src/ui/src/components/autocomplete/completions.tsx
+++ b/src/ui/src/components/autocomplete/completions.tsx
@@ -97,6 +97,7 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     '& > span': {
       ...theme.typography.body1,
       fontFamily: theme.typography.monospace.fontFamily,
+      '&$highlight': { fontWeight: 600 },
     },
     '&.active': {
       color: theme.palette.text.primary,


### PR DESCRIPTION
Summary: Restore the bold highlight of matched terms in breadcrumbs.
<img width="629" alt="image" src="https://github.com/pixie-io/pixie/assets/314133/bc9fe9a4-515e-491d-b3f2-2523b42893f8">

Type of change: /kind bugfix

Test Plan: Use the breadcrumbs. Search for something. Highlight should be restored.

