### PR TITLE
Add some inital fuzz tests for datastore

### DIFF
--- a/src/vizier/utils/datastore/pebbledb/pebbledb.go
+++ b/src/vizier/utils/datastore/pebbledb/pebbledb.go
@@ -217,7 +217,11 @@ func (w *DataStore) GetWithRange(from string, to string) ([]string, [][]byte, er
 
 // GetWithPrefix gets all keys and values with the given prefix.
 func (w *DataStore) GetWithPrefix(prefix string) ([]string, [][]byte, error) {
-	return w.GetWithRange(prefix, string(keyUpperBound([]byte(prefix))))
+	ub := KeyUpperBound([]byte(prefix))
+	if ub == nil {
+		return nil, nil, fmt.Errorf("unsupported prefix: %x", prefix)
+	}
+	return w.GetWithRange(prefix, string(ub))
 }
 
 // Delete deletes the value for the given key from the datastore.
@@ -239,7 +243,11 @@ func (w *DataStore) DeleteAll(keys []string) error {
 
 // DeleteWithPrefix deletes all keys and values with the given prefix.
 func (w *DataStore) DeleteWithPrefix(prefix string) error {
-	return w.db.DeleteRange([]byte(prefix), keyUpperBound([]byte(prefix)), pebble.Sync)
+	ub := KeyUpperBound([]byte(prefix))
+	if ub == nil {
+		return fmt.Errorf("unsupported prefix: %x", prefix)
+	}
+	return w.db.DeleteRange([]byte(prefix), ub, pebble.Sync)
 }
 
 // Close stops the TTL watcher, and closes the underlying datastore.

--- a/src/vizier/utils/datastore/pebbledb/pebbledb_utils.go
+++ b/src/vizier/utils/datastore/pebbledb/pebbledb_utils.go
@@ -35,7 +35,7 @@
 
 package pebbledb
 
-func keyUpperBound(b []byte) []byte {
+func KeyUpperBound(b []byte) []byte {
 	end := make([]byte, len(b))
 	copy(end, b)
 	for i := len(end) - 1; i >= 0; i-- {

--- a/src/vizier/utils/datastore/pebbledb/pebbledb_utils_test.go
+++ b/src/vizier/utils/datastore/pebbledb/pebbledb_utils_test.go
@@ -26,29 +26,66 @@ import (
 
 func TestKeyUpperBound_Simple(t *testing.T) {
 	in := "prefix"
-	upperBound := keyUpperBound([]byte(in))
+	upperBound := KeyUpperBound([]byte(in))
 	assert.Equal(t, "prefiy", string(upperBound))
 }
 
 func TestKeyUpperBound_Empty(t *testing.T) {
 	in := ""
-	upperBound := keyUpperBound([]byte(in))
+	upperBound := KeyUpperBound([]byte(in))
 	assert.Nil(t, upperBound)
 }
 
 func TestKeyUpperBound_Nil(t *testing.T) {
-	upperBound := keyUpperBound(nil)
+	upperBound := KeyUpperBound(nil)
 	assert.Nil(t, upperBound)
 }
 
 func TestKeyUpperBound_AllMax(t *testing.T) {
 	in := []byte{255, 255, 255, 255}
-	upperBound := keyUpperBound([]byte(in))
+	upperBound := KeyUpperBound([]byte(in))
 	assert.Nil(t, upperBound)
 }
 
 func TestKeyUpperBound_LastMax(t *testing.T) {
 	in := []byte{40, 41, 42, 255}
-	upperBound := keyUpperBound([]byte(in))
+	upperBound := KeyUpperBound([]byte(in))
 	assert.Equal(t, []byte{40, 41, 43}, upperBound)
+}
+
+func Fuzz_KeyUpperBound(f *testing.F) {
+	f.Add([]byte("test"))
+	f.Add([]byte{40, 41, 42, 255})
+	f.Add([]byte{40, 41, 255, 255})
+	f.Add([]byte{255, 255})
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		bound := KeyUpperBound(input)
+
+		if len(input) == 0 {
+			assert.Nil(t, bound)
+			return
+		}
+
+		// Find the last index that's not 0xff (i.e. max byte)
+		i := len(input) - 1
+		for i >= 0 {
+			if input[i] != 255 {
+				break
+			}
+			i--
+		}
+
+		// All bytes are max
+		if i < 0 {
+			assert.Nil(t, bound)
+			return
+		}
+
+		assert.Equal(t, i+1, len(bound))
+		assert.Equal(t, input[:i], bound[:i])
+		if i < len(input) {
+			assert.Equal(t, input[i]+1, bound[i])
+		}
+	})
 }


### PR DESCRIPTION
Summary: `golang` supports fuzz testing as of go `1.18`.
This adds a couple of simple fuzz tests to serve as an
example of how we can use fuzzing.

Type of change: /kind testing

Test Plan: Newly added tests run normally and also under
fuzzing.
