### PR TITLE
Address compiler warning

### DIFF
--- a/src/common/testing/test_utils/container_runner.cc
+++ b/src/common/testing/test_utils/container_runner.cc
@@ -41,7 +41,7 @@ ContainerRunner::ContainerRunner(std::filesystem::path image_tar,
   std::string_view image_line = lines.back();
   constexpr std::string_view kLoadedImagePrefix = "Loaded image";
   std::vector<std::string> splits = absl::StrSplit(image_line, absl::ByString(": "));
-  CHECK_EQ(splits.size(), 2);
+  CHECK_EQ(splits.size(), 2UL);
   CHECK(absl::StartsWith(splits[0], kLoadedImagePrefix));
   image_ = splits[1];
 }


### PR DESCRIPTION
Summary: This fixes a warning from `-Wsign-compare`

Type of change: /kind cleanup

Test Plan: bazel build should no longer warn about this comparison.
