### PR TITLE
[build] Fix coverage on remote

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -266,3 +266,6 @@ build:remote --jobs=100
 test:remote --jobs=100
 build:remote --nolegacy_important_outputs
 build:remote --build_metadata=VISIBILITY=PUBLIC
+coverage:remote --strategy=CoverageReport=local,remote
+coverage:remote --experimental_fetch_all_coverage_outputs
+coverage:remote --experimental_split_coverage_postprocessing

--- a/ci/collect_coverage.sh
+++ b/ci/collect_coverage.sh
@@ -144,7 +144,7 @@ cd $(bazel info workspace)
 bazel coverage --remote_download_outputs=all --combined_report=lcov //src/...
 
 # Copy the output file
-cp "$(bazel info output_path)/_coverage/_coverage_report.dat" ${COVERAGE_FILE}
+cp --no-preserve=mode "$(bazel info output_path)/_coverage/_coverage_report.dat" ${COVERAGE_FILE}
 
 # Print out the summary.
 lcov --summary ${COVERAGE_FILE}


### PR DESCRIPTION
Summary: Fix coverage build when running on remote executors.

Type of change: /kind test-infra

Test Plan: Tested that `./ci/collect_coverage` works now
