### PR TITLE
Ensure the `px.format_duration` pxl function has its doc string set

### DIFF
--- a/src/carnot/planner/objects/pixie_module.cc
+++ b/src/carnot/planner/objects/pixie_module.cc
@@ -539,6 +539,7 @@ Status PixieModule::RegisterCompileTimeFuncs() {
                                    std::placeholders::_2, std::placeholders::_3),
                          ast_visitor()));
   AddMethod(kFormatDurationOpID, format_duration_fn);
+  PX_RETURN_IF_ERROR(format_duration_fn->SetDocString(kFormatDurationDocstring));
 
   PX_RETURN_IF_ERROR(parse_time_fn->SetDocString(kParseTimeDocstring));
   AddMethod(kParseTimeOpID, parse_time_fn);

--- a/src/carnot/planner/objects/pixie_module.h
+++ b/src/carnot/planner/objects/pixie_module.h
@@ -212,7 +212,6 @@ class PixieModule : public QLObject {
     duration = px.format_duration(-5 * 60 * 1000 * 1000 * 1000)
     # duration = "5m" duration is rounded down to nearest whole minute.
     duration = px.parse_duration(-5 * 60 * 1000 * 1000 * 1000 + 5)
-
     # duration = "-5h"
     duration = px.format_duration(-5 * 60 * 60 * 1000 * 1000 * 1000)
 


### PR DESCRIPTION
Summary: Ensure the `px.format_duration` pxl function has its doc string set

When working on #1407 I noticed that the docs.px.dev site didn't include the `px.format_duration` function despite being updated recently. This change addresses the issue causing the missing docs. Rather than updating the docs.px.dev site manually, I'll wait to propagate this change to that repo once #1408 is complete.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Verified that the function exists in the documentation json file ([P401](https://phab.corp.pixielabs.ai/P401))