### PR TITLE
OTel export should send non-utf8 data as bytes

### DIFF
--- a/src/carnot/exec/BUILD.bazel
+++ b/src/carnot/exec/BUILD.bazel
@@ -50,6 +50,7 @@ pl_cc_library(
         "@com_github_opentelemetry_proto//:metrics_service_grpc_cc",
         "@com_github_opentelemetry_proto//:trace_service_grpc_cc",
         "@com_github_rlyeh_sole//:sole",
+        "@com_github_simdutf_simdutf//:libsimdutf",
         "@com_google_absl//absl/container:node_hash_map",
     ],
 )

--- a/src/carnot/exec/otel_export_sink_node_test.cc
+++ b/src/carnot/exec/otel_export_sink_node_test.cc
@@ -191,7 +191,7 @@ metrics {
 
   auto tester = exec::ExecNodeTester<OTelExportSinkNode, plan::OTelExportSinkOperator>(
       *plan_node, output_rd, {input_rd}, exec_state_.get());
-  char non_utf_8_bytes[] = {static_cast<char>(0xC0)};
+  std::string non_utf_8_bytes(1, 0xC0);
   auto rb1 = RowBatchBuilder(input_rd, 1, /*eow*/ false, /*eos*/ false)
                  .AddColumn<types::Time64NSValue>({10})
                  .AddColumn<types::Float64Value>({1.0})


### PR DESCRIPTION
Summary: When doing an otel export, Pixie sends all string data as a string value. This does not work for data with non-utf8 characters and results in many errors. Instead we should detect if non-utf8 characters are present and send bytes data instead.

Relevant Issues: #1594

Type of change: /kind bug

Test Plan: Added unit test, skaffolded Vizier

Changelog Message:
```release-note
Fix bug where we were sending data with non-UTF-8 characters as strings during OTel export.
```
