### PR TITLE
Update version info in UI build

### DIFF
--- a/src/ui/src/components/version-info/version-info.tsx
+++ b/src/ui/src/components/version-info/version-info.tsx
@@ -23,6 +23,6 @@ import { Tooltip } from '@mui/material';
 import { PIXIE_CLOUD_VERSION } from 'app/utils/env';
 
 export const VersionInfo = React.memo(() => (
-  <Tooltip title={PIXIE_CLOUD_VERSION.full}><span>Built {PIXIE_CLOUD_VERSION.date}</span></Tooltip>
+  <Tooltip title={PIXIE_CLOUD_VERSION.tag}><span>Built {PIXIE_CLOUD_VERSION.date}</span></Tooltip>
 ));
 VersionInfo.displayName = 'VersionInfo';

--- a/src/ui/src/utils/env.tsx
+++ b/src/ui/src/utils/env.tsx
@@ -23,31 +23,17 @@ import { SEGMENT_UI_WRITE_KEY } from 'app/containers/constants';
 // Webpack's EnvPlugin has trouble understanding destructuring when Babel gets to it first.
 // This is the case in our build (by necessity), so we must write this long-form.
 /* eslint-disable prefer-destructuring */
-const STABLE_BUILD_NUMBER = process.env.STABLE_BUILD_NUMBER;
-const STABLE_BUILD_SCM_REVISION = process.env.STABLE_BUILD_SCM_REVISION;
-const STABLE_BUILD_SCM_STATUS = process.env.STABLE_BUILD_SCM_STATUS;
+const STABLE_BUILD_TAG = process.env.STABLE_BUILD_TAG;
 const BUILD_TIMESTAMP = process.env.BUILD_TIMESTAMP;
 /* eslint-enable prefer-destructuring */
 
 const timestampSec = Number.parseInt(BUILD_TIMESTAMP, 10);
 const date = Number.isNaN(timestampSec) ? new Date() : new Date(timestampSec * 1000);
 const dateStr = format(date, 'yyyy.MM.dd.hh.mm');
-const parts = [];
-if (typeof STABLE_BUILD_SCM_REVISION === 'string') {
-  parts.push(STABLE_BUILD_SCM_REVISION.substr(0, 7));
-}
-if (STABLE_BUILD_SCM_STATUS) {
-  parts.push(STABLE_BUILD_SCM_STATUS);
-}
-parts.push(Number.isNaN(timestampSec) ? Math.floor(date.valueOf() / 1000) : timestampSec);
-if (STABLE_BUILD_NUMBER) {
-  parts.push(STABLE_BUILD_NUMBER);
-}
 
 export const PIXIE_CLOUD_VERSION = {
   date: dateStr,
-  build: parts.join('.'),
-  full: `${dateStr}+${parts.join('.')}`,
+  tag: STABLE_BUILD_TAG,
 };
 
 function isValidSegmentKey(k) {

--- a/src/ui/webpack.config.js
+++ b/src/ui/webpack.config.js
@@ -59,9 +59,7 @@ const plugins = [
     filename: 'index.html',
   }),
   new webpack.EnvironmentPlugin({
-    STABLE_BUILD_NUMBER: '0',
-    STABLE_BUILD_SCM_REVISION: '0000000',
-    STABLE_BUILD_SCM_STATUS: 'Modified',
+    STABLE_BUILD_TAG: '0.1.0',
     BUILD_TIMESTAMP: '0',
   }),
   new webpack.ContextReplacementPlugin(


### PR DESCRIPTION
Summary: Now that we use semver for cloud builds, we can use the
STABLE_BUILD_TAG to include the semver and not rely on the commit
hash.

Type of change: /kind cleanup

Test Plan: skaffold a dev cloud
