### PR TITLE
[build] Disable tcmalloc for GCC build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -133,6 +133,8 @@ build:gcc --copt -Wno-error=maybe-uninitialized
 build:gcc --build_tag_filters=-no_gcc,-qemu_interactive
 build:gcc --test_tag_filters=-no_gcc,-requires_root,-requires_bpf,-disabled,-qemu_interactive
 build:gcc --//bazel/cc_toolchains:compiler=gcc
+# TODO(#1462): Investigate why tcmalloc breaks linking of go binaries.
+build:gcc --define tcmalloc=disabled
 test:gcc --config=tmp-sandbox
 
 


### PR DESCRIPTION
Summary: tcmalloc was causing strange linker errors with CGO builds when linker with gold. Not really sure what's going on, since lld can link these things without issue. We should probably investigate this more, but for now this is a stop-gap that will unblock the coverage build. Since we don't ever deploy GCC built binaries, removing tcmalloc shouldn't matter too much for now.

Type of change: /kind cleanup

Test Plan: Ran `bazel build //src/vizier/services/query_broker:query_broker --config=gcc` without error, this was failing on main before this PR.
