### PR TITLE
Update static tls (BoringSSL) tracing feature flag default to true and announce BoringSSL support

### DIFF
--- a/src/cloud/config_manager/controllers/vizier_feature_flags.go
+++ b/src/cloud/config_manager/controllers/vizier_feature_flags.go
@@ -45,7 +45,7 @@ var availableFeatureFlags = []*featureFlag{
 	{
 		FeatureFlagName: "probe-static-tls-binaries",
 		VizierFlagName:  "PX_TRACE_STATIC_TLS_BINARIES",
-		DefaultValue:    false,
+		DefaultValue:    true,
 	},
 	{
 		FeatureFlagName: "debug-tls-sources",


### PR DESCRIPTION
Summary: Update static tls (BoringSSL) tracing feature flag default to true and announce BoringSSL support

Relevant Issues: #692

Type of change: /kind feature

Test Plan: This tls tracing has been enabled since v0.14.3's release last month (#1625) and the metrics for internal clusters have been validated

Changelog Message:
```release-notes
Enhance TLS tracing to support statically linked OpenSSL and BoringSSL (OpenSSL API compatible libraries).
```