### PR TITLE
Add UDF to convert IP to Pod given a trace time

### DIFF
--- a/src/carnot/funcs/metadata/metadata_ops.cc
+++ b/src/carnot/funcs/metadata/metadata_ops.cc
@@ -45,6 +45,7 @@ void RegisterMetadataOpsOrDie(px::carnot::udf::Registry* registry) {
   registry->RegisterOrDie<HasServiceNameUDF>("has_service_name");
   registry->RegisterOrDie<HasValueUDF>("has_value");
   registry->RegisterOrDie<IPToPodIDUDF>("ip_to_pod_id");
+  registry->RegisterOrDie<IPToPodIDAtTimeUDF>("ip_to_pod_id");
   registry->RegisterOrDie<PodIDToPodNameUDF>("pod_id_to_pod_name");
   registry->RegisterOrDie<PodIDToPodLabelsUDF>("pod_id_to_pod_labels");
   registry->RegisterOrDie<PodIDToNamespaceUDF>("pod_id_to_namespace");

--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -2982,7 +2982,7 @@ class IPToPodIDAtTimeUDF : public ScalarUDF {
   /**
    * @brief Gets the pod id of pod with given pod_ip
    */
-  StringValue Exec(FunctionContext* ctx, StringValue pod_ip, Int64Value time) {
+  StringValue Exec(FunctionContext* ctx, StringValue pod_ip, Time64NSValue time) {
     auto md = GetMetadataState(ctx);
     return md->k8s_metadata_state().PodIDByIPAtTime(pod_ip, time.val);
   }

--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -2977,6 +2977,41 @@ class IPToPodIDUDF : public ScalarUDF {
   static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_KELVIN; }
 };
 
+class IPToPodIDAtTimeUDF : public ScalarUDF {
+ public:
+  /**
+   * @brief Gets the pod id of pod with given pod_ip
+   */
+  StringValue Exec(FunctionContext* ctx, StringValue pod_ip, Int64Value time) {
+    auto md = GetMetadataState(ctx);
+    return md->k8s_metadata_state().PodIDByIPAtTime(pod_ip, time.val);
+  }
+  static udf::ScalarUDFDocBuilder Doc() {
+    return udf::ScalarUDFDocBuilder(
+               "Convert IP address to the kubernetes pod ID that runs the backing service "
+               "given the time that the request was made.")
+        .Details(
+            "Converts the IP address into a kubernetes pod ID at the given time for that IP "
+            "address if it exists, otherwise returns an empty string. Converting to a pod ID "
+            "means you can then extract the corresponding service name using "
+            "`px.pod_id_to_service_name`.\nNote that this will not be able to convert IP "
+            "addresses into DNS names generally as this is limited to internal Kubernetes state.")
+        .Example(R"doc(
+        | # Convert to the Kubernetes pod ID.
+        | df.pod_id = px.ip_to_pod_id(df.remote_addr, df.time_)
+        | # Convert the ID to a readable name.
+        | df.service = px.pod_id_to_service_name(df.pod_id)
+        )doc")
+        .Arg("pod_ip", "The IP of a pod to convert.")
+        .Arg("time", "The time at which this trace was captured.")
+        .Returns("The Kubernetes ID of the pod if it exists, otherwise an empty string.");
+  }
+
+  // This UDF can currently only run on Kelvins, because only Kelvins have the IP to pod
+  // information.
+  static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_KELVIN; }
+};
+
 class IPToServiceIDUDF : public ScalarUDF {
  public:
   StringValue Exec(FunctionContext* ctx, StringValue ip) {

--- a/src/shared/k8s/metadatapb/test_proto.h
+++ b/src/shared/k8s/metadatapb/test_proto.h
@@ -70,6 +70,25 @@ owner_references: {
 }
 )";
 
+const char* kReusedIPPodUpdatePbTxt = R"(
+uid: "101_uid"
+name: "reused_ip"
+namespace: "pl"
+start_timestamp_ns: 100
+container_ids: "pod1_container_1"
+qos_class: QOS_CLASS_GUARANTEED
+node_name: "test_node"
+hostname: "test_host"
+pod_ip: "1.1.1.1"
+phase: RUNNING
+message: "Running message"
+reason: "Running reason"
+conditions {
+  type: 2
+  status: 1
+}
+)";
+
 const char* kToBeTerminatedPodUpdatePbTxt = R"(
 uid: "2_uid"
 name: "terminating_pod"
@@ -346,6 +365,14 @@ conditions: {
 std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateRunningPodUpdatePB() {
   auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
   auto update_proto = absl::Substitute(kResourceUpdateTmpl, "pod_update", kRunningPodUpdatePbTxt);
+  CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
+      << "Failed to parse proto";
+  return update;
+}
+
+std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateReusedIPUpdatePB() {
+  auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
+  auto update_proto = absl::Substitute(kResourceUpdateTmpl, "pod_update", kReusedIPPodUpdatePbTxt);
   CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
       << "Failed to parse proto";
   return update;


### PR DESCRIPTION
Summary: This adds a UDF to resolve IP to Pod given the time of the trace.
This UDF uses the newly added `pods_by_ip_and_start_time_` tracker to
do the resolution and can handle IPs being reused in a cluster.

Relevant Issues: #885

Type of change: /kind bug

Test Plan: Added unit tests for the UDF. Did some end-to-end testing
on a cluster with a skaffolded vizier and a limited IP range and a
cronjob to spam pods.
