### PR TITLE
[artifact manifest] Generate manifest updates from mirror uploads.

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -19,6 +19,8 @@ jobs:
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    env:
+      ARTIFACT_UPLOAD_LOG: "artifact_uploads.json"
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -65,11 +67,17 @@ jobs:
       with:
         name: linux-artifacts
         path: artifacts/
-    - name: Update Manifest
+    - name: Update GCS Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+        # Use the old style versions file instead of the new updates for the gcs manifest.
+        MANIFEST_UPDATES: ""
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: artifact-upload-log
+        path: ${{ env.ARTIFACT_UPLOAD_LOG }}
   sign-release:
     name: Sign Release for MacOS
     runs-on: macos-latest
@@ -107,6 +115,8 @@ jobs:
     needs: [get-dev-image, sign-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    env:
+      MANIFEST_UPDATES: "manifest_updates.json"
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -114,6 +124,9 @@ jobs:
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
       with:
         name: macos-artifacts
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+      with:
+        name: artifact-upload-log
     - name: Import GPG key
       env:
         BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
@@ -128,6 +141,7 @@ jobs:
         REF: ${{ github.event.ref }}
         BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
+        ARTIFACT_UPLOAD_LOG: "artifact_uploads.json"
       shell: bash
       run: |
         export TAG_NAME="${REF#*/tags/}"
@@ -138,8 +152,11 @@ jobs:
       with:
         name: macos-artifacts
         path: artifacts/
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: manifest-updates
+        path: ${{ env.MANIFEST_UPDATES }}
   create-github-release:
-    if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github
     runs-on: ubuntu-latest
     needs: push-signed-artifacts
@@ -154,8 +171,6 @@ jobs:
       env:
         REF: ${{ github.event.ref }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
-        OWNER: pixie-io
-        REPO: pixie
       shell: bash
       # yamllint disable rule:indentation
       run: |
@@ -163,7 +178,61 @@ jobs:
         # actions/checkout doesn't get the tag annotation properly.
         git fetch origin tag "${TAG_NAME}" -f
         export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        gh release create "${TAG_NAME}" --title "CLI ${TAG_NAME#release/cli/}" \
+        prerelease=""
+        if [[ "${REF}" == *"-"* ]]; then
+          prerelease="--prerelease"
+        fi
+        gh release create "${TAG_NAME}" "${prerelease}" \
+          --title "CLI ${TAG_NAME#release/cli/}" \
           --notes $'Pixie CLI Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" linux-artifacts/* macos-artifacts/*
       # yamllint enable rule:indentation
+  update-gh-artifacts-manifest:
+    runs-on: ubuntu-latest-8-cores
+    needs: [get-dev-image, create-github-release]
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    concurrency: gh-pages
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        ref: gh-pages
+        path: gh-pages
+    - name: Add pwd to git safe dir
+      run: |
+        git config --global --add safe.directory `pwd`
+        git config --global --add safe.directory "$(pwd)/gh-pages"
+    - name: Import GPG key
+      env:
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+      run: |
+        echo "${BUILDBOT_GPG_KEY_B64}" | base64 --decode | gpg --no-tty --batch --import
+    - name: Setup git
+      shell: bash
+      env:
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+      run: |
+        git config --global user.name 'pixie-io-buildbot'
+        git config --global user.email 'build@pixielabs.ai'
+        git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
+        git config --global commit.gpgsign true
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+      id: download-artifact
+      with:
+        name: manifest-updates
+    - name: Update gh-pages Manifest
+      env:
+        ARTIFACT_MANIFEST_PATH: "gh-pages/artifacts/manifest.json"
+        MANIFEST_UPDATES: "manifest_updates.json"
+      run: |
+        ./ci/update_artifact_manifest.sh
+        cd gh-pages
+        export ARTIFACT_MANIFEST_PATH="${ARTIFACT_MANIFEST_PATH##gh-pages/}"
+        git add "${ARTIFACT_MANIFEST_PATH}" "${ARTIFACT_MANIFEST_PATH}.sha256"
+        git commit -s -m "Update artifact manifest"
+        git push origin "gh-pages"

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -19,6 +19,9 @@ jobs:
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    env:
+      MANIFEST_UPDATES: "manifest_updates.json"
+      ARTIFACT_UPLOAD_LOG: "artifact_uploads.json"
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -58,11 +61,17 @@ jobs:
         mkdir -p "${ARTIFACTS_DIR}"
         ./ci/save_version_info.sh
         ./ci/operator_build_release.sh
-    - name: Update Manifest
+    - name: Update GCS Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+        # Use the old style versions file instead of the new updates for the gcs manifest.
+        MANIFEST_UPDATES: ""
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: manifest-updates
+        path: ${{ env.MANIFEST_UPDATES }}
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: operator-artifacts
@@ -72,7 +81,6 @@ jobs:
         name: index-artifacts
         path: index.yaml
   create-github-release:
-    if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github
     runs-on: ubuntu-latest
     needs: build-release
@@ -87,8 +95,6 @@ jobs:
       env:
         REF: ${{ github.event.ref }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
-        OWNER: pixie-io
-        REPO: pixie
       shell: bash
       # yamllint disable rule:indentation
       run: |
@@ -96,7 +102,12 @@ jobs:
         # actions/checkout doesn't get the tag annotation properly.
         git fetch origin tag "${TAG_NAME}" -f
         export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        gh release create "${TAG_NAME}" --title "Operator ${TAG_NAME#release/operator/}" \
+        prerelease=""
+        if [[ "${REF}" == *"-"* ]]; then
+          prerelease="--prerelease"
+        fi
+        gh release create "${TAG_NAME}" "${prerelease}" \
+          --title "Operator ${TAG_NAME#release/operator/}" \
           --notes $'Pixie Operator Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" operator-artifacts/*
   create-helm-chart:
@@ -134,3 +145,52 @@ jobs:
         git commit -s -m "Release Helm chart ${VERSION}"
         git push origin "gh-pages"
       # yamllint enable rule:indentation
+  update-gh-artifacts-manifest:
+    runs-on: ubuntu-latest-8-cores
+    needs: [get-dev-image, create-github-release]
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    concurrency: gh-pages
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        ref: gh-pages
+        path: gh-pages
+    - name: Add pwd to git safe dir
+      run: |
+        git config --global --add safe.directory `pwd`
+        git config --global --add safe.directory "$(pwd)/gh-pages"
+    - name: Import GPG key
+      env:
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+      run: |
+        echo "${BUILDBOT_GPG_KEY_B64}" | base64 --decode | gpg --no-tty --batch --import
+    - name: Setup git
+      shell: bash
+      env:
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+      run: |
+        git config --global user.name 'pixie-io-buildbot'
+        git config --global user.email 'build@pixielabs.ai'
+        git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
+        git config --global commit.gpgsign true
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+      id: download-artifact
+      with:
+        name: manifest-updates
+    - name: Update gh-pages Manifest
+      env:
+        ARTIFACT_MANIFEST_PATH: "gh-pages/artifacts/manifest.json"
+        MANIFEST_UPDATES: "manifest_updates.json"
+      run: |
+        ./ci/update_artifact_manifest.sh
+        cd gh-pages
+        export ARTIFACT_MANIFEST_PATH="${ARTIFACT_MANIFEST_PATH##gh-pages/}"
+        git add "${ARTIFACT_MANIFEST_PATH}" "${ARTIFACT_MANIFEST_PATH}.sha256"
+        git commit -s -m "Update artifact manifest"
+        git push origin "gh-pages"

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -19,6 +19,9 @@ jobs:
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    env:
+      MANIFEST_UPDATES: "manifest_updates.json"
+      ARTIFACT_UPLOAD_LOG: "artifact_uploads.json"
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
@@ -65,11 +68,17 @@ jobs:
         docs="$(mktemp)"
         bazel run //src/carnot/docstring:docstring -- --output_json "${docs}"
         gsutil cp "${docs}" "${PXL_DOCS_GCS_PATH}"
-    - name: Update Manifest
+    - name: Update GCS Manifest
       env:
         ARTIFACT_MANIFEST_BUCKET: "pixie-dev-public"
+        # Use the old style versions file instead of the new updates for the gcs manifest.
+        MANIFEST_UPDATES: ""
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      with:
+        name: manifest-updates
+        path: ${{ env.MANIFEST_UPDATES }}
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: vizier-artifacts
@@ -79,7 +88,6 @@ jobs:
         name: index-artifacts
         path: index.yaml
   create-github-release:
-    if: ${{ !contains(github.event.ref, '-') }}
     name: Create Release on Github
     runs-on: ubuntu-latest
     needs: build-release
@@ -94,8 +102,6 @@ jobs:
       env:
         REF: ${{ github.event.ref }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
-        OWNER: pixie-io
-        REPO: pixie
       shell: bash
       # yamllint disable rule:indentation
       run: |
@@ -103,7 +109,12 @@ jobs:
         # actions/checkout doesn't get the tag annotation properly.
         git fetch origin tag "${TAG_NAME}" -f
         export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        gh release create "${TAG_NAME}" --title "Vizier ${TAG_NAME#release/vizier/}" \
+        prerelease=""
+        if [[ "${REF}" == *"-"* ]]; then
+          prerelease="--prerelease"
+        fi
+        gh release create "${TAG_NAME}" "${prerelease}" \
+          --title "Vizier ${TAG_NAME#release/vizier/}" \
           --notes $'Pixie Vizier Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" vizier-artifacts/*
       # yamllint enable rule:indentation
@@ -142,3 +153,52 @@ jobs:
         git commit -s -m "Release Helm chart Vizier ${VERSION}"
         git push origin "gh-pages"
       # yamllint enable rule:indentation
+  update-gh-artifacts-manifest:
+    runs-on: ubuntu-latest-8-cores
+    needs: [get-dev-image, create-github-release]
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    concurrency: gh-pages
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        fetch-depth: 0
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
+      with:
+        ref: gh-pages
+        path: gh-pages
+    - name: Add pwd to git safe dir
+      run: |
+        git config --global --add safe.directory `pwd`
+        git config --global --add safe.directory "$(pwd)/gh-pages"
+    - name: Import GPG key
+      env:
+        BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}
+      run: |
+        echo "${BUILDBOT_GPG_KEY_B64}" | base64 --decode | gpg --no-tty --batch --import
+    - name: Setup git
+      shell: bash
+      env:
+        BUILDBOT_GPG_KEY_ID: ${{ secrets.BUILDBOT_GPG_KEY_ID }}
+      run: |
+        git config --global user.name 'pixie-io-buildbot'
+        git config --global user.email 'build@pixielabs.ai'
+        git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
+        git config --global commit.gpgsign true
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+      id: download-artifact
+      with:
+        name: manifest-updates
+    - name: Update gh-pages Manifest
+      env:
+        ARTIFACT_MANIFEST_PATH: "gh-pages/artifacts/manifest.json"
+        MANIFEST_UPDATES: "manifest_updates.json"
+      run: |
+        ./ci/update_artifact_manifest.sh
+        cd gh-pages
+        export ARTIFACT_MANIFEST_PATH="${ARTIFACT_MANIFEST_PATH##gh-pages/}"
+        git add "${ARTIFACT_MANIFEST_PATH}" "${ARTIFACT_MANIFEST_PATH}.sha256"
+        git commit -s -m "Update artifact manifest"
+        git push origin "gh-pages"

--- a/ci/artifact_mirrors.yaml
+++ b/ci/artifact_mirrors.yaml
@@ -3,7 +3,7 @@
 # So the first mirror in the list will be pulled from first.
 - name: gh-releases
   type: gh-releases
-  url_format: 'https://github.com/pixie-io/pixie/releases/download/release/${component}/v${version}/${artifact_name}'
+  url_format: 'https://github.com/${gh_repo}/releases/download/release/${component}/v${version}/${artifact_name}'
 - name: pixie-oss-gcs
   type: gcs
   bucket: pixie-dev-public

--- a/ci/artifact_utils.sh
+++ b/ci/artifact_utils.sh
@@ -17,24 +17,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gh_artifacts_dir="${ARTIFACTS_DIR}"
+gh_repo="${GH_REPO:-pixie-io/pixie}"
 workspace=$(git rev-parse --show-toplevel)
 mirrors_file="${workspace}/ci/artifact_mirrors.yaml"
-
-BUILDBOT_GPG_KEY_ID="${BUILDBOT_GPG_KEY_ID:?}"
 
 upload_artifact_to_mirrors() {
   component="$1"
   version="$2"
   artifact_path="$3"
   artifact_name="$4"
+  artifact_type="$5"
 
+  BUILDBOT_GPG_KEY_ID="${BUILDBOT_GPG_KEY_ID:?}"
   # Create SHA and signature files for the artifact.
   sha256sum "${artifact_path}" | awk '{print $1}' > "${artifact_path}.sha256"
   gpg --no-tty --batch --yes --local-user "${BUILDBOT_GPG_KEY_ID}" --armor --detach-sign "${artifact_path}"
 
+  urls=()
   while read -r mirror; do
     mirror_def="$(yq '.[] | select(.name == "'"${mirror}"'")' "${mirrors_file}")"
     mirror_type="$(echo "${mirror_def}" | yq '.type')"
+    mirror_url_format="$(echo "${mirror_def}" | yq '.url_format')"
+    url="$(env - component="${component}" \
+          version="${version}" \
+          artifact_name="${artifact_name}" \
+          gh_repo="${gh_repo}" \
+          bash -c "echo ${mirror_url_format}")"
+    urls+=("${url}")
+
     case "${mirror_type}" in
       gh-releases)
         if [[ "${version}" == "latest" ]]; then
@@ -55,6 +65,12 @@ upload_artifact_to_mirrors() {
         ;;
     esac
   done < <(yq '.[].name' "${mirrors_file}")
+
+  if [[ -n "${artifact_type}" ]] && [[ "${version}" != "latest" ]]; then
+    artifact_upload_log="$(realpath "${ARTIFACT_UPLOAD_LOG:?}")"
+    jq --null-input --args '{artifactType: "'"${artifact_type}"'", sha256: "'"$(cat "${artifact_path}.sha256")"'", urls: $ARGS.positional}' -- \
+      "${urls[@]}" >> "${artifact_upload_log}"
+  fi
 }
 
 gh_release_mirror() {
@@ -62,7 +78,7 @@ gh_release_mirror() {
   artifact_name="$2"
   # This is expected to run in a github action with ARTIFACTS_DIR defined
   if [[ -z "${gh_artifacts_dir}" ]]; then
-    echo "Must run in github actions to use gh-releases mirror"
+    echo "Must run in github actions to use gh-releases mirror" >&2
     exit 1
   fi
 
@@ -79,4 +95,21 @@ upload_to_gcs() {
   gsutil cp "${artifact_path}" "gs://${gcs_bucket}/${gcs_path}"
   gsutil cp "${artifact_path}.sha256" "gs://${gcs_bucket}/${gcs_path}.sha256"
   gsutil cp "${artifact_path}.asc" "gs://${gcs_bucket}/${gcs_path}.asc"
+}
+
+create_manifest_update() {
+  component="$1"
+  version="$2"
+  artifact_upload_log="$(realpath "${ARTIFACT_UPLOAD_LOG:?}")"
+
+  commit_hash="$(git rev-parse HEAD)"
+
+  tag_name="release/${component}/v${version}"
+  # actions/checkout doesn't get the tag annotation properly.
+  git fetch origin tag "${tag_name}" -f
+  timestamp="$(git tag -l --format "%(taggerdate:raw)" "${tag_name}"  | awk '{print $1}' | jq '. | todate')"
+
+  jq -s \
+    "[{name: \"${component}\", artifact: [{timestamp: ${timestamp}, commitHash: \"${commit_hash}\", versionStr: \"${version}\", availableArtifactMirrors: .}]}]" \
+    "${artifact_upload_log}"
 }

--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -89,7 +89,7 @@ upload_artifacts() {
   version="$1"
   upload_artifact_to_mirrors "cli" "${version}" "${darwin_amd64_binary}" "cli_darwin_amd64_unsigned"
   upload_artifact_to_mirrors "cli" "${version}" "${darwin_arm64_binary}" "cli_darwin_arm64_unsigned"
-  upload_artifact_to_mirrors "cli" "${version}" "${linux_binary}" "cli_linux_amd64"
+  upload_artifact_to_mirrors "cli" "${version}" "${linux_binary}" "cli_linux_amd64" AT_LINUX_AMD64
 
   if [[ ! "$release_tag" == *"-"* ]]; then
     # RPM/DEB only exists for release builds.

--- a/ci/cli_upload_signed.sh
+++ b/ci/cli_upload_signed.sh
@@ -26,13 +26,21 @@ set -ex
 printenv
 
 release_tag=${TAG_NAME##*/v}
+manifest_updates="${MANIFEST_UPDATES:?}"
 
 for arch in amd64 arm64 universal
 do
-  upload_artifact_to_mirrors "cli" "${release_tag}" "cli_darwin_${arch}" "cli_darwin_${arch}"
+  artifact_type=""
+  case "${arch}" in
+    amd64) artifact_type="AT_DARWIN_AMD64" ;;
+    arm64) artifact_type="AT_DARWIN_ARM64" ;;
+  esac
+  upload_artifact_to_mirrors "cli" "${release_tag}" "cli_darwin_${arch}" "cli_darwin_${arch}" "${artifact_type}"
 
   # Check to see if it's production build. If so we should also write it to the latest directory.
   if [[ ! "$release_tag" == *"-"* ]]; then
     upload_artifact_to_mirrors "cli" "latest" "cli_darwin_${arch}" "cli_darwin_${arch}"
   fi
 done
+
+create_manifest_update "cli" "${release_tag}" > "${manifest_updates}"

--- a/ci/operator_build_release.sh
+++ b/ci/operator_build_release.sh
@@ -19,6 +19,7 @@
 set -ex
 
 versions_file="$(realpath "${VERSIONS_FILE:?}")"
+manifest_updates="${MANIFEST_UPDATES:?}"
 repo_path=$(pwd)
 release_tag=${TAG_NAME##*/v}
 
@@ -121,6 +122,8 @@ output_path="gs://${bucket}/operator/${release_tag}"
 bazel build //k8s/operator:operator_templates
 yamls_tar="${repo_path}/bazel-bin/k8s/operator/operator_templates.tar"
 
-upload_artifact_to_mirrors "operator" "${release_tag}" "${yamls_tar}" "operator_template_yamls.tar"
+upload_artifact_to_mirrors "operator" "${release_tag}" "${yamls_tar}" "operator_template_yamls.tar" AT_CONTAINER_SET_TEMPLATE_YAMLS
 
 ./ci/operator_helm_build_release.sh "${release_tag}"
+
+create_manifest_update "operator" "${release_tag}" > "${manifest_updates}"


### PR DESCRIPTION
Summary: Keep track of each upload to a mirror of artifacts. Create a manifest_updates.json based on the uploads, and then update the github pages manifest based on these updates.

Type of change: /kind cleanup

Test Plan: Tested the vizier and operator releases. The CLI release is blocked on problems with Apple, will test that once unblocked.

Changelog Message:
```release-note
The artifact manifest is now hosted on github pages instead of GCS. This shouldn't be a noticable change for users who aren't doing anything custom with the artifact manifest.
```
