### PR TITLE
[actions] Use remote buildbuddy execution for release builds

### DIFF
--- a/.github/actions/gcloud_creds/action.yaml
+++ b/.github/actions/gcloud_creds/action.yaml
@@ -1,0 +1,30 @@
+---
+name: setup-gcloud-creds
+description: Sets up the given gcloud service account.
+inputs:
+  SERVICE_ACCOUNT_KEY:
+    description: 'base64 encoded PEM file for the service account'
+    required: true
+outputs:
+  gcloud-creds:
+    description: 'value for GOOGLE_APPLICATION_CREDENTIALS environment variable'
+    value: ${{ steps.create-gcloud-key.outputs.gcloud-creds }}
+runs:
+  using: "composite"
+  steps:
+  - id: create-gcloud-key
+    shell: bash
+    env:
+      SERVICE_ACCOUNT_KEY: ${{ inputs.SERVICE_ACCOUNT_KEY }}
+    run: |
+      echo "$SERVICE_ACCOUNT_KEY" | base64 --decode > /tmp/gcloud.json
+      chmod 600 /tmp/gcloud.json
+      echo "gcloud-creds=/tmp/gcloud.json" >> $GITHUB_OUTPUT
+  - name: setup gcloud service account
+    shell: bash
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.create-gcloud-key.outputs.gcloud-creds }}
+    run: |
+      service_account="$(jq -r '.client_email' "$GOOGLE_APPLICATION_CREDENTIALS")"
+      gcloud auth activate-service-account "${service_account}" --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+      gcloud auth configure-docker

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -15,21 +15,22 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest-16-cores
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      options: --cpus 15 --privileged --cgroupns host
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
-    - name: Setup gcloud docker creds
-      run: gcloud init && gcloud auth configure-docker
+    - name: get bazel config
+      uses: ./.github/actions/bazelrc
+      with:
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
+        download_toplevel: 'true'
     - name: Setup podman
       run: |
         # With some kernel configs (eg. COS), podman only works with legacy iptables.
@@ -40,6 +41,10 @@ jobs:
         BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
       run: |
         echo "$BUILDBOT_GPG_KEY_B64" | base64 --decode > /tmp/gpg.key
+    - id: gcloud-creds
+      uses: ./.github/actions/gcloud_creds
+      with:
+        SERVICE_ACCOUNT_KEY: ${{ secrets.GH_RELEASE_SA_PEM_B64 }}
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
@@ -48,6 +53,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BUILD_NUMBER: ${{ github.run_attempt }}
         JOB_NAME: ${{ github.job }}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -63,6 +69,7 @@ jobs:
     - name: Update Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
   sign-release:
     name: Sign Release for MacOS
@@ -97,7 +104,7 @@ jobs:
         path: artifacts/
   push-signed-artifacts:
     name: Push Signed Artifacts for MacOS
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest
     needs: [get-dev-image, sign-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
@@ -113,11 +120,16 @@ jobs:
         BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
       run: |
         echo "$BUILDBOT_GPG_KEY_B64" | base64 --decode > /tmp/gpg.key
+    - id: gcloud-creds
+      uses: ./.github/actions/gcloud_creds
+      with:
+        SERVICE_ACCOUNT_KEY: ${{ secrets.GH_RELEASE_SA_PEM_B64 }}
     - name: Upload signed CLI
       env:
         REF: ${{ github.event.ref }}
         BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
         BUILDBOT_GPG_KEY_FILE: "/tmp/gpg.key"
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"

--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -15,23 +15,26 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest-16-cores
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      options: --cpus 15
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
-    - name: Setup gcloud docker creds
-      run: gcloud init && gcloud auth configure-docker
     - name: Use github bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
+        download_toplevel: 'true'
+    - id: gcloud-creds
+      uses: ./.github/actions/gcloud_creds
+      with:
+        SERVICE_ACCOUNT_KEY: ${{ secrets.GH_RELEASE_SA_PEM_B64 }}
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
@@ -40,6 +43,7 @@ jobs:
         GH_API_KEY: ${{ secrets.GITHUB_TOKEN }}
         COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -15,23 +15,26 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest-16-cores
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      options: --cpus 15
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
-    - name: Setup gcloud docker creds
-      run: gcloud init && gcloud auth configure-docker
     - name: Use github bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
+        download_toplevel: 'true'
+    - id: gcloud-creds
+      uses: ./.github/actions/gcloud_creds
+      with:
+        SERVICE_ACCOUNT_KEY: ${{ secrets.GH_RELEASE_SA_PEM_B64 }}
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
@@ -39,6 +42,7 @@ jobs:
         JOB_NAME: ${{ github.job }}
         COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -49,6 +53,7 @@ jobs:
     - name: Update Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
     - name: Sign Artifacts
       uses: ./.github/actions/sign_artifacts

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -15,23 +15,26 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: [self-hosted, nokvm]
+    runs-on: ubuntu-latest-16-cores
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-      options: --cpus 15
-      volumes:
-      - /etc/bazelrc:/etc/bazelrc
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
-    - name: Setup gcloud docker creds
-      run: gcloud init && gcloud auth configure-docker
     - name: Use github bazel config
       uses: ./.github/actions/bazelrc
+      with:
+        use_remote_exec: 'true'
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
+        download_toplevel: 'true'
+    - id: gcloud-creds
+      uses: ./.github/actions/gcloud_creds
+      with:
+        SERVICE_ACCOUNT_KEY: ${{ secrets.GH_RELEASE_SA_PEM_B64 }}
     - name: Build & Push Artifacts
       env:
         REF: ${{ github.event.ref }}
@@ -39,6 +42,7 @@ jobs:
         JOB_NAME: ${{ github.job }}
         COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -56,6 +60,7 @@ jobs:
     - name: Update Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
     - name: Sign Artifacts
       uses: ./.github/actions/sign_artifacts


### PR DESCRIPTION
Summary: Uses remote buildbuddy execution for release actions.

Type of change: /kind test-infra

Test Plan: Tested all release workflows with RCs.
