### PR TITLE
[versions_gen] Fix 3 separate bugs in versions_gen.

### DIFF
--- a/src/utils/artifacts/versions_gen/BUILD.bazel
+++ b/src/utils/artifacts/versions_gen/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",
         "@in_gopkg_src_d_go_git_v4//:go-git_v4",
-        "@in_gopkg_src_d_go_git_v4//plumbing/object",
+        "@in_gopkg_src_d_go_git_v4//plumbing",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )


### PR DESCRIPTION
Summary: Fixes three bugs causing issues in the manifest generation.
- Fixes a bug where the tag's hash was used instead of the commit's hash
- Fixes another bug where dangling annotated tags would still show up in the manifest. For example, if I have an annotated tag `release/vizier/v0.0.0` and I run `git tag -d release/vizier/v0.0.0` and then re-run the release tag script `./scripts/create_release_tag.sh vizier`, my git state will have two annotated tag objects, but the tag reference will only point to one of them, and the other will just be an object not pointed to by any reference. Becuase we were using `TagObjects` in go-git, both of these tag objects would be returned leading to duplicate entries in the generated versions file. This PR fixes this issue by iterating tag references instead of tag objects, and then skipping any lightweight tags (tags without annotated tag objects).
- Finally fixes a bug with getting the artifact download link, where the github repo was not being filled into the url format.

Type of change: /kind cleanup

Test Plan: Tested that the new generated versions manifest no longer has duplicate entries for a single version and that its commit hashes are valid.
