### PR TITLE
Inject an overrideable TimeSystem into the AgentState

### DIFF
--- a/src/carnot/funcs/metadata/BUILD.bazel
+++ b/src/carnot/funcs/metadata/BUILD.bazel
@@ -39,6 +39,8 @@ pl_cc_test(
     deps = [
         ":cc_library",
         "//src/carnot/udf:udf_testutils",
+        "//src/common/event:cc_library",
+        "//src/common/testing/event:cc_library",
         "//src/shared/k8s/metadatapb:metadata_testutils",
         "//src/shared/metadata:test_utils",
     ],

--- a/src/experimental/standalone_pem/standalone_pem_manager.cc
+++ b/src/experimental/standalone_pem/standalone_pem_manager.cc
@@ -103,7 +103,7 @@ StandalonePEMManager::StandalonePEMManager(sole::uuid agent_id, std::string_view
                 .ConsumeValueOrDie();
 
   mds_manager_ = std::make_unique<px::md::StandaloneAgentMetadataStateManager>(
-      info_.hostname, info_.asid, info_.pid, info_.agent_id);
+      info_.hostname, info_.asid, info_.pid, info_.agent_id, time_system_.get());
 
   tracepoint_manager_ =
       std::make_unique<TracepointManager>(dispatcher_.get(), stirling_.get(), table_store_.get());

--- a/src/shared/metadata/BUILD.bazel
+++ b/src/shared/metadata/BUILD.bazel
@@ -35,6 +35,7 @@ pl_cc_library(
     ),
     deps = [
         "//src/carnot/planner/distributedpb:distributed_plan_pl_cc_proto",
+        "//src/common/event:cc_library",
         "//src/common/system:cc_library",
         "//src/shared/bloomfilter:cc_library",
         "//src/shared/k8s/metadatapb:metadata_pl_cc_proto",
@@ -64,6 +65,7 @@ pl_cc_test(
     deps = [
         ":cc_library",
         ":test_utils",
+        "//src/common/testing/event:cc_library",
     ],
 )
 
@@ -108,5 +110,6 @@ pl_cc_test(
     srcs = ["metadata_state_test.cc"],
     deps = [
         ":cc_library",
+        "//src/common/testing/event:cc_library",
     ],
 )

--- a/src/shared/metadata/metadata_state.cc
+++ b/src/shared/metadata/metadata_state.cc
@@ -452,9 +452,7 @@ bool IsExpired(const T& obj, int64_t retention_time, int64_t now) {
   return now > expiry_time;
 }
 
-Status K8sMetadataState::CleanupExpiredMetadata(int64_t retention_time_ns) {
-  int64_t now = CurrentTimeNS();
-
+Status K8sMetadataState::CleanupExpiredMetadata(int64_t now, int64_t retention_time_ns) {
   for (auto iter = k8s_objects_by_id_.begin(); iter != k8s_objects_by_id_.end();) {
     const auto& k8s_object = iter->second;
 
@@ -512,8 +510,9 @@ Status K8sMetadataState::CleanupExpiredMetadata(int64_t retention_time_ns) {
 }
 
 std::shared_ptr<AgentMetadataState> AgentMetadataState::CloneToShared() const {
-  auto state = std::make_shared<AgentMetadataState>(hostname_, asid_, pid_, agent_id_, pod_name_,
-                                                    vizier_id_, vizier_name_, vizier_namespace_);
+  auto state =
+      std::make_shared<AgentMetadataState>(hostname_, asid_, pid_, agent_id_, pod_name_, vizier_id_,
+                                           vizier_name_, vizier_namespace_, time_system_);
   state->last_update_ts_ns_ = last_update_ts_ns_;
   state->epoch_id_ = epoch_id_;
   state->k8s_metadata_state_ = k8s_metadata_state_->Clone();

--- a/src/shared/metadata/standalone_state_manager.cc
+++ b/src/shared/metadata/standalone_state_manager.cc
@@ -74,7 +74,7 @@ Status StandaloneAgentMetadataStateManager::PerformMetadataStateUpdate() {
     asid = agent_metadata_state_->asid();
   }
 
-  int64_t ts = CurrentTimeNS();
+  int64_t ts = agent_metadata_state_->current_time();
   auto upids = ListUPIDs(px::system::proc_path(), asid);
   for (const md::UPID& up : agent_metadata_state_->upids()) {
     if (!upids.contains(up)) {

--- a/src/shared/metadata/standalone_state_manager.h
+++ b/src/shared/metadata/standalone_state_manager.h
@@ -24,6 +24,7 @@
 #include <absl/base/internal/spinlock.h>
 
 #include "src/common/base/error.h"
+#include "src/common/event/time_system.h"
 #include "src/shared/metadata/state_manager.h"
 
 namespace px {
@@ -35,10 +36,10 @@ namespace md {
 class StandaloneAgentMetadataStateManager : public AgentMetadataStateManager {
  public:
   StandaloneAgentMetadataStateManager(std::string_view hostname, uint32_t asid, uint32_t pid,
-                                      sole::uuid agent_id) {
-    agent_metadata_state_ =
-        std::make_shared<AgentMetadataState>(hostname, asid, pid, agent_id,
-                                             /*pod_name=*/"", sole::uuid(), "standalone_pem", "");
+                                      sole::uuid agent_id, event::TimeSystem* time_system) {
+    agent_metadata_state_ = std::make_shared<AgentMetadataState>(hostname, asid, pid, agent_id,
+                                                                 /*pod_name=*/"", sole::uuid(),
+                                                                 "standalone_pem", "", time_system);
   }
   virtual ~StandaloneAgentMetadataStateManager() = default;
   AgentMetadataFilter* metadata_filter() const override { return nullptr; }

--- a/src/shared/metadata/state_manager.cc
+++ b/src/shared/metadata/state_manager.cc
@@ -83,8 +83,7 @@ Status AgentMetadataStateManagerImpl::PerformMetadataStateUpdate() {
   VLOG(2) << "Current State: \n" << shadow_state->DebugString(1 /* indent_level */);
 
   // Get timestamp so all updates happen at the same timestamp.
-  // TODO(zasgar): Change this to an injected clock.
-  int64_t ts = CurrentTimeNS();
+  int64_t ts = agent_metadata_state_->current_time();
   PX_RETURN_IF_ERROR(
       ApplyK8sUpdates(ts, shadow_state.get(), metadata_filter_, &incoming_k8s_updates_));
 
@@ -299,7 +298,8 @@ Status ProcessPIDUpdates(
 }
 
 Status DeleteMetadataForDeadObjects(AgentMetadataState* state, int64_t retention_time) {
-  PX_RETURN_IF_ERROR(state->k8s_metadata_state()->CleanupExpiredMetadata(retention_time));
+  PX_RETURN_IF_ERROR(
+      state->k8s_metadata_state()->CleanupExpiredMetadata(state->current_time(), retention_time));
   return Status::OK();
 }
 

--- a/src/shared/metadata/state_manager.h
+++ b/src/shared/metadata/state_manager.h
@@ -30,6 +30,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include "src/common/base/base.h"
+#include "src/common/event/time_system.h"
 #include "src/common/system/system.h"
 #include "src/shared/k8s/metadatapb/metadata.pb.h"
 #include "src/shared/metadata/cgroup_metadata_reader.h"
@@ -122,11 +123,13 @@ class AgentMetadataStateManagerImpl : public AgentMetadataStateManager {
                                 std::string pod_name, sole::uuid agent_id, bool collects_data,
                                 const px::system::Config& config,
                                 AgentMetadataFilter* metadata_filter, sole::uuid vizier_id,
-                                std::string vizier_name, std::string vizier_namespace)
+                                std::string vizier_name, std::string vizier_namespace,
+                                event::TimeSystem* time_system)
       : pod_name_(pod_name), collects_data_(collects_data), metadata_filter_(metadata_filter) {
     md_reader_ = std::make_unique<CGroupMetadataReader>(config);
-    agent_metadata_state_ = std::make_shared<AgentMetadataState>(
-        hostname, asid, pid, agent_id, pod_name, vizier_id, vizier_name, vizier_namespace);
+    agent_metadata_state_ =
+        std::make_shared<AgentMetadataState>(hostname, asid, pid, agent_id, pod_name, vizier_id,
+                                             vizier_name, vizier_namespace, time_system);
   }
 
   AgentMetadataFilter* metadata_filter() const override { return metadata_filter_; }

--- a/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
+++ b/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
@@ -30,7 +30,7 @@ namespace stirling {
 #ifdef __OPTIMIZE__
 constexpr uint64_t kFileSizeLimitMB = 118;
 #else
-constexpr uint64_t kFileSizeLimitMB = 290;
+constexpr uint64_t kFileSizeLimitMB = 295;
 #endif
 
 TEST(StirlingWrapperSizeTest, ExecutableSizeLimit) {

--- a/src/vizier/services/agent/shared/manager/manager.cc
+++ b/src/vizier/services/agent/shared/manager/manager.cc
@@ -289,7 +289,7 @@ Status Manager::PostRegisterHook(uint32_t asid) {
       info_.hostname, info_.asid, info_.pid, info_.pod_name, info_.agent_id,
       info_.capabilities.collects_data(), px::system::Config::GetInstance(),
       agent_metadata_filter_.get(), sole::rebuild(FLAGS_vizier_id), FLAGS_vizier_name,
-      FLAGS_vizier_namespace);
+      FLAGS_vizier_namespace, time_system_.get());
   // Register the Carnot callback for metadata.
   carnot_->RegisterAgentMetadataCallback(
       std::bind(&px::md::AgentMetadataStateManager::CurrentAgentMetadataState, mds_manager_.get()));


### PR DESCRIPTION
Summary: Using a TimeSystem instead of directly calling the system
clock allows us to use a simulated clock for tests.
This already exists on the Manager base class, and needed to be
threaded into the AgentMetadataState.

Type of change: /kind cleanup

Test Plan: All the existing tests pass. The metadata_state tests
are now a bit cleaner.
