### PR TITLE
Remove some more container_push targets

### DIFF
--- a/src/e2e_test/jetstream_loadtest/k8s/publisher_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/publisher_deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/jetstream_loadtest/publisher_image:latest
+        image: jetstream_loadtest-publisher_image:latest
         ports:
         - containerPort: 8080
           name: metrics

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.namespace
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/jetstream_loadtest/subscriber_image:latest
+        image: jetstream_loadtest-subscriber_image:latest
         ports:
         - containerPort: 8080
           name: metrics

--- a/src/e2e_test/jetstream_loadtest/publisher/BUILD.bazel
+++ b/src/e2e_test/jetstream_loadtest/publisher/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -46,13 +45,4 @@ pl_go_image(
     name = "publisher_image",
     binary = ":publisher",
     visibility = ["//visibility:private"],
-)
-
-container_push(
-    name = "push_publisher_image",
-    format = "Docker",
-    image = ":publisher_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/src/e2e_test/jetstream_loadtest/publisher_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/e2e_test/jetstream_loadtest/skaffold_loadtest.yaml
+++ b/src/e2e_test/jetstream_loadtest/skaffold_loadtest.yaml
@@ -3,11 +3,11 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/jetstream_loadtest/publisher_image
+  - image: jetstream_loadtest-publisher_image
     context: .
     bazel:
       target: //src/e2e_test/jetstream_loadtest/publisher:publisher_image.tar
-  - image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/jetstream_loadtest/subscriber_image
+  - image: jetstream_loadtest-subscriber_image
     context: .
     bazel:
       target: //src/e2e_test/jetstream_loadtest/subscriber:subscriber_image.tar

--- a/src/e2e_test/jetstream_loadtest/subscriber/BUILD.bazel
+++ b/src/e2e_test/jetstream_loadtest/subscriber/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -46,13 +45,4 @@ pl_go_image(
     name = "subscriber_image",
     binary = ":subscriber",
     visibility = ["//visibility:private"],
-)
-
-container_push(
-    name = "push_subscriber_image",
-    format = "Docker",
-    image = ":subscriber_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/src/e2e_test/jetstream_loadtest/subscriber_image",
-    tag = "{STABLE_BUILD_TAG}",
 )

--- a/src/e2e_test/profiler_loadtest/go/BUILD.bazel
+++ b/src/e2e_test/profiler_loadtest/go/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -39,14 +38,4 @@ pl_go_image(
     visibility = [
         "//src/e2e_test:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_profiler_loadtest_golang_image",
-    format = "Docker",
-    image = ":profiler_loadtest_golang_image",
-    registry = "gcr.io",
-    repository = "gcr.io/pixie-oss/pixie-dev/src/e2e_test/profiler_loadtest/profiler_loadtest_golang",
-    tag = "{STABLE_BUILD_TAG}",
-    tags = ["manual"],
 )

--- a/src/e2e_test/profiler_loadtest/k8s/go_loadtest_deployment.yaml
+++ b/src/e2e_test/profiler_loadtest/k8s/go_loadtest_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/profiler_loadtest/profiler_loadtest_golang:latest
+        image: profiler_loadtest_golang:latest
         env:
         - name: NUM_GOROUTINES
           value: "50"

--- a/src/e2e_test/profiler_loadtest/skaffold_loadtest.yaml
+++ b/src/e2e_test/profiler_loadtest/skaffold_loadtest.yaml
@@ -3,7 +3,7 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/profiler_loadtest/profiler_loadtest_golang
+  - image: profiler_loadtest_golang
     context: .
     bazel:
       target: //src/e2e_test/profiler_loadtest/go:profiler_loadtest_golang_image.tar

--- a/src/e2e_test/protocol_loadtest/BUILD.bazel
+++ b/src/e2e_test/protocol_loadtest/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -42,14 +41,4 @@ pl_go_image(
     visibility = [
         "//src/e2e_test:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_protocol_loadtest_server_image",
-    format = "Docker",
-    image = ":protocol_loadtest_server_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/protocol_loadtest_server",
-    tag = "{STABLE_BUILD_TAG}",
-    tags = ["manual"],
 )

--- a/src/e2e_test/protocol_loadtest/client/BUILD.bazel
+++ b/src/e2e_test/protocol_loadtest/client/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -44,14 +43,4 @@ pl_go_image(
     visibility = [
         "//src/e2e_test:__subpackages__",
     ],
-)
-
-container_push(
-    name = "push_protocol_loadtest_client_image",
-    format = "Docker",
-    image = ":protocol_loadtest_client_image",
-    registry = "gcr.io",
-    repository = "pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/client/protocol_loadtest_client",
-    tag = "{STABLE_BUILD_TAG}",
-    tags = ["manual"],
 )

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: "8080"
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/client/protocol_loadtest_client_image:latest
+        image: protocol_loadtest_client_image:latest
         env:
         - name: HTTP_PORT
           value: "8080"

--- a/src/e2e_test/protocol_loadtest/k8s/server/server_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/server/server_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/protocol_loadtest_server_image:latest
+        image: protocol_loadtest_server_image:latest
         env:
         - name: HTTP_PORT
           value: "8080"

--- a/src/e2e_test/protocol_loadtest/skaffold_client.yaml
+++ b/src/e2e_test/protocol_loadtest/skaffold_client.yaml
@@ -3,7 +3,7 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/client/protocol_loadtest_client_image
+  - image: protocol_loadtest_client_image
     context: .
     bazel:
       target: //src/e2e_test/protocol_loadtest/client:protocol_loadtest_client_image.tar

--- a/src/e2e_test/protocol_loadtest/skaffold_loadtest.yaml
+++ b/src/e2e_test/protocol_loadtest/skaffold_loadtest.yaml
@@ -3,7 +3,7 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/protocol_loadtest_server_image
+  - image: protocol_loadtest_server_image
     context: .
     bazel:
       target: //src/e2e_test/protocol_loadtest:protocol_loadtest_server_image.tar

--- a/src/pixie_cli/BUILD.bazel
+++ b/src/pixie_cli/BUILD.bazel
@@ -79,12 +79,3 @@ container_push(
     repository = "pixie-oss/pixie-prod/px",
     tag = "{STABLE_BUILD_TAG}",
 )
-
-container_push(
-    name = "push_px_image_to_docker",
-    format = "Docker",
-    image = ":px_image",
-    registry = "index.docker.io",
-    repository = "pixielabs/px",
-    tag = "{STABLE_BUILD_TAG}",
-)


### PR DESCRIPTION
Summary: The container push targets for the e2e tests rely on a hardcoded
registry that folks might not have access to push to. Instead we can
switch to relying on skaffold to build the images, replace them in the k8s
yamls and deploy them as needed.

While this makes the yamls for these k8s tests not deployable via just
kustomize (since the referenced images don't exist), IMO it cleans things
up by relying on just having one way to run the tests (via skaffold).

Type of change: /kind cleanup

Test Plan: Skaffolded an e2e test and ensured that it was built
and deployed to my cluster.