### PR TITLE
[versions_gen] Support backfilling release manifests with links to artifacts.

### DIFF
--- a/src/utils/artifacts/versions_gen/BUILD.bazel
+++ b/src/utils/artifacts/versions_gen/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "@com_github_spf13_viper//:viper",
         "@in_gopkg_src_d_go_git_v4//:go-git_v4",
         "@in_gopkg_src_d_go_git_v4//plumbing/object",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )
 


### PR DESCRIPTION
Summary: Adds support to `versions_gen` to allow backfilling manifests with download links to artifacts. It will now read the `artifact_mirrors.yaml` file, to decide where to look for artifacts. Then it will add download links to the manifest's `available_artifact_mirrors` fields, for any artifacts it finds in the expected mirror locations. This will be used in a one off way to create the gh-pages manifest from scratch with the new style (`available_artifact_mirrors` instead of `available_artifacts`). Also, backwards compatibility is maintained so the GCS manifest can still be updated in the old format.

Type of change: /kind cleanup

Test Plan: Tested by running `versions_gen` pointing to `artifact_mirrors.yaml`. Saw that the manifest had the correct download links including some links to github releases.
