### PR TITLE
Bump openresty to address CVE

### DIFF
--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -36,12 +36,10 @@ def _gcr_io_image(name, digest, repo):
 
 def base_images():
     _gcr_io_image(
-        # This should be 1.21.4.1-7 but that version hasn't been tagged yet. So picking the versionless build.
-        # 1.21.4.1-6 uses alpine:3.15.7 with some open CVEs.
-        # As of writing this, alpine-apk-amd64 maps to a future 1.21.4.1-7 release based on alpine:3.15.8 with no known CVEs.
-        # https://hub.docker.com/layers/openresty/openresty/alpine-apk-amd64/images/sha256-eac84c6c543d2424e07e980b7aff897a4cb2463d79977e579f6285f27d8e8d99?context=explore
+        # Based on alpine 3.15.9, using OpenResty 1.21.4.1
+        # https://hub.docker.com/layers/openresty/openresty/alpine-apk-amd64/images/sha256-2259f28de01f85c22e32b6964254a4551c54a1d554cd4b5f1615d7497e1a09ce?context=explore
         "openresty",
-        "sha256:eac84c6c543d2424e07e980b7aff897a4cb2463d79977e579f6285f27d8e8d99",
+        "sha256:2259f28de01f85c22e32b6964254a4551c54a1d554cd4b5f1615d7497e1a09ce",
         "pixie-oss/pixie-dev-public/docker-deps/openresty/openresty",
     )
 


### PR DESCRIPTION
Summary: Bumps the base alpine version and included OpenSSL version
to address a CVE.

Relevant Issues: CVE-2023-2650

Type of change: /kind cleanup

Test Plan: cloud proxy should still work.
