### PR TITLE
Fix UI coverage reporting on codecov

### DIFF
--- a/ci/collect_coverage.sh
+++ b/ci/collect_coverage.sh
@@ -157,6 +157,7 @@ lcov -r ${COVERAGE_FILE} '**/*_test.go' -o ${COVERAGE_FILE}
 lcov -r ${COVERAGE_FILE} '**/*.gen.go' -o ${COVERAGE_FILE}
 lcov -r ${COVERAGE_FILE} '**/*-mock.tsx' -o ${COVERAGE_FILE}
 lcov -r ${COVERAGE_FILE} '**/*-mock.ts' -o ${COVERAGE_FILE}
+lcov -r ${COVERAGE_FILE} 'src/ui/src/types/generated/**' -o ${COVERAGE_FILE}
 
 # Print out the final summary.
 lcov --summary ${COVERAGE_FILE}

--- a/src/ui/jest.config.js
+++ b/src/ui/jest.config.js
@@ -46,6 +46,7 @@ module.exports = {
       ...a,
       [`^.+\\.${ext}$`]: ['esbuild-jest', {
         loader: ext,
+        sourcemap: true,
         target: 'node16',
       }]
     }), {}),


### PR DESCRIPTION
Summary: The file sizes and offsets reported for the UI coverage
in codecov were incorrect, this fixes them.

Type of change: /kind cleanup

Test Plan: Ran the coverage build locally and looked at the generated
lcov output.
