### PR TITLE
Fixup github release actions

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -177,11 +177,11 @@ jobs:
         # actions/checkout doesn't get the tag annotation properly.
         git fetch origin tag "${TAG_NAME}" -f
         export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        prerelease=""
+        prerelease=()
         if [[ "${REF}" == *"-"* ]]; then
-          prerelease="--prerelease"
+          prerelease=("--prerelease")
         fi
-        gh release create "${TAG_NAME}" "${prerelease}" \
+        gh release create "${TAG_NAME}" "${prerelease[@]}" \
           --title "CLI ${TAG_NAME#release/cli/}" \
           --notes $'Pixie CLI Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" linux-artifacts/* macos-artifacts/*

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -101,11 +101,11 @@ jobs:
         # actions/checkout doesn't get the tag annotation properly.
         git fetch origin tag "${TAG_NAME}" -f
         export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        prerelease=""
+        prerelease=()
         if [[ "${REF}" == *"-"* ]]; then
-          prerelease="--prerelease"
+          prerelease=("--prerelease")
         fi
-        gh release create "${TAG_NAME}" "${prerelease}" \
+        gh release create "${TAG_NAME}" "${prerelease[@]}" \
           --title "Operator ${TAG_NAME#release/operator/}" \
           --notes $'Pixie Operator Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" operator-artifacts/*

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -108,11 +108,11 @@ jobs:
         # actions/checkout doesn't get the tag annotation properly.
         git fetch origin tag "${TAG_NAME}" -f
         export changelog="$(git tag -l --format='%(contents)' "${TAG_NAME}")"
-        prerelease=""
+        prerelease=()
         if [[ "${REF}" == *"-"* ]]; then
-          prerelease="--prerelease"
+          prerelease=("--prerelease")
         fi
-        gh release create "${TAG_NAME}" "${prerelease}" \
+        gh release create "${TAG_NAME}" "${prerelease[@]}" \
           --title "Vizier ${TAG_NAME#release/vizier/}" \
           --notes $'Pixie Vizier Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" vizier-artifacts/*


### PR DESCRIPTION
Summary: This should fix non-prerelease builds.

Type of change: /kind bug

Test Plan: Ran the command locally.
