### PR TITLE
Run isort on privy imports

### DIFF
--- a/src/datagen/pii/privy/privy/analyze.py
+++ b/src/datagen/pii/privy/privy/analyze.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-from privy.providers.generic import GenericProvider
+
+import logging
 from collections import Counter
 from typing import Tuple
-import logging
+
+from privy.providers.generic import GenericProvider
 
 
 class DatasetAnalyzer:

--- a/src/datagen/pii/privy/privy/generate/generate.py
+++ b/src/datagen/pii/privy/privy/generate/generate.py
@@ -14,15 +14,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import csv
 import logging
-import argparse
-import requests
 import tarfile
-from pathlib import Path
-from typing import Tuple, Any
 from collections import defaultdict
-from privy.generate.utils import check_positive, check_percentage, PrivyWriter, PrivyFileType
+from pathlib import Path
+from typing import Any, Tuple
+
+import requests
+
+from privy.generate.utils import (PrivyFileType, PrivyWriter, check_percentage,
+                                  check_positive)
 from privy.payload import PayloadGenerator
 from privy.providers.english_us import English_US
 from privy.providers.german_de import German_DE

--- a/src/datagen/pii/privy/privy/generate/truncate.py
+++ b/src/datagen/pii/privy/privy/generate/truncate.py
@@ -14,13 +14,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from tempfile import NamedTemporaryFile
-import shutil
+import argparse
 import csv
+import logging
 import os
 import pathlib
-import argparse
-import logging
+import shutil
+from tempfile import NamedTemporaryFile
 
 
 def parse_args():

--- a/src/datagen/pii/privy/privy/generate/utils.py
+++ b/src/datagen/pii/privy/privy/generate/utils.py
@@ -14,10 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
 import argparse
+from dataclasses import dataclass
 from enum import Enum
-from typing import TextIO, Any
+from typing import Any, TextIO
 
 
 def check_positive(arg) -> int:

--- a/src/datagen/pii/privy/privy/generate/visualize.py
+++ b/src/datagen/pii/privy/privy/generate/visualize.py
@@ -14,10 +14,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import csv
 import argparse
+import csv
 import sys
 from collections import Counter
+
 import pandas as pd
 import plotly.express as px
 

--- a/src/datagen/pii/privy/privy/hooks.py
+++ b/src/datagen/pii/privy/privy/hooks.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import ast
 import logging
 import random
-from enum import Enum
 from copy import deepcopy
-from typing import Union, Optional, Tuple
+from enum import Enum
+from typing import Optional, Tuple, Union
+
 import schemathesis
 from hypothesis import given
 from hypothesis import strategies as st

--- a/src/datagen/pii/privy/privy/payload.py
+++ b/src/datagen/pii/privy/privy/payload.py
@@ -13,34 +13,34 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-import os
-import time
-import warnings
+
 import logging
+import os
 import random
-from pathlib import Path
-from datetime import timedelta
-from copy import deepcopy
+import time
 import traceback
+import warnings
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
 import schemathesis
-from joblib import Parallel, delayed
-from tqdm_joblib import tqdm_joblib
-from tqdm import tqdm
 from alive_progress import alive_bar
+from hypothesis import HealthCheck, Verbosity, given, settings
+from hypothesis import strategies as st
+from joblib import Parallel, delayed
 from schemathesis import DataGenerationMethod
 from schemathesis.specs.openapi.schemas import BaseOpenAPISchema
-from hypothesis import (
-    HealthCheck,
-    given,
-    Verbosity,
-    settings,
-    strategies as st,
-)
-from privy.generate.utils import PrivyWriter
-from privy.providers.generic import Provider
-from privy.hooks import SchemaHooks, ParamType
-from privy.route import PayloadRoute
+from tqdm import tqdm
+from tqdm_joblib import tqdm_joblib
+
 from privy.analyze import DatasetAnalyzer
+from privy.generate.utils import PrivyWriter
+from privy.hooks import ParamType, SchemaHooks
+from privy.providers.generic import Provider
+from privy.route import PayloadRoute
+
+
 # todo @benkilimnik add fine grained warning filter for schemathesis
 warnings.filterwarnings("ignore")
 

--- a/src/datagen/pii/privy/privy/providers/english_us.py
+++ b/src/datagen/pii/privy/privy/providers/english_us.py
@@ -13,34 +13,25 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-import pkg_resources
-from pathlib import Path
+
 import datetime
 from decimal import Decimal
-from faker_airtravel import AirTravelProvider
+from pathlib import Path
+
 import pandas as pd
+import pkg_resources
+from faker_airtravel import AirTravelProvider
 from presidio_evaluator.data_generator import PresidioDataGenerator
-from presidio_evaluator.data_generator.faker_extensions.providers import (
-    NationalityProvider,
-    AgeProvider,
-    AddressProviderNew,
-    PhoneNumberProviderNew,
-    IpAddressProvider,
-    OrganizationProvider,
-    UsDriverLicenseProvider,
-    ReligionProvider,
-)
 from presidio_evaluator.data_generator.faker_extensions import RecordsFaker
-from privy.providers.generic import (
-    GenericProvider,
-    Provider,
-    MacAddressProvider,
-    IMEIProvider,
-    GenderProvider,
-    PassportProvider,
-    StringProvider,
-    ITINProvider,
-)
+from presidio_evaluator.data_generator.faker_extensions.providers import (
+    AddressProviderNew, AgeProvider, IpAddressProvider, NationalityProvider,
+    OrganizationProvider, PhoneNumberProviderNew, ReligionProvider,
+    UsDriverLicenseProvider)
+
+from privy.providers.generic import (GenderProvider, GenericProvider,
+                                     IMEIProvider, ITINProvider,
+                                     MacAddressProvider, PassportProvider,
+                                     Provider, StringProvider)
 
 
 # English United States - inherits standard, region-agnostic methods

--- a/src/datagen/pii/privy/privy/providers/generic.py
+++ b/src/datagen/pii/privy/privy/providers/generic.py
@@ -18,12 +18,14 @@ import dataclasses
 import random
 import string
 from abc import ABC
-from typing import Union, Optional, Type, Set
 from decimal import Decimal
+from typing import Optional, Set, Type, Union
+
 import baluhn
 from faker.providers import BaseProvider
 from faker.providers.lorem.en_US import Provider as LoremProvider
-from presidio_evaluator.data_generator.faker_extensions.data_objects import FakerSpansResult
+from presidio_evaluator.data_generator.faker_extensions.data_objects import \
+    FakerSpansResult
 
 
 @dataclasses.dataclass()

--- a/src/datagen/pii/privy/privy/providers/german_de.py
+++ b/src/datagen/pii/privy/privy/providers/german_de.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-import string
+
 import random
-from privy.providers.english_us import English_US
+import string
+
 from faker.providers import BaseProvider
+
+from privy.providers.english_us import English_US
 
 
 # override gender provider from English_US

--- a/src/datagen/pii/privy/privy/route.py
+++ b/src/datagen/pii/privy/privy/route.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import json
 import logging
+
 from dicttoxml import dicttoxml
 from json2html import json2html
-from privy.sql import SQLQueryBuilder
+
 from privy.generate.utils import PrivyFileType
+from privy.sql import SQLQueryBuilder
 
 
 class PayloadRoute:

--- a/src/datagen/pii/privy/privy/sql.py
+++ b/src/datagen/pii/privy/privy/sql.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import random
-from pypika import Case, Table, Criterion, functions
-from pypika.dialects import (
-    MySQLQuery,
-    PostgreSQLQuery,
-)
+
+from pypika import Case, Criterion, Table, functions
+from pypika.dialects import MySQLQuery, PostgreSQLQuery
 
 
 class SQLQueryBuilder:

--- a/src/datagen/pii/privy/privy/tests/test_json.py
+++ b/src/datagen/pii/privy/privy/tests/test_json.py
@@ -14,14 +14,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import unittest
 import os
 import pathlib
+import unittest
+
+from privy.generate.utils import PrivyFileType
 from privy.providers.english_us import English_US
 from privy.providers.german_de import German_DE
-from privy.tests.utils import generate_one_api_spec
-from privy.tests.utils import read_generated_csv
-from privy.generate.utils import PrivyFileType
+from privy.tests.utils import generate_one_api_spec, read_generated_csv
 
 
 class TestPayloadGenerator(unittest.TestCase):

--- a/src/datagen/pii/privy/privy/tests/test_providers.py
+++ b/src/datagen/pii/privy/privy/tests/test_providers.py
@@ -15,7 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from hypothesis import strategies as st, given
+
+from hypothesis import given
+from hypothesis import strategies as st
+
 from privy.providers.english_us import English_US
 from privy.providers.german_de import German_DE
 

--- a/src/datagen/pii/privy/privy/tests/test_sql.py
+++ b/src/datagen/pii/privy/privy/tests/test_sql.py
@@ -14,14 +14,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import unittest
 import os
 import pathlib
+import unittest
+
 from privy.providers.english_us import English_US
 from privy.providers.german_de import German_DE
-from privy.tests.utils import generate_one_api_spec
-from privy.tests.utils import read_generated_csv
-from privy.tests.utils import get_delimited
+from privy.tests.utils import (generate_one_api_spec, get_delimited,
+                               read_generated_csv)
 
 
 class TestSQLGenerator(unittest.TestCase):

--- a/src/datagen/pii/privy/privy/tests/utils.py
+++ b/src/datagen/pii/privy/privy/tests/utils.py
@@ -14,13 +14,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import io
 import csv
+import io
 import json
 from collections import defaultdict
-import pandas as pd
+
 import numpy as np
-from privy.generate.utils import PrivyWriter, PrivyFileType
+import pandas as pd
+
+from privy.generate.utils import PrivyFileType, PrivyWriter
 from privy.payload import PayloadGenerator
 
 

--- a/src/datagen/pii/privy/privy/train/flair_ner.py
+++ b/src/datagen/pii/privy/privy/train/flair_ner.py
@@ -14,16 +14,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import argparse
 import ast
+import os
 from copy import deepcopy
-from presidio_evaluator.data_objects import InputSample
-from presidio_evaluator.data_generator.faker_extensions.data_objects import FakerSpansResult
-from presidio_evaluator.validation import split_dataset, save_to_json
-from presidio_evaluator.models import FlairTrainer
 from pathlib import Path
+
+from presidio_evaluator.data_generator.faker_extensions.data_objects import \
+    FakerSpansResult
+from presidio_evaluator.data_objects import InputSample
 from presidio_evaluator.evaluation import Evaluator
+from presidio_evaluator.models import FlairTrainer
+from presidio_evaluator.validation import save_to_json, split_dataset
 
 
 # entity mappings for flair sequence labelling model


### PR DESCRIPTION
Summary: Run `isort` to organize the imports and make it a bit more
clear as to which imports are third party deps.

Type of change: /kind clenaup

Test Plan: This change should be a noop.
