### PR TITLE
Update build an CI tooling to allow arbitrary container image registries

### DIFF
--- a/bazel/images.bzl
+++ b/bazel/images.bzl
@@ -16,16 +16,12 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
-PROPRIETARY_PREFIX = "gcr.io/pl-dev-infra/"
-PUBLIC_PREFIX = "gcr.io/pixie-oss/pixie-prod/"
-DEV_PREFIX = "gcr.io/pixie-oss/pixie-dev/"
-
-def image_replacements(image_map, existing_prefix, new_prefix):
+def image_replacements(image_map):
     replacements = {}
 
     for image in image_map.keys():
-        image = image.removeprefix("$(IMAGE_PREFIX)").removesuffix(":$(BUNDLE_VERSION)")
-        replacements[existing_prefix + image] = new_prefix + image + ":{BUNDLE_VERSION}"
+        image = image.removeprefix("$(IMAGE_PREFIX)/").removesuffix(":$(BUNDLE_VERSION)")
+        replacements[image] = "{IMAGE_PREFIX}/" + image + ":{BUNDLE_VERSION}"
 
     return replacements
 
@@ -46,14 +42,14 @@ bundle_version_provider = rule(
 def _image_prefix_provider_impl(ctx):
     return [
         platform_common.TemplateVariableInfo({
-            "IMAGE_PREFIX": ctx.attr.image_prefix,
+            "IMAGE_PREFIX": ctx.attr._image_prefix[BuildSettingInfo].value,
         }),
     ]
 
 image_prefix_provider = rule(
     implementation = _image_prefix_provider_impl,
     attrs = {
-        "image_prefix": attr.string(mandatory = True),
+        "_image_prefix": attr.label(default = "//k8s:image_repository"),
     },
 )
 

--- a/ci/image_utils.sh
+++ b/ci/image_utils.sh
@@ -27,11 +27,14 @@ push_images_for_arch() {
   arch="$1"
   image_rule="$2"
   release_tag="$3"
-  build_type="$4"
+  image_repo="$4"
 
-  bazel run --config=stamp -c opt --//k8s:image_version="${release_tag}-${arch}" \
+  bazel run -c opt \
+    --config=stamp \
     --config="${arch}_sysroot" \
-    --config=stamp "${build_type}" "${image_rule}" > /dev/null
+    --//k8s:image_repository="${image_repo}" \
+    --//k8s:image_version="${release_tag}-${arch}" \
+    "${image_rule}" > /dev/null
 }
 
 push_multiarch_image() {
@@ -54,14 +57,17 @@ push_all_multiarch_images() {
   image_rule="$1"
   image_list_rule="$2"
   release_tag="$3"
-  build_type="$4"
+  image_repo="$4"
 
-  push_images_for_arch "x86_64" "${image_rule}" "${release_tag}" "${build_type}"
-  push_images_for_arch "aarch64" "${image_rule}" "${release_tag}" "${build_type}"
+  push_images_for_arch "x86_64" "${image_rule}" "${release_tag}" "${image_repo}"
+  push_images_for_arch "aarch64" "${image_rule}" "${release_tag}" "${image_repo}"
 
   while read -r image;
   do
     push_multiarch_image "${image}"
-  done < <(bazel run --config=stamp -c opt --//k8s:image_version="${release_tag}" \
-          --config=stamp "${build_type}" "${image_list_rule}")
+  done < <(bazel run -c opt \
+    --config=stamp \
+    --//k8s:image_repository="${image_repo}" \
+    --//k8s:image_version="${release_tag}" \
+    "${image_list_rule}")
 }

--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -35,15 +35,15 @@ echo "The release tag is: ${release_tag}"
 bazel run -c opt //src/utils/artifacts/versions_gen:versions_gen -- \
       --repo_path "${repo_path}" --artifact_name vizier --versions_file "${versions_file}"
 
-build_type="--//k8s:build_type=public"
-if [[ $release_tag == *"-"* ]]; then
-  build_type="--//k8s:build_type=dev"
-fi
+image_repo="gcr.io/pixie-oss/pixie-prod"
 
-push_all_multiarch_images "//k8s/vizier:vizier_images_push" "//k8s/vizier:list_image_bundle" "${release_tag}" "${build_type}"
+push_all_multiarch_images "//k8s/vizier:vizier_images_push" "//k8s/vizier:list_image_bundle" "${release_tag}" "${image_repo}"
 
-bazel build --config=stamp -c opt --//k8s:image_version="${release_tag}" \
-    --config=stamp "${build_type}" //k8s/vizier:vizier_yamls
+bazel build -c opt \
+  --config=stamp \
+  --//k8s:image_repository="${image_repo}" \
+  --//k8s:image_version="${release_tag}" \
+  //k8s/vizier:vizier_yamls
 
 yamls_tar="${repo_path}/bazel-bin/k8s/vizier/vizier_yamls.tar"
 

--- a/k8s/BUILD.bazel
+++ b/k8s/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("//bazel:images.bzl", "DEV_PREFIX", "PROPRIETARY_PREFIX", "PUBLIC_PREFIX", "bundle_version_provider", "image_prefix_provider")
+load("//bazel:images.bzl", "bundle_version_provider", "image_prefix_provider")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,47 +24,15 @@ string_flag(
     build_setting_default = "latest",
 )
 
-string_flag(
-    name = "build_type",
-    build_setting_default = "dev",
-    values = [
-        "public",
-        "proprietary",
-        "dev",
-    ],
-)
-
-config_setting(
-    name = "dev",
-    flag_values = {
-        ":build_type": "dev",
-    },
-)
-
-config_setting(
-    name = "public",
-    flag_values = {
-        ":build_type": "public",
-    },
-)
-
-config_setting(
-    name = "proprietary",
-    flag_values = {
-        ":build_type": "proprietary",
-    },
-)
-
 bundle_version_provider(
     name = "bundle_version",
 )
 
+string_flag(
+    name = "image_repository",
+    build_setting_default = "localhost:5000",
+)
+
 image_prefix_provider(
     name = "image_prefix",
-    image_prefix = select({
-        ":dev": DEV_PREFIX,
-        ":proprietary": PROPRIETARY_PREFIX,
-        ":public": PUBLIC_PREFIX,
-        "//conditions:default": DEV_PREFIX,
-    }),
 )

--- a/k8s/cloud/BUILD.bazel
+++ b/k8s/cloud/BUILD.bazel
@@ -16,27 +16,27 @@
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
-load("//bazel:images.bzl", "DEV_PREFIX", "PROPRIETARY_PREFIX", "image_replacements", "list_image_bundle")
+load("//bazel:images.bzl", "image_replacements", "list_image_bundle")
 load("//bazel:kustomize.bzl", "kustomize_build")
 
 package(default_visibility = ["//visibility:public"])
 
 CLOUD_IMAGE_TO_LABEL = {
-    "$(IMAGE_PREFIX)cloud/api_server_image:$(BUNDLE_VERSION)": "//src/cloud/api:api_server_image",
-    "$(IMAGE_PREFIX)cloud/artifact_tracker_server_image:$(BUNDLE_VERSION)": "//src/cloud/artifact_tracker:artifact_tracker_server_image",
-    "$(IMAGE_PREFIX)cloud/auth_server_image:$(BUNDLE_VERSION)": "//src/cloud/auth:auth_server_image",
-    "$(IMAGE_PREFIX)cloud/config_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/config_manager:config_manager_server_image",
-    "$(IMAGE_PREFIX)cloud/cron_script_server_image:$(BUNDLE_VERSION)": "//src/cloud/cron_script:cron_script_server_image",
-    "$(IMAGE_PREFIX)cloud/indexer_server_image:$(BUNDLE_VERSION)": "//src/cloud/indexer:indexer_server_image",
-    "$(IMAGE_PREFIX)cloud/metrics_server_image:$(BUNDLE_VERSION)": "//src/cloud/metrics:metrics_server_image",
-    "$(IMAGE_PREFIX)cloud/plugin/load_db:$(BUNDLE_VERSION)": "//src/cloud/plugin/load_db:plugin_db_updater_image",
-    "$(IMAGE_PREFIX)cloud/plugin_server_image:$(BUNDLE_VERSION)": "//src/cloud/plugin:plugin_server_image",
-    "$(IMAGE_PREFIX)cloud/profile_server_image:$(BUNDLE_VERSION)": "//src/cloud/profile:profile_server_image",
-    "$(IMAGE_PREFIX)cloud/project_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/project_manager:project_manager_server_image",
-    "$(IMAGE_PREFIX)cloud/proxy_server_image:$(BUNDLE_VERSION)": "//src/cloud/proxy:proxy_server_image",
-    "$(IMAGE_PREFIX)cloud/scriptmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/scriptmgr:scriptmgr_server_image",
-    "$(IMAGE_PREFIX)cloud/vzconn_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzconn:vzconn_server_image",
-    "$(IMAGE_PREFIX)cloud/vzmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzmgr:vzmgr_server_image",
+    "$(IMAGE_PREFIX)/cloud/api_server_image:$(BUNDLE_VERSION)": "//src/cloud/api:api_server_image",
+    "$(IMAGE_PREFIX)/cloud/artifact_tracker_server_image:$(BUNDLE_VERSION)": "//src/cloud/artifact_tracker:artifact_tracker_server_image",
+    "$(IMAGE_PREFIX)/cloud/auth_server_image:$(BUNDLE_VERSION)": "//src/cloud/auth:auth_server_image",
+    "$(IMAGE_PREFIX)/cloud/config_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/config_manager:config_manager_server_image",
+    "$(IMAGE_PREFIX)/cloud/cron_script_server_image:$(BUNDLE_VERSION)": "//src/cloud/cron_script:cron_script_server_image",
+    "$(IMAGE_PREFIX)/cloud/indexer_server_image:$(BUNDLE_VERSION)": "//src/cloud/indexer:indexer_server_image",
+    "$(IMAGE_PREFIX)/cloud/metrics_server_image:$(BUNDLE_VERSION)": "//src/cloud/metrics:metrics_server_image",
+    "$(IMAGE_PREFIX)/cloud/plugin/load_db:$(BUNDLE_VERSION)": "//src/cloud/plugin/load_db:plugin_db_updater_image",
+    "$(IMAGE_PREFIX)/cloud/plugin_server_image:$(BUNDLE_VERSION)": "//src/cloud/plugin:plugin_server_image",
+    "$(IMAGE_PREFIX)/cloud/profile_server_image:$(BUNDLE_VERSION)": "//src/cloud/profile:profile_server_image",
+    "$(IMAGE_PREFIX)/cloud/project_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/project_manager:project_manager_server_image",
+    "$(IMAGE_PREFIX)/cloud/proxy_server_image:$(BUNDLE_VERSION)": "//src/cloud/proxy:proxy_server_image",
+    "$(IMAGE_PREFIX)/cloud/scriptmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/scriptmgr:scriptmgr_server_image",
+    "$(IMAGE_PREFIX)/cloud/vzconn_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzconn:vzconn_server_image",
+    "$(IMAGE_PREFIX)/cloud/vzmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzmgr:vzmgr_server_image",
 }
 
 kustomize_build(
@@ -51,11 +51,10 @@ kustomize_build(
     ),
     kustomization = "staging/kustomization.yaml",
     replacements = image_replacements(
-        existing_prefix = DEV_PREFIX,
         image_map = CLOUD_IMAGE_TO_LABEL,
-        new_prefix = PROPRIETARY_PREFIX,
     ),
     toolchains = [
+        "//k8s:image_prefix",
         "//k8s:bundle_version",
     ],
 )
@@ -72,11 +71,10 @@ kustomize_build(
     ),
     kustomization = "prod/kustomization.yaml",
     replacements = image_replacements(
-        existing_prefix = DEV_PREFIX,
         image_map = CLOUD_IMAGE_TO_LABEL,
-        new_prefix = PROPRIETARY_PREFIX,
     ),
     toolchains = [
+        "//k8s:image_prefix",
         "//k8s:bundle_version",
     ],
 )

--- a/k8s/cloud/base/api_deployment.yaml
+++ b/k8s/cloud/base/api_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: api-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/api_server_image
+        image: cloud/api_server_image
         ports:
         - containerPort: 51200
           name: http2

--- a/k8s/cloud/base/artifact_tracker_deployment.yaml
+++ b/k8s/cloud/base/artifact_tracker_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: artifact-tracker-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/artifact_tracker_server_image
+        image: cloud/artifact_tracker_server_image
         ports:
         - containerPort: 50750
           name: http2

--- a/k8s/cloud/base/auth_deployment.yaml
+++ b/k8s/cloud/base/auth_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: auth-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/auth_server_image
+        image: cloud/auth_server_image
         ports:
         - containerPort: 50100
           name: http2

--- a/k8s/cloud/base/config_manager_deployment.yaml
+++ b/k8s/cloud/base/config_manager_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: config-manager-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/config_manager_server_image
+        image: cloud/config_manager_server_image
         ports:
         - containerPort: 50500
           name: http2

--- a/k8s/cloud/base/cron_script_deployment.yaml
+++ b/k8s/cloud/base/cron_script_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: cron-script-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/cron_script_server_image
+        image: cloud/cron_script_server_image
         ports:
         - containerPort: 50700
           name: http2

--- a/k8s/cloud/base/indexer_deployment.yaml
+++ b/k8s/cloud/base/indexer_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: indexer-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/indexer_server_image
+        image: cloud/indexer_server_image
         ports:
         - containerPort: 51800
           name: http2

--- a/k8s/cloud/base/metrics_deployment.yaml
+++ b/k8s/cloud/base/metrics_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: metrics-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/metrics_server_image
+        image: cloud/metrics_server_image
         ports:
         - containerPort: 50800
           name: http2

--- a/k8s/cloud/base/plugin_deployment.yaml
+++ b/k8s/cloud/base/plugin_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: plugin-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/plugin_server_image
+        image: cloud/plugin_server_image
         ports:
         - containerPort: 50600
           name: http2

--- a/k8s/cloud/base/profile_deployment.yaml
+++ b/k8s/cloud/base/profile_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: profile-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/profile_server_image
+        image: cloud/profile_server_image
         ports:
         - containerPort: 51500
           name: http2

--- a/k8s/cloud/base/project_manager_deployment.yaml
+++ b/k8s/cloud/base/project_manager_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: project-manager-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/project_manager_server_image
+        image: cloud/project_manager_server_image
         ports:
         - containerPort: 50300
           name: http2

--- a/k8s/cloud/base/proxy_deployment.yaml
+++ b/k8s/cloud/base/proxy_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: cloud-proxy-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/proxy_server_image
+        image: cloud/proxy_server_image
         ports:
         - containerPort: 56000
           name: http2

--- a/k8s/cloud/base/scriptmgr_deployment.yaml
+++ b/k8s/cloud/base/scriptmgr_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: scriptmgr-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/scriptmgr_server_image
+        image: cloud/scriptmgr_server_image
         ports:
         - containerPort: 52000
           name: http2

--- a/k8s/cloud/base/vzconn_deployment.yaml
+++ b/k8s/cloud/base/vzconn_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: vzconn-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/vzconn_server_image
+        image: cloud/vzconn_server_image
         ports:
         - containerPort: 51600
           name: http2

--- a/k8s/cloud/base/vzmgr_deployment.yaml
+++ b/k8s/cloud/base/vzmgr_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: vzmgr-server
         imagePullPolicy: IfNotPresent
-        image: gcr.io/pixie-oss/pixie-dev/cloud/vzmgr_server_image
+        image: cloud/vzmgr_server_image
         ports:
         - containerPort: 51800
           name: http2

--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -28,7 +28,7 @@ spec:
             name: pl-db-config
       containers:
       - name: updater
-        image: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db:latest
+        image: cloud/plugin/load_db:latest
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: updater
-        image: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db:latest
+        image: cloud/plugin/load_db:latest
         command: ["/busybox/sh", "-c"]
         args:
         - |

--- a/k8s/cloud/public/base/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/base/plugin_db_updater_job.yaml
@@ -28,7 +28,7 @@ spec:
             name: pl-db-config
       containers:
       - name: updater
-        image: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db:latest
+        image: cloud/plugin/load_db:latest
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/public/kustomization.yaml
+++ b/k8s/cloud/public/kustomization.yaml
@@ -4,48 +4,48 @@ kind: Kustomization
 resources:
 - base/
 images:
-- name: gcr.io/pixie-oss/pixie-dev/cloud/api_server_image
+- name: cloud/api_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/api_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/artifact_tracker_server_image
+- name: cloud/artifact_tracker_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/artifact_tracker_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/auth_server_image
+- name: cloud/auth_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/auth_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/config_manager_server_image
+- name: cloud/config_manager_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/config_manager_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/proxy_server_image
+- name: cloud/proxy_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/proxy_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/indexer_server_image
+- name: cloud/indexer_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/indexer_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/metrics_server_image
+- name: cloud/metrics_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/metrics_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/plugin_server_image
+- name: cloud/plugin_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/plugin_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/profile_server_image
+- name: cloud/profile_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/profile_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/project_manager_server_image
+- name: cloud/project_manager_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/project_manager_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/scriptmgr_server_image
+- name: cloud/scriptmgr_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/scriptmgr_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/cron_script_server_image
+- name: cloud/cron_script_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/cron_script_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/vzconn_server_image
+- name: cloud/vzconn_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/vzconn_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/vzmgr_server_image
+- name: cloud/vzmgr_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud/vzmgr_server_image
   newTag: latest
-- name: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db
+- name: cloud/plugin/load_db
   newName: gcr.io/pixie-oss/pixie-prod/cloud/plugin/load_db
   newTag: latest

--- a/k8s/operator/BUILD.bazel
+++ b/k8s/operator/BUILD.bazel
@@ -23,8 +23,8 @@ load("//bazel:kustomize.bzl", "kustomize_build")
 package(default_visibility = ["//visibility:public"])
 
 OPERATOR_IMAGE_TO_LABEL = {
-    "$(IMAGE_PREFIX)operator/operator_image:$(BUNDLE_VERSION)": "//src/operator:operator_image",
-    "$(IMAGE_PREFIX)operator/vizier_deleter:$(BUNDLE_VERSION)": "//src/utils/pixie_deleter:vizier_deleter_image",
+    "$(IMAGE_PREFIX)/operator/operator_image:$(BUNDLE_VERSION)": "//src/operator:operator_image",
+    "$(IMAGE_PREFIX)/operator/vizier_deleter:$(BUNDLE_VERSION)": "//src/utils/pixie_deleter:vizier_deleter_image",
 }
 
 container_bundle(

--- a/k8s/operator/deployment/base/deployment.yaml
+++ b/k8s/operator/deployment/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: pixie-operator-service-account
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/operator/operator_image:latest
+        image: operator/operator_image:latest
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/operator/helm/templates/deleter.yaml
+++ b/k8s/operator/helm/templates/deleter.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: delete-job
-        image: gcr.io/pixie-oss/pixie-dev/operator/vizier_deleter:latest
+        image: operator/vizier_deleter:latest
         env:
         - name: PL_NAMESPACE
           valueFrom:

--- a/k8s/vizier/BUILD.bazel
+++ b/k8s/vizier/BUILD.bazel
@@ -17,19 +17,19 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//bazel:images.bzl", "DEV_PREFIX", "image_replacements", "list_image_bundle")
+load("//bazel:images.bzl", "image_replacements", "list_image_bundle")
 load("//bazel:kustomize.bzl", "kustomize_build")
 
 package(default_visibility = ["//visibility:public"])
 
 VIZIER_IMAGE_TO_LABEL = {
-    "$(IMAGE_PREFIX)vizier/cert_provisioner_image:$(BUNDLE_VERSION)": "//src/utils/cert_provisioner:cert_provisioner_image",
-    "$(IMAGE_PREFIX)vizier/cloud_connector_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/cloud_connector:cloud_connector_server_image",
-    "$(IMAGE_PREFIX)vizier/kelvin_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/kelvin:kelvin_image",
-    "$(IMAGE_PREFIX)vizier/metadata_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/metadata:metadata_server_image",
-    "$(IMAGE_PREFIX)vizier/pem_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/pem:pem_image",
-    "$(IMAGE_PREFIX)vizier/query_broker_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/query_broker:query_broker_server_image",
-    "$(IMAGE_PREFIX)vizier/vizier_updater_image:$(BUNDLE_VERSION)": "//src/utils/pixie_updater:vizier_updater_image",
+    "$(IMAGE_PREFIX)/vizier/cert_provisioner_image:$(BUNDLE_VERSION)": "//src/utils/cert_provisioner:cert_provisioner_image",
+    "$(IMAGE_PREFIX)/vizier/cloud_connector_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/cloud_connector:cloud_connector_server_image",
+    "$(IMAGE_PREFIX)/vizier/kelvin_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/kelvin:kelvin_image",
+    "$(IMAGE_PREFIX)/vizier/metadata_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/metadata:metadata_server_image",
+    "$(IMAGE_PREFIX)/vizier/pem_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/pem:pem_image",
+    "$(IMAGE_PREFIX)/vizier/query_broker_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/query_broker:query_broker_server_image",
+    "$(IMAGE_PREFIX)/vizier/vizier_updater_image:$(BUNDLE_VERSION)": "//src/utils/pixie_updater:vizier_updater_image",
 }
 
 kustomize_build(
@@ -49,9 +49,7 @@ kustomize_build(
     ),
     kustomization = "etcd_metadata/kustomization.yaml",
     replacements = image_replacements(
-        existing_prefix = DEV_PREFIX,
         image_map = VIZIER_IMAGE_TO_LABEL,
-        new_prefix = "{IMAGE_PREFIX}",
     ),
     toolchains = [
         "//k8s:bundle_version",
@@ -75,9 +73,7 @@ kustomize_build(
     ),
     kustomization = "etcd_metadata/autopilot/kustomization.yaml",
     replacements = image_replacements(
-        existing_prefix = DEV_PREFIX,
         image_map = VIZIER_IMAGE_TO_LABEL,
-        new_prefix = "{IMAGE_PREFIX}",
     ),
     toolchains = [
         "//k8s:bundle_version",
@@ -102,9 +98,7 @@ kustomize_build(
     ),
     kustomization = "persistent_metadata/kustomization.yaml",
     replacements = image_replacements(
-        existing_prefix = DEV_PREFIX,
         image_map = VIZIER_IMAGE_TO_LABEL,
-        new_prefix = "{IMAGE_PREFIX}",
     ),
     toolchains = [
         "//k8s:bundle_version",
@@ -128,9 +122,7 @@ kustomize_build(
     ),
     kustomization = "persistent_metadata/autopilot/kustomization.yaml",
     replacements = image_replacements(
-        existing_prefix = DEV_PREFIX,
         image_map = VIZIER_IMAGE_TO_LABEL,
-        new_prefix = "{IMAGE_PREFIX}",
     ),
     toolchains = [
         "//k8s:bundle_version",

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -59,7 +59,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/vizier/kelvin_image:latest
+        image: vizier/kelvin_image:latest
         envFrom:
         - configMapRef:
             name: pl-tls-config

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -63,7 +63,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/vizier/query_broker_server_image:latest
+        image: vizier/query_broker_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/bootstrap/cert_provisioner_job.yaml
+++ b/k8s/vizier/bootstrap/cert_provisioner_job.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: pl-cert-provisioner-service-account
       containers:
       - name: provisioner
-        image: gcr.io/pixie-oss/pixie-dev/vizier/cert_provisioner_image:latest
+        image: vizier/cert_provisioner_image:latest
         env:
         - name: PL_NAMESPACE
           valueFrom:

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -63,7 +63,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/vizier/cloud_connector_server_image:latest
+        image: vizier/cloud_connector_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -83,7 +83,7 @@ spec:
           name: certs
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/vizier/metadata_server_image:latest
+        image: vizier/metadata_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -72,7 +72,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: pem
-        image: gcr.io/pixie-oss/pixie-dev/vizier/pem_image:latest
+        image: vizier/pem_image:latest
         args: []
         env:
         - name: TCMALLOC_SAMPLE_PARAMETER

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/vizier/metadata_server_image:latest
+        image: vizier/metadata_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: "50300"
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/vizier/kelvin_image:latest
+        image: vizier/kelvin_image:latest
         envFrom:
         - configMapRef:
             name: pl-tls-config

--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -3,63 +3,63 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/api_server_image
+  - image: cloud/api_server_image
     context: .
     bazel:
       target: //src/cloud/api:api_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/auth_server_image
+  - image: cloud/auth_server_image
     context: .
     bazel:
       target: //src/cloud/auth:auth_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/profile_server_image
+  - image: cloud/profile_server_image
     context: .
     bazel:
       target: //src/cloud/profile:profile_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/proxy_server_image
+  - image: cloud/proxy_server_image
     context: .
     bazel:
       target: //src/cloud/proxy:proxy_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/plugin_server_image
+  - image: cloud/plugin_server_image
     context: .
     bazel:
       target: //src/cloud/plugin:plugin_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/project_manager_server_image
+  - image: cloud/project_manager_server_image
     context: .
     bazel:
       target: //src/cloud/project_manager:project_manager_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/config_manager_server_image
+  - image: cloud/config_manager_server_image
     context: .
     bazel:
       target: //src/cloud/config_manager:config_manager_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/vzconn_server_image
+  - image: cloud/vzconn_server_image
     context: .
     bazel:
       target: //src/cloud/vzconn:vzconn_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/vzmgr_server_image
+  - image: cloud/vzmgr_server_image
     context: .
     bazel:
       target: //src/cloud/vzmgr:vzmgr_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/indexer_server_image
+  - image: cloud/indexer_server_image
     context: .
     bazel:
       target: //src/cloud/indexer:indexer_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/artifact_tracker_server_image
+  - image: cloud/artifact_tracker_server_image
     context: .
     bazel:
       target: //src/cloud/artifact_tracker:artifact_tracker_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/scriptmgr_server_image
+  - image: cloud/scriptmgr_server_image
     context: .
     bazel:
       target: //src/cloud/scriptmgr:scriptmgr_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/cron_script_server_image
+  - image: cloud/cron_script_server_image
     context: .
     bazel:
       target: //src/cloud/cron_script:cron_script_server_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/plugin/load_db
+  - image: cloud/plugin/load_db
     context: .
     bazel:
       target: //src/cloud/plugin/load_db:plugin_db_updater_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/cloud/metrics_server_image
+  - image: cloud/metrics_server_image
     context: .
     bazel:
       target: //src/cloud/metrics:metrics_server_image.tar

--- a/skaffold/skaffold_operator.yaml
+++ b/skaffold/skaffold_operator.yaml
@@ -3,7 +3,7 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/operator/operator_image
+  - image: operator/operator_image
     context: .
     bazel:
       target: //src/operator:operator_image.tar

--- a/skaffold/skaffold_vizier.yaml
+++ b/skaffold/skaffold_vizier.yaml
@@ -3,37 +3,37 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/vizier/pem_image
+  - image: vizier/pem_image
     context: .
     bazel:
       target: //src/vizier/services/agent/pem:pem_image.tar
       args:
       - --compilation_mode=dbg
-  - image: gcr.io/pixie-oss/pixie-dev/vizier/kelvin_image
+  - image: vizier/kelvin_image
     context: .
     bazel:
       target: //src/vizier/services/agent/kelvin:kelvin_image.tar
       args:
       - --compilation_mode=dbg
-  - image: gcr.io/pixie-oss/pixie-dev/vizier/metadata_server_image
+  - image: vizier/metadata_server_image
     context: .
     bazel:
       target: //src/vizier/services/metadata:metadata_server_image.tar
       args:
       - --compilation_mode=dbg
-  - image: gcr.io/pixie-oss/pixie-dev/vizier/query_broker_server_image
+  - image: vizier/query_broker_server_image
     context: .
     bazel:
       target: //src/vizier/services/query_broker:query_broker_server_image.tar
       args:
       - --compilation_mode=dbg
-  - image: gcr.io/pixie-oss/pixie-dev/vizier/cloud_connector_server_image
+  - image: vizier/cloud_connector_server_image
     context: .
     bazel:
       target: //src/vizier/services/cloud_connector:cloud_connector_server_image.tar
       args:
       - --compilation_mode=dbg
-  - image: gcr.io/pixie-oss/pixie-dev/vizier/cert_provisioner_image
+  - image: vizier/cert_provisioner_image
     context: .
     bazel:
       target: //src/utils/cert_provisioner:cert_provisioner_image.tar


### PR DESCRIPTION
Summary: This updates our config flags and ci scripts to allow our
various container artifacts to be pushed to arbitrary image registies
via a config flag.

This doesn't yet support arbitrary registries since most registries don't
allow you to treat image paths like nested dirs, so
`$(IMAGE_PREFIX)/cloud/plugin/load_db` for example won't work.

However this is a stepping stone along the way to supporting other
registries without changing where we currently push images.

Type of change: /kind cleanup

Test Plan: Ran builds locally to test that image paths were sane.
More testing will require creating RCs and deploying those.