### PR TITLE
Remove debugging log message from `openssl_trace_bpf_test`

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -280,7 +280,6 @@ OPENSSL_TYPED_TEST(ssl_capture_node_client, {
 
   EXPECT_THAT(records.http_records, UnorderedElementsAre(EqHTTPRecord(expected_record)));
   EXPECT_THAT(records.remote_address, UnorderedElementsAre(StrEq("127.0.0.1")));
-  LOG(INFO) << "Trigger tests to see if it reduces flakiness";
 })
 
 }  // namespace stirling


### PR DESCRIPTION
Summary: Remove debugging log message from `openssl_trace_bpf_test`

This seems to be left over from some previous build flakiness investigation.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Existing tests