### PR TITLE
Update default password settings for Kratos

### DIFF
--- a/k8s/cloud/base/ory_auth/kratos/kratos_config.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_config.yaml
@@ -11,6 +11,8 @@ data:
       methods:
         password:
           enabled: true
+          config:
+            haveibeenpwned_enabled: false
         link:
           enabled: true
       flows:


### PR DESCRIPTION
Summary: By default Kratos has some pretty strict password settings: https://github.com/pixie-io/docs.px.dev/pull/258 which may make it harder for some users to try out the control plane.
Users can easily edit the settings to make them more strict if needbe, however we should make the defaults easy-to-use.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Kustomize build
