### PR TITLE
Switch to a distroless nats image

### DIFF
--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -159,7 +159,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: pl-nats
-        image: nats:2.9.16-alpine3.17@sha256:887f0193c5b72b66ff4795b807f3e9e324c34ffafbce612e54b2be8140a06de1
+        image: nats:2.9.17-scratch@sha256:8371b3bfc468a2294efb247531c2252c592398a98b574c2e81268d8c7f865d35
         ports:
         - containerPort: 4222
           name: client

--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -113,7 +113,7 @@ spec:
       containers:
       - name: pl-nats
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:multiarch-2.8.4-alpine3.15@sha256:988010f74b61749cfb82c28b50b47d26d0b972860ce6e9325a5afcde97713da2
+        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:2.9.17-scratch@sha256:8371b3bfc468a2294efb247531c2252c592398a98b574c2e81268d8c7f865d35
         ports:
         - containerPort: 4222
           name: client


### PR DESCRIPTION
Summary: Using a `scratch` based image is effectively distroless
since the first layer will be empty.
This also upgrades nats to the latest version.

Relevant Issues: #1363

Type of change: /kind cleanup

Test Plan: dev cloud and dev vizier builds work.
