### PR TITLE
Fix misspelling of `PX_TRACE_STATIC_TLS_BINARIES` PEM flag

### DIFF
--- a/src/cloud/config_manager/controllers/vizier_feature_flags.go
+++ b/src/cloud/config_manager/controllers/vizier_feature_flags.go
@@ -44,7 +44,7 @@ var availableFeatureFlags = []*featureFlag{
 	},
 	{
 		FeatureFlagName: "probe-static-tls-binaries",
-		VizierFlagName:  "PL_TRACE_STATIC_TLS_BINARIES",
+		VizierFlagName:  "PX_TRACE_STATIC_TLS_BINARIES",
 		DefaultValue:    false,
 	},
 }


### PR DESCRIPTION
Summary: Fix misspelling of `PX_TRACE_STATIC_TLS_BINARIES` PEM flag

Relevant Issues: #692

Type of change: /kind bug

Test Plan: grep'ed to make sure the flag is consistent with stirling's flag
```
ddelnano@vigenere:~/code/pixie (ddelnano/attempt-to-reproduce-amqproxy-issue) $ git grep PX_TRACE_STATIC_TLS_BINARIES
src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc:    stirling_trace_static_tls_binaries, gflags::BoolFromEnv("PX_TRACE_STATIC_TLS_BINARIES", false),
```