### PR TITLE
Update non operator upgrade to be a bit more robust to image paths

### DIFF
--- a/src/vizier/services/cloud_connector/bridge/server.go
+++ b/src/vizier/services/cloud_connector/bridge/server.go
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: pl-updater-service-account
       containers:
       - name: updater
-        image: gcr.io/pixie-oss/pixie-dev/vizier/vizier_updater_image:__VIZIER_UPDATER_IMAGE_TAG__
+        image: gcr.io/pixie-oss/pixie-prod/vizier/vizier_updater_image
         envFrom:
         - configMapRef:
             name: pl-cloud-config

--- a/src/vizier/services/cloud_connector/bridge/vzinfo.go
+++ b/src/vizier/services/cloud_connector/bridge/vzinfo.go
@@ -512,12 +512,9 @@ func (v *K8sVizierInfo) ParseJobYAML(yamlStr string, imageTag map[string]string,
 			imgPath := imgTag[0]
 
 			tagVers := semver.MustParse(val)
-
-			repoPath := publicImageRepo
-			if len(tagVers.Pre) > 0 {
-				repoPath = privateImageRepo
+			if len(tagVers.Pre) > 0 && strings.HasPrefix(imgPath, publicImageRepo) {
+				imgPath = strings.Replace(imgPath, publicImageRepo, privateImageRepo, 1)
 			}
-			imgPath = repoPath + imgPath[strings.Index(imgPath, "/vizier/"):]
 
 			job.Spec.Template.Spec.Containers[i].Image = imgPath + ":" + val
 		}


### PR DESCRIPTION
Summary: This allows us to make changes to the image path for the updater
more easily.

Type of change: /kind cleanup

Test Plan: Will test with a RC build.
