### PR TITLE
[record & replay] Create virtual base classes for wrapped maps & arrays. 

### DIFF
--- a/src/stirling/bpf_tools/bcc_wrapper.cc
+++ b/src/stirling/bpf_tools/bcc_wrapper.cc
@@ -451,6 +451,10 @@ void BCCWrapperImpl::Close() {
 
 std::unique_ptr<BCCWrapper> CreateBCC() { return std::make_unique<BCCWrapperImpl>(); }
 
+std::unique_ptr<WrappedBCCStackTable> WrappedBCCStackTable::Create(bpf_tools::BCCWrapper* bcc, const std::string& name) {
+  return std::make_unique<WrappedBCCStackTableImpl>(bcc, name);
+}
+
 }  // namespace bpf_tools
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/bpf_tools/bcc_wrapper.cc
+++ b/src/stirling/bpf_tools/bcc_wrapper.cc
@@ -451,7 +451,8 @@ void BCCWrapperImpl::Close() {
 
 std::unique_ptr<BCCWrapper> CreateBCC() { return std::make_unique<BCCWrapperImpl>(); }
 
-std::unique_ptr<WrappedBCCStackTable> WrappedBCCStackTable::Create(bpf_tools::BCCWrapper* bcc, const std::string& name) {
+std::unique_ptr<WrappedBCCStackTable> WrappedBCCStackTable::Create(bpf_tools::BCCWrapper* bcc,
+                                                                   const std::string& name) {
   return std::make_unique<WrappedBCCStackTableImpl>(bcc, name);
 }
 

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -515,8 +515,6 @@ class WrappedBCCStackTable {
   virtual std::vector<uintptr_t> GetStackAddr(const int stack_id, const bool clear_stack_id) = 0;
   virtual std::string GetAddrSymbol(const uintptr_t addr, const int pid) = 0;
   virtual void ClearStackID(const int stack_id) = 0;
-
-  // U* RawPtr() { return underlying_.get(); }
 };
 
 class WrappedBCCStackTableImpl : public WrappedBCCStackTable {
@@ -532,8 +530,6 @@ class WrappedBCCStackTableImpl : public WrappedBCCStackTable {
   }
 
   void ClearStackID(const int stack_id) override { underlying_->clear_stack_id(stack_id); }
-
-  // U* RawPtr() { return underlying_.get(); }
 
   WrappedBCCStackTableImpl(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
     underlying_ = std::make_unique<U>(bcc->BPF().get_stack_table(name_));

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -474,7 +474,8 @@ class WrappedBCCMapImpl : public WrappedBCCMap<K, V, kUserSpaceManaged> {
 template <typename T>
 class WrappedBCCPerCPUArrayTable {
  public:
-  static std::unique_ptr<WrappedBCCPerCPUArrayTable> Create(bpf_tools::BCCWrapper* bcc, const std::string& name);
+  static std::unique_ptr<WrappedBCCPerCPUArrayTable> Create(bpf_tools::BCCWrapper* bcc,
+                                                            const std::string& name);
   virtual ~WrappedBCCPerCPUArrayTable() {}
 
   virtual Status SetValues(const int idx, const T& value) = 0;
@@ -495,7 +496,8 @@ class WrappedBCCPerCPUArrayTableImpl : public WrappedBCCPerCPUArrayTable<T> {
     return Status::OK();
   }
 
-  WrappedBCCPerCPUArrayTableImpl(bpf_tools::BCCWrapper* bcc, const std::string& name) : name_(name) {
+  WrappedBCCPerCPUArrayTableImpl(bpf_tools::BCCWrapper* bcc, const std::string& name)
+      : name_(name) {
     underlying_ = std::make_unique<U>(bcc->BPF().get_percpu_array_table<T>(name_));
   }
 
@@ -506,7 +508,8 @@ class WrappedBCCPerCPUArrayTableImpl : public WrappedBCCPerCPUArrayTable<T> {
 
 class WrappedBCCStackTable {
  public:
-  static std::unique_ptr<WrappedBCCStackTable> Create(bpf_tools::BCCWrapper* bcc, const std::string& name);
+  static std::unique_ptr<WrappedBCCStackTable> Create(bpf_tools::BCCWrapper* bcc,
+                                                      const std::string& name);
   virtual ~WrappedBCCStackTable() {}
 
   virtual std::vector<uintptr_t> GetStackAddr(const int stack_id, const bool clear_stack_id) = 0;
@@ -546,25 +549,28 @@ class WrappedBCCStackTableImpl : public WrappedBCCStackTable {
 // Creators:
 template <typename BaseT, typename ImplT>
 std::unique_ptr<BaseT> CreateBCCWrappedMapOrArray(BCCWrapper* bcc, const std::string& name) {
- return std::make_unique<ImplT>(bcc, name);
+  return std::make_unique<ImplT>(bcc, name);
 }
 
 template <typename T>
-std::unique_ptr<WrappedBCCArrayTable<T>> WrappedBCCArrayTable<T>::Create(BCCWrapper* bcc, const std::string& name) {
+std::unique_ptr<WrappedBCCArrayTable<T>> WrappedBCCArrayTable<T>::Create(BCCWrapper* bcc,
+                                                                         const std::string& name) {
   using BaseT = WrappedBCCArrayTable<T>;
   using ImplT = WrappedBCCArrayTableImpl<T>;
   return CreateBCCWrappedMapOrArray<BaseT, ImplT>(bcc, name);
 }
 
 template <typename K, typename V, bool U>
-std::unique_ptr<WrappedBCCMap<K, V, U>> WrappedBCCMap<K, V, U>::Create(BCCWrapper* bcc, const std::string& name) {
+std::unique_ptr<WrappedBCCMap<K, V, U>> WrappedBCCMap<K, V, U>::Create(BCCWrapper* bcc,
+                                                                       const std::string& name) {
   using BaseT = WrappedBCCMap<K, V, U>;
   using ImplT = WrappedBCCMapImpl<K, V, U>;
   return CreateBCCWrappedMapOrArray<BaseT, ImplT>(bcc, name);
 }
 
 template <typename T>
-std::unique_ptr<WrappedBCCPerCPUArrayTable<T>> WrappedBCCPerCPUArrayTable<T>::Create(BCCWrapper* bcc, const std::string& name) {
+std::unique_ptr<WrappedBCCPerCPUArrayTable<T>> WrappedBCCPerCPUArrayTable<T>::Create(
+    BCCWrapper* bcc, const std::string& name) {
   using BaseT = WrappedBCCPerCPUArrayTable<T>;
   using ImplT = WrappedBCCPerCPUArrayTableImpl<T>;
   return CreateBCCWrappedMapOrArray<BaseT, ImplT>(bcc, name);

--- a/src/stirling/bpf_tools/bcc_wrapper.h
+++ b/src/stirling/bpf_tools/bcc_wrapper.h
@@ -332,10 +332,7 @@ class BCCWrapperImpl : public BCCWrapper {
 
 std::unique_ptr<BCCWrapper> CreateBCC();
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
 // Wrapped maps & arrays.
-
 template <typename T>
 class WrappedBCCArrayTable {
  public:
@@ -540,11 +537,11 @@ class WrappedBCCStackTableImpl : public WrappedBCCStackTable {
   std::unique_ptr<U> underlying_;
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Creators:
+// Creators fns for wrapped maps & arrays:
 template <typename BaseT, typename ImplT>
 std::unique_ptr<BaseT> CreateBCCWrappedMapOrArray(BCCWrapper* bcc, const std::string& name) {
+  // The decision logic for "normal" vs. "recording" vs. "replaying" impl. will be inserted
+  // here in a future PR.
   return std::make_unique<ImplT>(bcc, name);
 }
 


### PR DESCRIPTION
Summary: In preparation for introducing record & replay, we create a virtual base classes for wrapped BCC maps & arrays. In a future PR, we will introduce two new implementations, one for recording and one for replaying.

Relevant Issues: https://github.com/pixie-io/pixie/issues/1163

Type of change: /kind feature

Test Plan: fully covered by existing tests.