### PR TITLE
Update image paths to not use nested image locations

### DIFF
--- a/k8s/cloud/BUILD.bazel
+++ b/k8s/cloud/BUILD.bazel
@@ -22,21 +22,21 @@ load("//bazel:kustomize.bzl", "kustomize_build")
 package(default_visibility = ["//visibility:public"])
 
 CLOUD_IMAGE_TO_LABEL = {
-    "$(IMAGE_PREFIX)/cloud/api_server_image:$(BUNDLE_VERSION)": "//src/cloud/api:api_server_image",
-    "$(IMAGE_PREFIX)/cloud/artifact_tracker_server_image:$(BUNDLE_VERSION)": "//src/cloud/artifact_tracker:artifact_tracker_server_image",
-    "$(IMAGE_PREFIX)/cloud/auth_server_image:$(BUNDLE_VERSION)": "//src/cloud/auth:auth_server_image",
-    "$(IMAGE_PREFIX)/cloud/config_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/config_manager:config_manager_server_image",
-    "$(IMAGE_PREFIX)/cloud/cron_script_server_image:$(BUNDLE_VERSION)": "//src/cloud/cron_script:cron_script_server_image",
-    "$(IMAGE_PREFIX)/cloud/indexer_server_image:$(BUNDLE_VERSION)": "//src/cloud/indexer:indexer_server_image",
-    "$(IMAGE_PREFIX)/cloud/metrics_server_image:$(BUNDLE_VERSION)": "//src/cloud/metrics:metrics_server_image",
-    "$(IMAGE_PREFIX)/cloud/plugin/load_db:$(BUNDLE_VERSION)": "//src/cloud/plugin/load_db:plugin_db_updater_image",
-    "$(IMAGE_PREFIX)/cloud/plugin_server_image:$(BUNDLE_VERSION)": "//src/cloud/plugin:plugin_server_image",
-    "$(IMAGE_PREFIX)/cloud/profile_server_image:$(BUNDLE_VERSION)": "//src/cloud/profile:profile_server_image",
-    "$(IMAGE_PREFIX)/cloud/project_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/project_manager:project_manager_server_image",
-    "$(IMAGE_PREFIX)/cloud/proxy_server_image:$(BUNDLE_VERSION)": "//src/cloud/proxy:proxy_server_image",
-    "$(IMAGE_PREFIX)/cloud/scriptmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/scriptmgr:scriptmgr_server_image",
-    "$(IMAGE_PREFIX)/cloud/vzconn_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzconn:vzconn_server_image",
-    "$(IMAGE_PREFIX)/cloud/vzmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzmgr:vzmgr_server_image",
+    "$(IMAGE_PREFIX)/cloud-api_server_image:$(BUNDLE_VERSION)": "//src/cloud/api:api_server_image",
+    "$(IMAGE_PREFIX)/cloud-artifact_tracker_server_image:$(BUNDLE_VERSION)": "//src/cloud/artifact_tracker:artifact_tracker_server_image",
+    "$(IMAGE_PREFIX)/cloud-auth_server_image:$(BUNDLE_VERSION)": "//src/cloud/auth:auth_server_image",
+    "$(IMAGE_PREFIX)/cloud-config_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/config_manager:config_manager_server_image",
+    "$(IMAGE_PREFIX)/cloud-cron_script_server_image:$(BUNDLE_VERSION)": "//src/cloud/cron_script:cron_script_server_image",
+    "$(IMAGE_PREFIX)/cloud-indexer_server_image:$(BUNDLE_VERSION)": "//src/cloud/indexer:indexer_server_image",
+    "$(IMAGE_PREFIX)/cloud-metrics_server_image:$(BUNDLE_VERSION)": "//src/cloud/metrics:metrics_server_image",
+    "$(IMAGE_PREFIX)/cloud-plugin-load_db:$(BUNDLE_VERSION)": "//src/cloud/plugin/load_db:plugin_db_updater_image",
+    "$(IMAGE_PREFIX)/cloud-plugin_server_image:$(BUNDLE_VERSION)": "//src/cloud/plugin:plugin_server_image",
+    "$(IMAGE_PREFIX)/cloud-profile_server_image:$(BUNDLE_VERSION)": "//src/cloud/profile:profile_server_image",
+    "$(IMAGE_PREFIX)/cloud-project_manager_server_image:$(BUNDLE_VERSION)": "//src/cloud/project_manager:project_manager_server_image",
+    "$(IMAGE_PREFIX)/cloud-proxy_server_image:$(BUNDLE_VERSION)": "//src/cloud/proxy:proxy_server_image",
+    "$(IMAGE_PREFIX)/cloud-scriptmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/scriptmgr:scriptmgr_server_image",
+    "$(IMAGE_PREFIX)/cloud-vzconn_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzconn:vzconn_server_image",
+    "$(IMAGE_PREFIX)/cloud-vzmgr_server_image:$(BUNDLE_VERSION)": "//src/cloud/vzmgr:vzmgr_server_image",
 }
 
 kustomize_build(

--- a/k8s/cloud/base/api_deployment.yaml
+++ b/k8s/cloud/base/api_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: api-server
         imagePullPolicy: IfNotPresent
-        image: cloud/api_server_image
+        image: cloud-api_server_image
         ports:
         - containerPort: 51200
           name: http2

--- a/k8s/cloud/base/artifact_tracker_deployment.yaml
+++ b/k8s/cloud/base/artifact_tracker_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: artifact-tracker-server
         imagePullPolicy: IfNotPresent
-        image: cloud/artifact_tracker_server_image
+        image: cloud-artifact_tracker_server_image
         ports:
         - containerPort: 50750
           name: http2

--- a/k8s/cloud/base/auth_deployment.yaml
+++ b/k8s/cloud/base/auth_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: auth-server
         imagePullPolicy: IfNotPresent
-        image: cloud/auth_server_image
+        image: cloud-auth_server_image
         ports:
         - containerPort: 50100
           name: http2

--- a/k8s/cloud/base/config_manager_deployment.yaml
+++ b/k8s/cloud/base/config_manager_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: config-manager-server
         imagePullPolicy: IfNotPresent
-        image: cloud/config_manager_server_image
+        image: cloud-config_manager_server_image
         ports:
         - containerPort: 50500
           name: http2

--- a/k8s/cloud/base/cron_script_deployment.yaml
+++ b/k8s/cloud/base/cron_script_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: cron-script-server
         imagePullPolicy: IfNotPresent
-        image: cloud/cron_script_server_image
+        image: cloud-cron_script_server_image
         ports:
         - containerPort: 50700
           name: http2

--- a/k8s/cloud/base/indexer_deployment.yaml
+++ b/k8s/cloud/base/indexer_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: indexer-server
         imagePullPolicy: IfNotPresent
-        image: cloud/indexer_server_image
+        image: cloud-indexer_server_image
         ports:
         - containerPort: 51800
           name: http2

--- a/k8s/cloud/base/metrics_deployment.yaml
+++ b/k8s/cloud/base/metrics_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: metrics-server
         imagePullPolicy: IfNotPresent
-        image: cloud/metrics_server_image
+        image: cloud-metrics_server_image
         ports:
         - containerPort: 50800
           name: http2

--- a/k8s/cloud/base/plugin_deployment.yaml
+++ b/k8s/cloud/base/plugin_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: plugin-server
         imagePullPolicy: IfNotPresent
-        image: cloud/plugin_server_image
+        image: cloud-plugin_server_image
         ports:
         - containerPort: 50600
           name: http2

--- a/k8s/cloud/base/profile_deployment.yaml
+++ b/k8s/cloud/base/profile_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: profile-server
         imagePullPolicy: IfNotPresent
-        image: cloud/profile_server_image
+        image: cloud-profile_server_image
         ports:
         - containerPort: 51500
           name: http2

--- a/k8s/cloud/base/project_manager_deployment.yaml
+++ b/k8s/cloud/base/project_manager_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: project-manager-server
         imagePullPolicy: IfNotPresent
-        image: cloud/project_manager_server_image
+        image: cloud-project_manager_server_image
         ports:
         - containerPort: 50300
           name: http2

--- a/k8s/cloud/base/proxy_deployment.yaml
+++ b/k8s/cloud/base/proxy_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: cloud-proxy-server
         imagePullPolicy: IfNotPresent
-        image: cloud/proxy_server_image
+        image: cloud-proxy_server_image
         ports:
         - containerPort: 56000
           name: http2

--- a/k8s/cloud/base/scriptmgr_deployment.yaml
+++ b/k8s/cloud/base/scriptmgr_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: scriptmgr-server
         imagePullPolicy: IfNotPresent
-        image: cloud/scriptmgr_server_image
+        image: cloud-scriptmgr_server_image
         ports:
         - containerPort: 52000
           name: http2

--- a/k8s/cloud/base/vzconn_deployment.yaml
+++ b/k8s/cloud/base/vzconn_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: vzconn-server
         imagePullPolicy: IfNotPresent
-        image: cloud/vzconn_server_image
+        image: cloud-vzconn_server_image
         ports:
         - containerPort: 51600
           name: http2

--- a/k8s/cloud/base/vzmgr_deployment.yaml
+++ b/k8s/cloud/base/vzmgr_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: vzmgr-server
         imagePullPolicy: IfNotPresent
-        image: cloud/vzmgr_server_image
+        image: cloud-vzmgr_server_image
         ports:
         - containerPort: 51800
           name: http2

--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -28,7 +28,7 @@ spec:
             name: pl-db-config
       containers:
       - name: updater
-        image: cloud/plugin/load_db:latest
+        image: cloud-plugin-load_db:latest
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: updater
-        image: cloud/plugin/load_db:latest
+        image: cloud-plugin-load_db:latest
         command: ["/busybox/sh", "-c"]
         args:
         - |

--- a/k8s/cloud/public/base/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/base/plugin_db_updater_job.yaml
@@ -28,7 +28,7 @@ spec:
             name: pl-db-config
       containers:
       - name: updater
-        image: cloud/plugin/load_db:latest
+        image: cloud-plugin-load_db:latest
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/public/kustomization.yaml
+++ b/k8s/cloud/public/kustomization.yaml
@@ -4,48 +4,48 @@ kind: Kustomization
 resources:
 - base/
 images:
-- name: cloud/api_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/api_server_image
+- name: cloud-api_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-api_server_image
   newTag: latest
-- name: cloud/artifact_tracker_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/artifact_tracker_server_image
+- name: cloud-artifact_tracker_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-artifact_tracker_server_image
   newTag: latest
-- name: cloud/auth_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/auth_server_image
+- name: cloud-auth_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-auth_server_image
   newTag: latest
-- name: cloud/config_manager_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/config_manager_server_image
+- name: cloud-config_manager_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-config_manager_server_image
   newTag: latest
-- name: cloud/proxy_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/proxy_server_image
+- name: cloud-proxy_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-proxy_server_image
   newTag: latest
-- name: cloud/indexer_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/indexer_server_image
+- name: cloud-indexer_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-indexer_server_image
   newTag: latest
-- name: cloud/metrics_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/metrics_server_image
+- name: cloud-metrics_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-metrics_server_image
   newTag: latest
-- name: cloud/plugin_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/plugin_server_image
+- name: cloud-plugin_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-plugin_server_image
   newTag: latest
-- name: cloud/profile_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/profile_server_image
+- name: cloud-profile_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-profile_server_image
   newTag: latest
-- name: cloud/project_manager_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/project_manager_server_image
+- name: cloud-project_manager_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-project_manager_server_image
   newTag: latest
-- name: cloud/scriptmgr_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/scriptmgr_server_image
+- name: cloud-scriptmgr_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-scriptmgr_server_image
   newTag: latest
-- name: cloud/cron_script_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/cron_script_server_image
+- name: cloud-cron_script_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-cron_script_server_image
   newTag: latest
-- name: cloud/vzconn_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/vzconn_server_image
+- name: cloud-vzconn_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-vzconn_server_image
   newTag: latest
-- name: cloud/vzmgr_server_image
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/vzmgr_server_image
+- name: cloud-vzmgr_server_image
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-vzmgr_server_image
   newTag: latest
-- name: cloud/plugin/load_db
-  newName: gcr.io/pixie-oss/pixie-prod/cloud/plugin/load_db
+- name: cloud-plugin/load_db
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-plugin/load_db
   newTag: latest

--- a/k8s/operator/BUILD.bazel
+++ b/k8s/operator/BUILD.bazel
@@ -23,8 +23,8 @@ load("//bazel:kustomize.bzl", "kustomize_build")
 package(default_visibility = ["//visibility:public"])
 
 OPERATOR_IMAGE_TO_LABEL = {
-    "$(IMAGE_PREFIX)/operator/operator_image:$(BUNDLE_VERSION)": "//src/operator:operator_image",
-    "$(IMAGE_PREFIX)/operator/vizier_deleter:$(BUNDLE_VERSION)": "//src/utils/pixie_deleter:vizier_deleter_image",
+    "$(IMAGE_PREFIX)/operator-operator_image:$(BUNDLE_VERSION)": "//src/operator:operator_image",
+    "$(IMAGE_PREFIX)/operator-vizier_deleter:$(BUNDLE_VERSION)": "//src/utils/pixie_deleter:vizier_deleter_image",
 }
 
 container_bundle(

--- a/k8s/operator/deployment/base/deployment.yaml
+++ b/k8s/operator/deployment/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: pixie-operator-service-account
       containers:
       - name: app
-        image: operator/operator_image:latest
+        image: operator-operator_image:latest
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/operator/helm/templates/deleter.yaml
+++ b/k8s/operator/helm/templates/deleter.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: delete-job
-        image: operator/vizier_deleter:latest
+        image: operator-vizier_deleter:latest
         env:
         - name: PL_NAMESPACE
           valueFrom:

--- a/k8s/vizier/BUILD.bazel
+++ b/k8s/vizier/BUILD.bazel
@@ -23,13 +23,13 @@ load("//bazel:kustomize.bzl", "kustomize_build")
 package(default_visibility = ["//visibility:public"])
 
 VIZIER_IMAGE_TO_LABEL = {
-    "$(IMAGE_PREFIX)/vizier/cert_provisioner_image:$(BUNDLE_VERSION)": "//src/utils/cert_provisioner:cert_provisioner_image",
-    "$(IMAGE_PREFIX)/vizier/cloud_connector_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/cloud_connector:cloud_connector_server_image",
-    "$(IMAGE_PREFIX)/vizier/kelvin_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/kelvin:kelvin_image",
-    "$(IMAGE_PREFIX)/vizier/metadata_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/metadata:metadata_server_image",
-    "$(IMAGE_PREFIX)/vizier/pem_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/pem:pem_image",
-    "$(IMAGE_PREFIX)/vizier/query_broker_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/query_broker:query_broker_server_image",
-    "$(IMAGE_PREFIX)/vizier/vizier_updater_image:$(BUNDLE_VERSION)": "//src/utils/pixie_updater:vizier_updater_image",
+    "$(IMAGE_PREFIX)/vizier-cert_provisioner_image:$(BUNDLE_VERSION)": "//src/utils/cert_provisioner:cert_provisioner_image",
+    "$(IMAGE_PREFIX)/vizier-cloud_connector_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/cloud_connector:cloud_connector_server_image",
+    "$(IMAGE_PREFIX)/vizier-kelvin_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/kelvin:kelvin_image",
+    "$(IMAGE_PREFIX)/vizier-metadata_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/metadata:metadata_server_image",
+    "$(IMAGE_PREFIX)/vizier-pem_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/pem:pem_image",
+    "$(IMAGE_PREFIX)/vizier-query_broker_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/query_broker:query_broker_server_image",
+    "$(IMAGE_PREFIX)/vizier-vizier_updater_image:$(BUNDLE_VERSION)": "//src/utils/pixie_updater:vizier_updater_image",
 }
 
 kustomize_build(

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -59,7 +59,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: vizier/kelvin_image:latest
+        image: vizier-kelvin_image:latest
         envFrom:
         - configMapRef:
             name: pl-tls-config

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -63,7 +63,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: vizier/query_broker_server_image:latest
+        image: vizier-query_broker_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/bootstrap/cert_provisioner_job.yaml
+++ b/k8s/vizier/bootstrap/cert_provisioner_job.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: pl-cert-provisioner-service-account
       containers:
       - name: provisioner
-        image: vizier/cert_provisioner_image:latest
+        image: vizier-cert_provisioner_image:latest
         env:
         - name: PL_NAMESPACE
           valueFrom:

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -63,7 +63,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: vizier/cloud_connector_server_image:latest
+        image: vizier-cloud_connector_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -83,7 +83,7 @@ spec:
           name: certs
       containers:
       - name: app
-        image: vizier/metadata_server_image:latest
+        image: vizier-metadata_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -70,7 +70,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: pem
-        image: vizier/pem_image:latest
+        image: vizier-pem_image:latest
         args: []
         env:
         - name: TCMALLOC_SAMPLE_PARAMETER

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: app
-        image: vizier/metadata_server_image:latest
+        image: vizier-metadata_server_image:latest
         env:
         - name: PL_JWT_SIGNING_KEY
           valueFrom:

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: "50300"
       containers:
       - name: app
-        image: vizier/kelvin_image:latest
+        image: vizier-kelvin_image:latest
         envFrom:
         - configMapRef:
             name: pl-tls-config

--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -3,63 +3,63 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: cloud/api_server_image
+  - image: cloud-api_server_image
     context: .
     bazel:
       target: //src/cloud/api:api_server_image.tar
-  - image: cloud/auth_server_image
+  - image: cloud-auth_server_image
     context: .
     bazel:
       target: //src/cloud/auth:auth_server_image.tar
-  - image: cloud/profile_server_image
+  - image: cloud-profile_server_image
     context: .
     bazel:
       target: //src/cloud/profile:profile_server_image.tar
-  - image: cloud/proxy_server_image
+  - image: cloud-proxy_server_image
     context: .
     bazel:
       target: //src/cloud/proxy:proxy_server_image.tar
-  - image: cloud/plugin_server_image
+  - image: cloud-plugin_server_image
     context: .
     bazel:
       target: //src/cloud/plugin:plugin_server_image.tar
-  - image: cloud/project_manager_server_image
+  - image: cloud-project_manager_server_image
     context: .
     bazel:
       target: //src/cloud/project_manager:project_manager_server_image.tar
-  - image: cloud/config_manager_server_image
+  - image: cloud-config_manager_server_image
     context: .
     bazel:
       target: //src/cloud/config_manager:config_manager_server_image.tar
-  - image: cloud/vzconn_server_image
+  - image: cloud-vzconn_server_image
     context: .
     bazel:
       target: //src/cloud/vzconn:vzconn_server_image.tar
-  - image: cloud/vzmgr_server_image
+  - image: cloud-vzmgr_server_image
     context: .
     bazel:
       target: //src/cloud/vzmgr:vzmgr_server_image.tar
-  - image: cloud/indexer_server_image
+  - image: cloud-indexer_server_image
     context: .
     bazel:
       target: //src/cloud/indexer:indexer_server_image.tar
-  - image: cloud/artifact_tracker_server_image
+  - image: cloud-artifact_tracker_server_image
     context: .
     bazel:
       target: //src/cloud/artifact_tracker:artifact_tracker_server_image.tar
-  - image: cloud/scriptmgr_server_image
+  - image: cloud-scriptmgr_server_image
     context: .
     bazel:
       target: //src/cloud/scriptmgr:scriptmgr_server_image.tar
-  - image: cloud/cron_script_server_image
+  - image: cloud-cron_script_server_image
     context: .
     bazel:
       target: //src/cloud/cron_script:cron_script_server_image.tar
-  - image: cloud/plugin/load_db
+  - image: cloud-plugin-load_db
     context: .
     bazel:
       target: //src/cloud/plugin/load_db:plugin_db_updater_image.tar
-  - image: cloud/metrics_server_image
+  - image: cloud-metrics_server_image
     context: .
     bazel:
       target: //src/cloud/metrics:metrics_server_image.tar

--- a/skaffold/skaffold_operator.yaml
+++ b/skaffold/skaffold_operator.yaml
@@ -3,7 +3,7 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: operator/operator_image
+  - image: operator-operator_image
     context: .
     bazel:
       target: //src/operator:operator_image.tar

--- a/skaffold/skaffold_vizier.yaml
+++ b/skaffold/skaffold_vizier.yaml
@@ -3,37 +3,37 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: vizier/pem_image
+  - image: vizier-pem_image
     context: .
     bazel:
       target: //src/vizier/services/agent/pem:pem_image.tar
       args:
       - --compilation_mode=dbg
-  - image: vizier/kelvin_image
+  - image: vizier-kelvin_image
     context: .
     bazel:
       target: //src/vizier/services/agent/kelvin:kelvin_image.tar
       args:
       - --compilation_mode=dbg
-  - image: vizier/metadata_server_image
+  - image: vizier-metadata_server_image
     context: .
     bazel:
       target: //src/vizier/services/metadata:metadata_server_image.tar
       args:
       - --compilation_mode=dbg
-  - image: vizier/query_broker_server_image
+  - image: vizier-query_broker_server_image
     context: .
     bazel:
       target: //src/vizier/services/query_broker:query_broker_server_image.tar
       args:
       - --compilation_mode=dbg
-  - image: vizier/cloud_connector_server_image
+  - image: vizier-cloud_connector_server_image
     context: .
     bazel:
       target: //src/vizier/services/cloud_connector:cloud_connector_server_image.tar
       args:
       - --compilation_mode=dbg
-  - image: vizier/cert_provisioner_image
+  - image: vizier-cert_provisioner_image
     context: .
     bazel:
       target: //src/utils/cert_provisioner:cert_provisioner_image.tar

--- a/src/vizier/services/cloud_connector/bridge/server.go
+++ b/src/vizier/services/cloud_connector/bridge/server.go
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: pl-updater-service-account
       containers:
       - name: updater
-        image: gcr.io/pixie-oss/pixie-prod/vizier/vizier_updater_image
+        image: gcr.io/pixie-oss/pixie-prod/vizier-vizier_updater_image
         envFrom:
         - configMapRef:
             name: pl-cloud-config


### PR DESCRIPTION
Summary: This changes our images to not need any nesting
i.e. `cloud-api_server_image` instead of `cloud/api_server_image`
since most resitries only support one slash between the namespace
and the image repo. This will allow us to push these images to
our namespaces in non-GCR registries.

Type of change: /kind cleanup

Test Plan: Tested locally with skaffold etc.

Changelog Message:
```release note
This changes the path of our container images. The images are still
hosted on gcr.io but the image registry might change in the future.
```