### PR TITLE
Delete byteman file no longer used by `netty_tls_trace_bpf_test`

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/byteman_rule.txt
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/thriftmux/byteman_rule.txt
@@ -1,9 +1,0 @@
-RULE Create predictable dynamic library path for tcnative
-CLASS io.netty.util.internal.PlatformDependent
-METHOD createTempFile
-AT ENTRY
-BIND filePath:String = $1;
-     isTcNativeLib:boolean = filePath.contains("tcnative");
-IF isTcNativeLib
-DO return new File("/tmp/libnetty_tcnative_linux_x86.so")
-ENDRULE


### PR DESCRIPTION
Summary: Delete byteman file no longer used for by `netty_tls_trace_bpf_test`

This was cleanup that was missed in #606.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: `netty_tls_trace_bpf_test` still passes