### PR TITLE
Scope down github token permissions

### DIFF
--- a/.github/workflows/mirror_releases.yaml
+++ b/.github/workflows/mirror_releases.yaml
@@ -5,9 +5,11 @@ on:
     types: [released]
 permissions:
   contents: read
-  packages: write
 jobs:
   sync_image:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest-16-cores
     steps:
     - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc  # v2

--- a/.github/workflows/release_update_docs_px_dev.yaml
+++ b/.github/workflows/release_update_docs_px_dev.yaml
@@ -14,8 +14,6 @@ jobs:
   generate-docs:
     needs: get-dev-image
     runs-on: ubuntu-latest-8-cores
-    permissions:
-      contents: read
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     steps:

--- a/.github/workflows/release_update_readme.yaml
+++ b/.github/workflows/release_update_readme.yaml
@@ -8,8 +8,6 @@ permissions:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:


### PR DESCRIPTION
Summary: Update mirror_release to only have `package: write` on the job
Remove some dupe `content: read` perms.

Type of change: /kind cleanup

Test Plan: All the updated actions should continue to work.
