### PR TITLE
Upgrade rules_jvm_external to address maven install bugs

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -418,9 +418,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz"],
     ),
     rules_jvm_external = dict(
-        urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.2.tar.gz"],
-        sha256 = "2cd77de091e5376afaf9cc391c15f093ebd0105192373b334f0a855d89092ad5",
-        strip_prefix = "rules_jvm_external-4.2",
+        urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/5.2.tar.gz"],
+        sha256 = "c9ae901381ae7f7eca08aed96caeb542f96c5449052db9c9d27274a8dc154cdf",
+        strip_prefix = "rules_jvm_external-5.2",
     ),
     rules_pkg = dict(
         sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",


### PR DESCRIPTION
Summary: Upgrade rules_jvm_external to address maven install bugs

The thriftmux container used in the `netty_tls_trace_bpf` test previously ran into https://github.com/bazelbuild/rules_jvm_external/issues/686. This required us to manually install maven dependencies and override things to break the dependency loop (see TODO and `fetch_netty_tcnative_jars` from https://github.com/pixie-io/pixie/pull/562). This issue was fixed in rules_jvm_external v4.3, however, I opted to bump this to the latest version.

After this is merged, I will follow up with the netty dependency install cleanup.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Verified that `netty_tls_trace_bpf_test` containers avoid maven install issue and that antlr grammar builds and carnot tests pass (`bazel build //... && bazel test //src/carnot/...`)

I believe the carnot sql parsing is the only production artifact that relies on these jvm rules. Please let me know if the validation above does not exercise the antlr dependency the way I expect.