### PR TITLE
[cloud ingress] Remove slackin.* domains from certs in a safe, staged way (stage 2).

### DIFF
--- a/k8s/cloud/prod/cloud_ingress_managed_cert.yaml
+++ b/k8s/cloud/prod/cloud_ingress_managed_cert.yaml
@@ -8,5 +8,4 @@ spec:
   - withpixie.ai
   - work.withpixie.ai
   - docs.withpixie.ai
-  - slackin.withpixie.ai
   - segment.withpixie.ai

--- a/k8s/cloud/staging/cloud_ingress_managed_cert.yaml
+++ b/k8s/cloud/staging/cloud_ingress_managed_cert.yaml
@@ -8,5 +8,4 @@ spec:
   - staging.withpixie.dev
   - work.staging.withpixie.dev
   - docs.staging.withpixie.dev
-  - slackin.staging.withpixie.dev
   - segment.staging.withpixie.dev

--- a/k8s/cloud/testing/cloud_ingress_managed_cert.yaml
+++ b/k8s/cloud/testing/cloud_ingress_managed_cert.yaml
@@ -8,4 +8,3 @@ spec:
   - testing.withpixie.dev
   - work.testing.withpixie.dev
   - docs.testing.withpixie.dev
-  - slackin.testing.withpixie.dev


### PR DESCRIPTION
Summary: Stage 2 of removing slackin, see #1609 for more details. This PR removes `slackin.*` from the main cert. This shouldn't be landed until #1609 is released.

Type of change: /kind cleanup

Test Plan: All 3 stages described in #1609 were tested on the testing cluster successfully.
