### PR TITLE
Make UI build not use remote executors

### DIFF
--- a/src/ui/BUILD.bazel
+++ b/src/ui/BUILD.bazel
@@ -51,6 +51,7 @@ LICENSES_SRCS = [
 pl_webpack_deps(
     name = "ui_deps",
     srcs = UI_DEP_PACKAGES,
+    tags = ["no-remote-exec"],
 )
 
 pl_webpack_library(
@@ -62,12 +63,14 @@ pl_webpack_library(
         "//conditions:default": False,
     }),
     deps = ":ui_deps",
+    tags = ["no-remote-exec"],
 )
 
 pl_ui_test(
     name = "ui_tests",
     srcs = UI_SRCS,
     deps = ":ui_deps",
+    tags = ["no-remote-exec"],
 )
 
 pl_deps_licenses(
@@ -77,4 +80,5 @@ pl_deps_licenses(
     # Move that into source and remove this.
     visibility = ["//visibility:public"],
     deps = ":ui_deps",
+    tags = ["no-remote-exec"],
 )

--- a/src/ui/BUILD.bazel
+++ b/src/ui/BUILD.bazel
@@ -62,23 +62,23 @@ pl_webpack_library(
         "//bazel:stamped": True,
         "//conditions:default": False,
     }),
-    deps = ":ui_deps",
     tags = ["no-remote-exec"],
+    deps = ":ui_deps",
 )
 
 pl_ui_test(
     name = "ui_tests",
     srcs = UI_SRCS,
-    deps = ":ui_deps",
     tags = ["no-remote-exec"],
+    deps = ":ui_deps",
 )
 
 pl_deps_licenses(
     name = "npm_licenses",
     srcs = UI_DEP_PACKAGES + LICENSES_SRCS,
+    tags = ["no-remote-exec"],
     # TODO(PP-2567): This is used by tools/licenses.
     # Move that into source and remove this.
     visibility = ["//visibility:public"],
     deps = ":ui_deps",
-    tags = ["no-remote-exec"],
 )


### PR DESCRIPTION
Summary: The UI build seems unstable on the remote executors and
flakes sometimes. Let's just try to make it build locally at all
times.

Type of change: /kind devinfra

Test Plan: Check build runs on this PR.
