### PR TITLE
Let the Operator get the VizierID and send to Config Manager Service

### DIFF
--- a/src/operator/controllers/BUILD.bazel
+++ b/src/operator/controllers/BUILD.bazel
@@ -29,11 +29,13 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/api/proto/cloudpb:cloudapi_pl_go_proto",
+        "//src/api/proto/uuidpb:uuid_pl_go_proto",
         "//src/api/proto/vizierconfigpb:vizier_pl_go_proto",
         "//src/operator/apis/px.dev/v1alpha1",
         "//src/shared/goversion",
         "//src/shared/services",
         "//src/shared/status",
+        "//src/utils",
         "//src/utils/shared/certs",
         "//src/utils/shared/k8s",
         "@com_github_blang_semver//:semver",

--- a/src/operator/controllers/vizier_controller.go
+++ b/src/operator/controllers/vizier_controller.go
@@ -491,8 +491,7 @@ func (r *VizierReconciler) deployVizier(ctx context.Context, req ctrl.Request, v
 		return err
 	}
 
-	log.Info("Starting to get the vizier ID")
-	// Get the Vizier's ID from the cluster's secrets
+	// Get the Vizier's ID from the cluster's secrets.
 	vizierID, err := getVizierID(r.Clientset, req.Namespace)
 	if err != nil {
 		log.WithError(err).Error("Failed to retrieve the Vizier ID from the cluster's secrets")
@@ -814,7 +813,6 @@ func generateVizierYAMLsConfig(ctx context.Context, ns string, k8sVersion string
 	error) {
 	client := cloudpb.NewConfigServiceClient(conn)
 
-	log.Info("VizierID: ", vizierID)
 	req := &cloudpb.ConfigForVizierRequest{
 		Namespace:  ns,
 		K8sVersion: k8sVersion,
@@ -1150,7 +1148,6 @@ func getVizierID(clientset *kubernetes.Clientset, namespace string) (string, err
 				return "", errors.New("Missing cluster secrets")
 			}
 			if id, ok := s.Data["cluster-id"]; ok {
-				log.Info("Successfully received the Vizier ID")
 				vizierID = string(id)
 			}
 		}


### PR DESCRIPTION
Summary: This PR lets the operator get the VizierID from the cluster's secrets and then sends it to the config manager service for it to ultimately set feature flags.

Relevant Issues: Fixes #1632

Type of change: /kind bug

Test Plan: Skaffold the cloud changes on the testing cluster and then skaffold the operator changes on a dev cluster. Manually trigger an update on the operator side to send the VizierID to the config manager service. Check the config manager service's logs to see that the new logic is being executed as expected to handle the VizierID.