### PR TITLE
[carnot] Add Serialize/Deserialize to UDFDefinition

### DIFF
--- a/src/carnot/udf/udf_definition.h
+++ b/src/carnot/udf/udf_definition.h
@@ -209,6 +209,9 @@ class UDADefinition : public UDFDefinition {
     finalize_value_fn = UDAWrapper<T>::FinalizeValue;
 
     supports_partial_ = UDAWrapper<T>::SupportsPartial;
+
+    deserialize_fn_ = UDAWrapper<T>::Deserialize;
+    serialize_arrow_fn_ = UDAWrapper<T>::SerializeArrow;
     return Status::OK();
   }
 
@@ -245,6 +248,12 @@ class UDADefinition : public UDFDefinition {
   Status FinalizeArrow(UDA* uda, FunctionContext* ctx, arrow::ArrayBuilder* output) {
     return finalize_arrow_fn_(uda, ctx, output);
   }
+  Status Deserialize(UDA* uda, FunctionContext* ctx, const types::StringValue& serialized) {
+    return deserialize_fn_(uda, ctx, serialized);
+  }
+  Status SerializeArrow(UDA* uda, FunctionContext* ctx, arrow::ArrayBuilder* output) {
+    return serialize_arrow_fn_(uda, ctx, output);
+  }
 
  private:
   std::vector<types::DataType> init_arguments_;
@@ -270,6 +279,10 @@ class UDADefinition : public UDFDefinition {
   std::function<Status(UDA* uda, FunctionContext* ctx,
                        const std::vector<std::shared_ptr<types::BaseValueType>>& inputs)>
       init_wrapper_fn_;
+  std::function<Status(UDA* uda, FunctionContext* ctx, const types::StringValue& serialized)>
+      deserialize_fn_;
+  std::function<Status(UDA* uda, FunctionContext* ctx, arrow::ArrayBuilder* output)>
+      serialize_arrow_fn_;
 };
 
 class UDTFDefinition : public UDFDefinition {


### PR DESCRIPTION
Summary: In preparation for implementing partial aggregates on the exec side, this PR adds Serialize/Deserialize methods to the UDADefinition. This will allow the exec side to execute udas' Serialize and Deserialize methods in a type erased way, just as we do for Update, Merge, Finalize, etc.

Relevant Issues: #1440

Type of change: /kind cleanup

Test Plan: Added a test for the SerializeArrow and Deserialize methods. Also tested as part of broader partial aggregate implmentation.
