### PR TITLE
Skip coverage of generated UI code

### DIFF
--- a/src/ui/jest.config.js
+++ b/src/ui/jest.config.js
@@ -71,5 +71,6 @@ module.exports = {
     'src/*.tsx',
     'src/*.js',
     'src/*.jsx',
+    '!src/types/generated/**/*',
   ],
 };


### PR DESCRIPTION
Summary: `src/ui/src/types/generated` is, well, generated code. Coverage reporting should not be counting the 6,000+ lines of code in there.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: `yarn coverage`. The generated types should no longer count against the total.

