### PR TITLE
Reapply service accounts during operator update

### DIFF
--- a/src/operator/controllers/node_watcher.go
+++ b/src/operator/controllers/node_watcher.go
@@ -74,18 +74,18 @@ type nodeCompatTracker struct {
 
 func (n *nodeCompatTracker) addNode(node *v1.Node) {
 	n.numNodes++
-	kVersion := getNodeKernelVersion(node)
-	n.kernelVersionDist[kVersion]++
-	if !nodeIsCompatible(kVersion) {
+	kernelVersion := getNodeKernelVersion(node)
+	n.kernelVersionDist[kernelVersion]++
+	if !nodeIsCompatible(kernelVersion) {
 		n.numIncompatible++
 	}
 }
 
 func (n *nodeCompatTracker) removeNode(node *v1.Node) {
 	n.numNodes--
-	kVersion := getNodeKernelVersion(node)
-	n.kernelVersionDist[kVersion]--
-	if !nodeIsCompatible(kVersion) {
+	kernelVersion := getNodeKernelVersion(node)
+	n.kernelVersionDist[kernelVersion]--
+	if !nodeIsCompatible(kernelVersion) {
 		n.numIncompatible--
 	}
 }

--- a/src/operator/controllers/vizier_controller.go
+++ b/src/operator/controllers/vizier_controller.go
@@ -699,17 +699,6 @@ func (r *VizierReconciler) deployVizierCore(ctx context.Context, namespace strin
 		return err
 	}
 
-	// If updating, don't reapply service accounts as that will create duplicate service tokens.
-	if allowUpdate {
-		filteredResources := make([]*k8s.Resource, 0)
-		for _, r := range resources {
-			if r.GVK.Kind != "ServiceAccount" {
-				filteredResources = append(filteredResources, r)
-			}
-		}
-		resources = filteredResources
-	}
-
 	for _, r := range resources {
 		err = updateResourceConfiguration(r, vz)
 		if err != nil {


### PR DESCRIPTION
Summary: We used to filter out service accounts when reapplying the Vizier YAMLs during an update. This is because infinitely-lived service tokens would be created every single time as K8s secret, and lead to a very long list of secrets. However, that has since been phased out in K8s 1.24 and we want to make sure we properly handle cases where new service accounts need to be created. 
An alternative to this is to still filter out service accounts, but check which ones exist already. However, that adds more network calls to the process.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Deploy operator with skaffold
