### PR TITLE
Fix bug preventing GitHub action for pxl documentation updates from running

### DIFF
--- a/.github/workflows/release_update_docs_px_dev.yaml
+++ b/.github/workflows/release_update_docs_px_dev.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 jobs:
   get-dev-image:
-    if: startsWith(github.ref, 'release/vizier/')
+    if: contains(github.ref, 'release/vizier/')
     uses: ./.github/workflows/get_image.yaml
     with:
       image-base-name: "dev_image_with_extras"


### PR DESCRIPTION
Summary: Fix bug preventing GitHub action for pxl documentation updates from running

There was a vizier release today and the GitHub workflow [triggered](https://github.com/pixie-io/pixie/actions/runs/5272284093) from that was skipped. I believe this was because the `github.ref` field was likely prefixed with `refs/tags`. This change relaxes the criteria for the check to ensure that it matches on future vizier releases.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: Looked at the [GitHub docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to see what the `github.ref` context would be populated with