### PR TITLE
[build] Fix build on main

### DIFF
--- a/.github/actions/env_protected_pr/action.yaml
+++ b/.github/actions/env_protected_pr/action.yaml
@@ -15,7 +15,7 @@ runs:
     # yamllint disable rule:indentation
     if: github.event_name != 'pull_request_target'
     shell: bash
-    run:
+    run: |
       echo "" > env_name
       echo "${{ github.ref }}" >> ref
   - name: Member pull_request_target


### PR DESCRIPTION
Summary: Typo in action file causes build to fail on main.

Type of change: /kind cleanup.

Test Plan: Test on main
