### PR TITLE
Use larger workers for trivy_images workflow

### DIFF
--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         artifact: [cloud, operator, vizier]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}


### PR DESCRIPTION
Summary: The runner seems to run out of disk when loading images, so
use a larger runner.

Type of change: /kind cleanup

Test Plan: Check the action on this PR.
