### PR TITLE
Add short description for format_duration pxl function documentation

### DIFF
--- a/src/carnot/planner/objects/pixie_module.h
+++ b/src/carnot/planner/objects/pixie_module.h
@@ -203,6 +203,8 @@ class PixieModule : public QLObject {
 
   inline static constexpr char kFormatDurationOpID[] = "format_duration";
   inline static constexpr char kFormatDurationDocstring[] = R"doc(
+  Convert a duration in nanoseconds to a duration string.
+
   Convert an integer in nanoseconds (-3,000,000,000) to a duration string ("-5m") while
   preserving the sign. This function converts to whole milliseconds, seconds, minutes,
   hours or days. This means it will round down to the nearest whole number time unit.


### PR DESCRIPTION
Summary: Add short description for format_duration pxl function documentation

This is to pull in an update that was made in this commit (https://github.com/pixie-io/docs.px.dev/pull/267/commits/0fd2b8b32e46e608469a36a08dcca36d505833e2).

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Regenerated the docs and verified that there is only whitespace changes between github.com/pixie-io/docs.px.dev and the files generated from this repo
```
cd bazel-bin; ./src/carnot/docstring/docstring_/docstring
mv output.json ~/code/docs.px.dev/external/pxl_documentation.json
ddelnano@vigenere:~/code/docs.px.dev (main) $ git diff
diff --git a/external/pxl_documentation.json b/external/pxl_documentation.json
index dea613c..76f763b 100644
--- a/external/pxl_documentation.json
+++ b/external/pxl_documentation.json
@@ -8255,4 +8255,4 @@
       }
     ]
   }
-}
+}
\ No newline at end of file

```