### PR TITLE
Remove one off container push targets

### DIFF
--- a/src/cloud/api/BUILD.bazel
+++ b/src/cloud/api/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -60,13 +59,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_api_server_image",
-    format = "Docker",
-    image = ":api_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/api_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/artifact_tracker/BUILD.bazel
+++ b/src/cloud/artifact_tracker/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -57,13 +56,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_artifact_tracker_server_image",
-    format = "Docker",
-    image = ":artifact_tracker_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/artifact_tracker_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/auth/BUILD.bazel
+++ b/src/cloud/auth/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -57,13 +56,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_auth_server_image",
-    format = "Docker",
-    image = ":auth_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/auth_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/config_manager/BUILD.bazel
+++ b/src/cloud/config_manager/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -33,15 +32,6 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_config_manager_server_image",
-    format = "Docker",
-    image = ":config_manager_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/config_manager_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )
 
 go_library(

--- a/src/cloud/cron_script/BUILD.bazel
+++ b/src/cloud/cron_script/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -33,15 +32,6 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_cron_script_server_image",
-    format = "Docker",
-    image = ":cron_script_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/cron_script_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )
 
 go_library(

--- a/src/cloud/indexer/BUILD.bazel
+++ b/src/cloud/indexer/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -58,13 +57,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_indexer_server_image",
-    format = "Docker",
-    image = ":indexer_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/indexer_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/metrics/BUILD.bazel
+++ b/src/cloud/metrics/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -33,15 +32,6 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_metrics_server_image",
-    format = "Docker",
-    image = ":metrics_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/metrics_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )
 
 go_library(

--- a/src/cloud/plugin/BUILD.bazel
+++ b/src/cloud/plugin/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -33,15 +32,6 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_plugin_server_image",
-    format = "Docker",
-    image = ":plugin_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/plugin_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )
 
 go_library(

--- a/src/cloud/plugin/load_db/BUILD.bazel
+++ b/src/cloud/plugin/load_db/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image", "pl_go_test")
@@ -67,15 +66,6 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_plugin_db_updater_image",
-    format = "Docker",
-    image = ":plugin_db_updater_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/plugin/load_db",
-    tag = "{STABLE_BUILD_TAG}",
 )
 
 pl_go_test(

--- a/src/cloud/profile/BUILD.bazel
+++ b/src/cloud/profile/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -55,13 +54,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_profile_server_image",
-    format = "Docker",
-    image = ":profile_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/profile_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/project_manager/BUILD.bazel
+++ b/src/cloud/project_manager/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -55,13 +54,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_project_manager_server_image",
-    format = "Docker",
-    image = ":project_manager_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/project_manager_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/scriptmgr/BUILD.bazel
+++ b/src/cloud/scriptmgr/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -53,13 +52,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_scriptmgr_server_image",
-    format = "Docker",
-    image = ":scriptmgr_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/scriptmgr_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/vzconn/BUILD.bazel
+++ b/src/cloud/vzconn/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -57,13 +56,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_vzconn_server_image",
-    format = "Docker",
-    image = ":vzconn_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/vzconn_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/cloud/vzmgr/BUILD.bazel
+++ b/src/cloud/vzmgr/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -64,13 +63,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/cloud:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_vzmgr_server_image",
-    format = "Docker",
-    image = ":vzmgr_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/cloud/vzmgr_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/operator/BUILD.bazel
+++ b/src/operator/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -48,13 +47,4 @@ pl_go_image(
     visibility = [
         "//k8s:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_operator_image",
-    format = "Docker",
-    image = ":operator_image",
-    registry = "gcr.io",
-    repository = "pl-dev-infra/vizier/operator_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/utils/cert_provisioner/BUILD.bazel
+++ b/src/utils/cert_provisioner/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -50,13 +49,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_cert_provisioner_image",
-    format = "Docker",
-    image = ":cert_provisioner_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/cert_provisioner_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/utils/pixie_deleter/BUILD.bazel
+++ b/src/utils/pixie_deleter/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -46,13 +45,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_vizier_deleter_image",
-    format = "Docker",
-    image = ":vizier_deleter_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/vizier_delete_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/utils/pixie_updater/BUILD.bazel
+++ b/src/utils/pixie_updater/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -51,13 +50,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_vizier_updater_image",
-    format = "Docker",
-    image = ":vizier_updater_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/vizier_update_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/vizier/services/agent/kelvin/BUILD.bazel
+++ b/src/vizier/services/agent/kelvin/BUILD.bazel
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library")
 
 package(default_visibility = ["//src/vizier:__subpackages__"])
@@ -55,22 +54,4 @@ cc_image(
         "//k8s:__subpackages__",
         "//src/vizier:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_kelvin_image",
-    format = "Docker",
-    image = ":kelvin_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/kelvin_image",
-    tag = "{STABLE_BUILD_TAG}",
-)
-
-container_push(
-    name = "push_test_kelvin_image",
-    format = "Docker",
-    image = ":kelvin_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/kelvin_image",
-    tag = "{BUILD_USER}",
 )

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test")
 
 package(default_visibility = ["//src/vizier:__subpackages__"])
@@ -78,22 +78,4 @@ cc_image(
         "//k8s:__subpackages__",
         "//src/vizier:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_pem_image",
-    format = "Docker",
-    image = ":pem_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/pem_image",
-    tag = "{STABLE_BUILD_TAG}",
-)
-
-container_push(
-    name = "push_test_pem_image",
-    format = "Docker",
-    image = ":pem_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/pem_image",
-    tag = "{BUILD_USER}",
 )

--- a/src/vizier/services/cloud_connector/BUILD.bazel
+++ b/src/vizier/services/cloud_connector/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -58,13 +57,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/vizier:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_cloud_connector_server_image",
-    format = "Docker",
-    image = ":cloud_connector_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/cloud_connector_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/vizier/services/metadata/BUILD.bazel
+++ b/src/vizier/services/metadata/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -65,13 +64,4 @@ pl_go_image(
         "//k8s:__subpackages__",
         "//src/vizier:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_vizier_metadata_server_image",
-    format = "Docker",
-    image = ":metadata_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/metadata_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/vizier/services/query_broker/BUILD.bazel
+++ b/src/vizier/services/query_broker/BUILD.bazel
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary")
 
@@ -61,13 +60,4 @@ cc_image(
         "//k8s:__subpackages__",
         "//src/vizier:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_query_broker_server_image",
-    format = "Docker",
-    image = ":query_broker_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/vizier/query_broker_server_image",
-    tag = "{STABLE_BUILD_TAG}",
 )


### PR DESCRIPTION
Summary: We build and push most of our distributed images using
container bundles. We use skaffold to test local dev builds. So
these one off push targets are unused and increase maintenance
burden. Instead just remove them.

Type of change: /kind cleanup

Test Plan: All existing builds and deploys work.
