### PR TITLE
Add debug log prior to Go TLS uprobe attachment

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -883,6 +883,7 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
 
     // GoTLS Probes.
     if (!cfg_disable_go_tls_tracing_) {
+      VLOG(1) << absl::Substitute("Attempting to attach Go TLS uprobes to binary $0", binary);
       StatusOr<int> attach_status =
           AttachGoTLSUProbes(binary, elf_reader.get(), dwarf_reader.get(), pid_vec);
       if (!attach_status.ok()) {


### PR DESCRIPTION
Summary: Add debug log prior to Go TLS uprobe attachment

The relevant issues listed below have needed this logging. When #1111 occurred, a similar [log message](https://github.com/pixie-io/pixie/issues/1111#issuecomment-1494965870) was added adhoc but wasn't merged upstream. Now that #1646 needs to be debugged in a similar fashion, it would be helpful to have this log message available when verbose logging is enabled.

Relevant Issues: #1111 and #1646

Type of change: /kind bug

Test Plan: Verified the log message is available and identifies the correct binaries
```
$ ./scripts/sudo_bazel_run.sh  src/stirling/source_connectors/socket_tracer:go_tls_trace_bpf_test --test_arg='--vmodule=uprobe_manager=1' 2>&1 | tee output.txt

$ grep 'Attempting to attach Go TLS uprobes to binary' output.txt

[ ... ]

I20230803 16:02:04.912412 2586416 uprobe_manager.cc:886] Attempting to attach Go TLS uprobes to binary /proc/2586357/root/app/src/stirling/testing/demo_apps/go_https/client/golang_1_17_client_binary.runfiles/px/src/stirling/testing/demo_apps/go_https/client/golang_1_17_client_binary
```