### PR TITLE
[trivy] Fix trivy-images

### DIFF
--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -50,9 +50,13 @@ jobs:
         mkdir -p sarif/${{ matrix.artifact }}
         ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
+    # yamllint disable rule:indentation
     - run: |
-        jq '.runs[].tool.driver.name = "trivy-images"' < sarif/${{ matrix.artifact }} > tmp
-        mv tmp sarif/${{ matrix.artifact }}
+        for f in "sarif/${{ matrix.artifact }}/"*; do
+          jq '.runs[].tool.driver.name = "trivy-images"' < "$f" > tmp
+          mv tmp "$f"
+        done
+    # yamllint enable rule:indentation
     - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         sarif_file: sarif/${{ matrix.artifact }}


### PR DESCRIPTION
Summary: Trivy images wrongly assumed a single sarif file for changing the tool name. This fixes that bug.

Type of change: /kind cleanup

Test Plan: Testing by temporarily enabling trivy-images on this PR.
