### PR TITLE
Add `LEndianBytesToUint` byte utility function

### DIFF
--- a/src/common/base/byte_utils_test.cc
+++ b/src/common/base/byte_utils_test.cc
@@ -111,6 +111,26 @@ TEST(UtilsTest, TestLEndianBytesToInt) {
       -0xdcba98765432110);
 }
 
+TEST(UtilsTest, TestLEndianBytesToUint) {
+  // uint32_t cases.
+  EXPECT_EQ(LEndianBytesToUint<uint32_t>(ConstString("\x78\x56\x34\x12")), 0x12345678);
+  EXPECT_EQ((LEndianBytesToUint<uint32_t, 3>(ConstString("\xc6\x00\x00"))), 0x0000c6);
+  EXPECT_EQ(LEndianBytesToUint<uint32_t>(ConstString("\x33\x77\xbb\xff")), 0xffbb7733);
+
+  // uint32_t cases when promoted
+  EXPECT_EQ(LEndianBytesToUint<uint64_t>(ConstString("\x78\x56\x34\x12")), 0x12345678);
+  EXPECT_EQ((LEndianBytesToUint<uint64_t, 3>(ConstString("\xc6\x00\x00"))), 0x0000c6);
+  EXPECT_EQ(LEndianBytesToUint<uint64_t>(ConstString("\x33\x77\xbb\xff")), 0xffbb7733);
+
+  // 64-bit cases.
+  EXPECT_EQ(LEndianBytesToUint<uint64_t>(
+                std::string(ConstStringView("\xf0\xde\xbc\x9a\x78\x56\x34\x12"))),
+            0x123456789abcdef0);
+  EXPECT_EQ(LEndianBytesToUint<uint64_t>(
+                std::string(ConstStringView("\xf0\xde\xbc\x9a\x78\x56\x34\xf2"))),
+            0xf23456789abcdef0);
+}
+
 TEST(UtilsTest, TestLEndianBytesToFloat) {
   std::string float_bytes = ConstString("\x33\x33\x23\x41");
   std::string double_bytes = ConstString("\x66\x66\x66\x66\x66\x66\x24\x40");


### PR DESCRIPTION
Summary: Add `LEndianBytesToUint` byte utility function

In order to parse Go's buildinfo header, we need to parse pointers of [different sizes](https://github.com/golang/go/blob/1dbbafc70fd3e2c284469ab3e0936c1bb56129f6/src/debug/buildinfo/buildinfo.go#L199-L203) (4 and 8 bytes) depending on if a binary is 32 or 64 bit. This PR adds a `LEndianBytesToUint` function that allows parsing these pointers transparently, promoting a 32 bit ptr address (`uint32_t`) into a corresponding 64 bit type (`uint64_t`). This will simplify the conditional logic necessary to handle 32 and 64 bit cases across the little endian and big endian permutations.

Relevant Issues: #1300 #1318

Type of change: /kind feature

Test Plan: New tests pass and it successfully parses Golang 32 bit and 64 bit little endian binaries ([commit](https://github.com/pixie-io/pixie/commit/2bf916bd9cbe0cbd4a29326277243c2b5edaa4a6#diff-a5cd29c11ef9bc8c2ae92c1eb15bdace92d54e4e634fe5889a64979bd272e0b8R85-R93)), which leverage this integer promotion