### PR TITLE
Update openssl1_1_1 test to use a smaller alpine based container

### DIFF
--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -136,10 +136,11 @@ def stirling_test_images():
     )
 
     # NGINX with OpenSSL 1.1.1, for OpenSSL tracing tests.
+    # nginx:1.23.2-alpine
     _container_image(
         name = "nginx_openssl_1_1_1_base_image",
         repository = "nginx",
-        digest = "sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
+        digest = "sha256:0f2ab24c6aba5d96fcf6e7a736333f26dca1acf5fa8def4c276f6efc7d56251f",
     )
 
     # NGINX with OpenSSL 3.0.8, for OpenSSL tracing tests.

--- a/scripts/regclient/deps.lua
+++ b/scripts/regclient/deps.lua
@@ -23,7 +23,7 @@ local images = {
   "docker.io/datastax/dse-server@sha256:a98e1a877f9c1601aa6dac958d00e57c3f6eaa4b48d4f7cac3218643a4bfb36e",
   "docker.io/ibmjava@sha256:78e2dd462373b3c5631183cc927a54aef1b114c56fe2fb3e31c4b39ba2d919dc",
   "docker.io/mysql/mysql-server@sha256:3d50c733cc42cbef715740ed7b4683a8226e61911e3a80c3ed8a30c2fbd78e9a",
-  "docker.io/nginx@sha256:0b159cd1ee1203dad901967ac55eee18c24da84ba3be384690304be93538bea8",
+  "docker.io/nginx@sha256:0f2ab24c6aba5d96fcf6e7a736333f26dca1acf5fa8def4c276f6efc7d56251f",
   "docker.io/nginx@sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad",
   "docker.io/nginx@sha256:3eb380b81387e9f2a49cb6e5e18db016e33d62c37ea0e9be2339e9f0b3e26170",
   "docker.io/node@sha256:1b50792b5ed9f78fe08f24fbf57334cc810410af3861c5c748de055186bf082c",

--- a/src/stirling/source_connectors/socket_tracer/conn_stats_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_stats_bpf_test.cc
@@ -406,7 +406,7 @@ TEST_F(ConnStatsBPFTest, SSLConnections) {
     //               bytes_sent/bytes_rcvd should be 2730 and 1029 respectively
     //               once we perform our accounting on encrypted data.
     // The TLS handshake has 4 less bytes when using 127.0.0.1 instead of localhost.
-    EXPECT_THAT(bytes_sent, 2493);
+    EXPECT_THAT(bytes_sent, 2486);
     EXPECT_THAT(bytes_rcvd, 698);
     EXPECT_THAT(addr_family, static_cast<int>(SockAddrFamily::kIPv4));
     EXPECT_THAT(protocol, kProtocolHTTP);

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
@@ -79,6 +79,7 @@ container_image(
     base = "@nginx_openssl_1_1_1_base_image//image",
     layers = [
         "//src/stirling/source_connectors/socket_tracer/testing/containers/ssl:nginx_conf",
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/ssl:nginx_html",
         "//src/stirling/source_connectors/socket_tracer/testing/containers/ssl:ssl_keys_layer",
     ],
 )


### PR DESCRIPTION
Summary: This switches our nginx OpenSSL 1.1.1 container to use a
alpine and musl based image.
This adds some coverage by now testing a libssl that is musl based
on a system that is glibc based and doesn't have musl installed (this
setup would fail with the old SSL tracing impl).
This also reduces the size of this particular container image giving
us minor boosts in test speed.

Type of change: /kind cleanup

Test Plan: Ran all tests (bpf and regular), they all pass.
