### PR TITLE
Add compiler optimization to remove `px.contains` calls with empty strings

### DIFF
--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -35,7 +35,6 @@ spec:
                 operator: In
                 values:
                 - linux
-      shareProcessNamespace: true
       initContainers:
       - name: mds-wait
         # yamllint disable-line rule:line-length
@@ -86,8 +85,6 @@ spec:
               key: PL_CLOUD_ADDR
         - name: PL_DATA_ACCESS
           value: "Full"
-        - name: GOTRACEBACK
-          value: crash
         envFrom:
         - configMapRef:
             name: pl-tls-config
@@ -96,8 +93,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: certs
-        - mountPath: /tmp
-          name: coredump
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -125,6 +120,3 @@ spec:
       - name: envoy-yaml
         configMap:
           name: proxy-envoy-config
-      - name: coredump
-        hostPath:
-          path: /tmp

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -35,6 +35,7 @@ spec:
                 operator: In
                 values:
                 - linux
+      shareProcessNamespace: true
       initContainers:
       - name: mds-wait
         # yamllint disable-line rule:line-length

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -85,6 +85,8 @@ spec:
               key: PL_CLOUD_ADDR
         - name: PL_DATA_ACCESS
           value: "Full"
+        - name: GOTRACEBACK
+          value: crash
         envFrom:
         - configMapRef:
             name: pl-tls-config
@@ -93,6 +95,8 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: certs
+        - mountPath: /tmp
+          name: coredump
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -120,3 +124,6 @@ spec:
       - name: envoy-yaml
         configMap:
           name: proxy-envoy-config
+      - name: coredump
+        hostPath:
+          path: /tmp

--- a/src/carnot/planner/compiler/optimizer/BUILD.bazel
+++ b/src/carnot/planner/compiler/optimizer/BUILD.bazel
@@ -82,3 +82,13 @@ pl_cc_test(
         "//src/carnot/udf_exporter:cc_library",
     ],
 )
+
+pl_cc_test(
+    name = "prune_unused_contains_rule_test",
+    srcs = ["prune_unused_contains_rule_test.cc"],
+    deps = [
+        ":cc_library",
+        "//src/carnot/planner/compiler:test_utils",
+        "//src/carnot/udf_exporter:cc_library",
+    ],
+)

--- a/src/carnot/planner/compiler/optimizer/optimizer.h
+++ b/src/carnot/planner/compiler/optimizer/optimizer.h
@@ -26,6 +26,7 @@
 #include "src/carnot/planner/compiler/optimizer/merge_nodes_rule.h"
 #include "src/carnot/planner/compiler/optimizer/prune_unconnected_operators_rule.h"
 #include "src/carnot/planner/compiler/optimizer/prune_unused_columns_rule.h"
+#include "src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h"
 #include "src/carnot/planner/compiler_state/compiler_state.h"
 #include "src/carnot/planner/compiler_state/registry_info.h"
 #include "src/carnot/planner/ir/ir.h"
@@ -62,10 +63,16 @@ class Optimizer : public RuleExecutor<IR> {
     prune_unused_columns->AddRule<PruneUnusedColumnsRule>();
   }
 
+  void CreatePruneUnusedContainsBatch() {
+    RuleBatch* prune_unused_columns = CreateRuleBatch<DoOnce>("PruneUnusedContains");
+    prune_unused_columns->AddRule<PruneUnusedContainsRule>();
+  }
+
   Status Init() {
     CreatePruneUnconnectedOpsBatch();
     CreateMergeNodesBatch();
     CreatePruneUnusedColumnsBatch();
+    CreatePruneUnusedContainsBatch();
     return Status::OK();
   }
 

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.cc
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.cc
@@ -45,18 +45,18 @@ StatusOr<bool> PruneUnusedContainsRule::RemoveMatchingFilter(IRNode* ir_node) {
     return false;
   }
 
-  DCHECK_EQ(ir_graph->dag().ParentsOf(node_id).size(), 1);
+  DCHECK_EQ(ir_graph->dag().ParentsOf(node_id).size(), 1UL);
   auto parent_id = ir_graph->dag().ParentsOf(node_id)[0];
   auto parent_node = ir_graph->Get(parent_id);
 
   // If the first argument (string) to contains is not referenced anywhere,
   // it should be deleted from the graph.
-  if (ir_graph->dag().DependenciesOf(str->id()).size() == 0) {
+  if (ir_graph->dag().ParentsOf(str->id()).size() <= 1) {
     PX_RETURN_IF_ERROR(ir_graph->DeleteNode(str->id()));
   }
 
   // Delete the filter's contains function and the empty string argument
-  if (ir_graph->Get(substr->id()) != nullptr) {
+  if (ir_graph->dag().ParentsOf(substr->id()).size() <= 1) {
     PX_RETURN_IF_ERROR(ir_graph->DeleteNode(substr->id()));
   }
   PX_RETURN_IF_ERROR(ir_graph->DeleteNode(func->id()));
@@ -68,7 +68,6 @@ StatusOr<bool> PruneUnusedContainsRule::RemoveMatchingFilter(IRNode* ir_node) {
     if (!Match(child_node, Operator())) {
       continue;
     }
-    DCHECK_EQ(ir_graph->dag().ParentsOf(node_id).size(), 1);
     auto child_op_node = static_cast<OperatorIR*>(child_node);
 
     PX_RETURN_IF_ERROR(child_op_node->ReplaceParent(static_cast<OperatorIR*>(ir_node),

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.cc
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.cc
@@ -65,7 +65,6 @@ StatusOr<bool> PruneUnusedContainsRule::RemoveMatchingFilter(IRNode* ir_node) {
   for (int64_t child_id : ir_graph->dag().DependenciesOf(node_id)) {
     auto child_node = ir_graph->Get(child_id);
 
-    // Operator nodes are guaranteed to have a single parent but DCHECK as well.
     if (!Match(child_node, Operator())) {
       continue;
     }

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.cc
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h"
+
+#include <algorithm>
+#include <queue>
+
+namespace px {
+namespace carnot {
+namespace planner {
+namespace compiler {
+
+StatusOr<bool> PruneUnusedContainsRule::Apply(IRNode* ir_node) {
+  auto ir_graph = ir_node->graph();
+  auto node_id = ir_node->id();
+  if (!Match(ir_node, Filter())) return false;
+
+  FilterIR* filter = static_cast<FilterIR*>(ir_node);
+  ExpressionIR* expr = filter->filter_expr();
+
+  if (!Match(expr, Func("contains"))) return false;
+
+  FuncIR* func = static_cast<FuncIR*>(expr);
+  auto args = func->all_args();
+  auto contains_substr = args[1];
+
+  if (Match(contains_substr, String(""))) {
+    // Delete the filter, contains function and its arguments
+    PX_RETURN_IF_ERROR(ir_graph->DeleteNode(node_id));
+    PX_RETURN_IF_ERROR(ir_graph->DeleteNode(func->id()));
+    PX_RETURN_IF_ERROR(ir_graph->DeleteNode(args[0]->id()));
+    PX_RETURN_IF_ERROR(ir_graph->DeleteNode(args[1]->id()));
+
+    return true;
+  }
+  return false;
+}
+
+}  // namespace compiler
+}  // namespace planner
+}  // namespace carnot
+}  // namespace px

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h
@@ -42,6 +42,7 @@ class PruneUnusedContainsRule : public Rule {
 
  protected:
   StatusOr<bool> Apply(IRNode* ir_node) override;
+  StatusOr<bool> RemoveMatchingFilter(IRNode* ir_node);
 };
 
 }  // namespace compiler

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "src/carnot/planner/rules/rules.h"
+
+namespace px {
+namespace carnot {
+namespace planner {
+namespace compiler {
+
+/**
+ * @brief This rule removes contains functions that compare against an empty string.
+ * This results in returning the original dataset and so it is equivalent to no filter
+ * as seen in the example below:
+ *
+ * df = df[px.contains(df.pod, "")]
+ *
+ */
+class PruneUnusedContainsRule : public Rule {
+ public:
+  PruneUnusedContainsRule()
+      : Rule(nullptr, /*use_topo*/ true, /*reverse_topological_execution*/ true) {}
+
+ protected:
+  StatusOr<bool> Apply(IRNode* ir_node) override;
+};
+
+}  // namespace compiler
+}  // namespace planner
+}  // namespace carnot
+}  // namespace px

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule_test.cc
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule_test.cc
@@ -56,6 +56,11 @@ TEST_F(PruneUnusedContainsRuleTest, Basic) {
   auto filter_ir_1 = graph->CreateNode<FilterIR>(ast, mem_src, filter_func_1).ValueOrDie();
   auto filter_ir_2 = graph->CreateNode<FilterIR>(ast, filter_ir_1, filter_func_2).ValueOrDie();
 
+  auto filter_ir_1_id = filter_ir_1->id();
+  auto filter_ir_2_id = filter_ir_2->id();
+  auto filter_func_ir_1_id = filter_func_1->id();
+  auto filter_func_ir_2_id = filter_func_2->id();
+
   auto limit = MakeLimit(static_cast<OperatorIR*>(filter_ir_2), 1000);
 
   ResolveTypesRule type_rule(compiler_state_.get());
@@ -66,10 +71,10 @@ TEST_F(PruneUnusedContainsRuleTest, Basic) {
   ASSERT_OK(result);
   ASSERT_TRUE(result.ConsumeValueOrDie());
 
-  EXPECT_FALSE(graph->HasNode(filter_ir_1->id()));
-  EXPECT_FALSE(graph->HasNode(filter_ir_2->id()));
-  EXPECT_FALSE(graph->HasNode(filter_func_1->id()));
-  EXPECT_FALSE(graph->HasNode(filter_func_2->id()));
+  EXPECT_FALSE(graph->HasNode(filter_ir_1_id));
+  EXPECT_FALSE(graph->HasNode(filter_ir_2_id));
+  EXPECT_FALSE(graph->HasNode(filter_func_ir_1_id));
+  EXPECT_FALSE(graph->HasNode(filter_func_ir_2_id));
   EXPECT_TRUE(graph->HasNode(limit->id()));
 }
 

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule_test.cc
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule_test.cc
@@ -53,19 +53,10 @@ TEST_F(PruneUnusedContainsRuleTest, Basic) {
                                std::vector<ExpressionIR*>{constant2, empty_str})
           .ValueOrDie();
 
-  /* ColumnExpression empty_contains_1{"empty_contains_1", filter_func_1}; */
-  /* ColumnExpression contains{"contains", MakeFilter()}; */
-  /* ColumnExpression empty_contains_2{"empty_contains_2", filter_func_2}; */
-
   auto filter_ir_1 = graph->CreateNode<FilterIR>(ast, mem_src, filter_func_1).ValueOrDie();
   auto filter_ir_2 = graph->CreateNode<FilterIR>(ast, filter_ir_1, filter_func_2).ValueOrDie();
 
   auto limit = MakeLimit(static_cast<OperatorIR*>(filter_ir_2), 1000);
-
-  /* auto map1 = MakeMap(mem_src, {}, false); */
-  /* ASSERT_OK(filter_ir_1->AddParent(map1)); */
-  /* auto map1_id = map1->id(); */
-
 
   ResolveTypesRule type_rule(compiler_state_.get());
   ASSERT_OK(type_rule.Execute(graph.get()));

--- a/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule_test.cc
+++ b/src/carnot/planner/compiler/optimizer/prune_unused_contains_rule_test.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "src/carnot/planner/compiler/analyzer/analyzer.h"
+#include "src/carnot/planner/compiler/optimizer/prune_unused_contains_rule.h"
+#include "src/carnot/planner/compiler/test_utils.h"
+
+namespace px {
+namespace carnot {
+namespace planner {
+namespace compiler {
+
+using table_store::schema::Relation;
+
+using PruneUnusedContainsRuleTest = RulesTest;
+
+TEST_F(PruneUnusedContainsRuleTest, basic) {
+  MemorySourceIR* mem_src = MakeMemSource(MakeRelation());
+  compiler_state_->relation_map()->emplace("table", MakeRelation());
+
+  auto constant1 = graph->CreateNode<StringIR>(ast, "testing").ValueOrDie();
+  auto empty_str = graph->CreateNode<StringIR>(ast, "").ValueOrDie();
+
+  auto filter_func =
+      graph
+          ->CreateNode<FuncIR>(ast, FuncIR::Op{FuncIR::Opcode::non_op, "", "contains"},
+                               std::vector<ExpressionIR*>{constant1, empty_str})
+          .ValueOrDie();
+  auto filter_func_id = filter_func->id();
+
+  auto filter_ir = graph->CreateNode<FilterIR>(ast, mem_src, filter_func).ValueOrDie();
+  auto filter_ir_id = filter_ir->id();
+
+  ResolveTypesRule type_rule(compiler_state_.get());
+  ASSERT_OK(type_rule.Execute(graph.get()));
+
+  PruneUnusedContainsRule rule;
+  auto result = rule.Execute(graph.get());
+  ASSERT_OK(result);
+  ASSERT_TRUE(result.ConsumeValueOrDie());
+
+  EXPECT_FALSE(graph->HasNode(filter_ir_id));
+  EXPECT_FALSE(graph->HasNode(filter_func_id));
+}
+
+TEST_F(PruneUnusedContainsRuleTest, IgnoresNonEmptyStringContains) {
+  MemorySourceIR* mem_src = MakeMemSource(MakeRelation());
+  compiler_state_->relation_map()->emplace("table", MakeRelation());
+
+  auto constant1 = graph->CreateNode<StringIR>(ast, "testing").ValueOrDie();
+  auto constant2 = graph->CreateNode<StringIR>(ast, "existing value").ValueOrDie();
+
+  auto filter_func =
+      graph
+          ->CreateNode<FuncIR>(ast, FuncIR::Op{FuncIR::Opcode::non_op, "", "contains"},
+                               std::vector<ExpressionIR*>{constant1, constant2})
+          .ValueOrDie();
+  auto filter_func_id = filter_func->id();
+
+  auto filter_ir = graph->CreateNode<FilterIR>(ast, mem_src, filter_func).ValueOrDie();
+  auto filter_ir_id = filter_ir->id();
+
+  ResolveTypesRule type_rule(compiler_state_.get());
+  ASSERT_OK(type_rule.Execute(graph.get()));
+
+  PruneUnusedContainsRule rule;
+  auto result = rule.Execute(graph.get());
+  ASSERT_OK(result);
+  ASSERT_FALSE(result.ConsumeValueOrDie());
+
+  EXPECT_TRUE(graph->HasNode(filter_ir_id));
+  EXPECT_TRUE(graph->HasNode(filter_func_id));
+}
+
+}  // namespace compiler
+}  // namespace planner
+}  // namespace carnot
+}  // namespace px

--- a/src/carnot/planner/logical_planner_test.cc
+++ b/src/carnot/planner/logical_planner_test.cc
@@ -280,7 +280,7 @@ import px
 ###############################################################
 # Pods/services are formatted as <namespace>/<name>.
 # If you want to match a namespace, only keep the namespace portion
-match_name = 'sock-shop/order'
+match_name = ''
 k8s_object = 'service'
 requestor_filter = ''  # 'front-end'
 # Visualization Variables - Dont change unless you know what you are doing

--- a/src/carnot/planner/logical_planner_test.cc
+++ b/src/carnot/planner/logical_planner_test.cc
@@ -280,7 +280,7 @@ import px
 ###############################################################
 # Pods/services are formatted as <namespace>/<name>.
 # If you want to match a namespace, only keep the namespace portion
-match_name = ''
+match_name = 'sock-shop/order'
 k8s_object = 'service'
 requestor_filter = ''  # 'front-end'
 # Visualization Variables - Dont change unless you know what you are doing
@@ -699,7 +699,7 @@ def http_data(start_time: str, source_filter: str, destination_filter: str, num_
     return df
 )pxl";
 
-TEST_F(LogicalPlannerTest, SegFaultTest) {
+TEST_F(LogicalPlannerTest, VerifyEmptyContainsCallsDoNotSegFaultTest) {
   auto planner = LogicalPlanner::Create(info_).ConsumeValueOrDie();
   plannerpb::QueryRequest req;
   req.set_query_str(kHttpDataScript);


### PR DESCRIPTION
Summary: Add compiler optimization to remove `px.contains` calls with empty strings

The majority of our pxl scripts have parameters that default to empty strings. This results in `px.contains` function calls that will always return the original data set (an empty string `""` will always be found in any input string). An example of this can be seen in the following screenshot (the filter arguments highlighted below):

<img width="851" alt="Screenshot 2023-08-17 at 8 27 35 AM" src="https://github.com/pixie-io/pixie/assets/5855593/0dfdc093-0c3a-4c84-823d-efbb02d00e14">

Relevant Issues: Fixes #618

Type of change: /kind feature

Test Plan: Used analyze and explain query options to test the following conditions:
- Verified what the `http_data` pxl script looks like when there are no arguments supplied without any optimizations -- [graphviz_with_empty_contains](https://github.com/pixie-io/pixie/assets/5855593/3a07d707-5440-4ed6-a7f9-9bf4fd8d09a2)
- Verified what the `http_data` pxl script looks like if the `px.contains` calls [here](https://github.com/pixie-io/pixie/blob/c9813f7a7d23643be29b5cfa7a997d84891b571e/src/pxl_scripts/px/http_data/data.pxl#L34-L36) are removed from the script. The optimization should produce the same graph as this case. -- [graphviz_without_empty_contains](https://github.com/pixie-io/pixie/assets/5855593/0b7b4106-1cdc-45a8-9c39-87eb65689590)
- Verified the optimization results in the expected query graph and loaded a variety of pxl scripts to make sure queries appeared normal -- [latest_graphviz_with_optimization](https://github.com/pixie-io/pixie/assets/5855593/c60a3cc4-d6a3-4242-b47f-b9c1fb2a4df5)