### PR TITLE
Update stale flag description for the auth service

### DIFF
--- a/src/cloud/auth/auth_server.go
+++ b/src/cloud/auth/auth_server.go
@@ -42,7 +42,7 @@ import (
 
 func init() {
 	pflag.String("database_key", "", "The encryption key to use for the database")
-	pflag.String("oauth_provider", "auth0", "The auth provider to user. Currently support 'auth0' or 'hydra'")
+	pflag.String("oauth_provider", "auth0", "The auth provider to use. Supported values are 'oidc', 'auth0' or 'hydra'")
 	pflag.String("domain_name", "dev.withpixie.dev", "The domain name of Pixie Cloud")
 }
 


### PR DESCRIPTION
Summary: We support `oidc` based auth too and have done so for a while.
However this flag wasn't updated, so update it to reflect `oidc` support.

Type of change: /kind cleanup

Test Plan: Running the auth server with a help flag should show the new
help text.
