### PR TITLE
[artifact tracker] Poll HTTP location for manifest

### DIFF
--- a/k8s/cloud/base/artifact_config.yaml
+++ b/k8s/cloud/base/artifact_config.yaml
@@ -4,6 +4,5 @@ kind: ConfigMap
 metadata:
   name: pl-artifact-config
 data:
-  PL_ARTIFACT_BUCKET: pixie-dev-public
-  PL_ARTIFACT_MANIFEST_BUCKET: pixie-dev-public
+  PL_ARTIFACT_MANIFEST_URL: https://artifacts.px.dev/artifacts/manifest.json
   PL_SA_KEY_PATH: /creds/service_account.json


### PR DESCRIPTION
Summary: Use an HTTP url to poll for artifact manifests in the artifact tracker server. By default the manifest is polled from github pages.

Type of change: /kind cleanup

Test Plan: Tested that when github pages is updated a skaffold deploy of this PR sees the manifest update, and can download the latest release.
