### PR TITLE
Restore ability to disable tracing for protocols via PEM flags

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -78,27 +78,39 @@ DEFINE_string(socket_trace_data_events_output_path, "",
 // Due to BPF instruction limits (< 4096 instructions) on kernels older than
 // 5.2, we can't simultaneously enable all protocols. Thus, some protocols
 // are only enabled on newer kernels.
-DEFINE_int32(stirling_enable_http_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_http_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_HTTP_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process HTTP messages");
-DEFINE_int32(stirling_enable_http2_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_http2_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_HTTP2_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process gRPC RPCs.");
-DEFINE_int32(stirling_enable_mysql_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_mysql_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_MYSQL_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process MySQL messages.");
-DEFINE_int32(stirling_enable_pgsql_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_pgsql_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_PGSQL_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process PostgreSQL messages.");
-DEFINE_int32(stirling_enable_cass_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_cass_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_CASS_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process Cassandra messages.");
-DEFINE_int32(stirling_enable_dns_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_dns_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_DNS_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process DNS messages.");
-DEFINE_int32(stirling_enable_redis_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_redis_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_REDIS_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process Redis messages.");
-DEFINE_int32(stirling_enable_nats_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_nats_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_NATS_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process NATS messages.");
-DEFINE_int32(stirling_enable_kafka_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_kafka_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_KAFKA_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process Kafka messages.");
-DEFINE_int32(stirling_enable_mux_tracing, px::stirling::TraceMode::OnForNewerKernel,
+DEFINE_int32(stirling_enable_mux_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_MUX_TRACING",
+                                  px::stirling::TraceMode::OnForNewerKernel),
              "If true, stirling will trace and process Mux messages.");
-DEFINE_int32(stirling_enable_amqp_tracing, px::stirling::TraceMode::On,
+DEFINE_int32(stirling_enable_amqp_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_AMQP_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process AMQP messages.");
 
 DEFINE_bool(stirling_disable_golang_tls_tracing,


### PR DESCRIPTION
Summary: Restores ability to disable tracing of specific protocols via PEM flags (i.e. environment variable injection). Also changes the flag name listed in the [docs](https://docs.px.dev/reference/admin/deploy-options#set-a-pem-flag) for backwards compatibility, as a previously defined PEM flag could cause a type error.

Disabling specific protocols from tracing is requested by end users (e.g. for optimizing memory usage) and often useful when debugging (or side stepping) PEM bugs.

Related issues: Fixes #1614

Type of change: /kind feature

Related documentation change: https://github.com/pixie-io/docs.px.dev/pull/274

Test Plan: Verified that tracing is still on by default for each protocol and that tracing still runs as expected via the `socket_tracer` tests.

A further test is required to ensure that the enum `TraceMode::OnForNewerKernel` is set correctly for `mux` tracing in older kernels. Due to permission issues, I can't currently run this `QEMU` test:

```
bazel test -c opt --config=qemu-bpf --test_output=all  --cache_test_results=no --remote_download_outputs=all //src/stirling/source_connectors/socket_tracer:mux_trace_bpf_test --test_output=streamed --//bazel/test_runners/qemu_with_kernel:kernel_version=oldest
```