### PR TITLE
Update updater roles necessary for non-operator based viziers

### DIFF
--- a/k8s/vizier/bootstrap/updater_role.yaml
+++ b/k8s/vizier/bootstrap/updater_role.yaml
@@ -17,6 +17,7 @@ rules:
   - pods
   - services
   - persistentvolumes
+  - persistentvolumeclaims
   - serviceaccounts
   verbs:
   - create
@@ -26,6 +27,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - pods/log
+  verbs:
+  - get
+  - watch
+  - list
 - apiGroups:
   - apps
   resources:
@@ -54,6 +64,42 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - cloud-conn-election
+  - metadata-election
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - px.dev
+  resources:
+  - viziers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - px.dev
+  resources:
+  - viziers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
@@ -75,6 +121,67 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: pl-updater-role
+subjects:
+- kind: ServiceAccount
+  name: pl-updater-service-account
+  namespace: pl
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pl-updater-cluster-role
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  resourceNames:
+  - kube-system
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - services
+  - endpoints
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pl-updater-cluster-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pl-updater-cluster-role
 subjects:
 - kind: ServiceAccount
   name: pl-updater-service-account


### PR DESCRIPTION
Summary: The role refactors in ff26221 and then later 87b7751 caused us to drop some ClusterRoles that the updater relied on to upgrade viziers that don't have an operator. I believe the initial breakage was caused by ff26221 since it no longer included the necessary clusterrole, however it referenced an old clusterrole which meant that upgrades worked on clusters that had the old role. 87b7751 then removed the binding to the old seemingly non-existent clusterrole while then broke upgrades further. This attempts to add back the necessary permissions to unbreak such deploys.

Note that even with this change, I believe anyone running a non-operator deploy of vizier that was first deployed after v0.12.6 won't be able to auto-upgrade to any newer versions unless they manually patch the roles and clusterroles for the updater service account.

Type of change: /kind bug

Test Plan: Deployed a vizier on a freshly created cluster. Removed any traces of the CRD, olm, operator. Updated the roles and clusterroles by patching in this change on the cluster. Used the `px` CLI to upgrade said vizier to an RC, ensured that the non-operator Job based upgrade triggered and succeeded.

Changelog Message:
```release-note
This release adds additional ClusterRoles and Roles that the `vizier-upgrade-job` needs to upgrade Viziers deployed without an operator.
```