### PR TITLE
[cloud] Use two services for NATS

### DIFF
--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -43,11 +43,11 @@ data:
       name: pl-nats
       port: 6222
       routes [
-        nats://pl-nats-0.pl-nats:6222
-        nats://pl-nats-1.pl-nats:6222
-        nats://pl-nats-2.pl-nats:6222
-        nats://pl-nats-3.pl-nats:6222
-        nats://pl-nats-4.pl-nats:6222
+        nats://pl-nats-0.pl-nats-internal:6222
+        nats://pl-nats-1.pl-nats-internal:6222
+        nats://pl-nats-2.pl-nats-internal:6222
+        nats://pl-nats-3.pl-nats-internal:6222
+        nats://pl-nats-4.pl-nats-internal:6222
       ]
 
       tls {
@@ -65,7 +65,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pl-nats
+  name: pl-nats-internal
   labels:
     name: pl-nats
 spec:
@@ -86,6 +86,20 @@ spec:
   - name: gateways
     port: 7522
   publishNotReadyAddresses: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pl-nats
+  labels:
+    name: pl-nats
+spec:
+  selector:
+    name: pl-nats
+  clusterIP: None
+  ports:
+  - name: client
+    port: 4222
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -109,7 +123,7 @@ spec:
       name: pl-nats
   replicas: 5
   podManagementPolicy: Parallel
-  serviceName: pl-nats
+  serviceName: pl-nats-internal
   volumeClaimTemplates:
   - metadata:
       name: nats-sts-vol
@@ -190,7 +204,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CLUSTER_ADVERTISE
-          value: $(POD_NAME).pl-nats.$(POD_NAMESPACE).svc
+          value: $(POD_NAME).pl-nats-internal.$(POD_NAMESPACE).svc
         volumeMounts:
         - name: config-volume
           mountPath: /etc/nats-config

--- a/k8s/cloud_deps/dev/nats/config_patch.yaml
+++ b/k8s/cloud_deps/dev/nats/config_patch.yaml
@@ -25,9 +25,9 @@ data:
       name: pl-nats
       port: 6222
       routes [
-        nats://pl-nats-0.pl-nats:6222
-        nats://pl-nats-1.pl-nats:6222
-        nats://pl-nats-2.pl-nats:6222
+        nats://pl-nats-0.pl-nats-internal:6222
+        nats://pl-nats-1.pl-nats-internal:6222
+        nats://pl-nats-2.pl-nats-internal:6222
       ]
 
       tls {

--- a/k8s/cloud_deps/public/nats/config_patch.yaml
+++ b/k8s/cloud_deps/public/nats/config_patch.yaml
@@ -25,9 +25,9 @@ data:
       name: pl-nats
       port: 6222
       routes [
-        nats://pl-nats-0.pl-nats:6222
-        nats://pl-nats-1.pl-nats:6222
-        nats://pl-nats-2.pl-nats:6222
+        nats://pl-nats-0.pl-nats-internal:6222
+        nats://pl-nats-1.pl-nats-internal:6222
+        nats://pl-nats-2.pl-nats-internal:6222
       ]
 
       tls {

--- a/scripts/update_tls_certs.sh
+++ b/scripts/update_tls_certs.sh
@@ -61,8 +61,9 @@ if [ -z "${dir}" ]; then
   exit 1
 fi
 
-pushd "${dir}"
 bazel run //src/pixie_cli:px -- create-cloud-certs --namespace="$namespace" > certs.yaml
+mv certs.yaml "${dir}/certs.yaml"
+pushd "${dir}"
 sops --encrypt certs.yaml > service_tls_certs.yaml
 rm certs.yaml
 popd

--- a/src/utils/shared/certs/certs.go
+++ b/src/utils/shared/certs/certs.go
@@ -135,8 +135,11 @@ func getCloudDNSNamesForNamespace(namespace string) []string {
 		fmt.Sprintf("*.%s.svc.cluster.local", namespace),
 		fmt.Sprintf("*.%s.pod.cluster.local", namespace),
 		fmt.Sprintf("*.pl-nats.%s.svc", namespace),
+		fmt.Sprintf("*.pl-nats-internal.%s.svc", namespace),
 		"*.pl-nats",
+		"*.pl-nats-internal",
 		"pl-nats",
+		"pl-nats-internal",
 		"*.local",
 		"localhost",
 	}


### PR DESCRIPTION
Summary: Since NATS uses the service dns to join the cluster, we're required to set `publishNotReadyAddresses` on the service. This was causing issues where other pods, eg vzmgr, were connecting to a not-ready NATS pod. This would occur, for example, during cluster upgrades where the NATS pods would be moved to new nodes. This was causing vzmgr and other services to crash. This PR renames the current NATS service to `pl-nats-internal` and creates a new service for other services to connect to called `pl-nats`. The new service doesn't have `publishNotReadyAddresses` set, so the above issue should be avoided. Note that we'll need to update all the cluster certs after this change.

Type of change: /kind cleanup

Test Plan: Tested by deleting NATS pods and seeing that they were no longer in the routes for the `pl-nats` service, but still in the routes for the `pl-nats-internal` service. Also tested a k8s upgrade on testing cloud, and didn't see any crashes from `vzmgr` or others, but this could be due to the low load on testing.
