### PR TITLE
Operator helm releases should push index to GH pages

### DIFF
--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -95,6 +95,14 @@ jobs:
     #       --notes $'Pixie Operator Release:\n'"${changelog}"
     #     gh release upload "${TAG_NAME}" operator-artifacts/*
     #   # yamllint enable rule:indentation
+    - name: Setup git
+      shell: bash
+      env:
+        GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+      run: |
+        git config --global user.name 'pixie-io-buildbot'
+        git config --global user.email 'build@pixielabs.ai'
+        git remote add fork git@github.com:pixie-io-buildbot/pixie.git
     - name: Push Helm YAML to gh-pages
       shell: bash
       env:

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -67,7 +67,7 @@ jobs:
         name: operator-artifacts
         path: artifacts/
   create-github-release:
-    # if: ${{ !contains(github.event.ref, '-') }}
+    if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github
     runs-on: ubuntu-latest
     needs: build-release
@@ -78,22 +78,22 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
-    # - name: Create Release
-    #   env:
-    #     REF: ${{ github.event.ref }}
-    #     GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
-    #     OWNER: pixie-io
-    #     REPO: pixie
-    #   shell: bash
-    #   # yamllint disable rule:indentation
-    #   run: |
-    #     export TAG_NAME="${REF#*/tags/}"
-    #     # actions/checkout doesn't get the tag annotation properly.
-    #     git fetch origin tag "${TAG_NAME}" -f
-    #     export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-    #     gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
-    #       --notes $'Pixie Operator Release:\n'"${changelog}"
-    #     gh release upload "${TAG_NAME}" operator-artifacts/*
+    - name: Create Release
+      env:
+        REF: ${{ github.event.ref }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
+        OWNER: pixie-io
+        REPO: pixie
+      shell: bash
+      # yamllint disable rule:indentation
+      run: |
+        export TAG_NAME="${REF#*/tags/}"
+        # actions/checkout doesn't get the tag annotation properly.
+        git fetch origin tag "${TAG_NAME}" -f
+        export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
+        gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
+          --notes $'Pixie Operator Release:\n'"${changelog}"
+        gh release upload "${TAG_NAME}" operator-artifacts/*
     #   # yamllint enable rule:indentation
     - name: Setup git
       shell: bash

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -111,7 +111,8 @@ jobs:
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
       # yamllint disable rule:indentation
       run: |
-        git checkout -b "gh-pages"
+        git checkout "gh-pages"
+        git pull origin "gh-pages"
         cp operator-artifacts/index.yaml .
         git add index.yaml
         export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -67,7 +67,7 @@ jobs:
         name: operator-artifacts
         path: artifacts/
   create-github-release:
-    if: ${{ !contains(github.event.ref, '-') }}
+    # if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github
     runs-on: ubuntu-latest
     needs: build-release
@@ -78,23 +78,23 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
-    - name: Create Release
-      env:
-        REF: ${{ github.event.ref }}
-        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
-        OWNER: pixie-io
-        REPO: pixie
-      shell: bash
-      # yamllint disable rule:indentation
-      run: |
-        export TAG_NAME="${REF#*/tags/}"
-        # actions/checkout doesn't get the tag annotation properly.
-        git fetch origin tag "${TAG_NAME}" -f
-        export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
-          --notes $'Pixie Operator Release:\n'"${changelog}"
-        gh release upload "${TAG_NAME}" operator-artifacts/*
-      # yamllint enable rule:indentation
+    # - name: Create Release
+    #   env:
+    #     REF: ${{ github.event.ref }}
+    #     GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
+    #     OWNER: pixie-io
+    #     REPO: pixie
+    #   shell: bash
+    #   # yamllint disable rule:indentation
+    #   run: |
+    #     export TAG_NAME="${REF#*/tags/}"
+    #     # actions/checkout doesn't get the tag annotation properly.
+    #     git fetch origin tag "${TAG_NAME}" -f
+    #     export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
+    #     gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
+    #       --notes $'Pixie Operator Release:\n'"${changelog}"
+    #     gh release upload "${TAG_NAME}" operator-artifacts/*
+    #   # yamllint enable rule:indentation
     - name: Push Helm YAML to gh-pages
       shell: bash
       env:

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -43,6 +43,7 @@ jobs:
         COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
+        GH_REPO: ${{ github.repository }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -93,4 +94,19 @@ jobs:
         gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
           --notes $'Pixie Operator Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" operator-artifacts/*
+      # yamllint enable rule:indentation
+    - name: Push Helm YAML to gh-pages
+      shell: bash
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
+        GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+      # yamllint disable rule:indentation
+      run: |
+        git checkout -b "gh-pages"
+        cp operator-artifacts/index.yaml .
+        git add index.yaml
+        export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
+        git commit -s -m "Release Helm chart ${VERSION}"
+        git push origin "gh-pages"
       # yamllint enable rule:indentation

--- a/ci/operator_helm_build_release.sh
+++ b/ci/operator_helm_build_release.sh
@@ -94,7 +94,7 @@ gsutil rsync "${tmp_dir}/${helm_gcs_bucket}" "gs://${helm_gcs_bucket}"
 mkdir -p "${tmp_dir}/gh_helm_chart"
 helm package "${helm_path}" -d "${tmp_dir}/gh_helm_chart"
 # Pull index file.
-wget https://pixie-io.github.io/pixie/index.yaml -O old_index.yaml
+curl https://pixie-io.github.io/pixie/index.yaml -o old_index.yaml
 # Update the index file.
 helm repo index "${tmp_dir}/gh_helm_chart" --merge old_index.yaml --url "https://github.com/${gh_repo}/releases/download/release%2Foperator%2Fv${VERSION}"
 mv "${tmp_dir}/gh_helm_chart/index.yaml" "${artifacts_dir}/index.yaml"


### PR DESCRIPTION
Summary: We want to start using Github to host our Helm charts. As a part of that process, we should update the `index.yaml` with the new helm chart entry. This PR updates the helm build release script to generate the new index file, and also updates the Github workflow to push it to the gh-pages branch. 

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Build an rc
