### PR TITLE
[bb-executor] Update pool to latest images

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -122,7 +122,7 @@ platform(
     ],
     exec_properties = {
         "OSFamily": "Linux",
-        "Pool": "202305310009",
+        "Pool": "202305312341",
     },
 )
 

--- a/k8s/devinfra/buildbuddy-executor/values.yaml
+++ b/k8s/devinfra/buildbuddy-executor/values.yaml
@@ -32,7 +32,12 @@ image:
   repository: gcr.io/pixie-oss/pixie-dev-public/dev_image
   tag: '$IMAGE_TAG'
 
-customExecutorCommand: ['/bb-executor/executor', '--server_type=buildbuddy-executor']
+# Some clusters don't have ipv6 enabled, but we need it for some tests.
+customExecutorCommand:
+- /bin/sh
+- -c
+- 'sysctl -w net.ipv6.conf.lo.disable_ipv6=0 &&
+   /bb-executor/executor --server_type=buildbuddy-executor'
 
 poolName: '"$IMAGE_TAG"'
 


### PR DESCRIPTION
Summary: Updating the bb remote exec pool name to use the latest images. I'm running an extra pool of executors on px-dev-infra in the meantime to allow for both pools during the transition. I will then upgrade the equinix pool and teardown the px-dev-infra one.

Type of change: /kind cleanup

Test Plan: Testing the new pool in this PR.
