### PR TITLE
[chore] upgrade canvas

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -33,7 +33,7 @@
     "@yarnpkg/pnpify": "^3.1.0",
     "archiver": "^5.0.2",
     "babel-jest": "^27.3.1",
-    "canvas": "^2.8.0",
+    "canvas": "^2.11.2",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "compression-webpack-plugin": "^4.0.0",
     "concurrently": "^6.2.0",

--- a/src/ui/yarn.lock
+++ b/src/ui/yarn.lock
@@ -2300,7 +2300,7 @@ __metadata:
     assets: "link:./assets"
     axios: ^0.21.4
     babel-jest: ^27.3.1
-    canvas: ^2.8.0
+    canvas: ^2.11.2
     case-sensitive-paths-webpack-plugin: ^2.1.2
     compression-webpack-plugin: ^4.0.0
     concurrently: ^6.2.0
@@ -4677,15 +4677,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvas@npm:^2.8.0":
-  version: 2.8.0
-  resolution: "canvas@npm:2.8.0"
+"canvas@npm:^2.11.2":
+  version: 2.11.2
+  resolution: "canvas@npm:2.11.2"
   dependencies:
     "@mapbox/node-pre-gyp": ^1.0.0
-    nan: ^2.14.0
+    nan: ^2.17.0
     node-gyp: latest
     simple-get: ^3.0.3
-  checksum: 4cc909f63eaf88d22f9164601903745abcc6ccb7f70090b9389dc2cb68cbf139c220dbd75837e6d04602ff122b44a2eb17413bca850f9c6c602f74f1f0f1cc3f
+  checksum: 61e554aef80022841dc836964534082ec21435928498032562089dfb7736215f039c7d99ee546b0cf10780232d9bf310950f8b4d489dc394e0fb6f6adfc97994
   languageName: node
   linkType: hard
 
@@ -10741,12 +10741,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.14.0":
-  version: 2.15.0
-  resolution: "nan@npm:2.15.0"
+"nan@npm:^2.17.0":
+  version: 2.17.0
+  resolution: "nan@npm:2.17.0"
   dependencies:
     node-gyp: latest
-  checksum: 33e1bb4dfca447fe37d4bb5889be55de154828632c8d38646db67293a21afd61ed9909cdf1b886214a64707d935926c4e60e2b09de9edfc2ad58de31d6ce8f39
+  checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
   languageName: node
   linkType: hard
 
@@ -14206,14 +14206,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "tslib@npm:2.3.1"
-  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
-  languageName: node
-  linkType: hard
-
-"tslib@npm:~2.5.0":
+"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:~2.5.0":
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
   checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1


### PR DESCRIPTION
Summary: The version of canvas we depended on didn't have pre-built
binaries for node v18 and node-gyp was failing during the build step
on some machines.
This upgrades canvas to a version that publishes pre-built binaries
for node v18 and fixes the issue.

Type of change: /kind devinfra

Test Plan: `yarn install` doesn't call node-gyp for canvas and succeeds.
