### PR TITLE
[build] Add --config=remote, for running builds against buildbuddy remote executors.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -250,3 +250,18 @@ test --flaky_test_attempts=//src/stirling/source_connectors/socket_tracer/.*bpf_
 
 # Disable XNNPACK for tensorflow lite. There's currently an ASAN issue with XNNPACK, so disable for now.
 build --define=tflite_with_xnnpack=false
+
+build:remote --remote_executor=grpcs://remote.buildbuddy.io
+build:remote --host_platform=//bazel:remote_exec_platform
+build:remote --extra_execution_platforms=//bazel:remote_exec_platform
+build:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remote --bes_backend=grpcs://remote.buildbuddy.io
+build:remote --remote_cache=grpcs://remote.buildbuddy.io
+build:remote --experimental_remote_downloader=grpcs://remote.buildbuddy.io
+build:remote --remote_timeout=1h
+build:remote --remote_retries=5
+build:remote --spawn_strategy=remote,local
+build:remote --experimental_remote_cache_compression
+build:remote --jobs=100
+build:remote --nolegacy_important_outputs
+build:remote --build_metadata=VISIBILITY=PUBLIC

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -114,6 +114,18 @@ config_setting(
     },
 )
 
+platform(
+    name = "remote_exec_platform",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    exec_properties = {
+        "OSFamily": "Linux",
+        "Pool": "202305310009",
+    },
+)
+
 # Jenkins uses `bazel query` to find the reverse dependencies of a changed file.
 # Without this, that query on pl_build_system.bzl will fail, in the case of changing its content.
 exports_files(["pl_build_system.bzl"])


### PR DESCRIPTION
Summary: Add bazel configs for running against buildbuddy remote executors. In addition to these configs, a buildbuddy api key is needed.

Type of change: /kind cleanup

Test Plan: Tested that remote builds work (`--config=clang`, `--config=x86_64_sysroot` and `--config=qemu-bpf`)
