### PR TITLE
[cloud ingress] Revert removal of slackin.* domains from managed certs

### DIFF
--- a/k8s/cloud/prod/cloud_ingress_managed_cert.yaml
+++ b/k8s/cloud/prod/cloud_ingress_managed_cert.yaml
@@ -8,4 +8,5 @@ spec:
   - withpixie.ai
   - work.withpixie.ai
   - docs.withpixie.ai
+  - slackin.withpixie.ai
   - segment.withpixie.ai

--- a/k8s/cloud/staging/cloud_ingress_managed_cert.yaml
+++ b/k8s/cloud/staging/cloud_ingress_managed_cert.yaml
@@ -8,4 +8,5 @@ spec:
   - staging.withpixie.dev
   - work.staging.withpixie.dev
   - docs.staging.withpixie.dev
+  - slackin.staging.withpixie.dev
   - segment.staging.withpixie.dev


### PR DESCRIPTION
Summary: Removing slackin from the managed cert domains, causes the cert to be reprovisioned which will cause downtime. For now, we'll just leave the unused slackin domain in the certs to avoid the downtime.

Type of change: /kind cleanup

Test Plan: N/A
