### PR TITLE
Bring back remote exec for UI builds

### DIFF
--- a/src/ui/BUILD.bazel
+++ b/src/ui/BUILD.bazel
@@ -51,7 +51,6 @@ LICENSES_SRCS = [
 pl_webpack_deps(
     name = "ui_deps",
     srcs = UI_DEP_PACKAGES,
-    tags = ["no-remote-exec"],
 )
 
 pl_webpack_library(
@@ -62,21 +61,18 @@ pl_webpack_library(
         "//bazel:stamped": True,
         "//conditions:default": False,
     }),
-    tags = ["no-remote-exec"],
     deps = ":ui_deps",
 )
 
 pl_ui_test(
     name = "ui_tests",
     srcs = UI_SRCS,
-    tags = ["no-remote-exec"],
     deps = ":ui_deps",
 )
 
 pl_deps_licenses(
     name = "npm_licenses",
     srcs = UI_DEP_PACKAGES + LICENSES_SRCS,
-    tags = ["no-remote-exec"],
     # TODO(PP-2567): This is used by tools/licenses.
     # Move that into source and remove this.
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Summary: After the fixes in #1455, I'm hoping that remote
exec works for UI builds again. This tries to re-enable it.

Type of change: /kind cleanup

Test Plan: Check results on build run for this PR.
