### PR TITLE
Remove unused image pull support in container_runner

### DIFF
--- a/src/common/testing/test_utils/container_runner.cc
+++ b/src/common/testing/test_utils/container_runner.cc
@@ -26,13 +26,6 @@ namespace px {
 // Number of seconds to wait between each attempt.
 constexpr int kSleepSeconds = 1;
 
-ContainerRunner::ContainerRunner(std::string_view image, std::string_view instance_name_prefix,
-                                 std::string_view ready_message)
-    : image_(image), instance_name_prefix_(instance_name_prefix), ready_message_(ready_message) {
-  std::string out = px::Exec("podman pull -q" + image_).ConsumeValueOrDie();
-  LOG(INFO) << out;
-}
-
 ContainerRunner::ContainerRunner(std::filesystem::path image_tar,
                                  std::string_view instance_name_prefix,
                                  std::string_view ready_message)

--- a/src/common/testing/test_utils/container_runner.h
+++ b/src/common/testing/test_utils/container_runner.h
@@ -31,19 +31,6 @@ namespace px {
 class ContainerRunner {
  public:
   /**
-   * Set-up a container runner with image from a registry.
-   *
-   * @param image Image to run.
-   * @param instance_name_prefix The container instance name prefix. The instance name will
-   * automatically be suffixed with a timestamp.
-   * @param ready_message A pattern in the container logs that indicates that the container is
-   * ready. The Run() function will not return until this pattern is observed. Leave blank to skip
-   * this feature.
-   */
-  ContainerRunner(std::string_view image, std::string_view instance_name_prefix,
-                  std::string_view ready_message);
-
-  /**
    * Set-up a container runner from local tarball image.
    *
    * @param image_tar Image tarball.


### PR DESCRIPTION
Summary: With qemu and lack of network access, we expect all images
to be pulled by bazel and available as runfiles for tests. So we can
drop the support for pulling images in container_runner.

Type of change: /kind cleanup

Test Plan: All builds and tests continue to work.
