### PR TITLE
Make `LEndianBytesToInt` and `BEndianBytesToInt` compatible with `u8string_view`

### DIFF
--- a/src/common/base/byte_utils.h
+++ b/src/common/base/byte_utils.h
@@ -62,8 +62,8 @@ T ReverseBytes(const T* x) {
  * @param buf The sequence of bytes.
  * @return The decoded int value.
  */
-template <typename T, size_t N = sizeof(T)>
-T LEndianBytesToInt(std::string_view buf) {
+template <typename T, typename TCharType = char, size_t N = sizeof(T)>
+T LEndianBytesToIntInternal(std::basic_string_view<TCharType> buf) {
   // Doesn't make sense to process more bytes than the destination type.
   // Less bytes is okay, on the other hand, since the value will still fit.
   static_assert(N <= sizeof(T));
@@ -76,6 +76,16 @@ T LEndianBytesToInt(std::string_view buf) {
     result = static_cast<uint8_t>(buf[N - 1 - i]) | (result << 8);
   }
   return result;
+}
+
+template <typename T, size_t N = sizeof(T)>
+T LEndianBytesToInt(std::string_view buf) {
+  return LEndianBytesToIntInternal<T, char, N>(buf);
+}
+
+template <typename T, size_t N = sizeof(T), typename TCharType = char>
+T LEndianBytesToInt(std::basic_string_view<TCharType> buf) {
+  return LEndianBytesToIntInternal<T, TCharType, N>(buf);
 }
 
 /**
@@ -134,8 +144,8 @@ void IntToBEndianBytes(int64_t num, TCharType (&result)[N]) {
  * @param buf The sequence of bytes.
  * @return The decoded int value.
  */
-template <typename T, size_t N = sizeof(T)>
-T BEndianBytesToInt(std::string_view buf) {
+template <typename T, typename TCharType, size_t N = sizeof(T)>
+T BEndianBytesToIntInternal(std::basic_string_view<TCharType> buf) {
   // Doesn't make sense to process more bytes than the destination type.
   // Less bytes is okay, on the other hand, since the value will still fit.
   static_assert(N <= sizeof(T));
@@ -148,6 +158,16 @@ T BEndianBytesToInt(std::string_view buf) {
     result = static_cast<uint8_t>(buf[i]) | (result << 8);
   }
   return result;
+}
+
+template <typename T, size_t N = sizeof(T)>
+T BEndianBytesToInt(std::string_view buf) {
+  return BEndianBytesToIntInternal<T, char, N>(buf);
+}
+
+template <typename T, size_t N = sizeof(T), typename TCharType = char>
+T BEndianBytesToInt(std::basic_string_view<TCharType> buf) {
+  return BEndianBytesToIntInternal<T, TCharType, N>(buf);
 }
 
 /**

--- a/src/common/base/byte_utils_test.cc
+++ b/src/common/base/byte_utils_test.cc
@@ -23,6 +23,7 @@
 
 #include "src/common/base/byte_utils.h"
 #include "src/common/base/types.h"
+#include "src/common/base/utils.h"
 
 namespace px {
 namespace utils {
@@ -109,6 +110,11 @@ TEST(UtilsTest, TestLEndianBytesToInt) {
   EXPECT_EQ(
       LEndianBytesToInt<int64_t>(std::string(ConstStringView("\xf0\xde\xbc\x9a\x78\x56\x34\xf2"))),
       -0xdcba98765432110);
+
+  // Verify other std::basic_string_view types are supported
+  EXPECT_EQ(LEndianBytesToInt<int64_t>(
+                CreateStringView<u8string_view::value_type>("\xf0\xde\xbc\x9a\x78\x56\x34\x12")),
+            0x123456789abcdef0);
 }
 
 TEST(UtilsTest, TestLEndianBytesToFloat) {
@@ -238,6 +244,11 @@ TEST(UtilsTest, TestBEndianBytesToInt) {
   EXPECT_EQ(
       BEndianBytesToInt<int64_t>(std::string(ConstStringView("\xf2\x34\x56\x78\x9a\xbc\xde\xf0"))),
       -0xdcba98765432110);
+
+  // Verify other std::basic_string_view types are supported
+  EXPECT_EQ(BEndianBytesToInt<int64_t>(
+                CreateStringView<u8string_view::value_type>("\x12\x34\x56\x78\x9a\xbc\xde\xf0")),
+            0x123456789abcdef0);
 }
 
 TEST(UtilsTest, TestBEndianBytesToFloat) {


### PR DESCRIPTION
Summary: Make `LEndianBytesToInt` and `BEndianBytesToInt` compatible with `u8string_view`

In order to parse Go's buildinfo header, we need to convert bytes contained within a [u8string_view](https://github.com/pixie-io/pixie/blob/c092058a5172396ea9bead1e209c2ed4e2336943/src/common/base/byte_utils.h#L30-L31) (return values from [ElfReader](https://github.com/pixie-io/pixie/blob/c092058a5172396ea9bead1e209c2ed4e2336943/src/stirling/obj_tools/elf_reader.cc#L608)). This PR adds template specializations to the existing `LEndianBytesToInt` and `BEndianBytesToInt` functions so they are compatible with the `u8string_view` data type. This will allow the code that will eventually parse a Go buildinfo header to be cleaner by preventing an explicit conversion via `CreateStringView` as seen in [this commit](https://github.com/pixie-io/pixie/commit/ae5dd209520f4d25520b1ed41687a7f9daf85b1e#diff-a5cd29c11ef9bc8c2ae92c1eb15bdace92d54e4e634fe5889a64979bd272e0b8R109-R110).

Relevant Issues: #1300 #1318

Type of change: /kind feature

Test Plan: Verified that the new test cases fail to compile without this change and that this interface is more compatible for code linked above.