### PR TITLE
Prettier cluster loading state

### DIFF
--- a/src/ui/src/containers/admin/admin-overview.tsx
+++ b/src/ui/src/containers/admin/admin-overview.tsx
@@ -60,9 +60,13 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
   },
   tabContents: {
     margin: theme.spacing(1),
+    minHeight: `calc(100% - ${theme.spacing(2)})`,
+    height: 0, // min-height doesn't calculate an inheritable height otherwise
   },
   table: {
     paddingBottom: '1px', // Prevent an incorrect height calculation that shows a second scrollbar
+    minHeight: 'calc(100% - 1px)',
+    height: 0,
   },
 }), { name: 'AdminOverview' });
 


### PR DESCRIPTION
Summary: Moves the error/loading text to the center, and doesn't hide already-loaded clusters when refreshing the list.
First load...
<img width="730" alt="image" src="https://github.com/pixie-io/pixie/assets/314133/bdfcf9e0-98ab-43b8-bade-442d19d7b09b">
Refreshing...
<img width="1376" alt="Screenshot 2023-06-20 at 11 35 25" src="https://github.com/pixie-io/pixie/assets/314133/cfdcc4f2-ef04-435f-bb79-3bc81edcf8c6">

Relevant Issues: #1174

Type of change: /kind bugfix

Test Plan: Load `/admin/clusters`. Wait about a minute for the automatic refresh.

