### PR TITLE
Cleanup metadata_state dupes in test

### DIFF
--- a/src/carnot/funcs/metadata/metadata_ops_test.cc
+++ b/src/carnot/funcs/metadata/metadata_ops_test.cc
@@ -1268,10 +1268,7 @@ TEST_F(MetadataOpsTest, in_value_or_array_test) {
 }
 
 TEST_F(MetadataOpsTest, vizier_id_test) {
-  auto metadata_state = std::make_shared<px::md::AgentMetadataState>(
-      /* hostname */ "myhost",
-      /* asid */ 1, /* pid */ 123, agent_id_, "mypod", vizier_id_, "myvizier", "myviziernamespace");
-  auto function_ctx = std::make_unique<FunctionContext>(metadata_state, nullptr);
+  auto function_ctx = std::make_unique<FunctionContext>(metadata_state_, nullptr);
   auto udf_tester = px::carnot::udf::UDFTester<VizierIDUDF>(std::move(function_ctx));
   udf_tester.ForInput().Expect(vizier_id_.str());
 }
@@ -1287,45 +1284,31 @@ TEST_F(MetadataOpsTest, empty_vizier_id_test) {
 }
 
 TEST_F(MetadataOpsTest, vizier_name_test) {
-  auto metadata_state = std::make_shared<px::md::AgentMetadataState>(
-      /* hostname */ "myhost",
-      /* asid */ 1, /* pid */ 123, agent_id_, "mypod", vizier_id_, "myvizier", "myviziernamespace");
-  auto function_ctx = std::make_unique<FunctionContext>(metadata_state, nullptr);
+  auto function_ctx = std::make_unique<FunctionContext>(metadata_state_, nullptr);
   auto udf_tester = px::carnot::udf::UDFTester<VizierNameUDF>(std::move(function_ctx));
   udf_tester.ForInput().Expect("myvizier");
 }
 
 TEST_F(MetadataOpsTest, vizier_namespace_test) {
-  auto metadata_state = std::make_shared<px::md::AgentMetadataState>(
-      /* hostname */ "myhost",
-      /* asid */ 1, /* pid */ 123, agent_id_, "mypod", vizier_id_, "myvizier", "myviziernamespace");
-  auto function_ctx = std::make_unique<FunctionContext>(metadata_state, nullptr);
+  auto function_ctx = std::make_unique<FunctionContext>(metadata_state_, nullptr);
   auto udf_tester = px::carnot::udf::UDFTester<VizierNamespaceUDF>(std::move(function_ctx));
   udf_tester.ForInput().Expect("myviziernamespace");
 }
 
 TEST_F(MetadataOpsTest, basic_upid_test) {
-  auto metadata_state = std::make_shared<px::md::AgentMetadataState>(
-      /* hostname */ "myhost",
-      /* asid */ 1, /* pid */ 123, agent_id_, "mypod", vizier_id_, "myvizier", "myviziernamespace");
-  auto function_ctx = std::make_unique<FunctionContext>(metadata_state, nullptr);
+  auto function_ctx = std::make_unique<FunctionContext>(metadata_state_, nullptr);
   auto udf_tester = px::carnot::udf::UDFTester<CreateUPIDUDF>(std::move(function_ctx));
   udf_tester.ForInput(100, 23123).Expect(md::UPID(1, 100, 23123).value());
 }
 
 TEST_F(MetadataOpsTest, basic_upid_with_asid_test) {
-  auto metadata_state = std::make_shared<px::md::AgentMetadataState>(
-      /* hostname */ "myhost",
-      /* asid */ 1, /* pid */ 123, agent_id_, "mypod", vizier_id_, "myvizier", "myviziernamespace");
-  auto function_ctx = std::make_unique<FunctionContext>(metadata_state, nullptr);
+  auto function_ctx = std::make_unique<FunctionContext>(metadata_state_, nullptr);
   auto udf_tester = px::carnot::udf::UDFTester<CreateUPIDWithASIDUDF>(std::move(function_ctx));
   udf_tester.ForInput(2, 100, 23123).Expect(md::UPID(2, 100, 23123).value());
 }
 
 TEST_F(MetadataOpsTest, get_cidrs) {
-  auto metadata_state = std::make_shared<px::md::AgentMetadataState>(
-      /* hostname */ "myhost",
-      /* asid */ 1, /* pid */ 123, agent_id_, "mypod", vizier_id_, "myvizier", "myviziernamespace");
+  auto metadata_state = metadata_state_->CloneToShared();
   px::CIDRBlock pod_cidr;
   std::string pod_cidr_str("10.0.0.20/32");
   ASSERT_OK(px::ParseCIDRBlock(pod_cidr_str, &pod_cidr));


### PR DESCRIPTION
Summary: These tests use the same metadata state and the duplicate
construction of the state makes it difficult to keep track of the
state and update it.

Type of change: /kind cleanup

Test Plan: The metadata_ops_test still passes.
