### PR TITLE
Publish Vizier helm charts to release build

### DIFF
--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -73,6 +73,10 @@ jobs:
       with:
         name: vizier-artifacts
         path: artifacts/
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: index-artifacts
+        path: index.yaml
   create-github-release:
     if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -49,6 +49,7 @@ jobs:
         COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
         BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+        GH_REPO: ${{ github.repository }}
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -107,7 +107,7 @@ jobs:
         gh release upload "${TAG_NAME}" vizier-artifacts/*
       # yamllint enable rule:indentation
   create-helm-chart:
-    # if: ${{ !contains(github.event.ref, '-') }}
+    if: ${{ !contains(github.event.ref, '-') }}
     name: Create Helm chart on Github
     runs-on: ubuntu-latest
     needs: build-release

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -54,6 +54,7 @@ jobs:
         export TAG_NAME="${REF#*/tags/}"
         export ARTIFACTS_DIR="$(pwd)/artifacts"
         mkdir -p "${ARTIFACTS_DIR}"
+        export INDEX_FILE="$(pwd)/index.yaml"
         ./ci/save_version_info.sh
         ./ci/vizier_build_release.sh
     - name: Build & Export Docs
@@ -100,4 +101,39 @@ jobs:
         gh release create "${TAG_NAME}" --title "Vizier ${TAG_NAME#release/vizier/}" \
           --notes $'Pixie Vizier Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" vizier-artifacts/*
+      # yamllint enable rule:indentation
+  create-helm-chart:
+    # if: ${{ !contains(github.event.ref, '-') }}
+    name: Create Helm chart on Github
+    runs-on: ubuntu-latest
+    needs: build-release
+    concurrency: gh-pages
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+        ref: gh-pages
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - name: Setup git
+      shell: bash
+      env:
+        GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+      run: |
+        git config --global user.name 'pixie-io-buildbot'
+        git config --global user.email 'build@pixielabs.ai'
+    - name: Push Helm YAML to gh-pages
+      shell: bash
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
+        GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
+        GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
+      # yamllint disable rule:indentation
+      run: |
+        cp index-artifacts/index.yaml helm_charts/vizier/index.yaml
+        git add helm_charts/vizier/index.yaml
+        export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
+        git commit -s -m "Release Helm chart Vizier ${VERSION}"
+        git push origin "gh-pages"
       # yamllint enable rule:indentation

--- a/ci/helm_build_release.sh
+++ b/ci/helm_build_release.sh
@@ -34,10 +34,9 @@ parse_args() {
 
 parse_args "$@"
 
-helm_gcs_bucket="pixie-helm-charts"
 tmp_path="/tmp/helm-${VERSION}"
 tmp_dir="$(mktemp -d)"
-repo_path=$(pwd)
+artifacts_dir="${ARTIFACTS_DIR:?}"
 
 mkdir -p "${tmp_path}"
 # A Helm chart contains two main items:
@@ -46,7 +45,7 @@ mkdir -p "${tmp_path}"
 
 # Create Chart.yaml for this release.
 echo "apiVersion: v2
-name: pixie-chart
+name: vizier-chart
 type: application
 version: ${VERSION}" > "${tmp_path}/Chart.yaml"
 
@@ -54,15 +53,20 @@ version: ${VERSION}" > "${tmp_path}/Chart.yaml"
 tar xvf "${YAML_TAR}" -C "${tmp_dir}"
 mv "${tmp_dir}/pixie_yamls" "${tmp_path}/templates"
 
-# Fetch all of the current charts in GCS, because generating the index needs all pre-existing tar versions present.
-mkdir -p "${tmp_dir}/${helm_gcs_bucket}"
-gsutil rsync "gs://${helm_gcs_bucket}" "${tmp_dir}/${helm_gcs_bucket}"
+mkdir -p "${tmp_dir}/charts"
 
 # Generates tgz for the new release helm chart.
-helm package "${tmp_path}" -d "${tmp_dir}/${helm_gcs_bucket}"
+helm package "${tmp_path}" -d "${tmp_dir}/charts"
+
+cp "${tmp_dir}/charts/vizier-chart-${VERSION}.tgz" "${artifacts_dir}/vizier-chart-${VERSION}.tgz"
+sha256sum "${tmp_dir}/charts/vizier-chart-${VERSION}.tgz" | awk '{print $1}' > sha
+cp sha "${artifacts_dir}/vizier-chart-${VERSION}.tgz.sha256"
 
 # Update the index file.
 helm repo index "${tmp_dir}/${helm_gcs_bucket}" --url "https://${helm_gcs_bucket}.storage.googleapis.com"
 
-# Upload the new index and tar to gcs by syncing. This will help keep the timestamps for pre-existing tars the same.
-gsutil rsync "${tmp_dir}/${helm_gcs_bucket}" "gs://${helm_gcs_bucket}"
+# Pull index file.
+curl https://artifacts.px.dev/helm_charts/vizier/index.yaml -o old_index.yaml
+# Update the index file.
+helm repo index "${tmp_dir}/charts" --merge old_index.yaml --url "https://github.com/${gh_repo}/releases/download/release%2Fvizier%2Fv${VERSION}"
+mv "${tmp_dir}/charts/index.yaml" "${index_file}"

--- a/ci/helm_build_release.sh
+++ b/ci/helm_build_release.sh
@@ -37,6 +37,7 @@ parse_args "$@"
 tmp_path="/tmp/helm-${VERSION}"
 tmp_dir="$(mktemp -d)"
 artifacts_dir="${ARTIFACTS_DIR:?}"
+index_file="${INDEX_FILE:?}"
 
 mkdir -p "${tmp_path}"
 # A Helm chart contains two main items:

--- a/ci/helm_build_release.sh
+++ b/ci/helm_build_release.sh
@@ -62,9 +62,6 @@ cp "${tmp_dir}/charts/vizier-chart-${VERSION}.tgz" "${artifacts_dir}/vizier-char
 sha256sum "${tmp_dir}/charts/vizier-chart-${VERSION}.tgz" | awk '{print $1}' > sha
 cp sha "${artifacts_dir}/vizier-chart-${VERSION}.tgz.sha256"
 
-# Update the index file.
-helm repo index "${tmp_dir}/${helm_gcs_bucket}" --url "https://${helm_gcs_bucket}.storage.googleapis.com"
-
 # Pull index file.
 curl https://artifacts.px.dev/helm_charts/vizier/index.yaml -o old_index.yaml
 # Update the index file.

--- a/ci/helm_build_release.sh
+++ b/ci/helm_build_release.sh
@@ -38,6 +38,7 @@ tmp_path="/tmp/helm-${VERSION}"
 tmp_dir="$(mktemp -d)"
 artifacts_dir="${ARTIFACTS_DIR:?}"
 index_file="${INDEX_FILE:?}"
+gh_repo="${GH_REPO:?}"
 
 mkdir -p "${tmp_path}"
 # A Helm chart contains two main items:

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -56,9 +56,9 @@ tmpl_path="${tmp_dir}/yamls.tar"
 upload_artifact_to_mirrors "vizier" "${release_tag}" "${tmpl_path}" "vizier_template_yamls.tar"
 
 # Update helm chart if it is a release.
-# if [[ $VERSION != *"-"* ]]; then
+if [[ $VERSION != *"-"* ]]; then
   # Update Vizier YAMLS in latest.
   upload_artifact_to_mirrors "vizier" "latest" "${yamls_tar}" "vizier_yamls.tar"
 
   ./ci/helm_build_release.sh "${release_tag}" "${tmpl_path}"
-# fi
+fi

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -56,9 +56,9 @@ tmpl_path="${tmp_dir}/yamls.tar"
 upload_artifact_to_mirrors "vizier" "${release_tag}" "${tmpl_path}" "vizier_template_yamls.tar"
 
 # Update helm chart if it is a release.
-if [[ $public == "True" ]]; then
+# if [[ $VERSION != *"-"* ]]; then
   # Update Vizier YAMLS in latest.
   upload_artifact_to_mirrors "vizier" "latest" "${yamls_tar}" "vizier_yamls.tar"
 
   ./ci/helm_build_release.sh "${release_tag}" "${tmpl_path}"
-fi
+# fi


### PR DESCRIPTION
Summary: Our Vizier Helm chart now works again. This updates our build so that it builds the Helm chart and publishes it to our gh-pages.
We used to write our helm charts to GCS, however since we haven't maintained/publicized these charts + we are renaming the chart, I cleaned that up and move straight to gh instead.

Relevant Issues: #1350

Type of change: /kind cleanup

Test Plan: Create an rc and inspect the build
