### PR TITLE
Add time based IP to Pod tracking to agent metadata

### DIFF
--- a/src/shared/metadata/metadata_state.cc
+++ b/src/shared/metadata/metadata_state.cc
@@ -88,6 +88,19 @@ UID K8sMetadataState::PodIDByIP(std::string_view pod_ip) const {
   return (it == pods_by_ip_.end()) ? "" : it->second;
 }
 
+UID K8sMetadataState::PodIDByIPAtTime(std::string_view pod_ip, int64_t ts) const {
+  auto it = pods_by_ip_and_start_time_.find(pod_ip);
+  if (it == pods_by_ip_and_start_time_.end()) {
+    return "";
+  }
+  auto up = it->second.upper_bound({"", ts});
+  if (up == it->second.begin()) {
+    return "";
+  }
+  --up;
+  return up->first;
+}
+
 UID K8sMetadataState::ServiceIDByClusterIP(std::string_view cluster_ip) const {
   auto it = services_by_cluster_ip_.find(cluster_ip);
   return (it == services_by_cluster_ip_.end()) ? "" : it->second;
@@ -208,6 +221,14 @@ std::string K8sMetadataState::DebugString(int indent_level) const {
     str += absl::Substitute("cid: $0, name: $1\n", v, k);
   }
   str += "\n";
+  str += prefix + "IPs By Time:\n";
+  for (const auto& [k, v] : pods_by_ip_and_start_time_) {
+    str += absl::Substitute("ip: $0\n", k);
+    for (const auto& [id, ts] : v) {
+      str += absl::Substitute("\tpod_id: $0, start_time: $1\n", id, ts);
+    }
+  }
+  str += "\n";
   str += prefix + "IPs:\n";
   for (const auto& [k, v] : pods_by_ip_) {
     str += absl::Substitute("pod_id: $0, ip: $1\n", v, k);
@@ -275,6 +296,9 @@ Status K8sMetadataState::HandlePodUpdate(const PodUpdate& update) {
   // Filter out daemonsets which don't have their own, unique podIP.
   if (update.host_ip() != update.pod_ip() && update.pod_ip() != "") {
     pods_by_ip_[update.pod_ip()] = object_uid;
+    if (update.start_timestamp_ns() > 0) {
+      pods_by_ip_and_start_time_[update.pod_ip()].insert({object_uid, update.start_timestamp_ns()});
+    }
   }
 
   return Status::OK();
@@ -461,17 +485,24 @@ Status K8sMetadataState::CleanupExpiredMetadata(int64_t now, int64_t retention_t
       continue;
     }
 
+    std::string pod_ip;
     switch (k8s_object->type()) {
       case K8sObjectType::kPod:
         if (PodIDByName(std::make_pair(k8s_object->ns(), k8s_object->name())) ==
             k8s_object->uid()) {
           pods_by_name_.erase({k8s_object->ns(), k8s_object->name()});
         }
-        if (PodIDByIP(static_cast<PodInfo*>(k8s_object.get())->pod_ip()) ==
-            k8s_object
-                ->uid()) {  // There could be a new pod assigned to the podIP now, we should only
-                            // delete the IP from the map if it belongs to the terminated pod.
-          pods_by_ip_.erase(static_cast<PodInfo*>(k8s_object.get())->pod_ip());
+        pod_ip = static_cast<PodInfo*>(k8s_object.get())->pod_ip();
+        // There could be a new pod assigned to the podIP now, we should only
+        // delete the IP from the map if it belongs to the terminated pod.
+        if (PodIDByIP(pod_ip) == k8s_object->uid()) {
+          pods_by_ip_.erase(pod_ip);
+        }
+        if (pods_by_ip_and_start_time_.contains(pod_ip)) {
+          pods_by_ip_and_start_time_.find(pod_ip)->second.erase(
+              pods_by_ip_and_start_time_.find(pod_ip)->second.begin(),
+              pods_by_ip_and_start_time_.find(pod_ip)->second.upper_bound(
+                  {"", now - retention_time_ns}));
         }
         break;
       case K8sObjectType::kNamespace:


### PR DESCRIPTION
Summary: This tracks a IP to Pod map by start time in the agent
metadata state allowing us to lookup the historic state of which
IP corresponds to which pod.

Relevant Issues: #885

Type of change: /kind bug

Test Plan: Added a unit test.

Changelog Message:
```release-note
We now track all pods (in the last 24hrs) that use a given cluster IP
address instead of just the last pod to use a particular IP address.
```
