### PR TITLE
[script bundle] Use gh pages url for script bundle

### DIFF
--- a/k8s/cloud/base/script_bundles_config.yaml
+++ b/k8s/cloud/base/script_bundles_config.yaml
@@ -6,6 +6,6 @@ metadata:
 data:
   SCRIPT_BUNDLE_URLS: >-
     [
-    "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+    "https://artifacts.px.dev/pxl_scripts/bundle.json"
     ]
   SCRIPT_BUNDLE_DEV: "false"

--- a/k8s/cloud/dev/script_bundles_config.yaml
+++ b/k8s/cloud/dev/script_bundles_config.yaml
@@ -7,6 +7,6 @@ data:
   SCRIPT_BUNDLE_URLS: >-
     [
     "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-core.json",
-    "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+    "https://artifacts.px.dev/pxl_scripts/bundle.json"
     ]
   SCRIPT_BUNDLE_DEV: "false"

--- a/k8s/cloud/prod/script_bundles_config.yaml
+++ b/k8s/cloud/prod/script_bundles_config.yaml
@@ -7,6 +7,6 @@ data:
   SCRIPT_BUNDLE_URLS: >-
     [
     "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-core.json",
-    "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+    "https://artifacts.px.dev/pxl_scripts/bundle.json"
     ]
   SCRIPT_BUNDLE_DEV: "false"

--- a/k8s/cloud/public/base/script_bundles_config.yaml
+++ b/k8s/cloud/public/base/script_bundles_config.yaml
@@ -6,6 +6,6 @@ metadata:
 data:
   SCRIPT_BUNDLE_URLS: >-
     [
-    "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+    "https://artifacts.px.dev/pxl_scripts/bundle.json"
     ]
   SCRIPT_BUNDLE_DEV: "false"

--- a/k8s/cloud/staging/script_bundles_config.yaml
+++ b/k8s/cloud/staging/script_bundles_config.yaml
@@ -7,6 +7,6 @@ data:
   SCRIPT_BUNDLE_URLS: >-
     [
     "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-core.json",
-    "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+    "https://artifacts.px.dev/pxl_scripts/bundle.json"
     ]
   SCRIPT_BUNDLE_DEV: "false"

--- a/k8s/cloud/testing/script_bundles_config.yaml
+++ b/k8s/cloud/testing/script_bundles_config.yaml
@@ -7,6 +7,6 @@ data:
   SCRIPT_BUNDLE_URLS: >-
     [
     "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-core.json",
-    "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+    "https://artifacts.px.dev/pxl_scripts/bundle.json"
     ]
   SCRIPT_BUNDLE_DEV: "false"

--- a/src/cloud/api/api_server.go
+++ b/src/cloud/api/api_server.go
@@ -51,7 +51,7 @@ import (
 )
 
 const defaultBundleFile = "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-core.json"
-const ossBundleFile = "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+const ossBundleFile = "https://artifacts.px.dev/pxl_scripts/bundle.json"
 
 func init() {
 	pflag.String("domain_name", "dev.withpixie.dev", "The domain name of Pixie Cloud")

--- a/src/e2e_test/vizier/exectime/cmd/benchmark.go
+++ b/src/e2e_test/vizier/exectime/cmd/benchmark.go
@@ -49,7 +49,7 @@ var allowedOutputFmts = map[string]bool{
 	"json":  true,
 }
 
-const defaultBundleFile = "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+const defaultBundleFile = "https://artifacts.px.dev/pxl_scripts/bundle.json"
 
 const (
 	execTimeExternalLabel = "Exec Time: External"

--- a/src/pixie_cli/pkg/cmd/script_utils.go
+++ b/src/pixie_cli/pkg/cmd/script_utils.go
@@ -35,7 +35,7 @@ import (
 )
 
 const defaultBundleFile = "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-core.json"
-const ossBundleFile = "https://storage.googleapis.com/pixie-prod-artifacts/script-bundles/bundle-oss.json"
+const ossBundleFile = "https://artifacts.px.dev/pxl_scripts/bundle.json"
 
 func mustCreateBundleReader() *script.BundleManager {
 	br, err := createBundleReader()

--- a/src/pxl_scripts/Makefile
+++ b/src/pxl_scripts/Makefile
@@ -14,8 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-BUNDLE := gs://pixie-prod-artifacts/script-bundles/bundle-oss.json
-
 # Update dir name here if you want to add a new directory.
 dirs := bpftrace px pxbeta sotw
 script_files := $(foreach dir,$(dirs),$(wildcard $(dir)/**/*))
@@ -31,16 +29,6 @@ bundle-oss.json: $(script_files)
 
 bundle-oss.json.gz: bundle-oss.json
 	gzip -c $< > $@
-
-.PHONY: update_bundle
-update_bundle: bundle-oss.json.gz
-# Requires prod access to update, or needs to run in CI deploy.
-	gsutil -h "Cache-Control:no-cache,max-age=0" \
-	       -h "Content-Type:application/json" \
-	       -h "Content-Encoding: gzip" \
-	       cp $< $(BUNDLE)
-# Readable by everyone
-	gsutil acl ch -u allUsers:READER $(BUNDLE)
 
 update_readme:
 	./update_readme.py . https://github.com/pixie-io/pixie/tree/main/src/pxl_scripts


### PR DESCRIPTION
Summary: Switches CLI and cloud to use the github pages URL for the script bundle.

Type of change: /kind cleanup

Test Plan: Tested all the effected components.
- Tested the exectime benchmark with the new bundle.
- Tested that `bazel run //src/pixie_cli:px -- run px/http_data` fetchs the script bundle and runs the script properly.
- Skaffolded testing cloud with the new URL, tested that scripts are still accessible in the UI, also checked that the bundle was pulled from the expected URL. Tried the command palette and it autocompleted scripts as expected.
