### PR TITLE
Fix min height of heading in admin pods

### DIFF
--- a/src/ui/src/containers/admin/cluster-details/cluster-details-pods.tsx
+++ b/src/ui/src/containers/admin/cluster-details/cluster-details-pods.tsx
@@ -159,7 +159,7 @@ export const PixiePodsTab = React.memo<{
   const dataPlaneDisplay = dataPlanePods.map((podStatus) => formatPodStatus(podStatus));
 
   return (
-    <>
+    <div className={classes.root}>
       <div className={`${classes.podTypeHeader} ${classes.topPadding}`}> Control Plane Pods </div>
       <Table>
         <PodHeader />
@@ -205,7 +205,7 @@ export const PixiePodsTab = React.memo<{
           }
         </TableBody>
       </Table>
-    </>
+    </div>
   );
 });
 PixiePodsTab.displayName = 'PixiePodsTab';

--- a/src/ui/src/containers/admin/cluster-details/cluster-details-utils.ts
+++ b/src/ui/src/containers/admin/cluster-details/cluster-details-utils.ts
@@ -135,6 +135,7 @@ export const useClusterDetailStyles = makeStyles((theme: Theme) => createStyles(
     alignItems: 'center',
     height: '100%',
     paddingLeft: theme.spacing(2),
+    flex: '0 1',
   },
   topPadding: {
     paddingTop: theme.spacing(2),


### PR DESCRIPTION
Summary: See screenshots
Before...
![image](https://github.com/pixie-io/pixie/assets/314133/a600ecea-adb4-4f7d-b606-a23fcc1dfc07)
After...
<img width="1232" alt="image" src="https://github.com/pixie-io/pixie/assets/314133/9493ec4d-7a50-44dd-83ba-3741c7798ade">

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: `/admin/clusters`, open a cluster that doesn't have a lot going on, go to pods tab.

