### PR TITLE
Rename operator helmchart directory

### DIFF
--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -128,8 +128,8 @@ jobs:
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
       # yamllint disable rule:indentation
       run: |
-        cp index-artifacts/index.yaml helm_chart/index.yaml
-        git add helm_chart/index.yaml
+        cp index-artifacts/index.yaml helm_charts/operator/index.yaml
+        git add helm_charts/operator/index.yaml
         export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
         git commit -s -m "Release Helm chart ${VERSION}"
         git push origin "gh-pages"

--- a/ci/operator_helm_build_release.sh
+++ b/ci/operator_helm_build_release.sh
@@ -95,7 +95,7 @@ gsutil rsync "${tmp_dir}/${helm_gcs_bucket}" "gs://${helm_gcs_bucket}"
 mkdir -p "${tmp_dir}/gh_helm_chart"
 helm package "${helm_path}" -d "${tmp_dir}/gh_helm_chart"
 # Pull index file.
-curl https://artifacts.px.dev/helm_chart/index.yaml -o old_index.yaml
+curl https://artifacts.px.dev/helm_charts/operator/index.yaml -o old_index.yaml
 # Update the index file.
 helm repo index "${tmp_dir}/gh_helm_chart" --merge old_index.yaml --url "https://github.com/${gh_repo}/releases/download/release%2Foperator%2Fv${VERSION}"
 mv "${tmp_dir}/gh_helm_chart/index.yaml" "${index_file}"


### PR DESCRIPTION
Summary: Originally the path was just `helm_chart/index.yaml`. However if we name it `helm_charts/operator/index.yaml`, then we can potentially add more helm charts in the future.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Build runs
