### PR TITLE
Add stirling cli flag to opt into disabling Go TLS tracing

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -102,7 +102,7 @@ DEFINE_int32(stirling_enable_amqp_tracing, px::stirling::TraceMode::On,
              "If true, stirling will trace and process AMQP messages.");
 
 DEFINE_bool(stirling_disable_golang_tls_tracing,
-            gflags::BoolFromEnv("STIRLING_DISABLE_GOLANG_TLS_TRACING", false),
+            gflags::BoolFromEnv("PX_STIRLING_DISABLE_GOLANG_TLS_TRACING", false),
             "If true, stirling will not trace TLS traffic for Go applications. This implies "
             "stirling_enable_http2_tracing=false.");
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -101,6 +101,11 @@ DEFINE_int32(stirling_enable_mux_tracing, px::stirling::TraceMode::OnForNewerKer
 DEFINE_int32(stirling_enable_amqp_tracing, px::stirling::TraceMode::On,
              "If true, stirling will trace and process AMQP messages.");
 
+DEFINE_bool(stirling_disable_golang_tls_tracing,
+            gflags::BoolFromEnv("STIRLING_DISABLE_GOLANG_TLS_TRACING", false),
+            "If true, stirling will not trace TLS traffic for Go applications. This implies "
+            "stirling_enable_http2_tracing=false.");
+
 DEFINE_bool(stirling_disable_self_tracing, true,
             "If true, stirling will not trace and process syscalls made by itself.");
 
@@ -493,7 +498,8 @@ Status SocketTraceConnector::InitImpl() {
   conn_info_map_mgr_ = std::make_shared<ConnInfoMapManager>(this);
   ConnTracker::SetConnInfoMapManager(conn_info_map_mgr_);
 
-  uprobe_mgr_.Init(protocol_transfer_specs_[kProtocolHTTP2].enabled,
+  uprobe_mgr_.Init(FLAGS_stirling_disable_golang_tls_tracing,
+                   protocol_transfer_specs_[kProtocolHTTP2].enabled,
                    FLAGS_stirling_disable_self_tracing);
 
   openssl_trace_state_ =

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -116,10 +116,13 @@ class UProbeManager {
 
   /**
    * Mandatory initialization step before RunDeployUprobesThread can be called.
+   * @param disable_go_tls_tracing Whether to disable Go TLS tracing. Implies enable_http2_tracing
+   * is false.
    * @param enable_http2_tracing Whether to enable HTTP2 tracing.
    * @param disable_self_tracing Whether to enable uprobe deployment on Stirling itself.
    */
-  void Init(bool enable_http2_tracing, bool disable_self_tracing = true);
+  void Init(bool disable_go_tls_tracing, bool enable_http2_tracing,
+            bool disable_self_tracing = true);
 
   /**
    * Notify uprobe manager of an mmap event. An mmap may be indicative of a dlopen,
@@ -618,6 +621,10 @@ class UProbeManager {
 
   // Whether to try to uprobe ourself (e.g. for OpenSSL). Typically, we don't want to do that.
   bool cfg_disable_self_probing_;
+
+  // Whether we want to enable Go TLS tracing. When true, it implies cfg_enable_http2_tracing_ is
+  // false.
+  bool cfg_disable_go_tls_tracing_;
 
   // Whether we want to enable HTTP2 tracing. When false, we don't deploy HTTP2 uprobes.
   bool cfg_enable_http2_tracing_;


### PR DESCRIPTION
Summary: Add stirling cli flag to opt into disabling Go TLS tracing

I'm investigating an issue where a Golang app is crashing with a segfault. The Pixie user is claiming that this crash doesn't occur with a PEM running v0.13.2 but does when running v0.13.7. The segfault is happening when their go application is calling `crypto/tls.(*Conn).Write`, so I wanted to add a mechanism for disabling Go TLS tracing to verify if that stabilizes their application.

Relevant Issues: Issue not created yet (waiting to confirm more details)

Type of change: /kind feature

Test Plan: Existing test coverage passes and setting this flag to true within `go_tls_trace_bpf_test` results in test failures