### PR TITLE
Ensure that pods_by_ip_and_start_time_ is carried over in metadata state clones

### DIFF
--- a/src/shared/metadata/metadata_state.cc
+++ b/src/shared/metadata/metadata_state.cc
@@ -182,6 +182,7 @@ std::unique_ptr<K8sMetadataState> K8sMetadataState::Clone() const {
   other->deployments_by_name_ = deployments_by_name_;
   other->containers_by_name_ = containers_by_name_;
   other->pods_by_ip_ = pods_by_ip_;
+  other->pods_by_ip_and_start_time_ = pods_by_ip_and_start_time_;
   other->services_by_cluster_ip_ = services_by_cluster_ip_;
 
   return other;


### PR DESCRIPTION
Summary: This map copy was missed in #1445 which caused the ip_by_time
map to reset on every clone. Now it is maintained across clones.

Relevant Issues: #885

Type of change: /kind bug

Test Plan: Tested with a skaffolded vizier.
