### PR TITLE
[build] Remove exclusive tags from bpf tests

### DIFF
--- a/src/stirling/bpf_tools/BUILD.bazel
+++ b/src/stirling/bpf_tools/BUILD.bazel
@@ -120,12 +120,8 @@ pl_cc_bpf_test(
     name = "uprobe_extra_trigger_bpf_test",
     srcs = ["uprobe_extra_trigger_bpf_test.cc"],
     tags = [
-        # This test must be exclusive, because other tests that deploy the same container images
-        # could cause extra BPF triggers. In fact, this is what the test internally demonstrates
-        # is a problem.
-        "exclusive",
-        "requires_bpf",
         "cpu:16",
+        "requires_bpf",
     ],
     deps = [
         ":cc_library",

--- a/src/stirling/e2e_tests/BUILD.bazel
+++ b/src/stirling/e2e_tests/BUILD.bazel
@@ -78,7 +78,6 @@ pl_sh_bpf_test(
     flaky = True,
     tags = [
         "cpu:16",
-        "exclusive",
         "requires_bpf",
     ],
     deps = ["//src/stirling/scripts:sh_library"],
@@ -101,11 +100,8 @@ pl_sh_bpf_test(
     # TODO(PL-1462): Uprobe attaching sometimes fails.
     flaky = True,
     tags = [
-        "requires_bpf",
         "cpu:16",
-        # Run exclusive, otherwise BPF probe cleaner may conflict with open probes of other instances,
-        # which will emit warnings, that will then be considered a test failure.
-        "exclusive",
+        "requires_bpf",
     ],
     deps = ["//src/stirling/scripts:sh_library"],
 )
@@ -123,11 +119,8 @@ pl_sh_bpf_test(
     ],
     flaky = True,
     tags = [
-        "requires_bpf",
         "cpu:16",
-        # Run exclusive, otherwise BPF probe cleaner may conflict with open probes of other instances,
-        # which will emit warnings, that will then be considered a test failure.
-        "exclusive",
+        "requires_bpf",
     ],
     deps = [
         "//src/stirling/scripts:sh_library",
@@ -151,9 +144,6 @@ pl_sh_bpf_test(
     tags = [
         "requires_bpf",
         "cpu:16",
-        # Run exclusive, otherwise BPF probe cleaner may conflict with open probes of other instances,
-        # which will emit warnings, that will then be considered a test failure.
-        "exclusive",
         # TODO(oazizi): This test times out in TSAN. Figure out why.
         # Likely related to the fact that its running though docker.
         "no_tsan",
@@ -174,8 +164,6 @@ pl_sh_bpf_test(
     tags = [
         "requires_bpf",
         "cpu:16",
-        # Run exclusive to get as little noise as possible while measuring performance.
-        "exclusive",
         # Only intention is to run this with opt builds.
         # Can still run it with -c dbg, but on Jenkins, we only run opt version.
         "no_asan",
@@ -203,9 +191,6 @@ pl_sh_bpf_test(
     tags = [
         "requires_bpf",
         "cpu:16",
-        # Run exclusive, otherwise BPF probe cleaner may conflict with open probes of other instances,
-        # which will emit warnings, that will then be considered a test failure.
-        "exclusive",
         # TODO(PP-1742): Test is flaky, especially with ASAN, likely due to timing issues.
         "manual",
         "no_asan",
@@ -242,7 +227,6 @@ pl_sh_bpf_test(
     flaky = True,
     tags = [
         "cpu:16",
-        "exclusive",
         "requires_bpf",
     ],
     deps = ["//src/stirling/scripts:sh_library"],

--- a/src/stirling/source_connectors/jvm_stats/BUILD.bazel
+++ b/src/stirling/source_connectors/jvm_stats/BUILD.bazel
@@ -40,7 +40,6 @@ pl_cc_test(
         "//src/stirling/source_connectors/jvm_stats/testing:HelloWorld",
     ],
     tags = [
-        "exclusive",
         "no_coverage",
         # Currently we detect java processes by checking the name of the command run.
         # This fails when run under userspace qemu, because the name of the command run is qemu-aarch64-static.

--- a/src/stirling/source_connectors/perf_profiler/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/BUILD.bazel
@@ -58,7 +58,6 @@ pl_cc_bpf_test(
     shard_count = 3,
     tags = [
         "cpu:16",
-        "exclusive",
         "no_qemu",
         "requires_bpf",
     ],

--- a/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
+++ b/src/stirling/source_connectors/perf_profiler/java/agent/BUILD.bazel
@@ -97,7 +97,6 @@ pl_cc_test(
         "//src/stirling/source_connectors/perf_profiler/testing/java:profiler_test_with_agent",
     ],
     tags = [
-        "exclusive",
         "no_asan",
     ],
     deps = [

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -314,12 +314,9 @@ pl_cc_bpf_test(
     flaky = True,
     shard_count = 3,
     tags = [
-        "requires_bpf",
         "cpu:16",
-        # This test runs Go gRPC client & server, which causes other tests to attach & detach
-        # uprobes and slowed down significantly.
-        "exclusive",
         "no_asan",
+        "requires_bpf",
     ],
     deps = [
         ":cc_library",
@@ -338,12 +335,9 @@ pl_cc_bpf_test(
     srcs = ["http2_trace_bpf_test.cc"],
     flaky = True,
     tags = [
-        "requires_bpf",
         "cpu:16",
-        # This test runs Go gRPC client & server, which causes other tests to attach & detach
-        # uprobes, slowing them down significantly.
-        "exclusive",
         "no_asan",
+        "requires_bpf",
     ],
     deps = [
         ":cc_library",
@@ -495,7 +489,6 @@ pl_cc_bpf_test(
     flaky = True,
     tags = [
         "cpu:16",
-        "exclusive",
         "no_asan",
         "requires_bpf",
     ],


### PR DESCRIPTION
Summary: Removes the "exclusive" tags from bpf tests. Since we now run bpf tests under qemu, the exclusive tags aren't necessary. This has the added benefit of making these tests work with remote execution. The only downside is that `bazel test //... --config=bpf` won't run these tests exclusively anymore, but as far as I'm aware nobody runs that because it requires root.

Type of change: /kind cleanup

Test Plan: Tested that all the tests still work running simulataneously under qemu. Ran with `--runs_per_test=20` only saw 2 failures in `grpc_trace_bpf_test` and 2 failures in `http2_trace_bpf_test`, which is inline with the flakiness we usually see.
