### PR TITLE
Fix dropdown selection in admin cluster detail view

### DIFF
--- a/src/ui/src/containers/admin/cluster-details/cluster-details.tsx
+++ b/src/ui/src/containers/admin/cluster-details/cluster-details.tsx
@@ -113,12 +113,12 @@ const ClusterDetailsNavigationBreadcrumbs = React.memo<{ selectedClusterName: st
           .map((c) => ({ value: c.prettyClusterName }));
         return { items, hasMoreItems: false };
       },
-      onSelect: (/* input */) => {
+      onSelect: (input) => {
         history.push(getClusterDetailsURL(
-          clusters.find(({ prettyClusterName }) => prettyClusterName === selectedClusterName)?.clusterName));
+          clusters.find(({ prettyClusterName }) => prettyClusterName === input)?.clusterName));
       },
     },
-  ], [clusters, error, history, loading, selectedClusterName, selectedClusterPrettyName]);
+  ], [clusters, error, history, loading, selectedClusterPrettyName]);
 
   return <Breadcrumbs breadcrumbs={breadcrumbs} />;
 });


### PR DESCRIPTION
Summary: A wrong variable reference was causing "unknown cluster" to be selected instead of what the user clicked.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Visit `/admin/clusters`. Click one. In the dialog that comes up, use the dropdown in the top left to choose another.
Now, it should reload the dialog with info for the new cluster correctly.
