### PR TITLE
Add logging for when Vizier registers

### DIFF
--- a/src/cloud/vzmgr/deployment/BUILD.bazel
+++ b/src/cloud/vzmgr/deployment/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//src/cloud/vzmgr/vzmgrpb:service_pl_go_proto",
         "//src/utils",
         "@com_github_gofrs_uuid//:uuid",
+        "@com_github_sirupsen_logrus//:logrus",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],

--- a/src/cloud/vzmgr/deployment/deployment_test.go
+++ b/src/cloud/vzmgr/deployment/deployment_test.go
@@ -38,6 +38,7 @@ import (
 var (
 	testOrgID  = uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426655440000")
 	testUserID = uuid.FromStringOrNil("423e4567-e89b-12d3-a456-426655440000")
+	testKeyID  = uuid.FromStringOrNil("323e4567-e89b-12d3-a456-426655440000")
 
 	testValidClusterID = uuid.FromStringOrNil("553e4567-e89b-12d3-a456-426655440000")
 
@@ -46,11 +47,11 @@ var (
 
 type fakeDF struct{}
 
-func (f *fakeDF) FetchOrgUserIDUsingDeploymentKey(ctx context.Context, key string) (uuid.UUID, uuid.UUID, error) {
+func (f *fakeDF) FetchOrgUserIDUsingDeploymentKey(ctx context.Context, key string) (uuid.UUID, uuid.UUID, uuid.UUID, error) {
 	if key == testValidDeploymentKey {
-		return testOrgID, testUserID, nil
+		return testOrgID, testUserID, testKeyID, nil
 	}
-	return uuid.Nil, uuid.Nil, vzerrors.ErrDeploymentKeyNotFound
+	return uuid.Nil, uuid.Nil, uuid.Nil, vzerrors.ErrDeploymentKeyNotFound
 }
 
 type fakeProvisioner struct {

--- a/src/cloud/vzmgr/deploymentkey/deployment_keys.go
+++ b/src/cloud/vzmgr/deploymentkey/deployment_keys.go
@@ -209,20 +209,24 @@ func (s *Service) Delete(ctx context.Context, req *vzmgrpb.DeleteDeploymentKeyRe
 }
 
 // FetchOrgUserIDUsingDeploymentKey gets the org and user ID based on the deployment key.
-func (s *Service) FetchOrgUserIDUsingDeploymentKey(ctx context.Context, key string) (uuid.UUID, uuid.UUID, error) {
+func (s *Service) FetchOrgUserIDUsingDeploymentKey(ctx context.Context, key string) (uuid.UUID, uuid.UUID, uuid.UUID, error) {
 	resp, err := s.fetchDeploymentKeyUsingKeyFromDB(ctx, key)
 	if err != nil {
-		return uuid.Nil, uuid.Nil, err
+		return uuid.Nil, uuid.Nil, uuid.Nil, err
 	}
 	oid, err := utils.UUIDFromProto(resp.OrgID)
 	if err != nil {
-		return uuid.Nil, uuid.Nil, err
+		return uuid.Nil, uuid.Nil, uuid.Nil, err
 	}
 	uid, err := utils.UUIDFromProto(resp.UserID)
 	if err != nil {
-		return uuid.Nil, uuid.Nil, err
+		return uuid.Nil, uuid.Nil, uuid.Nil, err
 	}
-	return oid, uid, nil
+	keyID, err := utils.UUIDFromProto(resp.ID)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, uuid.Nil, err
+	}
+	return oid, uid, keyID, nil
 }
 
 // LookupDeploymentKey gets the complete Deployment key information using just the Key.

--- a/src/cloud/vzmgr/deploymentkey/deployment_keys_test.go
+++ b/src/cloud/vzmgr/deploymentkey/deployment_keys_test.go
@@ -454,10 +454,11 @@ func TestService_FetchOrgUserIDUsingDeploymentKey(t *testing.T) {
 			ctx := test.ctx
 			svc := New(db, testDBKey)
 
-			orgID, userID, err := svc.FetchOrgUserIDUsingDeploymentKey(ctx, "px-dep-key1")
+			orgID, userID, keyID, err := svc.FetchOrgUserIDUsingDeploymentKey(ctx, "px-dep-key1")
 			require.NoError(t, err)
 			assert.Equal(t, testAuthOrgID, orgID)
 			assert.Equal(t, testAuthUserID, userID)
+			assert.Equal(t, testKey1ID, keyID)
 		})
 	}
 }
@@ -484,10 +485,11 @@ func TestService_FetchOrgUserIDUsingDeploymentKey_OldKeys(t *testing.T) {
 			ctx := test.ctx
 			svc := New(db, testDBKey)
 
-			orgID, userID, err := svc.FetchOrgUserIDUsingDeploymentKey(ctx, "key1")
+			orgID, userID, keyID, err := svc.FetchOrgUserIDUsingDeploymentKey(ctx, "key1")
 			require.NoError(t, err)
 			assert.Equal(t, testAuthOrgID, orgID)
 			assert.Equal(t, testAuthUserID, userID)
+			assert.Equal(t, testKey1ID, keyID)
 		})
 	}
 }
@@ -513,11 +515,12 @@ func TestService_FetchOrgUserIDUsingDeploymentKey_BadKey(t *testing.T) {
 			ctx := test.ctx
 			svc := New(db, testDBKey)
 
-			orgID, userID, err := svc.FetchOrgUserIDUsingDeploymentKey(ctx, "some rando key that does not exist")
+			orgID, userID, keyID, err := svc.FetchOrgUserIDUsingDeploymentKey(ctx, "some rando key that does not exist")
 			assert.NotNil(t, err)
 			assert.Equal(t, vzerrors.ErrDeploymentKeyNotFound, err)
 			assert.Equal(t, uuid.Nil, orgID)
 			assert.Equal(t, uuid.Nil, userID)
+			assert.Equal(t, uuid.Nil, keyID)
 		})
 	}
 }


### PR DESCRIPTION
Summary: We were recommended to add logging for when a Vizier registers. This is useful for auditing, so users can track when/who/how Viziers were registered to an org.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Unit tests
