### PR TITLE
Make test less flaky

### DIFF
--- a/src/ui/src/containers/admin/cluster-details/cluster-details-test.tsx
+++ b/src/ui/src/containers/admin/cluster-details/cluster-details-test.tsx
@@ -118,7 +118,7 @@ describe('<ClusterDetails />', () => {
       ));
     });
     await waitFor(() => {});
-    const el = within(container).getByText('foo:name');
+    const el = await within(container).findByText('foo:name');
     expect(el.tagName).toBe('TD');
   });
 
@@ -130,7 +130,7 @@ describe('<ClusterDetails />', () => {
       ));
     });
     await waitFor(() => {});
-    const opener = within(container).getByText('foo:prettyName');
+    const opener = await within(container).findByText('foo:prettyName');
     expect(opener).toBeDefined();
     await act(async () => {
       fireEvent.click(opener);
@@ -150,7 +150,7 @@ describe('<ClusterDetails />', () => {
       ));
     });
     await waitFor(() => {});
-    const opener = within(container).getByText('foo:prettyName');
+    const opener = await within(container).findByText('foo:prettyName');
     expect(opener).toBeDefined();
     await act(async () => {
       fireEvent.click(opener);


### PR DESCRIPTION
Summary: If this works, it will prevent the test from flaking on certain very fast Linux hosts.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: `yarn coverage --no-cache`. May have to try many times.

