### PR TITLE
[trivy] Only run trivy-images action on main

### DIFF
--- a/.github/workflows/trivy_fs.yaml
+++ b/.github/workflows/trivy_fs.yaml
@@ -29,3 +29,4 @@ jobs:
     - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         sarif_file: 'trivy-results.sarif'
+        category: trivy-fs

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -4,32 +4,12 @@ on:
   push:
     branches:
     - main
-  pull_request_target:
-    branches:
-    - main
   schedule:
   - cron: "37 19 * * *"
 permissions:
   contents: read
 jobs:
-  env-protect-setup:
-    runs-on: ubuntu-latest
-    outputs:
-      env-name: ${{ steps.output.outputs.env-name }}
-      ref: ${{ steps.output.outputs.ref }}
-      sha: ${{ steps.output.outputs.sha }}
-    steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
-    - id: output
-      uses: ./.github/actions/env_protected_pr
-  authorize:
-    runs-on: ubuntu-latest
-    needs: env-protect-setup
-    environment: ${{ needs.env-protect-setup.outputs.env-name }}
-    steps:
-    - run: echo "Authorized"
   get-dev-image:
-    needs: authorize
     uses: ./.github/workflows/get_image.yaml
     with:
       image-base-name: "dev_image_with_extras"
@@ -39,7 +19,7 @@ jobs:
       matrix:
         artifact: [cloud, operator, vizier]
     runs-on: ubuntu-latest
-    needs: [authorize, env-protect-setup, get-dev-image]
+    needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     permissions:
@@ -48,8 +28,6 @@ jobs:
       security-events: write
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
-      with:
-        ref: ${{ needs.env-protect-setup.outputs.ref }}
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - name: Use github bazel config
@@ -75,5 +53,4 @@ jobs:
     - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         sarif_file: sarif/${{ matrix.artifact }}
-        ref: ${{ needs.env-protect-setup.outputs.ref }}
-        sha: ${{ needs.env-protect-setup.outputs.sha }}
+        category: trivy-images


### PR DESCRIPTION
Summary: Only run trivy images on main. I gave the sarif upload's categories so hopefully the trivy-fs and trivy-images will be considered separate by github.

Type of change: /kind cleanup

Test Plan: Testing in this PR to see if trivy-fs will still show as missing configurations.
