### PR TITLE
[actions] Do not run release triggered actions on prereleases

### DIFF
--- a/.github/workflows/release_update_docs_px_dev.yaml
+++ b/.github/workflows/release_update_docs_px_dev.yaml
@@ -2,7 +2,7 @@
 name: update-docs-px-dev-on-release
 on:
   release:
-    types: [published]
+    types: [released]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/release_update_readme.yaml
+++ b/.github/workflows/release_update_readme.yaml
@@ -2,7 +2,7 @@
 name: update-readme-on-release
 on:
   release:
-    types: [published]
+    types: [released]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Summary: Only run the release triggered jobs on actual releases, instead of also on prereleases.

Type of change: /kind cleanup

Test Plan: N/A
