### PR TITLE
[artifacts] Allow unknown fields in the artifact manifest

### DIFF
--- a/src/shared/artifacts/manifest/json.go
+++ b/src/shared/artifacts/manifest/json.go
@@ -56,7 +56,10 @@ func (a *ArtifactManifest) MarshalJSON() ([]byte, error) {
 
 func (as *sortedArtifactSet) UnmarshalJSON(b []byte) error {
 	pb := &versionspb.ArtifactSet{}
-	if err := jsonpb.Unmarshal(bytes.NewReader(b), pb); err != nil {
+	u := &jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}
+	if err := u.Unmarshal(bytes.NewReader(b), pb); err != nil {
 		return err
 	}
 	as.name = pb.Name

--- a/src/shared/artifacts/manifest/manifest_test.go
+++ b/src/shared/artifacts/manifest/manifest_test.go
@@ -203,6 +203,56 @@ func TestManifest_JSONDecode(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "single artifact set with artifact mirrors",
+			json: fmt.Sprintf(`
+[
+  {"name": "vizier", "artifact": [{
+    "timestamp": "%s",
+    "commitHash": "1234",
+    "versionStr": "0.12.17",
+    "availableArtifacts": [
+      "AT_CONTAINER_SET_LINUX_AMD64",
+      "AT_CONTAINER_SET_YAMLS",
+      "AT_CONTAINER_SET_TEMPLATE_YAMLS"
+    ],
+    "availableArtifactMirrors": [
+      {
+        "artifactType": "AT_CONTAINER_SET_YAMLS",
+        "urls": [
+          "https://artifacts.px.dev/testing"
+        ]
+      },
+      {
+        "artifactType": "AT_CONTAINER_SET_TEMPLATE_YAMLS",
+        "urls": [
+          "https://artifacts.px.dev/testing_template"
+        ]
+      }
+    ],
+    "changelog": "changelog1"
+  }]}
+]
+`, time1Str),
+			expectedArtifactSets: []*versionspb.ArtifactSet{
+				{
+					Name: "vizier",
+					Artifact: []*versionspb.Artifact{
+						{
+							Timestamp:  time1Proto,
+							CommitHash: "1234",
+							VersionStr: "0.12.17",
+							AvailableArtifacts: []versionspb.ArtifactType{
+								versionspb.AT_CONTAINER_SET_LINUX_AMD64,
+								versionspb.AT_CONTAINER_SET_YAMLS,
+								versionspb.AT_CONTAINER_SET_TEMPLATE_YAMLS,
+							},
+							Changelog: "changelog1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Summary: Allow unknown fields in the artifact manifest. This is in preparation for changes to the manifest format, which will add a field. This PR ensures that clouds that are unaware of the new changes to the format, won't error when trying to decode the manifest.json.

Type of change: /kind cleanup

Test Plan: Added a test that ensures that the new manifest field can be in the manifest, and it can still be successfully decoded.
