### PR TITLE
Throw more accurate error if trying to create existing user

### DIFF
--- a/src/cloud/auth/controllers/login.go
+++ b/src/cloud/auth/controllers/login.go
@@ -378,7 +378,7 @@ func (s *Server) Signup(ctx context.Context, in *authpb.SignupRequest) (*authpb.
 
 	_, err = s.getUser(ctx, userInfo)
 	if err == nil {
-		return nil, status.Error(codes.PermissionDenied, "user already exists, please login.")
+		return nil, status.Error(codes.AlreadyExists, "user already exists, please login.")
 	}
 
 	// Case 1: User was invited to join an organization.


### PR DESCRIPTION
Summary: We currently throw a "PermissionDenied" error if a user already exists. However, a "AlreadyExists" error is more accurate.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Existing tests pass
