### PR TITLE
Add logging for when plugins are enabled/disabled

### DIFF
--- a/src/cloud/plugin/controllers/server.go
+++ b/src/cloud/plugin/controllers/server.go
@@ -640,6 +640,8 @@ func (s *Server) UpdateOrgRetentionPluginConfig(ctx context.Context, req *plugin
 			return nil, err
 		}
 
+		log.WithField("plugin_id", req.PluginID).WithField("version", req.Version).WithField("org", orgID).Info("Plugin enabled")
+
 		// Track enable event.
 		events.Client().Enqueue(&analytics.Track{
 			UserId: orgID.String(),
@@ -655,6 +657,7 @@ func (s *Server) UpdateOrgRetentionPluginConfig(ctx context.Context, req *plugin
 		if err != nil {
 			return nil, err
 		}
+		log.WithField("plugin_id", req.PluginID).WithField("org", orgID).Info("Plugin disabled")
 
 		// Track disable event.
 		events.Client().Enqueue(&analytics.Track{


### PR DESCRIPTION
Summary: To allow for an audit trail in Pixie, we were suggested to add logging for when plugins are enable/disabled. Added some logging in the plugin service.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: No functionality change, just adds logging
