### PR TITLE
Enable TLS tracing python interpreters linked with libpython

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -121,9 +121,6 @@ build:qemu-bpf --sandbox_fake_username
 build:qemu-bpf --//bazel/cc_toolchains:libc_version=glibc2_36
 build:qemu-bpf --//bazel/test_runners:test_runner=qemu_with_kernel
 build:qemu-bpf --run_under="bazel/test_runners/qemu_with_kernel/test_runner.sh"
-# TODO(ddelnano): Temporary until https://github.com/pixie-io/pixie/issues/1347
-# is addressed. This is to limit the size of the change needed to fix
-build:qemu-bpf --copt -DPL_BPF_TESTING
 test:qemu-bpf --test_timeout=180,600,1800,3600
 
 # Build for GCC.

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -296,24 +296,13 @@ static constexpr const auto kLibSSLMatchers = MakeArray<SSLLibMatcher>({
         .libcrypto = "libcrypto.so.3",
         .search_type = HostPathForPIDPathSearchType::kSearchTypeEndsWith,
     },
-#ifdef PL_BPF_TESTING
-    // TODO(ddelnano): Remove this once Pixie can TLS trace libpython linked interpreters.
-    //
-    // This ifdef allows the test for TLS tracing python 3.10 and later to succeed. Python 3.10
-    // and later require probing the _ex variants of SSL_write/SSL_read, but depending on the
-    // python interpreter may also require probing an so file not probed today
-    // (libpython${VERSION}.so).
-    //
-    // Our BPF test uses a distroless python container image, which ships with an interpreter built
-    // with --enable-shared. This results in a libpython shared library that contains openssl
-    // and other dynamically linked library's symbols. Please see
-    // https://github.com/pixie-io/pixie/issues/1347 for more background and the follow up work.
     SSLLibMatcher{
-        .libssl = "libpython3.10.so.1.0",
-        .libcrypto = "libpython3.10.so.1.0",
-        .search_type = HostPathForPIDPathSearchType::kSearchTypeEndsWith,
+        // This must match independent of python version and INSTSONAME suffix
+        // (e.g. libpython3.10.so.0.1).
+        .libssl    = "libpython",
+        .libcrypto = "libpython",
+        .search_type = HostPathForPIDPathSearchType::kSearchTypeContains,
     },
-#endif
     SSLLibMatcher{
         .libssl = kLibNettyTcnativePrefix,
         .libcrypto = kLibNettyTcnativePrefix,

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -299,7 +299,7 @@ static constexpr const auto kLibSSLMatchers = MakeArray<SSLLibMatcher>({
     SSLLibMatcher{
         // This must match independent of python version and INSTSONAME suffix
         // (e.g. libpython3.10.so.0.1).
-        .libssl    = "libpython",
+        .libssl = "libpython",
         .libcrypto = "libpython",
         .search_type = HostPathForPIDPathSearchType::kSearchTypeContains,
     },


### PR DESCRIPTION
Summary: Enable TLS tracing python interpreters linked with libpython

Relevant Issues: Fixes #1347

Type of change: /kind feature

Test Plan: `openssl_trace_bpf_test`'s Python 3.10 test case passes, which covers this scenario

Changelog Message:
```release-note
Enhance TLS tracing to support Python interpreters that link libpython
```