### PR TITLE
Fix an update issue caused by React being out of scope at a bad time

### DIFF
--- a/src/ui/src/api/api-context.tsx
+++ b/src/ui/src/api/api-context.tsx
@@ -43,7 +43,7 @@ export const PixieAPIContextProvider: React.FC<PixieAPIContextProviderProps> = R
   const { authToken } = React.useContext(AuthContext);
 
   // PixieAPIManager exists outside of React's scope. If it replaces its instance, we'll never know.
-  // By putting a setState function somwhere that PixieAPIManager can reach, we can force the update from there.
+  // By putting a setState function somewhere that PixieAPIManager can reach, we can force the update from there.
   // This is not a typical or conventional thing to need to do, so please don't do this anywhere else.
   const [updateFromOutsideReact, setUpdateFromOutsideReact] = React.useState(0);
   React.useEffect(() => {

--- a/src/ui/src/api/api-manager.ts
+++ b/src/ui/src/api/api-manager.ts
@@ -46,6 +46,8 @@ export class PixieAPIManager {
     if (PixieAPIManager._authToken != null) opts.authToken = PixieAPIManager._authToken;
     if (PixieAPIManager._onUnauthorized != null) opts.onUnauthorized = PixieAPIManager._onUnauthorized;
     PixieAPIManager._instance = PixieAPIClient.create(opts);
+    // See api-context.tsx for why this exists
+    if (window.apiContextUpdates) window.apiContextUpdates((prev) => prev + 1);
   }
 
   public static get uri() { return PixieAPIManager._uri; }

--- a/src/ui/src/api/api-manager.ts
+++ b/src/ui/src/api/api-manager.ts
@@ -47,7 +47,7 @@ export class PixieAPIManager {
     if (PixieAPIManager._onUnauthorized != null) opts.onUnauthorized = PixieAPIManager._onUnauthorized;
     PixieAPIManager._instance = PixieAPIClient.create(opts);
     // See api-context.tsx for why this exists
-    if (window.apiContextUpdates) window.apiContextUpdates((prev) => prev + 1);
+    if (window.setApiContextUpdatesFromOutsideReact) window.setApiContextUpdatesFromOutsideReact((prev) => prev + 1);
   }
 
   public static get uri() { return PixieAPIManager._uri; }

--- a/src/ui/src/containers/App/live.tsx
+++ b/src/ui/src/containers/App/live.tsx
@@ -283,7 +283,8 @@ export default function PixieWithContext(): React.ReactElement {
   if (errMsg) {
     // This is an error with pixie cloud, it is probably not relevant to the user.
     // Show a generic error message instead.
-    showSnackbar({ message: 'There was a problem connecting to Pixie', autoHideDuration: 5000 });
+    // Wait one update cycle, since this can happen in the middle of updating other components in some cases
+    setTimeout(() => showSnackbar({ message: 'There was a problem connecting to Pixie', autoHideDuration: 5000 }));
     // eslint-disable-next-line no-console
     console.error(errMsg);
   }


### PR DESCRIPTION
Summary: Moving PixieAPIManager out of React's scope was a risky move.
As it turns out, PixieAPIContext wasn't catching one of the updates during the embed authentication procedure because of this.
By implementing an unholy hack to tell React when this happens, the `authorized` network call still fires with a bearer token.

Type of change: /kind bugfix

Test Plan: Try to embed Pixie using `embedPixieToken` to authenticate. Before, it would give up trying right before the `postMessage` comes through. After, it should try once more as soon as the auth token is provided to Pixie.

