### PR TITLE
Fix default metadata namespaces

### DIFF
--- a/src/vizier/services/metadata/metadata_server.go
+++ b/src/vizier/services/metadata/metadata_server.go
@@ -238,6 +238,9 @@ func main() {
 	mdh := k8smeta.NewHandler(updateCh, k8sMds, k8sMds, nc)
 
 	namespaces := viper.GetStringSlice("metadata_namespaces")
+	if len(namespaces) == 0 {
+		namespaces = []string{v1.NamespaceAll}
+	}
 	k8sMc, err := k8smeta.NewController(namespaces, updateCh)
 	defer k8sMc.Stop()
 


### PR DESCRIPTION
Summary: #1368 added the ability to limit the metadata service to specific namespaces. By default, if no namespaces are mentioned, the flag is supposed to choose all namespaces.
However, if the environment variable is not specified, it is actually parsed as an empty list and the default is not properly chosen. Instead, we can assume no users actually want to watch 0 namespaces, and set it to all namespaces when that occurs.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Skaffold deploy metadata service
