### PR TITLE
Replace deprecated linters

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -142,12 +142,6 @@
         "--out-format=checkstyle"
       ]
     },
-    "golint": {
-      "type": "golint",
-      "include": [
-        "(\\.go$)"
-      ]
-    },
     "jshint-ui": {
       "type": "jshint",
       "jshint.jshintrc": "./src/ui/.jshintrc",

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,7 +17,6 @@ issues:
 linters:
   enable:
   - asciicheck
-  - deadcode
   - errcheck
   # Although goimports includes gofmt, it doesn't support the simplify option.
   # So we include gofmt here.
@@ -31,12 +30,12 @@ linters:
   - nolintlint
   - nonamedreturns
   - predeclared
+  - revive
   - staticcheck
   # https://github.com/golangci/golangci-lint/issues/2649
   # - structcheck
   - typecheck
   - unused
-  - varcheck
   # https://github.com/golangci/golangci-lint/issues/2649
   # - wastedassign
   - whitespace
@@ -44,7 +43,6 @@ linters:
   # The following linters are run separately by arcanist at the moment.
   # This is because we have autofix hooks for these linters.
   - goimports
-  - golint
   disable-all: false
 
 linters-settings:


### PR DESCRIPTION
Summary: `golint` is archived and deprecated. `golangci-lint` suggests
using `revive` instead.
`deadcode` and `varcheck` are covered by `unused` instead.

Type of change: /kind cleanup

Test Plan: Ran the linters, they seem to work. Will fix newly
found issues as a followup.
