### PR TITLE
[trivy] Change tool name

### DIFF
--- a/.github/workflows/trivy_fs.yaml
+++ b/.github/workflows/trivy_fs.yaml
@@ -26,6 +26,9 @@ jobs:
         ignore-unfixed: true
         format: 'sarif'
         output: 'trivy-results.sarif'
+    - run: |
+        jq '.runs[].tool.driver.name = "trivy-fs"' < trivy-results.sarif > tmp
+        mv tmp trivy-results.sarif
     - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -50,6 +50,9 @@ jobs:
         mkdir -p sarif/${{ matrix.artifact }}
         ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
+    - run: |
+        jq '.runs[].tool.driver.name = "trivy-images"' < sarif/${{ matrix.artifact }} > tmp
+        mv tmp sarif/${{ matrix.artifact }}
     - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         sarif_file: sarif/${{ matrix.artifact }}


### PR DESCRIPTION
Summary: Change the trivy tool names so that `trivy-images` and `trivy-fs` are treated as separate code scanning tools. This makes the PR checks not complain about missing code scanning configurations.

Type of change: /kind cleanup

Test Plan: Tested with this PR, saw that code scanning no longer complains about missing configurations.
