### PR TITLE
Trace statically linked OpenSSL compatible TLS libraries

### DIFF
--- a/bazel/external/boringssl.patch
+++ b/bazel/external/boringssl.patch
@@ -3,7 +3,7 @@
 @@ -206,7 +206,7 @@
    BIO_puts(bio.get(), "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n");
    PrintConnectionInfo(bio.get(), ssl);
- 
+
 -  char request[4];
 +  char request[74];
    size_t request_len = 0;

--- a/bazel/external/boringssl.patch
+++ b/bazel/external/boringssl.patch
@@ -1,0 +1,11 @@
+--- src/tool/server.cc	2023-01-20 13:31:06.619119943 -0800
++++ src/tool/server.cc	2023-01-20 13:30:59.707052958 -0800
+@@ -206,7 +206,7 @@
+   BIO_puts(bio.get(), "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n");
+   PrintConnectionInfo(bio.get(), ssl);
+ 
+-  char request[4];
++  char request[74];
+   size_t request_len = 0;
+   while (request_len < sizeof(request)) {
+     int ssl_ret =

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -124,7 +124,7 @@ def _cc_deps():
     _bazel_repo("com_google_protobuf", patches = ["//bazel/external:protobuf_gogo_hack.patch", "//bazel/external:protobuf_text_format.patch", "//bazel/external:protobuf_warning.patch"], patch_args = ["-p1"])
     _bazel_repo("com_github_grpc_grpc", patches = ["//bazel/external:grpc.patch", "//bazel/external:grpc_go_toolchain.patch", "//bazel/external:grpc_test_visibility.patch"], patch_args = ["-p1"])
 
-    _bazel_repo("boringssl")
+    _bazel_repo("boringssl", patches = ["//bazel/external:boringssl.patch"], patch_args = ["-p0"])
     _bazel_repo("com_google_benchmark")
     _bazel_repo("com_google_googletest")
     _bazel_repo("com_github_gflags_gflags")

--- a/src/cloud/config_manager/controllers/vizier_feature_flags.go
+++ b/src/cloud/config_manager/controllers/vizier_feature_flags.go
@@ -42,6 +42,11 @@ var availableFeatureFlags = []*featureFlag{
 		VizierFlagName:  "PL_PROFILER_JAVA_SYMBOLS",
 		DefaultValue:    true,
 	},
+	{
+		FeatureFlagName: "probe-static-tls-binaries",
+		VizierFlagName:  "PL_PROBE_STATIC_TLS_BINARIES",
+		DefaultValue:    false,
+	},
 }
 
 // NewVizierFeatureFlagClient creates a LaunchDarkly feature flag client if the SDK key is provided,

--- a/src/cloud/config_manager/controllers/vizier_feature_flags.go
+++ b/src/cloud/config_manager/controllers/vizier_feature_flags.go
@@ -44,7 +44,7 @@ var availableFeatureFlags = []*featureFlag{
 	},
 	{
 		FeatureFlagName: "probe-static-tls-binaries",
-		VizierFlagName:  "PL_PROBE_STATIC_TLS_BINARIES",
+		VizierFlagName:  "PL_TRACE_STATIC_TLS_BINARIES",
 		DefaultValue:    false,
 	},
 }

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -471,6 +471,27 @@ pl_cc_bpf_test(
 )
 
 pl_cc_bpf_test(
+    name = "boringssl_trace_bpf_test",
+    timeout = "long",
+    srcs = ["boringssl_trace_bpf_test.cc"],
+    flaky = True,
+    shard_count = 2,
+    tags = [
+        "cpu:16",
+        "no_asan",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/common/testing/test_utils:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:bssl_container",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:curl_container",
+        "//src/stirling/testing:cc_library",
+    ],
+)
+
+pl_cc_bpf_test(
     name = "netty_tls_trace_bpf_test",
     timeout = "long",
     srcs = ["netty_tls_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
@@ -102,4 +102,5 @@ enum ssl_source_t {
   kLibSSL_3_Source,
   kLibPythonSource,
   kLibNettyTcnativeSource,
+  kStaticallyLinkedSource,
 };

--- a/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
@@ -18,6 +18,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <prometheus/text_serializer.h>
 
 #include <string>
 

--- a/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "src/common/base/base.h"
+#include "src/common/exec/exec.h"
+#include "src/common/testing/test_environment.h"
+#include "src/shared/types/column_wrapper.h"
+#include "src/shared/types/types.h"
+#include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images/bssl_container.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images/curl_container.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
+#include "src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.h"
+#include "src/stirling/testing/common.h"
+
+namespace px {
+namespace stirling {
+
+namespace http = protocols::http;
+
+using ::px::stirling::testing::EqHTTPRecord;
+using ::px::stirling::testing::FindRecordIdxMatchesPID;
+using ::px::stirling::testing::GetTargetRecords;
+using ::px::stirling::testing::SocketTraceBPFTestFixture;
+using ::px::stirling::testing::ToRecordVector;
+
+using ::testing::StrEq;
+using ::testing::UnorderedElementsAre;
+
+bool Init() {
+  FLAGS_stirling_enable_mux_tracing = false;
+  return true;
+}
+
+class Bssl_ContainerWrapper : public ::px::stirling::testing::BsslContainer {};
+
+// Includes all information we need to extract from the trace records, which are used to verify
+// against the expected results.
+struct TraceRecords {
+  std::vector<http::Record> http_records;
+  std::vector<std::string> remote_address;
+};
+
+template <typename TServerContainer, bool TForceFptrs>
+class BaseBoringSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing */ false> {
+ protected:
+  BaseBoringSSLTraceTest() {
+    // Run the nginx HTTPS server.
+    // The container runner will make sure it is in the ready state before unblocking.
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60});
+    PX_CHECK_OK(run_result);
+
+    // Sleep an additional second, just to be safe.
+    sleep(1);
+  }
+
+  void SetUp() override {
+    FLAGS_openssl_force_raw_fptrs = force_fptr_;
+
+    SocketTraceBPFTestFixture::SetUp();
+  }
+
+  // Returns the trace records of the process specified by the input pid.
+  TraceRecords GetTraceRecords(int pid) {
+    std::vector<TaggedRecordBatch> tablets =
+        this->ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
+    if (tablets.empty()) {
+      LOG(WARNING) << "GetTraceRecords is returning empty!";
+      return {};
+    }
+    types::ColumnWrapperRecordBatch record_batch = tablets[0].records;
+    std::vector<size_t> server_record_indices =
+        FindRecordIdxMatchesPID(record_batch, kHTTPUPIDIdx, pid);
+    std::vector<http::Record> http_records =
+        ToRecordVector<http::Record>(record_batch, server_record_indices);
+    std::vector<std::string> remote_addresses =
+        testing::GetRemoteAddrs(record_batch, server_record_indices);
+    return {std::move(http_records), std::move(remote_addresses)};
+  }
+
+  TServerContainer server_;
+  bool force_fptr_ = TForceFptrs;
+};
+
+//-----------------------------------------------------------------------------
+// Test Scenarios
+//-----------------------------------------------------------------------------
+
+http::Record GetExpectedHTTPRecord() {
+  http::Record expected_record;
+  /* expected_record.req.minor_version = 1; */
+  expected_record.req.req_method = "GET";
+  expected_record.req.req_path = "/";
+  /* expected_record.req.body = ""; */
+  expected_record.resp.resp_status = 200;
+  expected_record.resp.resp_message = "OK";
+  /* expected_record.resp.body = kNginxRespBody; */
+  return expected_record;
+}
+
+typedef ::testing::Types<Bssl_ContainerWrapper> BoringSSLServerImplementations;
+
+template <typename T>
+using BoringSSLTraceDlsymTest = BaseBoringSSLTraceTest<T, false>;
+
+#define OPENSSL_TYPED_TEST(TestCase, CodeBlock) \
+  TYPED_TEST(BoringSSLTraceDlsymTest, TestCase) \
+  CodeBlock
+
+TYPED_TEST_SUITE(BoringSSLTraceDlsymTest, BoringSSLServerImplementations);
+
+OPENSSL_TYPED_TEST(ssl_capture_curl_client, {
+  FLAGS_stirling_conn_trace_pid = this->server_.process_pid();
+  this->StartTransferDataThread();
+
+  // Make an SSL request with curl.
+  // Because the server uses a self-signed certificate, curl will normally refuse to connect.
+  // This is similar to the warning pages that Firefox/Chrome would display.
+  // To take an exception and make the SSL connection anyways, we use the --insecure flag.
+
+  // Run the client in the network of the server, so they can connect to each other.
+  ::px::stirling::testing::CurlContainer client;
+  ASSERT_OK(
+      client.Run(std::chrono::seconds{60},
+                 {absl::Substitute("--network=container:$0", this->server_.container_name())},
+                 {"--user-agent", "Testing", "--insecure", "-s", "-S", "https://localhost:4433/"}));
+  client.Wait();
+  this->StopTransferDataThread();
+
+  TraceRecords records = this->GetTraceRecords(this->server_.process_pid());
+  http::Record expected_record = GetExpectedHTTPRecord();
+
+  EXPECT_GT(records.http_records.size(), 0);
+  /* EXPECT_THAT(records.remote_address, UnorderedElementsAre(StrEq("127.0.0.1"))); */
+})
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
@@ -40,19 +40,10 @@ namespace stirling {
 
 namespace http = protocols::http;
 
-using ::px::stirling::testing::EqHTTPRecord;
 using ::px::stirling::testing::FindRecordIdxMatchesPID;
 using ::px::stirling::testing::GetTargetRecords;
 using ::px::stirling::testing::SocketTraceBPFTestFixture;
 using ::px::stirling::testing::ToRecordVector;
-
-using ::testing::StrEq;
-using ::testing::UnorderedElementsAre;
-
-bool Init() {
-  FLAGS_stirling_enable_mux_tracing = false;
-  return true;
-}
 
 class Bssl_ContainerWrapper : public ::px::stirling::testing::BsslContainer {};
 
@@ -108,18 +99,6 @@ class BoringSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracin
 // Test Scenarios
 //-----------------------------------------------------------------------------
 
-http::Record GetExpectedHTTPRecord() {
-  http::Record expected_record;
-  /* expected_record.req.minor_version = 1; */
-  expected_record.req.req_method = "GET";
-  expected_record.req.req_path = "/";
-  /* expected_record.req.body = ""; */
-  expected_record.resp.resp_status = 200;
-  expected_record.resp.resp_message = "OK";
-  /* expected_record.resp.body = kNginxRespBody; */
-  return expected_record;
-}
-
 typedef ::testing::Types<Bssl_ContainerWrapper> BoringSSLServerImplementations;
 
 TYPED_TEST_SUITE(BoringSSLTraceTest, BoringSSLServerImplementations);
@@ -142,7 +121,6 @@ TYPED_TEST(BoringSSLTraceTest, ssl_capture_curl_client) {
   this->StopTransferDataThread();
 
   TraceRecords records = this->GetTraceRecords(this->server_.process_pid());
-  http::Record expected_record = GetExpectedHTTPRecord();
 
   EXPECT_EQ(records.http_records.size(), 1);
   EXPECT_EQ(records.http_records[0].req.req_path, "/");

--- a/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
@@ -69,7 +69,7 @@ class BoringSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracin
   }
 
   void SetUp() override {
-    FLAGS_probe_static_tls_binaries = true;
+    FLAGS_stirling_trace_static_tls_binaries = true;
 
     SocketTraceBPFTestFixture::SetUp();
   }

--- a/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/boringssl_trace_bpf_test.cc
@@ -18,7 +18,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <prometheus/text_serializer.h>
 
 #include <string>
 

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -18,7 +18,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <prometheus/text_serializer.h>
 
 #include <string>
 
@@ -199,11 +198,6 @@ TYPED_TEST(OpenSSLTraceTest, ssl_capture_curl_client) {
 
   EXPECT_THAT(records.http_records, UnorderedElementsAre(EqHTTPRecord(expected_record)));
   EXPECT_THAT(records.remote_address, UnorderedElementsAre(StrEq("127.0.0.1")));
-
-  auto& registry = GetMetricsRegistry();
-  auto metrics = registry.Collect();
-  auto metrics_text = prometheus::TextSerializer().Serialize(metrics);
-  LOG(WARNING) << absl::Substitute("with metric text: $0", metrics_text);
 }
 
 TYPED_TEST(OpenSSLTraceTest, ssl_capture_ruby_client) {

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -18,6 +18,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <prometheus/text_serializer.h>
 
 #include <string>
 
@@ -198,6 +199,11 @@ TYPED_TEST(OpenSSLTraceTest, ssl_capture_curl_client) {
 
   EXPECT_THAT(records.http_records, UnorderedElementsAre(EqHTTPRecord(expected_record)));
   EXPECT_THAT(records.remote_address, UnorderedElementsAre(StrEq("127.0.0.1")));
+
+  auto& registry = GetMetricsRegistry();
+  auto metrics = registry.Collect();
+  auto metrics_text = prometheus::TextSerializer().Serialize(metrics);
+  LOG(WARNING) << absl::Substitute("with metric text: $0", metrics_text);
 }
 
 TYPED_TEST(OpenSSLTraceTest, ssl_capture_ruby_client) {

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -152,6 +152,10 @@ DEFINE_uint32(datastream_buffer_retention_size,
 DEFINE_uint64(max_body_bytes, gflags::Uint64FromEnv("PL_STIRLING_MAX_BODY_BYTES", 512),
               "The maximum number of bytes in the body of protocols like HTTP");
 
+DEFINE_bool(
+    probe_static_tls_binaries, gflags::BoolFromEnv("PL_PROBE_STATIC_TLS_BINARIES", false),
+    "If true, stirling will tls trace binaries statically linked with OpenSSL or BoringSSL");
+
 OBJ_STRVIEW(socket_trace_bcc_script, socket_trace);
 
 namespace px {

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -153,7 +153,7 @@ DEFINE_uint64(max_body_bytes, gflags::Uint64FromEnv("PL_STIRLING_MAX_BODY_BYTES"
               "The maximum number of bytes in the body of protocols like HTTP");
 
 DEFINE_bool(
-    stirling_trace_static_tls_binaries, gflags::BoolFromEnv("PL_TRACE_STATIC_TLS_BINARIES", false),
+    stirling_trace_static_tls_binaries, gflags::BoolFromEnv("PX_TRACE_STATIC_TLS_BINARIES", false),
     "If true, stirling will tls trace binaries statically linked with OpenSSL or BoringSSL");
 
 OBJ_STRVIEW(socket_trace_bcc_script, socket_trace);

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -153,7 +153,7 @@ DEFINE_uint64(max_body_bytes, gflags::Uint64FromEnv("PL_STIRLING_MAX_BODY_BYTES"
               "The maximum number of bytes in the body of protocols like HTTP");
 
 DEFINE_bool(
-    probe_static_tls_binaries, gflags::BoolFromEnv("PL_PROBE_STATIC_TLS_BINARIES", false),
+    stirling_trace_static_tls_binaries, gflags::BoolFromEnv("PL_TRACE_STATIC_TLS_BINARIES", false),
     "If true, stirling will tls trace binaries statically linked with OpenSSL or BoringSSL");
 
 OBJ_STRVIEW(socket_trace_bcc_script, socket_trace);

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
@@ -29,6 +29,16 @@ pl_all_supported_go_sdk_versions = pl_supported_go_sdk_versions + pl_boringcrypt
 package(default_visibility = ["//src/stirling:__subpackages__"])
 
 pl_cc_test_library(
+    name = "bssl_container",
+    srcs = [],
+    hdrs = ["bssl_container.h"],
+    data = [
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/bssl:bssl_image.tar",
+    ],
+    deps = ["//src/common/testing/test_utils:cc_library"],
+)
+
+pl_cc_test_library(
     name = "cassandra_container",
     srcs = [],
     hdrs = ["cassandra_container.h"],

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images/bssl_container.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images/bssl_container.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string>
+
+#include "src/common/testing/test_environment.h"
+#include "src/common/testing/test_utils/container_runner.h"
+
+namespace px {
+namespace stirling {
+namespace testing {
+
+class BsslContainer : public ContainerRunner {
+ public:
+  BsslContainer()
+      : ContainerRunner(::px::testing::BazelRunfilePath(kBazelImageTar), kContainerNamePrefix,
+                        kReadyMessage) {}
+
+ private:
+  static constexpr std::string_view kBazelImageTar =
+      "src/stirling/source_connectors/socket_tracer/testing/containers/bssl/bssl_image.tar";
+  static constexpr std::string_view kContainerNamePrefix = "boringssl-bssl";
+  static constexpr std::string_view kReadyMessage = "";
+};
+
+}  // namespace testing
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/bssl/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/bssl/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
+
+package(default_visibility = ["//src/stirling:__subpackages__"])
+
+cc_image(
+    name = "bssl_image",
+    args = [
+        "s_server",
+        "-www",
+        "-accept",
+        "4433",
+        "-loop",
+    ],
+    base = "//:pl_cc_base_image",
+    binary = "@boringssl//:bssl",
+)

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -66,7 +66,9 @@ UProbeManager::UProbeManager(bpf_tools::BCCWrapper* bcc) : bcc_(bcc) {
   proc_parser_ = std::make_unique<system::ProcParser>();
 }
 
-void UProbeManager::Init(bool enable_http2_tracing, bool disable_self_probing) {
+void UProbeManager::Init(bool disable_go_tls_tracing, bool enable_http2_tracing,
+                         bool disable_self_probing) {
+  cfg_disable_go_tls_tracing_ = disable_go_tls_tracing;
   cfg_enable_http2_tracing_ = enable_http2_tracing;
   cfg_disable_self_probing_ = disable_self_probing;
 
@@ -276,6 +278,15 @@ StatusOr<std::vector<std::filesystem::path>> FindHostPathForPIDLibs(
                                 HostPathForPIDPathSearchType::kSearchTypeEndsWith);
 }
 
+enum class SSLSocketFDAccess {
+  // Specifies that a connection's socket fd will be identified by accessing struct members
+  // of the SSL struct exposed by OpenSSL's API when the SSL_write/SSL_read functions are called.
+  kUserSpaceOffsets,
+  // Specifies that a connection's socket fd will be identified based on the underlying syscall
+  // (read, write, etc) while a user space tls function is on the stack.
+  kNestedSyscall,
+};
+
 // SSLLibMatcher allows customizing the search of shared object files
 // that need to be traced with the SSL_write and SSL_read uprobes.
 // In dynamically linked cases, it's likely that there are two
@@ -285,7 +296,7 @@ struct SSLLibMatcher {
   std::string_view libssl;
   std::string_view libcrypto;
   HostPathForPIDPathSearchType search_type;
-  std::string_view probe_suffix;
+  SSLSocketFDAccess socket_fd_access;
 };
 
 constexpr char kLibSSL_1_1[] = "libssl.so.1.1";
@@ -297,13 +308,13 @@ static constexpr const auto kLibSSLMatchers = MakeArray<SSLLibMatcher>({
         .libssl = kLibSSL_1_1,
         .libcrypto = "libcrypto.so.1.1",
         .search_type = HostPathForPIDPathSearchType::kSearchTypeEndsWith,
-        .probe_suffix = "_syscall_fd_access",
+        .socket_fd_access = SSLSocketFDAccess::kNestedSyscall,
     },
     SSLLibMatcher{
         .libssl = kLibSSL_3,
         .libcrypto = "libcrypto.so.3",
         .search_type = HostPathForPIDPathSearchType::kSearchTypeEndsWith,
-        .probe_suffix = "_syscall_fd_access",
+        .socket_fd_access = SSLSocketFDAccess::kNestedSyscall,
     },
     SSLLibMatcher{
         // This must match independent of python version and INSTSONAME suffix
@@ -311,16 +322,15 @@ static constexpr const auto kLibSSLMatchers = MakeArray<SSLLibMatcher>({
         .libssl = kLibPython,
         .libcrypto = kLibPython,
         .search_type = HostPathForPIDPathSearchType::kSearchTypeContains,
-        .probe_suffix = "_syscall_fd_access",
+        .socket_fd_access = SSLSocketFDAccess::kNestedSyscall,
     },
     // non BIO native TLS applications cannot be probed by accessing the socket fd
-    // within the underlying syscall. Specifying an empty probe_suffix results in TLS
-    // tracing via the legacy mechanism (finding socket fd with user space memory offsets).
+    // within the underlying syscall.
     SSLLibMatcher{
         .libssl = kLibNettyTcnativePrefix,
         .libcrypto = kLibNettyTcnativePrefix,
         .search_type = HostPathForPIDPathSearchType::kSearchTypeContains,
-        .probe_suffix = "",
+        .socket_fd_access = SSLSocketFDAccess::kUserSpaceOffsets,
     },
 });
 
@@ -338,6 +348,19 @@ ssl_source_t SSLSourceFromLib(std::string_view libssl) {
   DCHECK(false) << "Unable to find matching ssl_source_t for library matcher: " << libssl;
 
   return kSSLUnspecified;
+}
+
+std::string ProbeFuncForSocketAccessMethod(std::string_view probe_fn,
+                                           SSLSocketFDAccess socket_fd_access) {
+  std::string probe_suffix = "";
+  switch (socket_fd_access) {
+    case SSLSocketFDAccess::kUserSpaceOffsets:
+      break;
+    case SSLSocketFDAccess::kNestedSyscall:
+      probe_suffix = "_syscall_fd_access";
+  }
+
+  return absl::StrCat(probe_fn, probe_suffix);
 }
 
 // Return error if something unexpected occurs.
@@ -395,7 +418,8 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
     openssl_source_map_->UpdateValue(pid, ssl_source);
     for (auto spec : kOpenSSLUProbes) {
       spec.binary_path = container_libssl.string();
-      spec.probe_fn = absl::StrCat(spec.probe_fn, ssl_library_match.probe_suffix);
+      spec.probe_fn =
+          ProbeFuncForSocketAccessMethod(spec.probe_fn, ssl_library_match.socket_fd_access);
 
       PX_RETURN_IF_ERROR(LogAndAttachUProbe(spec));
     }
@@ -488,7 +512,6 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid) {
   PX_ASSIGN_OR_RETURN(auto uprobe_tmpls, GetNodeOpensslUProbeTmpls(ver));
   PX_ASSIGN_OR_RETURN(auto elf_reader, ElfReader::Create(host_proc_exe));
   PX_ASSIGN_OR_RETURN(int count, AttachUProbeTmpl(uprobe_tmpls, host_proc_exe, elf_reader.get()));
-  openssl_source_map_->UpdateValue(pid, kNodeJSSource);
 
   return kOpenSSLUProbes.size() + count;
 }
@@ -859,7 +882,7 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
     }
 
     // GoTLS Probes.
-    {
+    if (!cfg_disable_go_tls_tracing_) {
       StatusOr<int> attach_status =
           AttachGoTLSUProbes(binary, elf_reader.get(), dwarf_reader.get(), pid_vec);
       if (!attach_status.ok()) {
@@ -873,7 +896,7 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
     }
 
     // Go HTTP2 Probes.
-    if (cfg_enable_http2_tracing_) {
+    if (!cfg_disable_go_tls_tracing_ && cfg_enable_http2_tracing_) {
       StatusOr<int> attach_status =
           AttachGoHTTP2UProbes(binary, elf_reader.get(), dwarf_reader.get(), pid_vec);
       if (!attach_status.ok()) {

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -582,7 +582,8 @@ class UProbeManager {
    * data if the binary uses the OpenSSL API in a BIO native way -- where OpenSSL IO primitives
    * are used rather than just its encryption functionality.
    *
-   * @param pid The PID of the process whose binary is examined for OpenSSL symbols statically linked.
+   * @param pid The PID of the process whose binary is examined for OpenSSL symbols statically
+   * linked.
    * @return The number of uprobes deployed. It is not an error if the binary
    *         does not contain the necessary symbols to probe; instead the return value will be zero.
    */

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -45,7 +45,7 @@
 DECLARE_bool(stirling_rescan_for_dlopen);
 DECLARE_bool(stirling_enable_grpc_c_tracing);
 DECLARE_double(stirling_rescan_exp_backoff_factor);
-DECLARE_bool(probe_static_tls_binaries);
+DECLARE_bool(stirling_trace_static_tls_binaries);
 
 namespace px {
 namespace stirling {

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -45,6 +45,7 @@
 DECLARE_bool(stirling_rescan_for_dlopen);
 DECLARE_bool(stirling_enable_grpc_c_tracing);
 DECLARE_double(stirling_rescan_exp_backoff_factor);
+DECLARE_bool(probe_static_tls_binaries);
 
 namespace px {
 namespace stirling {
@@ -574,6 +575,18 @@ class UProbeManager {
    * does not use OpenSSL; instead the return value will be zero.
    */
   StatusOr<int> AttachNodeJsOpenSSLUprobes(uint32_t pid);
+
+  /**
+   * Attaches the required probes for TLS tracing to the specified PID if the binary is
+   * statically linked with the necessary OpenSSL compatible symbols. This will only capture
+   * data if the binary uses the OpenSSL API in a BIO native way -- where OpenSSL IO primitives
+   * are used rather than just its encryption functionality.
+   *
+   * @param pid The PID of the process whose binary is examined for OpenSSL symbols statically linked.
+   * @return The number of uprobes deployed. It is not an error if the binary
+   *         does not contain the necessary symbols to probe; instead the return value will be zero.
+   */
+  StatusOr<int> AttachOpenSSLUProbesOnStaticBinary(uint32_t pid);
 
   /**
    * Calls BCCWrapper.AttachUProbe() with a probe template and log any errors to the probe status


### PR DESCRIPTION
Summary: Trace statically linked OpenSSL compatible TLS libraries

This adds a feature toggle for enabling TLS tracing applications statically linked with an OpenSSL compatible library. The plan is to enable this for internal clusters for 1 week before enabling it for all users (and making it the default).

We originally intended to add these probes for BoringSSL applications, however, detecting BoringSSL is more difficult than anticipated. One of the reliable indicators, checking for BoringSSL's [magic tag](https://github.com/google/boringssl/commit/89386ac89bef26888b8d866ebb98b696d82dfde8), is only available if an application is using a BoringSSL from Oct 2021 or later and from checking the following dependencies (different envoy distributions, Clickhouse, the Mono runtime, [cloudflare/boring](https://github.com/cloudflare/boring) applications and Go binaries with `boringcrypto` enabled) that wasn't the case. In addition, checking for the magic tag could cause performance issues.

Since our latest TLS tracing implementation provides a broad set of coverage, we opted to trace any application that contains one of the OpenSSL compatible symbols necessary for tracing (`SSL_write`). For BIO native applications, we will successfully trace the traffic. For non BIO native cases (envoy), the uprobes will trigger but won't capture any data. This was deemed an acceptable trade off since detecting BoringSSL was challenging and any indicator would likely involve a long tail of upstream adoption.

Relevant Issues: #692

Type of change: /kind feature

Test Plan: Verified this change through the following:
- [x] `boringssl_trace_bpf_test` verifies tracing is successful
- [x] Verified that new tls source (`kStaticallyLinkedSource`) is identified during `boringssl_trace_bpf_test` (when prometheus metrics are logged out)
```
$ ./scripts/sudo_bazel_run.sh src/stirling/source_connectors/socket_tracer:boringssl_trace_bpf_test
data_loss_bytes{protocol="kProtocolHTTP",tls_source="kStaticallyLinkedSource"} 1244
data_loss_bytes{protocol="kProtocolDNS",tls_source="kSSLNone"} 90
data_loss_bytes{protocol="kProtocolUnknown",tls_source="kSSLNone"} 0
# HELP conn_stats_bytes Total bytes of data tracked by conn stats for this protocol.
# TYPE conn_stats_bytes counter
conn_stats_bytes{protocol="kProtocolHTTP",tls_source="kStaticallyLinkedSource"} 1638
conn_stats_bytes{protocol="kProtocolDNS",tls_source="kSSLNone"} 0
conn_stats_bytes{protocol="kProtocolUnknown",tls_source="kSSLNone"} 76521
```

Changelog Message:
```release-note
Add support for tracing encrypted traffic for statically linked OpenSSL/BoringSSL applications. This functionality is currently disabled but will be enabled by default in an upcoming release.
```