### PR TITLE
Detect homoglyphs by rendering punycode version of Vizier names

### DIFF
--- a/src/cloud/api/controllers/BUILD.bazel
+++ b/src/cloud/api/controllers/BUILD.bazel
@@ -91,6 +91,7 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_net//idna",
     ],
 )
 

--- a/src/cloud/api/controllers/vizier_cluster_grpc.go
+++ b/src/cloud/api/controllers/vizier_cluster_grpc.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/gofrs/uuid"
+	"golang.org/x/net/idna"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -181,6 +182,11 @@ func (v *VizierClusterInfo) getClusterInfoForViziers(ctx context.Context, ids []
 		s := vzStatusToClusterStatus(vzInfo.Status)
 		prevS := vzStatusToClusterStatus(vzInfo.PreviousStatus)
 		prettyName := PrettifyClusterName(vzInfo.ClusterName, false)
+		// Convert to punycode (if non-latin) to help detect homoglyphs.
+		prettyName, err = idna.Punycode.ToASCII(prettyName)
+		if err != nil {
+			return nil, err
+		}
 
 		if val, ok := cNames[prettyName]; ok {
 			cNames[prettyName] = val + 1


### PR DESCRIPTION
Summary: Display a punycode version of vizier names to guard against homoglyphs (e.g. `clυster` - which looks similar to `cluster` - would display as `xn--clster-q1e`).

Relevant Issues: Fixes #1653

Type of change: /kind feature

Test Plan: unittest in [vizier_cluster_test.go](https://github.com/pixie-io/pixie/blob/4219a60d9fb6f5735f866059c701c9c763659e5e/src/cloud/api/controllers/vizier_cluster_test.go#L297)