### PR TITLE
Consistent widths and header styles for admin tabs

### DIFF
--- a/src/ui/src/containers/admin/api-keys.tsx
+++ b/src/ui/src/containers/admin/api-keys.tsx
@@ -122,7 +122,8 @@ export const APIKeyRow = React.memo<{ apiKey: APIKeyDisplay }>(({ apiKey }) => {
       <StyledTableCell>{apiKey.createdAt}</StyledTableCell>
       <StyledTableCell>{apiKey.desc}</StyledTableCell>
       <MonoSpaceCell data={'••••••••••••'} />
-      <StyledTableCell>
+      {/* eslint-disable-next-line react-memo/require-usememo */}
+      <StyledTableCell sx={{ textAlign: 'right' }}>
         <KeyActionButtons
           copyOnClick={copyAction}
           deleteOnClick={deleteAction} />
@@ -156,9 +157,9 @@ export const APIKeysTable = React.memo(() => {
   const apiKeys = (data?.apiKeys ?? []).map((key) => formatAPIKey(key));
   return (
     <>
-      <Table>
+      <Table className={classes.table}>
         <TableHead>
-          <TableRow>
+          <TableRow className={classes.tableHeadRow}>
             <StyledTableHeaderCell>ID</StyledTableHeaderCell>
             <StyledTableHeaderCell>Created</StyledTableHeaderCell>
             <StyledTableHeaderCell>Description</StyledTableHeaderCell>

--- a/src/ui/src/containers/admin/deployment-keys.tsx
+++ b/src/ui/src/containers/admin/deployment-keys.tsx
@@ -125,7 +125,8 @@ export const DeploymentKeyRow = React.memo<{
       <StyledTableCell>{deploymentKey.createdAt}</StyledTableCell>
       <StyledTableCell>{deploymentKey.desc}</StyledTableCell>
       <MonoSpaceCell data={'••••••••••••'} />
-      <StyledTableCell>
+      {/* eslint-disable-next-line react-memo/require-usememo */}
+      <StyledTableCell sx={{ textAlign: 'right' }}>
         <KeyActionButtons
           copyOnClick={copyAction}
           deleteOnClick={deleteAction} />
@@ -158,9 +159,9 @@ export const DeploymentKeysTable = React.memo(() => {
   const deploymentKeys = (data?.deploymentKeys ?? []).map((key) => formatDeploymentKey(key));
   return (
     <>
-      <Table>
+      <Table className={classes.table}>
         <TableHead>
-          <TableRow>
+          <TableRow className={classes.tableHeadRow}>
             <StyledTableHeaderCell>ID</StyledTableHeaderCell>
             <StyledTableHeaderCell>Created</StyledTableHeaderCell>
             <StyledTableHeaderCell>Description</StyledTableHeaderCell>

--- a/src/ui/src/containers/admin/key-list.tsx
+++ b/src/ui/src/containers/admin/key-list.tsx
@@ -27,6 +27,18 @@ import { Theme } from '@mui/material/styles';
 import { createStyles, makeStyles } from '@mui/styles';
 
 export const useKeyListStyles = makeStyles((theme: Theme) => createStyles({
+  table: {
+    width: '100%',
+    maxWidth: theme.breakpoints.values.lg,
+    margin: '0 auto',
+  },
+  tableHeadRow: {
+    '& > th': {
+      fontWeight: 'normal',
+      textTransform: 'uppercase',
+      color: theme.palette.foreground.grey4,
+    },
+  },
   keyValue: {
     padding: 0,
     fontWeight: theme.typography.fontWeightLight,

--- a/src/ui/src/containers/admin/keys-overview.tsx
+++ b/src/ui/src/containers/admin/keys-overview.tsx
@@ -51,8 +51,13 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     paddingTop: theme.spacing(2),
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
-    backgroundColor: theme.palette.background.default,
     zIndex: 1,
+  },
+  tabsRoot: {
+    backgroundColor: theme.palette.background.default,
+    width: '100%',
+    maxWidth: theme.breakpoints.values.lg,
+    margin: '0 auto',
   },
   tabExtras: {
     position: 'absolute',
@@ -160,23 +165,27 @@ export const KeysOverview = React.memo(() => {
   return (
     <>
       <div className={classes.barContainer}>
-        {/* eslint-disable-next-line react-memo/require-usememo */}
-        <StyledTabs value={tab === 'keys' ? 'api' : tab} onChange={(_, newTab) => navTab(newTab)}>
+        <StyledTabs
+          className={classes.tabsRoot}
+          value={tab === 'keys' ? 'api' : tab}
+          // eslint-disable-next-line react-memo/require-usememo
+          onChange={(_, newTab) => navTab(newTab)}
+        >
           <StyledTab value='api' label='API Keys' />
           <StyledTab value='deployment' label='Deployment Keys' />
+          {onAddClick != null && (
+            <div className={classes.tabExtras}>
+              <Button
+                onClick={onAddClick}
+                variant='outlined'
+                // eslint-disable-next-line react-memo/require-usememo
+                startIcon={<AddIcon />}
+              >
+                New key
+              </Button>
+            </div>
+          )}
         </StyledTabs>
-        {onAddClick != null && (
-          <div className={classes.tabExtras}>
-            <Button
-              onClick={onAddClick}
-              variant='outlined'
-              // eslint-disable-next-line react-memo/require-usememo
-              startIcon={<AddIcon />}
-            >
-              New key
-            </Button>
-          </div>
-        )}
       </div>
       <div className={classes.content}>
         <Switch>

--- a/src/ui/src/containers/admin/org-settings.tsx
+++ b/src/ui/src/containers/admin/org-settings.tsx
@@ -38,6 +38,18 @@ import {
 } from './utils';
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
+  root: {
+    width: '100%',
+    maxWidth: theme.breakpoints.values.lg,
+    margin: '0 auto',
+  },
+  tableHeadRow: {
+    '& > th': {
+      fontWeight: 'normal',
+      textTransform: 'uppercase',
+      color: theme.palette.foreground.grey4,
+    },
+  },
   error: {
     padding: theme.spacing(1),
   },
@@ -89,10 +101,10 @@ export const OrgSettings = React.memo(() => {
   }
 
   return (
-    <>
+    <div className={classes.root}>
       <Table>
         <TableHead>
-          <TableRow>
+          <TableRow className={classes.tableHeadRow}>
             <StyledTableHeaderCell>Setting</StyledTableHeaderCell>
             <StyledTableHeaderCell>Description</StyledTableHeaderCell>
             <StyledTableHeaderCell>Action</StyledTableHeaderCell>
@@ -134,7 +146,7 @@ export const OrgSettings = React.memo(() => {
         </TableBody>
       </Table>
       {!domainName && <InviteLinkReset orgID={org?.id} />}
-    </>
+    </div>
   );
 });
 OrgSettings.displayName = 'OrgSettings';

--- a/src/ui/src/containers/admin/org-users.tsx
+++ b/src/ui/src/containers/admin/org-users.tsx
@@ -52,6 +52,18 @@ interface UserRowProps {
 }
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
+  root: {
+    width: '100%',
+    maxWidth: theme.breakpoints.values.lg,
+    margin: '0 auto',
+  },
+  tableHeadRow: {
+    '& > th': {
+      fontWeight: 'normal',
+      textTransform: 'uppercase',
+      color: theme.palette.foreground.grey4,
+    },
+  },
   buttonContainer: {
     display: 'flex',
     justifyContent: 'flex-end',
@@ -281,7 +293,7 @@ export const UsersTable = React.memo(() => {
   }
 
   return (
-    <>
+    <div className={classes.root}>
       <div className={classes.inviteButtonWrapper}>
         <InviteUserButton startOpen={showInviteDialog} onClose={onCloseInviteDialog} />
       </div>
@@ -309,7 +321,7 @@ export const UsersTable = React.memo(() => {
       )}
       <Table>
         <TableHead>
-          <TableRow>
+          <TableRow className={classes.tableHeadRow}>
             <StyledTableHeaderCell>Name</StyledTableHeaderCell>
             <StyledTableHeaderCell>Email</StyledTableHeaderCell>
             <StyledTableHeaderCell />
@@ -321,7 +333,7 @@ export const UsersTable = React.memo(() => {
           ))}
         </TableBody>
       </Table>
-    </>
+    </div>
   );
 });
 UsersTable.displayName = 'UsersTable';

--- a/src/ui/src/containers/admin/user-settings.tsx
+++ b/src/ui/src/containers/admin/user-settings.tsx
@@ -37,6 +37,18 @@ import {
 } from './utils';
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
+  root: {
+    width: '100%',
+    maxWidth: theme.breakpoints.values.lg,
+    margin: '0 auto',
+  },
+  tableHeadRow: {
+    '& > th': {
+      fontWeight: 'normal',
+      textTransform: 'uppercase',
+      color: theme.palette.foreground.grey4,
+    },
+  },
   error: {
     padding: theme.spacing(1),
   },
@@ -83,10 +95,10 @@ export const UserSettings = React.memo(() => {
   }
 
   return (
-    <>
+    <div className={classes.root}>
       <Table>
         <TableHead>
-          <TableRow>
+          <TableRow className={classes.tableHeadRow}>
             <StyledTableHeaderCell>Setting</StyledTableHeaderCell>
             <StyledTableHeaderCell>Description</StyledTableHeaderCell>
             <StyledTableHeaderCell>Action</StyledTableHeaderCell>
@@ -131,7 +143,7 @@ export const UserSettings = React.memo(() => {
           </TableRow>
         </TableBody>
       </Table>
-    </>
+    </div>
   );
 });
 UserSettings.displayName = 'UserSettings';


### PR DESCRIPTION
Summary: TSIA. The Cluster List tab already had these styles, just making the rest match.

Relevant Issues: #1174

Type of change: /kind cleanup

Test Plan: Visit the various `/admin` tabs. Now, they should all center their contents with the same max width as each other.

