### PR TITLE
[equinix] Add raid setup script

### DIFF
--- a/k8s/devinfra/equinix_k3s/README.md
+++ b/k8s/devinfra/equinix_k3s/README.md
@@ -1,3 +1,7 @@
+- For each server, run the following only once:
+```
+./setup_raid.sh <SERVER_IP>
+```
 - Install k3sup (this installs k3sup to `~/bin` if that's not in your path choose somewhere that is)
 ```
 curl -sLS https://get.k3sup.dev | sh

--- a/k8s/devinfra/equinix_k3s/setup_raid.sh
+++ b/k8s/devinfra/equinix_k3s/setup_raid.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ "$#" -lt 1 ]]; then
+  echo "Usage: $0 <server_ip>"
+  exit 1
+fi
+
+server_ip="$1"
+disks=(/dev/nvme0n1 /dev/nvme1n1)
+mount_dir="/data"
+
+{
+cat <<EOF
+set -ex
+mdadm --create --verbose /dev/md0 --level=0 --raid-devices="${#disks[@]}" ${disks[@]}
+mkfs -t ext4 /dev/md0
+mdadm --detail --scan >> /etc/mdadm/mdadm.conf
+
+mkdir -p "${mount_dir}"
+mount /dev/md0 "${mount_dir}"
+
+echo "/dev/md0 ${mount_dir} ext4 defaults 0 0" >> /etc/fstab
+
+update-initramfs -u
+EOF
+} | ssh "root@${server_ip}" '/bin/bash -s'


### PR DESCRIPTION
Summary: Adds a script to setup a RAID0 device of the two large SSDs on the equinix machines.

Type of change: /kind cleanup

Test Plan: Tested that the script creates a RAID0 device and mounts it at `/data`, and that it's persistent across reboots.
