### PR TITLE
Setup/fix skaffold instructions for stirling demo_apps

### DIFF
--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/README.md
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/README.md
@@ -7,18 +7,9 @@ a `_pl` suffix.
 These client and server rules are built against different versions of Golang releases as well,
 in order for tests to verify Stirling against different Golang versions.
 
-To run, first build everything:
-```
-bazel run //src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_16_grpc_tls_server -- --norun
-bazel run //src/stirling/testing/demo_apps/go_grpc_tls_pl/client:golang_1_16_grpc_tls_client -- --norun
-```
+You can use skaffold to run these demos:
 
-Then execute the following commands in two separate terminals:
-
-```
-docker run --name=grpc_tls_server bazel/src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_16_grpc_tls_server
-```
-
-```
-docker run --name=grpc_tls_client --network=container:grpc_tls_server bazel/src/stirling/testing/demo_apps/go_grpc_tls_pl/client:golang_1_16_grpc_tls_client
+```shell
+kubectl create ns px-grpc-test
+skaffold run -f src/stirling/testing/demo_apps/go_grpc_tls_pl/skaffold.yaml
 ```

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/client_deployment.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/client_deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grpc-client
-  namespace: px-grpc-test
   labels:
     name: grpc-client
 spec:
@@ -18,7 +17,7 @@ spec:
     spec:
       containers:
       - name: grpc-client
-        image: gcr.io/pixie-oss/pixie-dev/src/stirling/testing/demo_apps/go_grpc_tls_pl/client:latest
+        image: go_grpc_tls_pl-client
         args:
         - --address=grpc-server:50400
         - --count=100000

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_deployment.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grpc-server
-  namespace: px-grpc-test
 spec:
   replicas: 1
   selector:
@@ -16,7 +15,7 @@ spec:
     spec:
       containers:
       - name: grpc-server
-        image: gcr.io/pixie-oss/pixie-dev/src/stirling/testing/demo_apps/go_grpc_tls_pl/server:latest
+        image: go_grpc_tls_pl-server
         ports:
         - containerPort: 50400
         imagePullPolicy: Always

--- a/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_service.yaml
+++ b/src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s/server_service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grpc-server
-  namespace: px-grpc-test
 spec:
   type: ClusterIP
   ports:

--- a/src/stirling/testing/demo_apps/go_http/README.md
+++ b/src/stirling/testing/demo_apps/go_http/README.md
@@ -1,15 +1,8 @@
 # HTTP client & server applications
 
-To push container image to GCR, run `:push_image` target with `--config=stamp`:
+You can use skaffold to run these demos:
 
-```
-bazel run --config=stamp //src/stirling/testing/demo_apps/go_http/go_http_client:push_image
-bazel run --config=stamp //src/stirling/testing/demo_apps/go_http/go_http_server:push_image
-```
-
-To deploy the client & server onto a Kubernetes cluster:
-
-```
-kubectl create ns px-go-http
-sed "s/{{USER}}/$USER/" src/stirling/testing/demo_apps/go_http/go_http_{client,server}/deployment.yaml | kubectl apply -f - -n px-go-http
+```shell
+kubectl create ns px-http-test
+skaffold run -f src/stirling/testing/demo_apps/go_http/skaffold.yaml
 ```

--- a/src/stirling/testing/demo_apps/go_http/go_http_client/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_http/go_http_client/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -34,13 +33,4 @@ pl_go_binary(
 pl_go_image(
     name = "image",
     binary = ":go_http_client",
-)
-
-container_push(
-    name = "push_image",
-    format = "Docker",
-    image = ":image",
-    registry = "gcr.io",
-    repository = "pl-dev-infra/demos/go_http_client",
-    tag = "{BUILD_USER}",
 )

--- a/src/stirling/testing/demo_apps/go_http/go_http_server/BUILD.bazel
+++ b/src/stirling/testing/demo_apps/go_http/go_http_server/BUILD.bazel
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//bazel:pl_build_system.bzl", "pl_go_binary", "pl_go_image")
 
@@ -34,13 +33,4 @@ pl_go_binary(
 pl_go_image(
     name = "image",
     binary = ":go_http_server",
-)
-
-container_push(
-    name = "push_image",
-    format = "Docker",
-    image = ":image",
-    registry = "gcr.io",
-    repository = "pl-dev-infra/demos/go_http_server",
-    tag = "{BUILD_USER}",
 )

--- a/src/stirling/testing/demo_apps/go_http/k8s/client_deployment.yaml
+++ b/src/stirling/testing/demo_apps/go_http/k8s/client_deployment.yaml
@@ -17,10 +17,9 @@ spec:
     spec:
       containers:
       - name: go-http-client
-        # Replace with your own username.
-        image: gcr.io/pl-dev-infra/demos/go_http_client:{{USER}}
+        image: go_http_client
         args:
-        - --address=fe:50051
+        - --address=http-server:50051
         - --count=0
         - --sleep=1000
         - --reqSize=16384

--- a/src/stirling/testing/demo_apps/go_http/k8s/kustomization.yaml
+++ b/src/stirling/testing/demo_apps/go_http/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: px-http-test
+resources:
+- server_deployment.yaml
+- server_service.yaml
+- client_deployment.yaml

--- a/src/stirling/testing/demo_apps/go_http/k8s/server_deployment.yaml
+++ b/src/stirling/testing/demo_apps/go_http/k8s/server_deployment.yaml
@@ -17,8 +17,7 @@ spec:
     spec:
       containers:
       - name: go-http-server
-        # Replace with your own username.
-        image: gcr.io/pl-dev-infra/demos/go_http_server:{{USER}}
+        image: go_http_server
         ports:
         - containerPort: 50051
         args:
@@ -30,17 +29,3 @@ spec:
           requests:
             cpu: 10m
             memory: 512Mi
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: fe
-  labels:
-    name: fe
-spec:
-  ports:
-  - protocol: "TCP"
-    port: 50051
-    targetPort: 50051
-  selector:
-    name: go-http-server

--- a/src/stirling/testing/demo_apps/go_http/k8s/server_service.yaml
+++ b/src/stirling/testing/demo_apps/go_http/k8s/server_service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-server
+  labels:
+    name: http-server
+spec:
+  ports:
+  - protocol: "TCP"
+    port: 50051
+    targetPort: 50051
+  selector:
+    name: go-http-server

--- a/src/stirling/testing/demo_apps/go_http/skaffold.yaml
+++ b/src/stirling/testing/demo_apps/go_http/skaffold.yaml
@@ -3,14 +3,14 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: go_grpc_tls_pl-server
+  - image: go_http_client
     context: .
     bazel:
-      target: //src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_20_grpc_tls_server.tar
-  - image: go_grpc_tls_pl-client
+      target: //src/stirling/testing/demo_apps/go_http/go_http_client:image.tar
+  - image: go_http_server
     context: .
     bazel:
-      target: //src/stirling/testing/demo_apps/go_grpc_tls_pl/client:golang_1_20_grpc_tls_client.tar
+      target: //src/stirling/testing/demo_apps/go_http/go_http_server:image.tar
   tagPolicy:
     dateTime: {}
   local:
@@ -18,7 +18,7 @@ build:
 manifests:
   kustomize:
     paths:
-    - src/stirling/testing/demo_apps/go_grpc_tls_pl/k8s
+    - src/stirling/testing/demo_apps/go_http/k8s
 profiles:
 - name: aarch64_sysroot
   patches:


### PR DESCRIPTION
Summary: This updates the `go_http` demo to use skaffold to testing.
This makes it independent of the container registry and will now use
the default repo configured for skaffold to run the demo.
Also updates the `go_grpc_tls_pl` app to cleanup the kustomization,
update the readme and cleanup the image path.

Type of change: /kind cleanup

Test Plan: Ran the deploy instructions in the README.md and verified
that they work.
