### PR TITLE
Update instructions for slackin

### DIFF
--- a/k8s/slackin/README.md
+++ b/k8s/slackin/README.md
@@ -1,6 +1,6 @@
-## Slackin
-Slackin is our slack signup helper. More info [here](https://github.com/pixie-io/slackin).
+# Slackin
 
+Slackin is our slack signup helper. More info [here](https://github.com/pixie-io/slackin).
 
 ## Deployment instructions
 
@@ -11,4 +11,46 @@ kubectl create namespace slackin
 sops -d private/credentials/k8s/slackin/slackin_secrets.yaml | kubectl apply -f -
 sops -d private/credentials/k8s/slackin/slackin_config.yaml | kubectl apply -f -
 kustomize build k8s/slackin | kubectl apply -f -
+```
+
+## Cert-manager and Ingress-Nginx
+
+Install cert-manager and Ingress-Nginx Controller.
+See [link](https://cert-manager.io/docs/tutorials/acme/nginx-ingress/) for an example.
+
+```shell
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+```
+
+WARNING: Ensure that cert-manager isn't already installed before installing it.
+
+```shell
+helm repo add jetstack https://charts.jetstack.io
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.crds.yaml
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.12.0
+```
+
+Add a ClusterIssuer for cert-manager, see [here](https://cert-manager.io/docs/tutorials/acme/nginx-ingress/#step-6---configure-a-lets-encrypt-issuer).
+
+Deploy the ingress without the TLS config
+
+```shell
+kubectl apply -f k8s/slackin/ingress_no_tls.yaml
+```
+
+Setup DNS for slackin to point to the nginx-ingress external IP.
+Ensure that the site is reachable via the domain name.
+
+Switch to the ingress with TLS and wait for Cert-Manager to get certs for the ingress.
+
+```shell
+kubectl apply -f k8s/slackin/ingress.yaml
 ```

--- a/k8s/slackin/deployment.yaml
+++ b/k8s/slackin/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: slackin-server
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-prod/slackin/slackin-server:20201222_1@sha256:cd7b02475021e13f44595e3a9ad136a9727eb10e277c9f6b99bf7efdc6debefa
+        image: ghcr.io/pixie-io/slackin:0.1.0@sha256:6811d908c353b4bacb3108d853e60e7b98149a7f6e71c110c2d212e58632271b
         ports:
         - containerPort: 58000
         readinessProbe:

--- a/k8s/slackin/ingress.yaml
+++ b/k8s/slackin/ingress.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: slackin-ingress
+  namespace: slackin
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  rules:
+  - host: slackin.px.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: slackin
+            port:
+              number: 58000
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - slackin.px.dev
+    secretName: slackin-tls

--- a/k8s/slackin/ingress_no_tls.yaml
+++ b/k8s/slackin/ingress_no_tls.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: slackin-ingress
+  namespace: slackin
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  rules:
+  - host: slackin.px.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: slackin
+            port:
+              number: 58000
+  ingressClassName: nginx

--- a/k8s/slackin/service.yaml
+++ b/k8s/slackin/service.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 58000
+  - port: 80
     protocol: TCP
     targetPort: 58000
     name: http


### PR DESCRIPTION
Summary: Updates the slackin instructions to use the new image registry.
Also adds details to configure a cert-manager and ingress.

Type of change: /kind cleanup

Test Plan: Deployed it on the equinix cluster
