### PR TITLE
Remove unintended drop shadow in light mode

### DIFF
--- a/src/ui/src/components/breadcrumbs/__snapshots__/breadcrumbs-test.tsx.snap
+++ b/src/ui/src/components/breadcrumbs/__snapshots__/breadcrumbs-test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Breadcrumbs/> renders correctly 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 Breadcrumbs-triggerWrapper-1 css-zsf01h-MuiPaper-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 Breadcrumbs-triggerWrapper-1 css-mvwo72-MuiPaper-root"
   >
     <div
       class="Breadcrumbs-breadcrumbs-2"

--- a/src/ui/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/ui/src/components/breadcrumbs/breadcrumbs.tsx
@@ -496,7 +496,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = React.memo(({ breadcrumbs
     AutocompleteContext,
   );
   return (
-    <Paper className={classes.triggerWrapper}>
+    <Paper className={classes.triggerWrapper} elevation={0}>
       <div className={classes.breadcrumbs}>
         {breadcrumbs.map((breadcrumb, i) => (
           // Key is needed to prevent a console error when a key is missing in a list element.


### PR DESCRIPTION
Summary: There was an elevation shadow from Material that was no longer needed.
Without change...
![image](https://github.com/pixie-io/pixie/assets/314133/ca89b65f-b09f-4a29-a944-ae34d609edd2)
With change...
<img width="717" alt="image" src="https://github.com/pixie-io/pixie/assets/314133/198c7c3e-16f3-44bf-8fd2-4f064621aecb">

Type of change: /kind bugfix

Test Plan: Open live view in light mode. No more weird boxy shadow on the breadcrumbs.

