### PR TITLE
Update etcd image to include busybox tools but not use alpine

### DIFF
--- a/k8s/vizier_deps/base/etcd/etcd_statefulset.yaml
+++ b/k8s/vizier_deps/base/etcd/etcd_statefulset.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - name: etcd
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/etcd:3.5.8@sha256:0d082909691395a301c40a2f86ab5b1e86b162804ac7de6dbcd6ebd305b68385
+        image: gcr.io/pixie-oss/pixie-dev-public/etcd:3.5.9@sha256:e18afc6dda592b426834342393c4c4bd076cb46fa7e10fa7818952cae3047ca9
         ports:
         - containerPort: 2379
           name: client

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -127,7 +127,7 @@ KERNEL_BUILD_TARGETS = $(addprefix $(KERNEL_BUILD_DIR)/, $(patsubst %,$(KERNEL_B
 KERNEL_BUILD_TS := $(shell date +%Y%m%d%H%M%S)
 KERNEL_BUILD_GS_PATH := gs://pixie-dev-public/kernel-build/$(KERNEL_BUILD_TS)
 
-ETCD_IMAGE_VERSION := 3.5.8
+ETCD_IMAGE_VERSION := 3.5.9
 ETCD_IMAGE_TAG := "gcr.io/pixie-oss/pixie-dev-public/etcd:$(ETCD_IMAGE_VERSION)"
 
 ##############################################

--- a/tools/docker/etcd_image/Dockerfile
+++ b/tools/docker/etcd_image/Dockerfile
@@ -14,15 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$TARGETPLATFORM quay.io/coreos/etcd:3.5.8@sha256:522b262f24209d7f60c01eaa98a925aa9c20a5c17aa307aeb9dff0345ffb92db
-
-ARG BUILDPLATFORM
-ARG TARGETPLATFORM
-
-FROM --platform=$TARGETPLATFORM alpine:3.17@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
-COPY --from=0 /usr/local/bin/etcd /usr/local/bin/etcd
-COPY --from=0 /usr/local/bin/etcdctl /usr/local/bin/etcdctl
-COPY --from=0 /usr/local/bin/etcdutl /usr/local/bin/etcdutl
+FROM quay.io/coreos/etcd:3.5.9@sha256:18ca110b5ce9a177bb80d6b4a08d73bda54b549d7a0eb6f66e6da69bf919c63f
+COPY --from=busybox:1.36.1-musl@sha256:a0f497089b970e099fe76fc28f352851c6a99d8191c67c9269b02f1e96db5db9 /bin /bin
 
 COPY ./*.sh /etc/etcd/scripts/
 


### PR DESCRIPTION
Summary: We need the busybox tools for the etcd setup scripts etc
but don't really need alpine. This change makes the etcd image
distroless but includes the static musl based busybox tools so that
the init, healthcheck etc scripts continue to work.

Relevant Issues: Partially addresses #1363

Type of change: /kind cleanup

Test Plan: Deployed new etcd image to cluster via kustomize and ensured
that it came up successfully.
