### PR TITLE
Use the ref from env-protect-setup to get the docker image tag

### DIFF
--- a/.github/actions/env_protected_pr/action.yaml
+++ b/.github/actions/env_protected_pr/action.yaml
@@ -33,8 +33,8 @@ runs:
     shell: bash
     run: |
       echo "" > env_name
-      echo "${{ github.event.pull_request.head.sha  }}" >> ref
-      echo "${{ github.event.pull_request.head.sha  }}" >> sha
+      echo "${{ github.event.pull_request.head.sha }}" >> ref
+      echo "${{ github.event.pull_request.head.sha }}" >> sha
   - name: Require external environment authorization.
     # yamllint disable rule:indentation
     if: >-
@@ -47,8 +47,8 @@ runs:
     shell: bash
     run: |
       echo "pr-actions-approval" > env_name
-      echo "${{ github.event.pull_request.head.sha  }}" >> ref
-      echo "${{ github.event.pull_request.head.sha  }}" >> sha
+      echo "${{ github.event.pull_request.head.sha }}" >> ref
+      echo "${{ github.event.pull_request.head.sha }}" >> sha
   - name: Set Output
     id: output
     shell: bash

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -30,10 +30,11 @@ jobs:
     steps:
     - run: echo "Authorized"
   get-dev-image:
-    needs: authorize
+    needs: [authorize, env-protect-setup]
     uses: ./.github/workflows/get_image.yaml
     with:
       image-base-name: "dev_image_with_extras"
+      ref: ${{ needs.env-protect-setup.outputs.ref }}
   clang-tidy:
     runs-on: ubuntu-latest-16-cores
     needs: [authorize, env-protect-setup, get-dev-image]


### PR DESCRIPTION
Summary: TSIA. This ensures that the `build-and-test` action runs
on the new image when running on a PR that bumps the image.

Type of change: /kind devinfra

Test Plan: Check the github actions run on a PR that bumps the docker
tag.
