### PR TITLE
[artifact tracker] Add back artifact bucket config

### DIFF
--- a/k8s/cloud/base/artifact_config.yaml
+++ b/k8s/cloud/base/artifact_config.yaml
@@ -5,4 +5,5 @@ metadata:
   name: pl-artifact-config
 data:
   PL_ARTIFACT_MANIFEST_URL: https://artifacts.px.dev/artifacts/manifest.json
+  PL_ARTIFACT_BUCKET: pixie-dev-public
   PL_SA_KEY_PATH: /creds/service_account.json


### PR DESCRIPTION
Summary: The `PL_ARTIFACT_BUCKET` config was mistakenly removed in a previous change. This causes issues for users deploying self-hosted cloud.

Type of change: /kind cleanup

Test Plan: Followed the self-hosted cloud install guide successfully.
