### PR TITLE
Refresh cluster list look and feel

### DIFF
--- a/src/ui/src/containers/admin/cluster-details.tsx
+++ b/src/ui/src/containers/admin/cluster-details.tsx
@@ -37,7 +37,7 @@ import {
 import { Theme, styled } from '@mui/material/styles';
 import { createStyles, makeStyles } from '@mui/styles';
 import { formatDistance } from 'date-fns';
-import { useHistory, useParams } from 'react-router';
+import { useHistory } from 'react-router';
 import { Link } from 'react-router-dom';
 import { BehaviorSubject } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
@@ -85,11 +85,6 @@ StyledBreadcrumbLink.displayName = 'StyledBreadcrumbLink';
 const useBreadcrumbsStyles = makeStyles((theme: Theme) => createStyles({
   root: {
     display: 'flex',
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-    marginRight: theme.spacing(4.5),
-    marginLeft: theme.spacing(3),
-    marginBottom: theme.spacing(1),
   },
   separator: {
     display: 'flex',
@@ -99,16 +94,6 @@ const useBreadcrumbsStyles = makeStyles((theme: Theme) => createStyles({
     width: theme.spacing(1),
   },
 }), { name: 'ClusterDetailsBreadcrumbs' });
-
-const StyledBreadcrumbs: React.FC<WithChildren> = React.memo(({ children }) => {
-  const classes = useBreadcrumbsStyles();
-  return (
-    <MaterialBreadcrumbs classes={classes}>
-      {children}
-    </MaterialBreadcrumbs>
-  );
-});
-StyledBreadcrumbs.displayName = 'StyledBreadcrumbs';
 
 const AGENT_STATUS_SCRIPT = `import px
 px.display(px.GetAgentStatus())`;
@@ -375,12 +360,34 @@ const ExpandablePodRow: React.FC<{ podStatus: GroupedPodStatus }> = (({ podStatu
 ExpandablePodRow.displayName = 'ExpandablePodRow';
 
 const useClusterDetailStyles = makeStyles((theme: Theme) => createStyles({
+  root: {
+    position: 'relative',
+    height: '100%',
+    display: 'flex',
+    flexFlow: 'column nowrap',
+  },
+  header: {
+    flex: '0 0 auto',
+    backgroundColor: theme.palette.background.four,
+    height: theme.spacing(7),
+    padding: theme.spacing(1.5),
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    justifyContent: 'space-between',
+  },
   errorMessage: {
     ...theme.typography.body1,
     padding: theme.spacing(3),
   },
+  tabHeader: {
+    flex: '0 0 auto',
+  },
   tabContents: {
+    flex: '1 1 auto',
+    overflow: 'auto',
     margin: theme.spacing(1),
+    display: 'flex',
+    flexFlow: 'column nowrap',
   },
   tableContainer: {
     maxHeight: theme.spacing(100),
@@ -619,10 +626,9 @@ const ClusterDetailsNavigationBreadcrumbs = ({ selectedClusterName }) => {
   });
 
   const breadcrumbs = [{
-    title: 'clusterName',
+    title: 'cluster',
     value: selectedClusterPrettyName,
     selectable: true,
-    omitKey: true,
     // eslint-disable-next-line
     getListItems: async (input) => {
       const items = clusters
@@ -757,6 +763,7 @@ const ClusterDetailsTabs: React.FC<{ clusterName: string }> = ({ clusterName }) 
       <StyledTabs
         value={tab}
         onChange={(event, newTab) => setTab(newTab)}
+        classes={{ root: classes.tabHeader }}
       >
         <StyledTab value='details' label='Details' />
         <StyledTab value='agents' label='Agents' />
@@ -789,19 +796,22 @@ const ClusterDetailsTabs: React.FC<{ clusterName: string }> = ({ clusterName }) 
 };
 ClusterDetailsTabs.displayName = 'ClusterDetailsTabs';
 
-export const ClusterDetails: React.FC = () => {
-  const { name } = useParams<{ name: string }>();
+export const ClusterDetails = React.memo<{ name: string, headerAffix?: React.ReactNode }>(({ name, headerAffix }) => {
+  const breadcrumbsClasses = useBreadcrumbsStyles();
+  const classes = useClusterDetailStyles();
+
   const clusterName = decodeURIComponent(name);
 
   return (
-    <div>
-      <StyledBreadcrumbs>
-        <StyledBreadcrumbLink to='/admin'>Admin</StyledBreadcrumbLink>
-        <StyledBreadcrumbLink to='/admin'>Clusters</StyledBreadcrumbLink>
-        <ClusterDetailsNavigationBreadcrumbs selectedClusterName={clusterName} />
-      </StyledBreadcrumbs>
+    <div className={classes.root}>
+      <div className={classes.header}>
+        <MaterialBreadcrumbs classes={breadcrumbsClasses}>
+          <ClusterDetailsNavigationBreadcrumbs selectedClusterName={clusterName} />
+        </MaterialBreadcrumbs>
+        {headerAffix || null}
+      </div>
       <ClusterDetailsTabs clusterName={clusterName} />
     </div>
   );
-};
+});
 ClusterDetails.displayName = 'ClusterDetails';

--- a/src/ui/src/containers/admin/utils.tsx
+++ b/src/ui/src/containers/admin/utils.tsx
@@ -159,8 +159,7 @@ export const StyledTableCell = styled(TableCell)(({ theme }) => ({
   fontWeight: theme.typography.fontWeightLight,
   fontSize: theme.typography.body2.fontSize,
   color: theme.palette.foreground.one,
-  borderWidth: theme.spacing(1),
-  borderColor: theme.palette.background.default,
+  borderColor: 'transparent',
 }));
 
 // eslint-disable-next-line react-memo/require-memo

--- a/src/ui/src/pages/admin/admin.tsx
+++ b/src/ui/src/pages/admin/admin.tsx
@@ -33,7 +33,6 @@ import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 
 import { ClusterIcon, scrollbarStyles, Footer } from 'app/components';
 import { AdminOverview } from 'app/containers/admin/admin-overview';
-import { ClusterDetails } from 'app/containers/admin/cluster-details';
 import { LiveViewButton } from 'app/containers/admin/utils';
 import NavBars from 'app/containers/App/nav-bars';
 import { LinkItemProps } from 'app/containers/App/sidebar';
@@ -186,17 +185,8 @@ const AdminOverviewPage = () => (
 AdminOverviewPage.displayName = 'AdminOverviewPage';
 
 // eslint-disable-next-line react-memo/require-memo
-const ClusterDetailsPage = () => (
-  <AdminPage>
-    <ClusterDetails />
-  </AdminPage>
-);
-ClusterDetailsPage.displayName = 'ClusterDetailsPage';
-
-// eslint-disable-next-line react-memo/require-memo
 const AdminView: React.FC = () => (
   <Switch>
-    <Route exact path='/admin/clusters/:name' component={ClusterDetailsPage} />
     <Redirect exact from='/admin' to='/admin/clusters' />
     <Route path='/admin' component={AdminOverviewPage} />
   </Switch>

--- a/src/ui/src/pages/live/live.tsx
+++ b/src/ui/src/pages/live/live.tsx
@@ -44,6 +44,7 @@ import { SCRATCH_SCRIPT, ScriptsContext } from 'app/containers/App/scripts-conte
 import { LinkItemProps } from 'app/containers/App/sidebar';
 import { DataDrawerSplitPanel } from 'app/containers/data-drawer/data-drawer';
 import { EditorSplitPanel } from 'app/containers/editor/editor';
+import { deepLinkURLFromScript } from 'app/containers/live-widgets/utils/live-view-params';
 import { LiveViewBreadcrumbs } from 'app/containers/live/breadcrumbs';
 import Canvas from 'app/containers/live/canvas';
 import ClusterSelector from 'app/containers/live/cluster-selector';

--- a/src/ui/src/pages/live/live.tsx
+++ b/src/ui/src/pages/live/live.tsx
@@ -44,7 +44,6 @@ import { SCRATCH_SCRIPT, ScriptsContext } from 'app/containers/App/scripts-conte
 import { LinkItemProps } from 'app/containers/App/sidebar';
 import { DataDrawerSplitPanel } from 'app/containers/data-drawer/data-drawer';
 import { EditorSplitPanel } from 'app/containers/editor/editor';
-import { deepLinkURLFromScript } from 'app/containers/live-widgets/utils/live-view-params';
 import { LiveViewBreadcrumbs } from 'app/containers/live/breadcrumbs';
 import Canvas from 'app/containers/live/canvas';
 import ClusterSelector from 'app/containers/live/cluster-selector';


### PR DESCRIPTION
Summary: Fixes a few alignment and spacing issues in the cluster list table.
Moves the details of a cluster into a modal instead of a separate page.
Another PR will be created for each details tab, to improve their look and feel too.

Cluster list now has limited width, doesn't align titles strangely anymore.
<img width="1579" alt="245565072-e23f5dba-e510-4164-96ce-b69bc5e10966" src="https://github.com/pixie-io/pixie/assets/314133/f1d045ea-96bc-4460-948a-bb6fb069b966">

Details now open in a modal with tabs.
<img width="1230" alt="Screenshot 2023-06-13 at 11 01 05" src="https://github.com/pixie-io/pixie/assets/314133/870fb806-3aaa-4c4e-a555-bcc486774ded">


Relevant Issues: #1174

Type of change: /kind cleanup

Test Plan: Open `/admin`. Use the clusters table. Click a cluster for details. Click the tabs within the modal that comes up. Try scrolling in the modal.
