### PR TITLE
[build-and-test] Use buildbuddy remote execution for build and test actions.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -228,19 +228,19 @@ coverage --define PL_COVERAGE=true
 coverage --copt -DPL_COVERAGE
 coverage --test_tag_filters=-requires_root,-requires_bpf,-no_coverage,-disabled,-no_gcc
 
+
+try-import %workspace%/bes.bazelrc
 # jenkins.bazelrc is copied from ci/jenkins.bazelrc by Jenkins workers during the build.
 # The intention is to avoid polluting configurations of bazel for developers.
 try-import %workspace%/jenkins.bazelrc
 # github.bazelrc is copied from ci/github/bazelrc by the github action workers during the build.
 try-import %workspace%/github.bazelrc
 
-# Put your own configurations into user.bazelrc, which is ignored by git.
-try-import %workspace%/user.bazelrc
-
 # Import a machine specific bazelrc. This can be used to enable caching.
 try-import /etc/bazelrc
 
-try-import %workspace%/bes.bazelrc
+# Put your own configurations into user.bazelrc, which is ignored by git.
+try-import %workspace%/user.bazelrc
 
 # Tensorflow requires this option
 common --experimental_repo_remote_exec
@@ -263,5 +263,6 @@ build:remote --remote_retries=5
 build:remote --spawn_strategy=remote,local
 build:remote --experimental_remote_cache_compression
 build:remote --jobs=100
+test:remote --jobs=100
 build:remote --nolegacy_important_outputs
 build:remote --build_metadata=VISIBILITY=PUBLIC

--- a/.github/actions/bazelrc/action.yaml
+++ b/.github/actions/bazelrc/action.yaml
@@ -8,6 +8,12 @@ inputs:
   dev:
     description: 'Whether to use DEV or CI settings for the bazelrc. defaults to dev'
     default: 'true'
+  use_remote_exec:
+    description: 'Use buildbuddy remote execution'
+    default: 'false'
+  BB_API_KEY:
+    description: 'API key to use for buildbuddy if `use_remote_exec`'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -34,4 +40,12 @@ runs:
     if: inputs.dev != 'true'
     run: |
       echo "build --build_metadata=ROLE=CI" >> github.bazelrc
+    shell: bash
+  - name: Add remote execution
+    if: inputs.use_remote_exec == 'true'
+    env:
+      BB_API_KEY: ${{ inputs.BB_API_KEY }}
+    run: |
+      echo "build:remote --remote_header=x-buildbuddy-api-key=$BB_API_KEY" >> github.bazelrc
+      echo "build --config=remote" >> github.bazelrc
     shell: bash

--- a/.github/actions/get_environment/action.yaml
+++ b/.github/actions/get_environment/action.yaml
@@ -1,0 +1,46 @@
+---
+name: Get PR environment
+description: Uses the github context to determine the correct secrets environment to use.
+outputs:
+  env-name:
+    description: 'name of secrets environment to use'
+    value: ${{ steps.output.outputs.env-name }}
+runs:
+  using: "composite"
+  steps:
+  - name: No environment needed.
+    if: github.event_name != 'pull_request'
+    run: |
+      touch env_name
+    shell: bash
+  - name: Using internal environment.
+    # yamllint disable rule:indentation
+    if: >-
+      github.event_name == 'pull_request' &&
+      (
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER'
+      )
+    # yamllint enable rule:indentation
+    run: |
+      echo "pr-secrets-members" > env_name
+    shell: bash
+  - name: Using external environment.
+    # yamllint disable rule:indentation
+    if: >-
+      github.event_name == 'pull_request' &&
+      !(
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER'
+      )
+    # yamllint enable rule:indentation
+    run: |
+      echo "pr-secrets-external" > env_name
+    shell: bash
+  - name: Set Output
+    id: output
+    run: |
+      echo "Github author_association: ${{ github.event.pull_request.author_association }}"
+      echo "Env: $(cat env_name)"
+      echo "env-name=$(cat env_name)" >> $GITHUB_OUTPUT
+    shell: bash

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -11,18 +11,23 @@ on:
 permissions:
   contents: read
 jobs:
+  get-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      env-name: ${{ steps.output.outputs.env-name }}
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+    - uses: ./.github/actions/get_environment
   get-dev-image:
     uses: ./.github/workflows/get_image.yaml
     with:
       image-base-name: "dev_image_with_extras"
   clang-tidy:
-    needs: get-dev-image
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest
+    needs: [get-environment, get-dev-image]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
-      options: --cpus 16
+    environment: ${{ needs.get-environment.outputs.env-name }}
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -31,6 +36,9 @@ jobs:
       run: git config --global --add safe.directory `pwd`
     - name: get bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
     - name: Save Diff Info
       run: ./ci/save_diff_info.sh
     - name: Run Clang Tidy
@@ -46,13 +54,9 @@ jobs:
   code-coverage:
     if: github.event_name == 'push'
     needs: get-dev-image
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
-      # Needs to be priviledged to enable IPV6
-      options: --cpus 16 --privileged
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -63,6 +67,8 @@ jobs:
       uses: ./.github/actions/bazelrc
       with:
         dev: 'false'
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
     - name: Collect and upload coverage
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -71,15 +77,13 @@ jobs:
         sysctl -w net.ipv6.conf.lo.disable_ipv6=0
         ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r pixie-io/pixie
   generate-matrix:
-    needs: get-dev-image
-    runs-on: [self-hosted, nokvm]
+    needs: [get-environment, get-dev-image]
+    runs-on: ubuntu-latest
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
-      options: --cpus 16
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    environment: ${{ needs.get-environment.outputs.env-name }}
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -88,6 +92,9 @@ jobs:
       run: git config --global --add safe.directory `pwd`
     - name: get bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
     - name: Set matrix
       id: set-matrix
       shell: bash
@@ -103,17 +110,13 @@ jobs:
           bazel_buildables_*
           bazel_tests_*
   build-and-test:
-    needs: [get-dev-image, generate-matrix]
-    runs-on:
-    - self-hosted
-    - ${{ matrix.runner }}
+    needs: [get-environment, get-dev-image, generate-matrix]
+    runs-on: ubuntu-latest
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
-      - /var/run/docker.sock:/var/run/docker.sock
       options: --privileged
     if: ${{ needs.generate-matrix.outputs.matrix && (toJson(fromJson(needs.generate-matrix.outputs.matrix)) != '[]') }}
+    environment: ${{ needs.get-environment.outputs.env-name }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       fail-fast: false
@@ -127,11 +130,15 @@ jobs:
       uses: ./.github/actions/bazelrc
       with:
         dev: 'true'
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
     - name: get ci bazel config
       if: github.event_name == 'push'
       uses: ./.github/actions/bazelrc
       with:
         dev: 'false'
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
     - name: Build ${{ matrix.name }}
       shell: bash
       # yamllint disable rule:indentation


### PR DESCRIPTION
Summary: Uses buildbuddy remote execution to run build and test bazel commands. Uses Github "environments" to access the BB_API_KEY secret.

Type of change: /kind test-infra.

Test Plan: Testing with this PR. Also need to test with an external contributor PR to make sure it does the right thing.
