### PR TITLE
Collect and maintain branch coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -226,6 +226,7 @@ coverage --instrument_test_targets
 coverage --define PL_COVERAGE=true
 coverage --copt -DPL_COVERAGE
 coverage --test_tag_filters=-requires_root,-requires_bpf,-no_coverage,-disabled,-no_gcc
+coverage --action_env=COVERAGE_GCOV_OPTIONS=-b
 
 
 try-import %workspace%/bes.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ user.bazelrc
 # A cache directory to be use by Bazel.
 .bazel-cache
 
+# Coverage output file
+coverage.info
+
 # Arc liberate cache
 .phutil_module_cache
 

--- a/ci/collect_coverage.sh
+++ b/ci/collect_coverage.sh
@@ -138,6 +138,8 @@ check_config
 # Print config parameters.
 print_config
 
+lcov_opts=(--rc lcov_branch_coverage=1)
+
 cd $(bazel info workspace)
 
 # Get coverage from bazel targets.
@@ -147,20 +149,20 @@ bazel coverage --remote_download_outputs=all --combined_report=lcov //src/...
 cp --no-preserve=mode "$(bazel info output_path)/_coverage/_coverage_report.dat" ${COVERAGE_FILE}
 
 # Print out the summary.
-lcov --summary ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" --summary ${COVERAGE_FILE}
 
 # Remove test files from the coverage files.
-lcov -r ${COVERAGE_FILE} '**/*_test.cc' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} '**/*_mock.cc' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} '**/*_mock.h' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} '**/*_test.go' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} '**/*.gen.go' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} '**/*-mock.tsx' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} '**/*-mock.ts' -o ${COVERAGE_FILE}
-lcov -r ${COVERAGE_FILE} 'src/ui/src/types/generated/**' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*_test.cc' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*_mock.cc' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*_mock.h' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*_test.go' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*.gen.go' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*-mock.tsx' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} '**/*-mock.ts' -o ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" -r ${COVERAGE_FILE} 'src/ui/src/types/generated/**' -o ${COVERAGE_FILE}
 
 # Print out the final summary.
-lcov --summary ${COVERAGE_FILE}
+lcov "${lcov_opts[@]}" --summary ${COVERAGE_FILE}
 
 # Upload to codecov.io.
 if [ "${UPLOAD_TO_CODECOV}" = true ]; then


### PR DESCRIPTION
Summary: gcov doesn't collect branch coverage by default and lcov
drops branch coverage from the files if it exists.
This change ensures that we maintain and track branch coverage.

Type of change: /kind cleanup

Test Plan: Ran the coverage build and then the coverage cleanup
script. Ensured that it now maintains branch coverage.
