### PR TITLE
Update SimulatedTimeSystem to simplify it's usage in tests

### DIFF
--- a/src/common/testing/event/simulated_time_system.cc
+++ b/src/common/testing/event/simulated_time_system.cc
@@ -85,9 +85,9 @@ SystemTimePoint SimulatedTimeSystem::SystemTime() const { return system_time_; }
 MonotonicTimePoint SimulatedTimeSystem::MonotonicTime() const { return monotonic_time_; }
 
 void SimulatedTimeSystem::Sleep(const Duration& duration) {
-  MonotonicTimePoint monotonic_time =
-      monotonic_time_ + std::chrono::duration_cast<MonotonicTimePoint::duration>(duration);
-  SetMonotonicTimeAndActivateTimers(monotonic_time);
+  SystemTimePoint system_time = 
+    system_time_ + std::chrono::duration_cast<SystemTimePoint::duration>(duration);
+  SetSystemTime(system_time);
 }
 
 void SimulatedTimeSystem::SetMonotonicTimeAndActivateTimers(MonotonicTimePoint monotonic_time) {

--- a/src/common/testing/event/simulated_time_system.cc
+++ b/src/common/testing/event/simulated_time_system.cc
@@ -85,8 +85,8 @@ SystemTimePoint SimulatedTimeSystem::SystemTime() const { return system_time_; }
 MonotonicTimePoint SimulatedTimeSystem::MonotonicTime() const { return monotonic_time_; }
 
 void SimulatedTimeSystem::Sleep(const Duration& duration) {
-  SystemTimePoint system_time = 
-    system_time_ + std::chrono::duration_cast<SystemTimePoint::duration>(duration);
+  SystemTimePoint system_time =
+      system_time_ + std::chrono::duration_cast<SystemTimePoint::duration>(duration);
   SetSystemTime(system_time);
 }
 

--- a/src/common/testing/event/simulated_time_system.h
+++ b/src/common/testing/event/simulated_time_system.h
@@ -35,8 +35,14 @@ namespace event {
 
 class SimulatedTimer;
 
+constexpr auto kDefaultSimulatedTime = std::chrono::seconds(1577865601);
+
 class SimulatedTimeSystem final : public TimeSystem {
  public:
+  SimulatedTimeSystem() 
+    : index_(0), 
+      monotonic_time_(kDefaultSimulatedTime), 
+      system_time_(kDefaultSimulatedTime) {}
   SimulatedTimeSystem(MonotonicTimePoint monotonic_time, SystemTimePoint system_time)
       : index_(0), monotonic_time_(monotonic_time), system_time_(system_time) {}
   ~SimulatedTimeSystem();
@@ -56,6 +62,7 @@ class SimulatedTimeSystem final : public TimeSystem {
    * Sleep for the given duration. This updates the monotonic and system time.
    */
   void Sleep(const Duration& duration);
+
   /**
    * Sets the time forward monotonically. If the supplied argument moves
    * backward in time, the call is a no-op. If the supplied argument moves

--- a/src/common/testing/event/simulated_time_system.h
+++ b/src/common/testing/event/simulated_time_system.h
@@ -40,10 +40,8 @@ constexpr auto kDefaultSimulatedTime = std::chrono::seconds(1577865601);
 
 class SimulatedTimeSystem final : public TimeSystem {
  public:
-  SimulatedTimeSystem() 
-    : index_(0), 
-      monotonic_time_(kDefaultSimulatedTime), 
-      system_time_(kDefaultSimulatedTime) {}
+  SimulatedTimeSystem()
+      : index_(0), monotonic_time_(kDefaultSimulatedTime), system_time_(kDefaultSimulatedTime) {}
   SimulatedTimeSystem(MonotonicTimePoint monotonic_time, SystemTimePoint system_time)
       : index_(0), monotonic_time_(monotonic_time), system_time_(system_time) {}
   ~SimulatedTimeSystem();


### PR DESCRIPTION
Summary: This adds a constructor for SimulatedTime that uses a default
timestamp. It also makes the SetMonotonicTime and SetSystemTime methods
private and updates the tests to use the Sleep method to update the clock.
This allows the tests to not need to keep track of the current_time
and makes it simpler to bump the clock.

Type of change: /kind cleanup

Test Plan: All the existing tests that use the SimulatedTime and the
unit tests for the SimulatedTime provide coverage.
