### PR TITLE
`stirling/bpf_tools/bcc_wrapper.h`: Add wrapped BPF maps & arrays.

### DIFF
--- a/src/stirling/benchmarks/bpf_map_ops_benchmark.cc
+++ b/src/stirling/benchmarks/bpf_map_ops_benchmark.cc
@@ -205,7 +205,7 @@ static void BM_userspace_update_get_remove(benchmark::State& state) {
     for (int i = 0; i < kNumKeys; ++i) {
       auto status = bpf_map->GetValue(i);
       if (status.ok() && status.ValueOrDie() != 0) {
-        PX_UNUSED(bpf_map->RemoveValue(i));
+        PX_CHECK_OK(bpf_map->RemoveValue(i));
       }
     }
   }

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -479,10 +479,6 @@ class WrappedBCCStackTable {
   std::unique_ptr<U> underlying_;
 };
 
-// ebpf::BPFStackTable GetStackTable(const std::string& table_name) {
-//   return bpf_.get_stack_table(table_name);
-// }
-
 }  // namespace bpf_tools
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -303,10 +303,6 @@ class WrappedBCCArrayTable {
  public:
   using U = ebpf::BPFArrayTable<T>;
 
-  WrappedBCCArrayTable(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
-    underlying_ = std::make_unique<U>(bcc->BPF().get_array_table<T>(name_));
-  }
-
   static std::unique_ptr<WrappedBCCArrayTable> Create(bpf_tools::BCCWrapper* bcc,
                                                       const std::string& name) {
     return std::unique_ptr<WrappedBCCArrayTable>(new WrappedBCCArrayTable(bcc, name));
@@ -332,6 +328,10 @@ class WrappedBCCArrayTable {
   }
 
  private:
+  WrappedBCCArrayTable(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
+    underlying_ = std::make_unique<U>(bcc->BPF().get_array_table<T>(name_));
+  }
+
   const std::string name_;
   std::unique_ptr<U> underlying_;
 };
@@ -341,13 +341,9 @@ class WrappedBCCMap {
  public:
   using U = ebpf::BPFHashTable<K, V>;
 
-  WrappedBCCMap(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
-    underlying_ = std::make_unique<U>(bcc->BPF().get_hash_table<K, V>(name_));
-  }
-
-  static std::unique_ptr<WrappedBCCMap> Create(bpf_tools::BCCWrapper* bcc,
-                                               const std::string& name) {
-    return std::unique_ptr<WrappedBCCMap>(new WrappedBCCMap(bcc, name));
+  static std::unique_ptr<WrappedBCCMap> Create(bpf_tools::BCCWrapper* bcc, const std::string& name,
+                                               const bool user_space_managed = false) {
+    return std::unique_ptr<WrappedBCCMap>(new WrappedBCCMap(bcc, name, user_space_managed));
   }
 
   size_t capacity() const { return underlying_->capacity(); }
@@ -367,28 +363,39 @@ class WrappedBCCMap {
       return error::Internal(
           absl::Substitute("BCC failed to set value for array table: $0, key: $1.", name_, key));
     }
-    shadow_keys_.insert(key);
+    if (user_space_managed_) {
+      shadow_keys_.insert(key);
+    }
     return Status::OK();
   }
 
   Status RemoveValue(const K& key) {
-    if (shadow_keys_.contains(key)) {
-      const auto s = underlying_->remove_value(key);
-      if (!s.ok()) {
-        return error::Internal(absl::Substitute("BPF failed to remove value for key: $0.", key));
-      }
+    if (user_space_managed_ && !shadow_keys_.contains(key)) {
+      return Status::OK();
+    }
+    const auto s = underlying_->remove_value(key);
+    if (!s.ok()) {
+      return error::Internal(absl::Substitute("BPF failed to remove value for key: $0.", key));
+    }
+    if (user_space_managed_) {
       shadow_keys_.erase(key);
     }
     return Status::OK();
   }
 
-  absl::flat_hash_map<K, V> GetTableOffline(const bool clear_table = false) {
-    absl::flat_hash_map<K, V> r;
+  std::vector<std::pair<K, V>> GetTableOffline(const bool clear_table = false) {
+    if (!user_space_managed_) {
+      return underlying_->get_table_offline(clear_table);
+    }
 
+    // "r" our result.
+    std::vector<std::pair<K, V>> r;
+
+    // This is a user space managed map: we can iterate over the shadow keys.
     for (const auto& k : shadow_keys_) {
       auto s = GetValue(k);
       const auto v = s.ConsumeValueOrDie();
-      r[k] = v;
+      r.push_back({k, v});
       if (clear_table) {
         PX_UNUSED(underlying_->remove_value(k));
       }
@@ -400,7 +407,13 @@ class WrappedBCCMap {
   }
 
  private:
+  WrappedBCCMap(bpf_tools::BCCWrapper* bcc, const std::string& name, const bool user_space_managed)
+      : name_(name), user_space_managed_(user_space_managed) {
+    underlying_ = std::make_unique<U>(bcc->BPF().get_hash_table<K, V>(name_));
+  }
+
   const std::string name_;
+  const bool user_space_managed_;
   std::unique_ptr<U> underlying_;
   absl::flat_hash_set<K> shadow_keys_;
 };
@@ -409,10 +422,6 @@ template <typename T>
 class WrappedBCCPerCPUArrayTable {
  public:
   using U = ebpf::BPFPercpuArrayTable<T>;
-
-  WrappedBCCPerCPUArrayTable(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
-    underlying_ = std::make_unique<U>(bcc->BPF().get_percpu_array_table<T>(name_));
-  }
 
   static std::unique_ptr<WrappedBCCPerCPUArrayTable> Create(bpf_tools::BCCWrapper* bcc,
                                                             const std::string& name) {
@@ -430,6 +439,10 @@ class WrappedBCCPerCPUArrayTable {
   }
 
  private:
+  WrappedBCCPerCPUArrayTable(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
+    underlying_ = std::make_unique<U>(bcc->BPF().get_percpu_array_table<T>(name_));
+  }
+
   const std::string name_;
   std::unique_ptr<U> underlying_;
 };
@@ -437,10 +450,6 @@ class WrappedBCCPerCPUArrayTable {
 class WrappedBCCStackTable {
  public:
   using U = ebpf::BPFStackTable;
-
-  WrappedBCCStackTable(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
-    underlying_ = std::make_unique<U>(bcc->BPF().get_stack_table(name_));
-  }
 
   static std::unique_ptr<WrappedBCCStackTable> Create(bpf_tools::BCCWrapper* bcc,
                                                       const std::string& name) {
@@ -460,6 +469,10 @@ class WrappedBCCStackTable {
   U* RawPtr() { return underlying_.get(); }
 
  private:
+  WrappedBCCStackTable(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
+    underlying_ = std::make_unique<U>(bcc->BPF().get_stack_table(name_));
+  }
+
   const std::string name_;
   std::unique_ptr<U> underlying_;
 };

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -237,34 +237,6 @@ class BCCWrapper {
    */
   void Close();
 
-  // template <typename TKeyType, typename TValueType>
-  // ebpf::BPFHashTable<TKeyType, TValueType> GetHashTable(const std::string& table_name) {
-  //   return bpf_.get_hash_table<TKeyType, TValueType>(table_name);
-  // }
-  //
-  // template <typename TValueType>
-  // ebpf::BPFArrayTable<TValueType> GetArrayTable(const std::string& table_name) {
-  //   return bpf_.get_array_table<TValueType>(table_name);
-  // }
-  //
-  // ebpf::BPFStackTable GetStackTable(const std::string& table_name) {
-  //   return bpf_.get_stack_table(table_name);
-  // }
-  //
-  // template <typename TKeyType>
-  // ebpf::BPFMapInMapTable<TKeyType> GetMapInMapTable(const std::string& table_name) {
-  //   return bpf_.get_map_in_map_table<TKeyType>(table_name);
-  // }
-  //
-  // ebpf::BPFPerfBuffer* GetPerfBuffer(const std::string& perf_buffer_name) {
-  //   return bpf_.get_perf_buffer(perf_buffer_name);
-  // }
-  //
-  // template <typename TValueType>
-  // ebpf::BPFPercpuArrayTable<TValueType> GetPerCPUArrayTable(const std::string& table_name) {
-  //   return bpf_.get_percpu_array_table<TValueType>(table_name);
-  // }
-
   // These are static counters of attached/open probes across all instances.
   // It is meant for verification that we have cleaned-up all resources in tests.
   static size_t num_attached_probes() { return num_attached_kprobes_ + num_attached_uprobes_; }

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -335,9 +335,8 @@ class WrappedBCCArrayTable {
   std::unique_ptr<U> underlying_;
 };
 
-// WrappedBCCMap includes templates parameter kUserSpaceManaged which enables the "shadow keys"
-// optimization. Files uprobe_manager.h|cc in socket tracer use this feature to speed up maps
-// that are only modified from user space.
+// Template parameter kUserSpaceManaged enables the "shadow keys" optimization.
+// Set to true iff the map is modified/updated from user space only.
 template <typename K, typename V, bool kUserSpaceManaged = false>
 class WrappedBCCMap {
  public:

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -335,6 +335,9 @@ class WrappedBCCArrayTable {
   std::unique_ptr<U> underlying_;
 };
 
+// WrappedBCCMap includes templates parameter kUserSpaceManaged which enables the "shadow keys"
+// optimization. Files uprobe_manager.h|cc in socket tracer use this feature to speed up maps
+// that are only modified from user space.
 template <typename K, typename V, bool kUserSpaceManaged = false>
 class WrappedBCCMap {
  public:

--- a/src/stirling/bpf_tools/uprobe_extra_trigger_bpf_test.cc
+++ b/src/stirling/bpf_tools/uprobe_extra_trigger_bpf_test.cc
@@ -83,8 +83,8 @@ TEST(BCCWrapper, DISABLED_UnexpectedExtraTrigger) {
   client1.Wait();
 
   // We expect the probe to be triggered once, and it is.
-  int trigger_count1;
-  bcc_wrapper.GetArrayTable<int>("count").get_value(0, trigger_count1);
+  auto counts = WrappedBCCArrayTable<int>::Create(&bcc_wrapper, "count");
+  ASSERT_OK_AND_ASSIGN(const int trigger_count1, counts->GetValue(0));
   ASSERT_EQ(trigger_count1, 1);
 
   // Now spawn a second server in a separate container, and attach a uprobe to it.
@@ -99,8 +99,7 @@ TEST(BCCWrapper, DISABLED_UnexpectedExtraTrigger) {
   client2.Wait();
 
   // We expect the probe to be triggered one additional time, but it's actually triggered twice.
-  int trigger_count2;
-  bcc_wrapper.GetArrayTable<int>("count").get_value(0, trigger_count2);
+  ASSERT_OK_AND_ASSIGN(const int trigger_count2, counts->GetValue(0));
   ASSERT_EQ(trigger_count2, 3);
 
   // Why does this happen?

--- a/src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h
+++ b/src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h
@@ -55,8 +55,8 @@ struct stack_trace_key_t {
 
 #ifdef __cplusplus
   template <typename H>
-  friend H AbslHashValue(H h, const stack_trace_key_t& s) {
-    return H::combine(std::move(h), s.upid, s.user_stack_id, s.kernel_stack_id);
+  friend H AbslHashValue(H h, const stack_trace_key_t& k) {
+    return H::combine(std::move(h), k.upid, k.user_stack_id, k.kernel_stack_id);
   }
 
   friend bool operator==(const stack_trace_key_t& lhs, const stack_trace_key_t& rhs) {

--- a/src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h
+++ b/src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h
@@ -18,6 +18,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+#include <utility>
+#endif
+
 #include "src/stirling/upid/upid.h"
 
 // TODO(jps): add a macro that wraps bpf_trace_printk for debug & no-ops for prod builds.
@@ -48,6 +52,23 @@ struct stack_trace_key_t {
 
   // kernel_stack_id, an index into the stack-traces map.
   int kernel_stack_id;
+
+#ifdef __cplusplus
+  template <typename H>
+  friend H AbslHashValue(H h, const stack_trace_key_t& s) {
+    return H::combine(std::move(h), s.upid, s.user_stack_id, s.kernel_stack_id);
+  }
+
+  friend bool operator==(const stack_trace_key_t& lhs, const stack_trace_key_t& rhs) {
+    if (lhs.upid != rhs.upid) {
+      return false;
+    }
+    if (lhs.user_stack_id != rhs.user_stack_id) {
+      return false;
+    }
+    return lhs.kernel_stack_id == rhs.kernel_stack_id;
+  }
+#endif
 };
 
 // Bit positions in the error status bitfield:
@@ -58,3 +79,8 @@ static const uint32_t kMapReadFailureBitPos = 1;
 static const uint64_t kPerfProfilerStatusOk = 0ULL;
 static const uint64_t kOverflowError = 1ULL << kOverflowBitPos;
 static const uint64_t kMapReadFailureError = 1ULL << kMapReadFailureBitPos;
+
+#ifdef __cplusplus
+static constexpr std::string_view kHistogramAName = "histogram_a";
+static constexpr std::string_view kHistogramBName = "histogram_b";
+#endif

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
@@ -364,7 +364,8 @@ void PerfProfileConnector::ProcessBPFStackTraces(ConnectorContext* ctx, DataTabl
 }
 
 void PerfProfileConnector::CheckProfilerState(const uint64_t num_stack_traces) {
-  const uint64_t error_code = profiler_state_->GetValue(kErrorStatusIdx).ValueOr(0);
+  const uint64_t error_code =
+      profiler_state_->GetValue(kErrorStatusIdx).ValueOr(kPerfProfilerStatusOk);
 
   DCHECK_EQ(error_code, kPerfProfilerStatusOk);
 
@@ -396,7 +397,7 @@ void PerfProfileConnector::CheckProfilerState(const uint64_t num_stack_traces) {
   // Reset the BPF map to its default value so that each occurrence
   // can be detected.
   if (error_code != kPerfProfilerStatusOk) {
-    PX_UNUSED(profiler_state_->SetValue(kErrorStatusIdx, 0));
+    PX_UNUSED(profiler_state_->SetValue(kErrorStatusIdx, kPerfProfilerStatusOk));
   }
 }
 

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
@@ -42,6 +42,9 @@
 namespace px {
 namespace stirling {
 
+using bpf_tools::WrappedBCCArrayTable;
+using bpf_tools::WrappedBCCStackTable;
+
 namespace profiler {
 static constexpr std::string_view kNotSymbolizedMessage = "<not symbolized>";
 }  // namespace profiler
@@ -94,10 +97,10 @@ class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrappe
   void ProcessBPFStackTraces(ConnectorContext* ctx, DataTable* data_table);
 
   // Read BPF data structures, build & incorporate records to the table.
-  void CreateRecords(ebpf::BPFStackTable* stack_traces, ConnectorContext* ctx,
+  void CreateRecords(WrappedBCCStackTable* stack_traces, ConnectorContext* ctx,
                      DataTable* data_table);
 
-  StackTraceHisto AggregateStackTraces(ConnectorContext* ctx, ebpf::BPFStackTable* stack_traces);
+  StackTraceHisto AggregateStackTraces(ConnectorContext* ctx, WrappedBCCStackTable* stack_traces);
 
   void CleanupSymbolizers(const absl::flat_hash_set<md::UPID>& deleted_upids);
 
@@ -105,10 +108,10 @@ class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrappe
   void CheckProfilerState(const uint64_t num_stack_traces);
 
   // data structures shared with BPF:
-  std::unique_ptr<ebpf::BPFStackTable> stack_traces_a_;
-  std::unique_ptr<ebpf::BPFStackTable> stack_traces_b_;
+  std::unique_ptr<WrappedBCCStackTable> stack_traces_a_;
+  std::unique_ptr<WrappedBCCStackTable> stack_traces_b_;
 
-  std::unique_ptr<ebpf::BPFArrayTable<uint64_t>> profiler_state_;
+  std::unique_ptr<WrappedBCCArrayTable<uint64_t>> profiler_state_;
   prometheus::Gauge& profiler_state_overflow_gauge_;
   prometheus::Counter& profiler_transfer_data_counter_;
   prometheus::Counter& profiler_state_overflow_counter_;
@@ -140,9 +143,9 @@ class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrappe
   // Called by HandleHistoEvent() to add the stack-trace-key to raw_histo_data_.
   void AcceptStackTraceKey(stack_trace_key_t* data);
 
-  ebpf::BPFPerfBuffer* histogram_a_perf_buffer_;
-  ebpf::BPFPerfBuffer* histogram_b_perf_buffer_;
-
+  // -- TODO -- remove -- ebpf::BPFPerfBuffer* histogram_a_perf_buffer_;
+  // -- TODO -- remove -- ebpf::BPFPerfBuffer* histogram_b_perf_buffer_;
+  // -- TODO -- remove --
   const uint32_t stats_log_interval_;
   utils::StatCounter<StatKey> stats_;
 };

--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.h
@@ -143,9 +143,6 @@ class PerfProfileConnector : public SourceConnector, public bpf_tools::BCCWrappe
   // Called by HandleHistoEvent() to add the stack-trace-key to raw_histo_data_.
   void AcceptStackTraceKey(stack_trace_key_t* data);
 
-  // -- TODO -- remove -- ebpf::BPFPerfBuffer* histogram_a_perf_buffer_;
-  // -- TODO -- remove -- ebpf::BPFPerfBuffer* histogram_b_perf_buffer_;
-  // -- TODO -- remove --
   const uint32_t stats_log_interval_;
   utils::StatCounter<StatKey> stats_;
 };

--- a/src/stirling/source_connectors/perf_profiler/stringifier.cc
+++ b/src/stirling/source_connectors/perf_profiler/stringifier.cc
@@ -30,7 +30,7 @@ namespace px {
 namespace stirling {
 
 Stringifier::Stringifier(Symbolizer* u_symbolizer, Symbolizer* k_symbolizer,
-                         ebpf::BPFStackTable* stack_traces)
+                         WrappedBCCStackTable* stack_traces)
     : u_symbolizer_(u_symbolizer), k_symbolizer_(k_symbolizer), stack_traces_(stack_traces) {}
 
 std::string Stringifier::BuildStackTraceString(const std::vector<uintptr_t>& addrs,
@@ -93,7 +93,7 @@ std::string Stringifier::FindOrBuildStackTraceString(const int stack_id,
     constexpr bool kClearStackId = true;
 
     // Get the stack trace (as a vector of addresses) from the shared BPF stack trace table.
-    const std::vector<uintptr_t> addrs = stack_traces_->get_stack_addr(stack_id, kClearStackId);
+    const std::vector<uintptr_t> addrs = stack_traces_->GetStackAddr(stack_id, kClearStackId);
     VLOG_IF(1, addrs.empty()) << absl::Substitute("[empty_stack_trace] stack_id: $0", stack_id);
 
     iter->second = BuildStackTraceString(addrs, symbolize_fn, prefix);

--- a/src/stirling/source_connectors/perf_profiler/stringifier.h
+++ b/src/stirling/source_connectors/perf_profiler/stringifier.h
@@ -21,12 +21,15 @@
 #include <string>
 #include <vector>
 
+#include "src/stirling/bpf_tools/bcc_wrapper.h"
 #include "src/stirling/source_connectors/perf_profiler/bcc_bpf_intf/stack_event.h"
 #include "src/stirling/source_connectors/perf_profiler/symbolizers/symbolizer.h"
 #include "src/stirling/upid/upid.h"
 
 namespace px {
 namespace stirling {
+
+using bpf_tools::WrappedBCCStackTable;
 
 // Stringifier serves two purposes:
 // 1. constructs a "folded stack trace string" based on the stack frame addresses.
@@ -59,7 +62,7 @@ class Stringifier {
    * @param stack_traces Pointer to the BCC collected stack traces.
    */
   Stringifier(Symbolizer* u_symbolizer, Symbolizer* k_symbolizer,
-              ebpf::BPFStackTable* stack_traces);
+              WrappedBCCStackTable* stack_traces);
 
   // Returns a folded stack trace string based on the stack trace histogram key.
   // The key contains both a user & kernel stack-trace-id, which are subsequently
@@ -86,7 +89,7 @@ class Stringifier {
   // a destructive read, i.e. such that the BPF stack trace table does not need
   // to be explicitly cleared (by re-iterating the histogram) after an iteration
   // of the continuous perf. profiler is completed.
-  ebpf::BPFStackTable* const stack_traces_;
+  WrappedBCCStackTable* const stack_traces_;
 };
 
 }  // namespace stirling

--- a/src/stirling/source_connectors/pid_runtime/pid_runtime_connector.h
+++ b/src/stirling/source_connectors/pid_runtime/pid_runtime_connector.h
@@ -35,6 +35,8 @@ namespace stirling {
 
 class PIDRuntimeConnector : public SourceConnector, public bpf_tools::BCCWrapper {
  public:
+  using BPFMapDataT = bpf_tools::WrappedBCCMap<uint16_t, pidruntime_val_t>;
+
   static constexpr std::string_view kName = "bcc_cpu_stat";
   static constexpr auto kSamplingPeriod = std::chrono::milliseconds{100};
   static constexpr auto kPushPeriod = std::chrono::milliseconds{1000};
@@ -76,6 +78,7 @@ class PIDRuntimeConnector : public SourceConnector, public bpf_tools::BCCWrapper
       MakeArray<bpf_tools::SamplingProbeSpec>({"trace_pid_runtime", kSamplingFreqHz});
 
   std::map<uint16_t, uint64_t> prev_run_time_map_;
+  std::unique_ptr<BPFMapDataT> bpf_data_;
 };
 
 }  // namespace stirling

--- a/src/stirling/source_connectors/proc_exit/proc_exit_connector.cc
+++ b/src/stirling/source_connectors/proc_exit/proc_exit_connector.cc
@@ -53,11 +53,6 @@ void HandleProcExitEventLoss(void* /*cb_cookie*/, uint64_t /*lost*/) {
   // TODO(yzhao): Add stats counter.
 }
 
-const auto kPerfBufferSpecs = MakeArray<bpf_tools::PerfBufferSpec>({
-    {"proc_exit_events", HandleProcExitEvent, HandleProcExitEventLoss, kPerfBufferPerCPUSizeBytes,
-     bpf_tools::PerfBufferSizeCategory::kControl},
-});
-
 // Use char array to meet the user's interface, which expects std::string.
 constexpr char kJavaProcCrashedCounter[] = "java_proc_crashed";
 constexpr char kJavaProcCrashedWithProfilerCounter[] = "java_proc_crashed_with_profiler";
@@ -92,15 +87,19 @@ Status ProcExitConnector::InitImpl() {
         "Writing exit_code's offset to BPF array: offset=$0 bpf_array=$1 index=$2",
         offset_opt.value().exit_code_offset, kProcExitControlValuesArrayName,
         TASK_STRUCT_EXIT_CODE_OFFSET_INDEX);
-    auto control_values_table_handle =
-        GetPerCPUArrayTable<uint64_t>(kProcExitControlValuesArrayName);
-    PX_RETURN_IF_ERROR(bpf_tools::UpdatePerCPUArrayValue(TASK_STRUCT_EXIT_CODE_OFFSET_INDEX,
-                                                         offset_opt.value().exit_code_offset,
-                                                         &control_values_table_handle));
+    auto control_table = bpf_tools::WrappedBCCPerCPUArrayTable<uint64_t>::Create(
+        this, kProcExitControlValuesArrayName);
+    PX_RETURN_IF_ERROR(control_table->SetValues(TASK_STRUCT_EXIT_CODE_OFFSET_INDEX,
+                                                offset_opt.value().exit_code_offset));
   }
 
+  const auto perf_buffer_specs = MakeArray<bpf_tools::PerfBufferSpec>({
+      {"proc_exit_events", HandleProcExitEvent, HandleProcExitEventLoss, kPerfBufferPerCPUSizeBytes,
+       bpf_tools::PerfBufferSizeCategory::kControl},
+  });
+
   PX_RETURN_IF_ERROR(AttachTracepoints(kTracepointSpecs));
-  PX_RETURN_IF_ERROR(OpenPerfBuffers(kPerfBufferSpecs, this));
+  PX_RETURN_IF_ERROR(OpenPerfBuffers(perf_buffer_specs, this));
 
   return Status::OK();
 }

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_tables.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_tables.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -28,6 +29,8 @@ DECLARE_uint32(stirling_conn_map_cleanup_threshold);
 
 namespace px {
 namespace stirling {
+
+using px::stirling::bpf_tools::WrappedBCCMap;
 
 // Forward declaration.
 class ConnTrackersManager;
@@ -43,8 +46,8 @@ class ConnInfoMapManager {
   void CleanupBPFMapLeaks(ConnTrackersManager* conn_trackers_mgr);
 
  private:
-  ebpf::BPFHashTable<uint64_t, struct conn_info_t> conn_info_map_;
-  ebpf::BPFHashTable<uint64_t, uint64_t> conn_disabled_map_;
+  std::unique_ptr<WrappedBCCMap<uint64_t, struct conn_info_t>> conn_info_map_;
+  std::unique_ptr<WrappedBCCMap<uint64_t, uint64_t>> conn_disabled_map_;
 
   std::vector<struct conn_id_t> pending_release_queue_;
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -662,7 +662,7 @@ void SocketTraceConnector::CheckTracerState() {
     return;
   }
 
-  const int error_code = openssl_trace_state_->GetValue(kOpenSSLTraceStatusIdx).ConsumeValueOr(0);
+  const int error_code = openssl_trace_state_->GetValue(kOpenSSLTraceStatusIdx).ConsumeValueOr(kOpenSSLTraceOk);
   const bool mismatched_fds = error_code == kOpenSSLMismatchedFDsDetected;
 
   if (FLAGS_stirling_debug_tls_sources || mismatched_fds) {

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -662,7 +662,8 @@ void SocketTraceConnector::CheckTracerState() {
     return;
   }
 
-  const int error_code = openssl_trace_state_->GetValue(kOpenSSLTraceStatusIdx).ConsumeValueOr(kOpenSSLTraceOk);
+  const int error_code =
+      openssl_trace_state_->GetValue(kOpenSSLTraceStatusIdx).ConsumeValueOr(kOpenSSLTraceOk);
   const bool mismatched_fds = error_code == kOpenSSLMismatchedFDsDetected;
 
   if (FLAGS_stirling_debug_tls_sources || mismatched_fds) {

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -80,6 +80,8 @@ DECLARE_uint64(max_body_bytes);
 namespace px {
 namespace stirling {
 
+using px::stirling::bpf_tools::WrappedBCCArrayTable;
+
 // Whether the protocol traced is turned on, off, or on but only for newer kernels.
 enum TraceMode : int32_t {
   Off = 0,
@@ -110,8 +112,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
   // TODO(yzhao): This is not used right now. Eventually use this to control data push frequency.
   static constexpr auto kPushPeriod = std::chrono::milliseconds{1000};
 
-  static std::unique_ptr<SourceConnector> Create(std::string_view name) {
-    return std::unique_ptr<SourceConnector>(new SocketTraceConnector(name));
+  static std::unique_ptr<SocketTraceConnector> Create(std::string_view name) {
+    return std::unique_ptr<SocketTraceConnector>(new SocketTraceConnector(name));
   }
 
   Status InitImpl() override;
@@ -180,8 +182,9 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
 
   explicit SocketTraceConnector(std::string_view source_name);
 
-  Status InitBPF();
   auto InitPerfBufferSpecs();
+  Status InitBPF();
+  void InitPerfBufferSpec();
   void InitProtocolTransferSpecs();
 
   ConnTracker& GetOrCreateConnTracker(struct conn_id_t conn_id);
@@ -231,8 +234,8 @@ class SocketTraceConnector : public SourceConnector, public bpf_tools::BCCWrappe
 
   ConnStats conn_stats_;
 
-  std::unique_ptr<ebpf::BPFArrayTable<int>> openssl_trace_state_;
-  std::unique_ptr<ebpf::BPFHashTable<uint32_t, struct openssl_trace_state_debug_t>>
+  std::unique_ptr<WrappedBCCArrayTable<int>> openssl_trace_state_;
+  std::unique_ptr<WrappedBCCMap<uint32_t, struct openssl_trace_state_debug_t>>
       openssl_trace_state_debug_;
   prometheus::Family<prometheus::Counter>& openssl_trace_mismatched_fds_counter_family_;
   prometheus::Family<prometheus::Counter>& openssl_trace_tls_source_counter_family_;

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -72,18 +72,15 @@ void UProbeManager::Init(bool disable_go_tls_tracing, bool enable_http2_tracing,
   cfg_enable_http2_tracing_ = enable_http2_tracing;
   cfg_disable_self_probing_ = disable_self_probing;
 
-  openssl_source_map_ = WrappedBCCMap<uint32_t, ssl_source_t>::Create(bcc_, "openssl_source_map");
-  openssl_symaddrs_map_ =
-      WrappedBCCMap<uint32_t, struct openssl_symaddrs_t>::Create(bcc_, "openssl_symaddrs_map");
+  openssl_source_map_ = MapT<ssl_source_t>::Create(bcc_, "openssl_source_map");
+  openssl_symaddrs_map_ = MapT<struct openssl_symaddrs_t>::Create(bcc_, "openssl_symaddrs_map");
   go_common_symaddrs_map_ =
-      WrappedBCCMap<uint32_t, struct go_common_symaddrs_t>::Create(bcc_, "go_common_symaddrs_map");
-  go_http2_symaddrs_map_ =
-      WrappedBCCMap<uint32_t, struct go_http2_symaddrs_t>::Create(bcc_, "http2_symaddrs_map");
-  go_tls_symaddrs_map_ =
-      WrappedBCCMap<uint32_t, struct go_tls_symaddrs_t>::Create(bcc_, "go_tls_symaddrs_map");
-  node_tlswrap_symaddrs_map_ = WrappedBCCMap<uint32_t, struct node_tlswrap_symaddrs_t>::Create(
-      bcc_, "node_tlswrap_symaddrs_map");
-  grpc_c_versions_map_ = WrappedBCCMap<uint32_t, uint64_t>::Create(bcc_, "grpc_c_versions");
+      MapT<struct go_common_symaddrs_t>::Create(bcc_, "go_common_symaddrs_map");
+  go_http2_symaddrs_map_ = MapT<struct go_http2_symaddrs_t>::Create(bcc_, "http2_symaddrs_map");
+  go_tls_symaddrs_map_ = MapT<struct go_tls_symaddrs_t>::Create(bcc_, "go_tls_symaddrs_map");
+  node_tlswrap_symaddrs_map_ =
+      MapT<struct node_tlswrap_symaddrs_t>::Create(bcc_, "node_tlswrap_symaddrs_map");
+  grpc_c_versions_map_ = MapT<uint64_t>::Create(bcc_, "grpc_c_versions");
 }
 
 void UProbeManager::NotifyMMapEvent(upid_t upid) {

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -409,7 +409,7 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnDynamicLib(uint32_t pid) {
     // before the BPF map is updated. This value is cleaned up when the upid is
     // terminated, so if attachment fails it will be deleted prior to the pid being
     // reused.
-    PX_RETURN_IF_ERROR(openssl_source_map_->SetValue(pid, ssl_source));
+    PX_UNUSED(openssl_source_map_->SetValue(pid, ssl_source));
     for (auto spec : kOpenSSLUProbes) {
       spec.binary_path = container_libssl.string();
       spec.probe_fn =
@@ -493,7 +493,7 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid) {
   // before the BPF map is updated. This value is cleaned up when the upid is
   // terminated, so if attachment fails it will be deleted prior to the pid being
   // reused.
-  PX_RETURN_IF_ERROR(openssl_source_map_->SetValue(pid, kNodeJSSource));
+  PX_UNUSED(openssl_source_map_->SetValue(pid, kNodeJSSource));
 
   // These probes are attached on OpenSSL dynamic library (if present) as well.
   // Here they are attached on statically linked OpenSSL library (eg. for node).

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -68,6 +68,9 @@ using px::stirling::bpf_tools::WrappedBCCMap;
  * This includes: OpenSSL uprobes, GoTLS uprobes and Go HTTP2 uprobes.
  */
 class UProbeManager {
+  template <typename V>
+  using MapT = WrappedBCCMap<uint32_t, V, /* user space managed */ true>;
+
  public:
   /**
    * Construct a UProbeManager.
@@ -632,15 +635,14 @@ class UProbeManager {
   absl::flat_hash_set<std::string> grpc_c_probed_binaries_;
 
   // BPF maps through which the addresses of symbols for a given pid are communicated to uprobes.
-  std::unique_ptr<WrappedBCCMap<uint32_t, ssl_source_t>> openssl_source_map_;
-  std::unique_ptr<WrappedBCCMap<uint32_t, struct openssl_symaddrs_t>> openssl_symaddrs_map_;
-  std::unique_ptr<WrappedBCCMap<uint32_t, struct go_common_symaddrs_t>> go_common_symaddrs_map_;
-  std::unique_ptr<WrappedBCCMap<uint32_t, struct go_http2_symaddrs_t>> go_http2_symaddrs_map_;
-  std::unique_ptr<WrappedBCCMap<uint32_t, struct go_tls_symaddrs_t>> go_tls_symaddrs_map_;
-  std::unique_ptr<WrappedBCCMap<uint32_t, struct node_tlswrap_symaddrs_t>>
-      node_tlswrap_symaddrs_map_;
+  std::unique_ptr<MapT<ssl_source_t>> openssl_source_map_;
+  std::unique_ptr<MapT<struct openssl_symaddrs_t>> openssl_symaddrs_map_;
+  std::unique_ptr<MapT<struct go_common_symaddrs_t>> go_common_symaddrs_map_;
+  std::unique_ptr<MapT<struct go_http2_symaddrs_t>> go_http2_symaddrs_map_;
+  std::unique_ptr<MapT<struct go_tls_symaddrs_t>> go_tls_symaddrs_map_;
+  std::unique_ptr<MapT<struct node_tlswrap_symaddrs_t>> node_tlswrap_symaddrs_map_;
   // Key is python gRPC module's md5 hash, value is the corresponding version enum's numeric value.
-  std::unique_ptr<WrappedBCCMap<uint32_t, uint64_t>> grpc_c_versions_map_;
+  std::unique_ptr<MapT<uint64_t>> grpc_c_versions_map_;
 
   const system::Config& syscfg_ = system::Config::GetInstance();
   StirlingMonitor& monitor_ = *StirlingMonitor::GetInstance();


### PR DESCRIPTION
Summary: We add wrappers for BPF maps and arrays to our BCC wrapper class. These wrappers anticipate our upcoming "record & replay" feature. In specific, they will be used to shim in recording logic and return replayed values, i.e. when either record or replay ("RR") is in use. When "RR" is not in use, they pass through to the underlying BPF map or array.

Relevant Issues: https://github.com/pixie-io/pixie/issues/1163

Type of change: /kind feature

Test Plan: Existing test coverage exercises all of these.
