### PR TITLE
[operator] Check for CSIDriver matching StorageClass provisioner

### DIFF
--- a/k8s/operator/deployment/base/rbac.yaml
+++ b/k8s/operator/deployment/base/rbac.yaml
@@ -56,11 +56,12 @@ rules:
   - viziers/status
   - podsecuritypolicies
   verbs: ["*"]
-# Allow read-only access to storage class.
+# Allow read-only access to storage class / csi drivers.
 - apiGroups:
   - storage.k8s.io
   - ""
   resources:
   - storageclasses
   - namespaces
+  - csidrivers
   verbs: ["get", "list"]

--- a/src/operator/controllers/BUILD.bazel
+++ b/src/operator/controllers/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@com_github_sirupsen_logrus//:logrus",
         "@io_k8s_api//apps/v1:apps",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//storage/v1:storage",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured",


### PR DESCRIPTION
Summary: Previously the operator checked for a specific `ebs-csi-controller` in the `kube-system` namespace on EKS clusters to determine whether PVCs are supported. This was a bit fragile and led to issues like #1577. Instead, this PR changes the operator to check that the provisioner of the default storage class has a corresponding CSIDriver. This avoids the need to look for a specific deployment, and should allow people to use non-etcd pixie with custom PVC controller setups. For now to avoid to much change, we only do this check for the EKS clusters we used to check for the deployment, but in theory we could do this check for all clusters.

Relevant Issues: Fixes #1577

Type of change: /kind bug

Test Plan: Tested that the new operator deployed to an EKS cluster with the default EKS ebs csi controller in `kube-system` doesn't cause an etcd deploy of pixie. Tested that the new operator deployed to an EKS cluster with `aws-ebs-csi-controller` helm chart deployed to a custom namespace now doesn't use etcd (i.e. tested the bug in #1577). Also tested that a deploy to EKS without an csi controller deployed will still use an etcd version of pixie.

Changelog Message:
```release-notes
Fixes bug in the operator where some EKS clusters were being forced into an etcd version of pixie despite having support for PVCs.
```
