### PR TITLE
fix: add cleanup of expirred metadata for ReplicaSets and Deployments

### DIFF
--- a/src/shared/metadata/metadata_state.cc
+++ b/src/shared/metadata/metadata_state.cc
@@ -532,6 +532,18 @@ Status K8sMetadataState::CleanupExpiredMetadata(int64_t now, int64_t retention_t
           services_by_name_.erase({k8s_object->ns(), k8s_object->name()});
         }
         break;
+      case K8sObjectType::kReplicaSet:
+        if (ReplicaSetIDByName(std::make_pair(k8s_object->ns(), k8s_object->name())) ==
+            k8s_object->uid()) {
+          replica_sets_by_name_.erase({k8s_object->ns(), k8s_object->name()});
+        }
+        break;
+      case K8sObjectType::kDeployment:
+        if (DeploymentIDByName(std::make_pair(k8s_object->ns(), k8s_object->name())) ==
+            k8s_object->uid()) {
+          deployments_by_name_.erase({k8s_object->ns(), k8s_object->name()});
+        }
+        break;
       default:
         LOG(DFATAL) << absl::Substitute("Unexpected object type: $0",
                                         static_cast<int>(k8s_object->type()));


### PR DESCRIPTION
Summary: The existing cleanup of resources does not include these kinds. When kelvin encounters them in a cluster, a fatal error is raised and a traceback printed as kelvin crashes (in debug builds). In non-debug builds, the metadata service will just continue to collect these expired resources; never removing them.

This patch adds cleanup of these resources to prevent crashing (in debug builds) and to reclaim resources and do housekeeping in non-debug builds.

Relevant Issues: #1620

Type of change: /kind bugfix

Test Plan: Tests in the metadata_state_test's CleanupExpiredMetadata were enhanced to include tests for these two kinds