### PR TITLE
Operator should only switch users to etcd on initial deploy

### DIFF
--- a/src/operator/controllers/vizier_controller.go
+++ b/src/operator/controllers/vizier_controller.go
@@ -394,7 +394,7 @@ func (r *VizierReconciler) deployVizier(ctx context.Context, req ctrl.Request, v
 		vz.Spec.Pod.NodeSelector = make(map[string]string)
 	}
 
-	if !vz.Spec.UseEtcdOperator {
+	if !vz.Spec.UseEtcdOperator && !update {
 		// Check if the cluster offers PVC support.
 		// If it does not, we should default to using the etcd operator, which does not
 		// require PVC support.


### PR DESCRIPTION
Summary: We were hearing reports where some user's clusters were switching to an etcd-based deploy after having already been deployed with the persistent-metadata version for a while. We should gate this check only for when we're deploying Vizier for the first time.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Skaffold deploy operator
