### PR TITLE
Add support for tolerations in helm

### DIFF
--- a/k8s/operator/helm/templates/04_vizier.yaml
+++ b/k8s/operator/helm/templates/04_vizier.yaml
@@ -63,7 +63,7 @@ spec:
     electionPeriodMs: {{ .Values.leadershipElectionParams.electionPeriodMs }}
     {{- end }}
   {{- end }}
-  {{- if or .Values.pod.securityContext (or .Values.pod.nodeSelector (or .Values.pod.annotations (or .Values.pod.labels .Values.pod.resources))) }}
+  {{- if or .Values.pod.securityContext (or .Values.pod.nodeSelector (or .Values.pod.tolerations (or .Values.pod.annotations (or .Values.pod.labels .Values.pod.resources)))) }}
   pod:
     {{- if .Values.pod.annotations }}
     annotations: {{ .Values.pod.annotations | toYaml | nindent 6 }}
@@ -76,6 +76,9 @@ spec:
     {{- end }}
     {{- if .Values.pod.nodeSelector }}
     nodeSelector: {{ .Values.pod.nodeSelector | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if .Values.pod.tolerations }}
+    tolerations: {{ .Values.pod.tolerations | toYaml | nindent 4 }}
     {{- end }}
     {{- if .Values.pod.securityContext }}
     securityContext:

--- a/k8s/operator/helm/values.yaml
+++ b/k8s/operator/helm/values.yaml
@@ -67,6 +67,7 @@ pod:
   #   cpu: 100m
   #   memory: 5Gi
   nodeSelector: {}
+  tolerations: []
 # A set of custom patches to apply to the deployed Vizier resources.
 # The key should be the name of the resource to apply the patch to, and the value is the patch to apply.
 # Currently, only a JSON format is accepted, such as:


### PR DESCRIPTION
Summary: Adds support for tolerations to enable users to deploy PEMs to nodes that have taints through helm.

Relevant Issues: #598

Type of change: /kind feature

Test Plan: ran `helm install` using the [previous operator helm chart ](https://github.com/pixie-io/pixie/releases/download/release%2Foperator%2Fv0.1.4/pixie-operator-chart-0.1.4.tgz) with these changes and verified that tolerations appear in the CRD.