### PR TITLE
[trivy] Provide sha as well as ref

### DIFF
--- a/.github/actions/env_protected_pr/action.yaml
+++ b/.github/actions/env_protected_pr/action.yaml
@@ -8,6 +8,9 @@ outputs:
   ref:
     description: 'ref to checkout'
     value: ${{ steps.output.outputs.ref }}
+  sha:
+    description: 'sha to checkout'
+    value: ${{ steps.output.outputs.sha }}
 runs:
   using: "composite"
   steps:
@@ -18,6 +21,7 @@ runs:
     run: |
       echo "" > env_name
       echo "${{ github.ref }}" >> ref
+      echo "${{ github.sha }}" >> sha
   - name: Member pull_request_target
     if: >-
       github.event_name == 'pull_request_target' &&
@@ -30,6 +34,7 @@ runs:
     run: |
       echo "" > env_name
       echo "${{ github.event.pull_request.head.sha  }}" >> ref
+      echo "${{ github.event.pull_request.head.sha  }}" >> sha
   - name: Require external environment authorization.
     # yamllint disable rule:indentation
     if: >-
@@ -43,11 +48,14 @@ runs:
     run: |
       echo "pr-actions-approval" > env_name
       echo "${{ github.event.pull_request.head.sha  }}" >> ref
+      echo "${{ github.event.pull_request.head.sha  }}" >> sha
   - name: Set Output
     id: output
     shell: bash
     run: |
       echo "env: $(cat env_name)"
       echo "ref: $(cat ref)"
+      echo "sha: $(cat sha)"
       echo "env-name=$(cat env_name)" >> $GITHUB_OUTPUT
       echo "ref=$(cat ref)" >> $GITHUB_OUTPUT
+      echo "sha=$(cat sha)" >> $GITHUB_OUTPUT

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       env-name: ${{ steps.output.outputs.env-name }}
       ref: ${{ steps.output.outputs.ref }}
+      sha: ${{ steps.output.outputs.sha }}
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
     - id: output
@@ -75,3 +76,4 @@ jobs:
       with:
         sarif_file: sarif/${{ matrix.artifact }}
         ref: ${{ needs.env-protect-setup.outputs.ref }}
+        sha: ${{ needs.env-protect-setup.outputs.sha }}


### PR DESCRIPTION
Summary: The upload sarif action requires both sha and ref if either are provided.

Type of change: /kind cleanup

Test Plan: N/A
