### PR TITLE
Replace duration calculation in http_trace_id script with `px.format_duration`

### DIFF
--- a/src/pxl_scripts/px/http_trace_id/script.pxl
+++ b/src/pxl_scripts/px/http_trace_id/script.pxl
@@ -100,15 +100,11 @@ def add_trace_id_link(df, start_time: str):
     any data frames that have empty trace ids have been filtered prior.
     '''
 
-    # Until PxL has support for performing the inverse of px.parse_duration,
-    # compute 2x the original start_time manually. The goal is to avoid allowing
-    # a user to load the script with a specified trace id when the requests involved
-    # have aged out of the original start_time window. If PxL supported specifying
-    # the sort order of the table visualization (descending time), this
-    # wouldn't be a concern.
-    extended_start = 2 * px.parse_duration(start_time)
-    nanos_per_min = 60 * 1000 * 1000 * 1000
-    extended_start_time = px.itoa(px.floor(extended_start / nanos_per_min)) + 'm'
+    # Use 2x the original start_time to avoid allowing a user to load the script for
+    # a specified trace id when the requests involved have aged out of their original
+    # start_time window. If PxL supported specifying the sort order of the table visualization
+    # (descending time), this wouldn't be a concern.
+    extended_start_time = px.format_duration(2 * px.parse_duration(start_time))
 
     df.trace_id_link = px.script_reference(df.trace_id, 'px/http_trace_id', {
         'start_time': extended_start_time,


### PR DESCRIPTION
Summary: Replace duration calculation in http_trace_id script with `px.format_duration`

The `px.format_duration` function was added in https://github.com/pixie-io/pixie/pull/1256, but the http_trace_id pxl script was not updated since end users must upgrade in order to get access to that function. It's been one month since that change was made, so let's update the pxl script to use the new function.

Relevant Issues: N/A

Type of change: /kind new-pxl-script

Test Plan: Used the pxl scratch pad to verify that the time window is 2x'ed and rounded down to nearest whole number upon deep linking (35m x 2 = 70m -> 1h)

<img width="1680" alt="Screenshot 2023-06-01 at 9 28 54 AM" src="https://github.com/pixie-io/pixie/assets/5855593/d3ff0877-5962-47ec-81e8-b5c6def88d3d">

<img width="1665" alt="Screenshot 2023-06-01 at 9 29 00 AM" src="https://github.com/pixie-io/pixie/assets/5855593/3271fc4c-2ce4-4d38-b42d-912f4432e34e">