### PR TITLE
Fix Vizier Helm templates

### DIFF
--- a/src/utils/shared/yamls/templates.go
+++ b/src/utils/shared/yamls/templates.go
@@ -292,6 +292,7 @@ func TemplatizeK8sYAML(inputYAML string, tmplOpts []*K8sTemplateOptions) (string
 		if err != nil {
 			return nil, err
 		}
+
 		for _, opt := range tmplOpts {
 			if opt.TemplateMatcher != nil && !opt.TemplateMatcher(unstructuredObj.Object, resourceKind) {
 				continue
@@ -375,7 +376,7 @@ func updateImageTags(unstructuredObj unstructured.Unstructured) {
 func templatizeImagePath(path string) string {
 	newImage := strings.ReplaceAll(path, "/", "-")
 
-	return fmt.Sprintf("{{ if .Values.registry }}{{ .Values.registry }}/%s{{ else }}%s{{ end }}", newImage, path)
+	return fmt.Sprintf("{{ if .Values.registry }}{{ .Values.registry }}/%s{{else}}%s{{end}}", newImage, path)
 }
 
 type resourceProcessFn func(schema.GroupVersionKind, string, unstructured.Unstructured, []byte) ([]byte, error)


### PR DESCRIPTION
Summary: Before adding the operator, we used to push Helm charts for Vizier. Since the introduction of the operator helm charts, we neglected maintenance and testing of the old Vizier helm charts. After doing some testing, these charts were very close to working properly minus two issues:
- When adding autopilot mode, we needed to wrap the autopilot YAMLs with a check for whether autopilot is enabled. Otherwise, these YAMLs would be deployed every time regardless of whether autopilot is enabled or not.
- We added some templating for customRegistries. When generating the template YAMLs, we iterate through each of the images and templatize the image paths to support custom registries. At this point, we are processing the resources as JSONs. However, when we convert these JSONs to YAMLs, additional new lines get added in between the spaces for `{{ end }}`. Our operator is still able to execute the templates properly despite the new lines, but Helm does not. I dug far enough to pinpoint that the newlines are being added in https://github.com/kubernetes-sigs/yaml/blob/master/yaml.go#L102, but didn't dig farther since we don't actually need the spaces in the template anyway.

Relevant Issues: #1350

Type of change: /kind cleanup

Test Plan: Generate the templates, put them in a helm-chart directory and try to deploy via Helm with various settings.

Changelog Message:
```release-note
Fix Vizier helm charts.
```
