### PR TITLE
Added cgid capture to stirling with testing

### DIFF
--- a/src/shared/metadata/cgroup_path_resolver.cc
+++ b/src/shared/metadata/cgroup_path_resolver.cc
@@ -26,6 +26,8 @@
 
 #include <fstream>
 #include "src/common/fs/fs_wrapper.h"
+#include "src/common/system/config.h"
+#include "src/common/system/proc_pid_path.h"
 #include "src/shared/metadata/cgroup_path_resolver.h"
 
 DEFINE_bool(force_cgroup2_mode, true, "Flag to force assume cgroup2 fs for testing purposes");
@@ -78,7 +80,7 @@ StatusOr<std::string> FindSelfCGroupProcs(std::string_view base_path) {
 }
 
 StatusOr<uint64_t> FindCgroupIDFromPID(pid_t pid) {
-  std::string cgroup_name = absl::StrCat("/proc/", pid, "/cgroup");
+  auto cgroup_name = px::system::ProcPidPath(pid, "cgroup");
   std::ifstream proc_cgroup(cgroup_name);
 
   // get rid of the id at the front
@@ -94,7 +96,9 @@ StatusOr<uint64_t> FindCgroupIDFromPID(pid_t pid) {
     return error::NotFound(failure_string);
   }
 
-  std::string cgroup_path_name = absl::StrCat("/sys/fs/cgroup/", line.substr(2, line.size()));
+  std::string cgroup_path_name =
+      absl::StrCat(px::system::Config::GetInstance().sysfs_path().string(), "/cgroup/",
+                   line.substr(2, line.size()));
 
   // lstat what we are pointing to
   struct stat stat_buf;

--- a/src/shared/metadata/cgroup_path_resolver.cc
+++ b/src/shared/metadata/cgroup_path_resolver.cc
@@ -24,7 +24,6 @@
 
 #include <absl/strings/str_replace.h>
 
-#include <stdio.h>
 #include <fstream>
 #include "src/common/fs/fs_wrapper.h"
 #include "src/shared/metadata/cgroup_path_resolver.h"

--- a/src/shared/metadata/cgroup_path_resolver.h
+++ b/src/shared/metadata/cgroup_path_resolver.h
@@ -91,6 +91,11 @@ StatusOr<std::string> CGroupBasePath(std::string_view sysfs_path);
 StatusOr<std::string> FindSelfCGroupProcs(std::string_view base_path);
 
 /**
+ * Finds the cgroup id corresponding to the pid
+ **/
+StatusOr<uint64_t> FindCgroupIDFromPID(pid_t pid);
+
+/**
  * Given a path to a sample cgroup.procs file for a K8s pod,
  * this function produces a templated spec from which paths for other pods can be generated.
  */

--- a/src/stirling/core/canonical_types.h
+++ b/src/stirling/core/canonical_types.h
@@ -45,6 +45,14 @@ constexpr DataElement kUPID = {
     types::SemanticType::ST_UPID,
     types::PatternType::GENERAL};
 
+constexpr std::string_view kCGIDColName = "cgid";
+constexpr DataElement kCGID = {
+    kCGIDColName,
+    "An opaque numeric ID that globally identify a running process inside the cluster.",
+    types::DataType::INT64,
+    types::SemanticType::ST_NONE,
+    types::PatternType::GENERAL};
+
 // clang-format on
 
 }  // namespace canonical_data_elements

--- a/src/stirling/core/canonical_types.h
+++ b/src/stirling/core/canonical_types.h
@@ -40,7 +40,7 @@ constexpr DataElement kTime = {
 constexpr std::string_view kUPIDColName = "upid";
 constexpr DataElement kUPID = {
     kUPIDColName,
-    "An opaque numeric ID that globally identify a running process inside the cluster.",
+    "An opaque numeric ID that globally identifies a running process inside the cluster.",
     types::DataType::UINT128,
     types::SemanticType::ST_UPID,
     types::PatternType::GENERAL};
@@ -48,7 +48,7 @@ constexpr DataElement kUPID = {
 constexpr std::string_view kCGIDColName = "cgid";
 constexpr DataElement kCGID = {
     kCGIDColName,
-    "An opaque numeric ID that globally identify a running process inside the cluster.",
+    "The cgroup id that the process was in when this probe was triggered.",
     types::DataType::INT64,
     types::SemanticType::ST_NONE,
     types::PatternType::GENERAL};

--- a/src/stirling/source_connectors/socket_tracer/amqp_table.h
+++ b/src/stirling/source_connectors/socket_tracer/amqp_table.h
@@ -31,6 +31,7 @@ namespace stirling {
 static constexpr DataElement kAMQPElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -84,6 +85,7 @@ DEFINE_PRINT_TABLE(AMQP)
 
 constexpr int kAMQPTimeIdx = kAMQPTable.ColIndex("time_");
 constexpr int kAMQPUUIDIdx = kAMQPTable.ColIndex("upid");
+constexpr int kAMQPCGIDIdx = kAMQPTable.ColIndex("cgid");
 constexpr int kAMQPFrameTypeIdx = kAMQPTable.ColIndex("frame_type");
 constexpr int kAMQPChannelIdx = kAMQPTable.ColIndex("channel");
 constexpr int kAMQPLatencyIdx = kAMQPTable.ColIndex("latency");

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -136,6 +136,8 @@ static __inline void init_conn_id(uint32_t tgid, int32_t fd, struct conn_id_t* c
   conn_id->upid.start_time_ticks = get_tgid_start_time();
   conn_id->fd = fd;
   conn_id->tsid = bpf_ktime_get_ns();
+  // Until we have proper cgids tracing
+  conn_id->cgid = bpf_get_current_cgroup_id();
 }
 
 static __inline void init_conn_info(uint32_t tgid, int32_t fd, struct conn_info_t* conn_info) {

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
@@ -79,6 +79,8 @@ struct conn_id_t {
   int32_t fd;
   // Unique id of the conn_id (timestamp).
   uint64_t tsid;
+  // TODO(AdityaAtulTewari) This belongs in the Upid struct but that creates a rewrite.
+  uint64_t cgid;
 };
 
 // Specifies the corresponding indexes of the entries of a per-cpu array.

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
@@ -79,7 +79,7 @@ struct conn_id_t {
   int32_t fd;
   // Unique id of the conn_id (timestamp).
   uint64_t tsid;
-  // TODO(AdityaAtulTewari) This belongs in the Upid struct but that creates a rewrite.
+  // cgid of the connection
   uint64_t cgid;
 };
 

--- a/src/stirling/source_connectors/socket_tracer/cass_table.h
+++ b/src/stirling/source_connectors/socket_tracer/cass_table.h
@@ -37,6 +37,7 @@ static const std::map<int64_t, std::string_view> kCQLRespOpDecoder =
 static constexpr DataElement kCQLElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -71,6 +72,7 @@ DEFINE_PRINT_TABLE(CQL)
 
 static constexpr int kCQLTraceRoleIdx = kCQLTable.ColIndex("trace_role");
 static constexpr int kCQLUPIDIdx = kCQLTable.ColIndex("upid");
+static constexpr int kCQLCGIDIdx = kCQLTable.ColIndex("cgid");
 static constexpr int kCQLReqOp = kCQLTable.ColIndex("req_op");
 static constexpr int kCQLReqBody = kCQLTable.ColIndex("req_body");
 static constexpr int kCQLRespOp = kCQLTable.ColIndex("resp_op");

--- a/src/stirling/source_connectors/socket_tracer/conn_stats.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_stats.cc
@@ -76,6 +76,7 @@ absl::flat_hash_map<ConnStats::AggKey, ConnStats::Stats>& ConnStats::UpdateStats
     stats.conn_close += conn_close;
     stats.bytes_recv += bytes_recv;
     stats.bytes_sent += bytes_sent;
+    stats.cgid_curr = tracker->conn_id().cgid;
 
     stats.last_update = update_counter_;
   }

--- a/src/stirling/source_connectors/socket_tracer/conn_stats.h
+++ b/src/stirling/source_connectors/socket_tracer/conn_stats.h
@@ -75,6 +75,7 @@ class ConnStats {
     uint64_t conn_close = 0;
     uint64_t bytes_sent = 0;
     uint64_t bytes_recv = 0;
+    uint64_t cgid_curr = 0;
 
     // Keep track of whether this stats object has ever been previously reported.
     // Used to determine whether it should be reported in the future, after the connection

--- a/src/stirling/source_connectors/socket_tracer/conn_stats_table.h
+++ b/src/stirling/source_connectors/socket_tracer/conn_stats_table.h
@@ -29,6 +29,7 @@ namespace stirling {
 constexpr DataElement kConnStatsElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -68,6 +69,7 @@ namespace conn_stats_idx {
 
 constexpr int kTime = kConnStatsTable.ColIndex("time_");
 constexpr int kUPID = kConnStatsTable.ColIndex("upid");
+constexpr int kCGID = kConnStatsTable.ColIndex("cgid");
 constexpr int kRemoteAddr = kConnStatsTable.ColIndex("remote_addr");
 constexpr int kRemotePort = kConnStatsTable.ColIndex("remote_port");
 constexpr int kAddrFamily = kConnStatsTable.ColIndex("addr_family");

--- a/src/stirling/source_connectors/socket_tracer/conn_stats_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_stats_test.cc
@@ -89,6 +89,7 @@ TEST_F(ConnStatsTest, Basic) {
       .upid = {.pid = 12345, .start_time_ticks = 1000},
       .fd = 3,
       .tsid = 111110,
+      .cgid = UINT64_MAX,
   };
 
   // The basic conn_stats_event template.
@@ -165,6 +166,7 @@ TEST_F(ConnStatsTest, ServerSide) {
       .upid = {.pid = 12345, .start_time_ticks = 1000},
       .fd = 3,
       .tsid = 10000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn0_stats_event;
@@ -193,6 +195,7 @@ TEST_F(ConnStatsTest, ServerSide) {
       .upid = {.pid = 12345, .start_time_ticks = 1000},
       .fd = 4,
       .tsid = 20000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn1_stats_event;
@@ -221,6 +224,7 @@ TEST_F(ConnStatsTest, ServerSide) {
       .upid = {.pid = 12345, .start_time_ticks = 1000},
       .fd = 5,
       .tsid = 30000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn2_stats_event;
@@ -257,6 +261,7 @@ TEST_F(ConnStatsTest, ClientSide) {
       .upid = {.pid = 11111, .start_time_ticks = 1000},
       .fd = 3,
       .tsid = 10000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn0_stats_event;
@@ -285,6 +290,7 @@ TEST_F(ConnStatsTest, ClientSide) {
       .upid = {.pid = 11111, .start_time_ticks = 1000},
       .fd = 4,
       .tsid = 20000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn1_stats_event;
@@ -313,6 +319,7 @@ TEST_F(ConnStatsTest, ClientSide) {
       .upid = {.pid = 11111, .start_time_ticks = 1000},
       .fd = 5,
       .tsid = 30000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn2_stats_event;
@@ -344,6 +351,7 @@ TEST_F(ConnStatsTest, NoEventsIfNoRemoteAddr) {
       .upid = {.pid = 11111, .start_time_ticks = 1000},
       .fd = 3,
       .tsid = 10000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn_stats_event;
@@ -371,6 +379,7 @@ TEST_F(ConnStatsTest, DisabledConnTracker) {
       .upid = {.pid = 11111, .start_time_ticks = 1000},
       .fd = 3,
       .tsid = 10000,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn_stats_event;

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker_http2_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker_http2_test.cc
@@ -47,7 +47,7 @@ class ConnTrackerHTTP2Test : public ::testing::Test {
   }
 
   const conn_id_t kConnID = {
-      .upid = {{.pid = 123}, .start_time_ticks = 11000000}, .fd = 3, .tsid = 21};
+      .upid = {{.pid = 123}, .start_time_ticks = 11000000}, .fd = 3, .tsid = 21, .cgid = 33};
 
   ConnTracker tracker_;
   testing::MockClock mock_clock_;
@@ -193,7 +193,7 @@ TEST_F(ConnTrackerHTTP2Test, MixedHeadersAndData) {
 TEST_F(ConnTrackerHTTP2Test, ZeroFD) {
   ConnTracker tracker;
   const conn_id_t kConnID = {
-      .upid = {{.pid = 123}, .start_time_ticks = 11000000}, .fd = 0, .tsid = 21};
+      .upid = {{.pid = 123}, .start_time_ticks = 11000000}, .fd = 0, .tsid = 21, .cgid=33};
   tracker.SetConnID(kConnID);
 
   const int kStreamID = 7;

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker_http2_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker_http2_test.cc
@@ -193,7 +193,7 @@ TEST_F(ConnTrackerHTTP2Test, MixedHeadersAndData) {
 TEST_F(ConnTrackerHTTP2Test, ZeroFD) {
   ConnTracker tracker;
   const conn_id_t kConnID = {
-      .upid = {{.pid = 123}, .start_time_ticks = 11000000}, .fd = 0, .tsid = 21, .cgid=33};
+      .upid = {{.pid = 123}, .start_time_ticks = 11000000}, .fd = 0, .tsid = 21, .cgid = 33};
   tracker.SetConnID(kConnID);
 
   const int kStreamID = 7;

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker_test.cc
@@ -769,6 +769,7 @@ TEST_F(ConnTrackerTest, ConnStats) {
       .upid = {.pid = 12345, .start_time_ticks = 1000},
       .fd = 3,
       .tsid = 111110,
+      .cgid = UINT64_MAX,
   };
 
   struct conn_stats_event_t conn_stats_event;

--- a/src/stirling/source_connectors/socket_tracer/conn_trackers_manager_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_trackers_manager_test.cc
@@ -84,7 +84,7 @@ TEST_F(ConnTrackersManagerTest, Fuzz) {
       int32_t fd = 1;
       uint64_t tsid = tsid_dist(rng_);
 
-      struct conn_id_t conn_id = {{{pid}, 0}, fd, tsid};
+      struct conn_id_t conn_id = {{{pid}, 0}, fd, tsid, UINT64_MAX};
       TrackerEvent(conn_id, protocol.value());
     } else if (x < 0.95) {
       int death_countdown = death_countdown_dist(rng_);

--- a/src/stirling/source_connectors/socket_tracer/dns_table.h
+++ b/src/stirling/source_connectors/socket_tracer/dns_table.h
@@ -32,6 +32,7 @@ namespace stirling {
 static constexpr DataElement kDNSElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -63,6 +64,7 @@ static constexpr auto kDNSTable =
 DEFINE_PRINT_TABLE(DNS)
 
 static constexpr int kDNSUPIDIdx = kDNSTable.ColIndex("upid");
+static constexpr int kDNSCGIDIdx = kDNSTable.ColIndex("cgid");
 static constexpr int kDNSReqHdrIdx = kDNSTable.ColIndex("req_header");
 static constexpr int kDNSReqBodyIdx = kDNSTable.ColIndex("req_body");
 static constexpr int kDNSRespHdrIdx = kDNSTable.ColIndex("resp_header");

--- a/src/stirling/source_connectors/socket_tracer/http2_messages_table.h
+++ b/src/stirling/source_connectors/socket_tracer/http2_messages_table.h
@@ -27,6 +27,7 @@ namespace stirling {
 constexpr DataElement kHTTP2MessagesElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -58,6 +59,7 @@ DEFINE_PRINT_TABLE(HTTP2Messages)
 
 constexpr int kHTTP2MessagesTimeIdx = kHTTP2MessagesTable.ColIndex("time_");
 constexpr int kHTTP2MessagesUPIDIdx = kHTTP2MessagesTable.ColIndex("upid");
+constexpr int kHTTP2MessagesCGIDIdx = kHTTP2MessagesTable.ColIndex("cgid");
 constexpr int kHTTP2MessagesRemoteAddrIdx = kHTTP2MessagesTable.ColIndex("remote_addr");
 constexpr int kHTTP2MessagesRemotePortIdx = kHTTP2MessagesTable.ColIndex("remote_port");
 constexpr int kHTTP2MessagesTraceRoleIdx = kHTTP2MessagesTable.ColIndex("trace_role");

--- a/src/stirling/source_connectors/socket_tracer/http_table.h
+++ b/src/stirling/source_connectors/socket_tracer/http_table.h
@@ -41,6 +41,7 @@ static const std::map<int64_t, std::string_view> kHTTPContentTypeDecoder =
 constexpr DataElement kHTTPElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -110,6 +111,7 @@ DEFINE_PRINT_TABLE(HTTP)
 
 constexpr int kHTTPTimeIdx = kHTTPTable.ColIndex("time_");
 constexpr int kHTTPUPIDIdx = kHTTPTable.ColIndex("upid");
+constexpr int kHTTPCGIDIdx = kHTTPTable.ColIndex("cgid");
 constexpr int kHTTPRemoteAddrIdx = kHTTPTable.ColIndex("remote_addr");
 constexpr int kHTTPRemotePortIdx = kHTTPTable.ColIndex("remote_port");
 constexpr int kHTTPTraceRoleIdx = kHTTPTable.ColIndex("trace_role");

--- a/src/stirling/source_connectors/socket_tracer/kafka_table.h
+++ b/src/stirling/source_connectors/socket_tracer/kafka_table.h
@@ -35,6 +35,7 @@ static const std::map<int64_t, std::string_view> kKafkaAPIKeyDecoder =
 static constexpr DataElement kKafkaElements[] = {
       canonical_data_elements::kTime,
       canonical_data_elements::kUPID,
+      canonical_data_elements::kCGID,
       canonical_data_elements::kRemoteAddr,
       canonical_data_elements::kRemotePort,
       canonical_data_elements::kTraceRole,
@@ -68,6 +69,7 @@ DEFINE_PRINT_TABLE(Kafka)
 
 constexpr int kKafkaTimeIdx = kKafkaTable.ColIndex("time_");
 constexpr int kKafkaUPIDIdx = kKafkaTable.ColIndex("upid");
+constexpr int kKafkaCGIDIdx = kKafkaTable.ColIndex("cgid");
 constexpr int kKafkaReqCmdIdx = kKafkaTable.ColIndex("req_cmd");
 constexpr int kKafkaClientIDIdx = kKafkaTable.ColIndex("client_id");
 constexpr int kKafkaReqBodyIdx = kKafkaTable.ColIndex("req_body");

--- a/src/stirling/source_connectors/socket_tracer/mux_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mux_table.h
@@ -32,6 +32,7 @@ namespace stirling {
 static constexpr DataElement kMuxElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -56,6 +57,7 @@ static constexpr auto kMuxTable =
 DEFINE_PRINT_TABLE(Mux)
 
 static constexpr int kMuxUPIDIdx = kMuxTable.ColIndex("upid");
+static constexpr int kMuxCGIDIdx = kMuxTable.ColIndex("cgid");
 static constexpr int kMuxReqTypeIdx = kMuxTable.ColIndex("req_type");
 
 }  // namespace stirling

--- a/src/stirling/source_connectors/socket_tracer/mysql_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mysql_table.h
@@ -37,6 +37,7 @@ static const std::map<int64_t, std::string_view> kMySQLRespStatusDecoder =
 static constexpr DataElement kMySQLElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -71,6 +72,7 @@ DEFINE_PRINT_TABLE(MySQL)
 
 constexpr int kMySQLTimeIdx = kMySQLTable.ColIndex("time_");
 constexpr int kMySQLUPIDIdx = kMySQLTable.ColIndex("upid");
+constexpr int kMySQLCGIDIdx = kMySQLTable.ColIndex("cgid");
 constexpr int kMySQLReqCmdIdx = kMySQLTable.ColIndex("req_cmd");
 constexpr int kMySQLReqBodyIdx = kMySQLTable.ColIndex("req_body");
 constexpr int kMySQLRespStatusIdx = kMySQLTable.ColIndex("resp_status");

--- a/src/stirling/source_connectors/socket_tracer/nats_table.h
+++ b/src/stirling/source_connectors/socket_tracer/nats_table.h
@@ -29,6 +29,7 @@ namespace stirling {
 constexpr DataElement kNATSElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -53,6 +54,7 @@ namespace nats_idx {
 
 constexpr int kTime = kNATSTable.ColIndex("time_");
 constexpr int kUPID = kNATSTable.ColIndex("upid");
+constexpr int kCGID = kNATSTable.ColIndex("cgid");
 constexpr int kRemoteAddr = kNATSTable.ColIndex("remote_addr");
 constexpr int kRemotePort = kNATSTable.ColIndex("remote_port");
 constexpr int kRemoteRole = kNATSTable.ColIndex("trace_role");

--- a/src/stirling/source_connectors/socket_tracer/pgsql_table.h
+++ b/src/stirling/source_connectors/socket_tracer/pgsql_table.h
@@ -29,6 +29,7 @@ namespace stirling {
 static constexpr DataElement kPGSQLElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -56,6 +57,7 @@ static constexpr auto kPGSQLTable = DataTableSchema(
 DEFINE_PRINT_TABLE(PGSQL)
 
 constexpr int kPGSQLUPIDIdx = kPGSQLTable.ColIndex("upid");
+constexpr int kPGSQLCGIDIdx = kPGSQLTable.ColIndex("cgid");
 constexpr int kPGSQLReqIdx = kPGSQLTable.ColIndex("req");
 constexpr int kPGSQLRespIdx = kPGSQLTable.ColIndex("resp");
 constexpr int kPGSQLReqCmdIdx = kPGSQLTable.ColIndex("req_cmd");

--- a/src/stirling/source_connectors/socket_tracer/proto/sock_event.proto
+++ b/src/stirling/source_connectors/socket_tracer/proto/sock_event.proto
@@ -31,6 +31,7 @@ message ConnID {
   uint64 start_time_ns = 2;
   uint32 fd = 3;
   uint32 generation = 4;
+  uint64 cgid = 5;
 }
 
 message SocketDataEvent {

--- a/src/stirling/source_connectors/socket_tracer/redis_table.h
+++ b/src/stirling/source_connectors/socket_tracer/redis_table.h
@@ -32,6 +32,7 @@ namespace stirling {
 static constexpr DataElement kRedisElements[] = {
         canonical_data_elements::kTime,
         canonical_data_elements::kUPID,
+        canonical_data_elements::kCGID,
         canonical_data_elements::kRemoteAddr,
         canonical_data_elements::kRemotePort,
         canonical_data_elements::kTraceRole,
@@ -59,6 +60,7 @@ static constexpr auto kRedisTable =
 DEFINE_PRINT_TABLE(Redis)
 
 constexpr int kRedisUPIDIdx = kRedisTable.ColIndex("upid");
+constexpr int kRedisCGIDIdx = kRedisTable.ColIndex("cgid");
 constexpr int kRedisCmdIdx = kRedisTable.ColIndex("req_cmd");
 constexpr int kRedisReqIdx = kRedisTable.ColIndex("req_args");
 constexpr int kRedisRespIdx = kRedisTable.ColIndex("resp");

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
@@ -197,6 +197,7 @@ TEST_P(NonVecSyscallTests, NonVecSyscalls) {
     EXPECT_EQ(1, records[kHTTPMajorVersionIdx]->Get<types::Int64Value>(1).val);
     EXPECT_EQ(static_cast<uint64_t>(HTTPContentType::kJSON),
               records[kHTTPContentTypeIdx]->Get<types::Int64Value>(1).val);
+    EXPECT_EQ(system.ServerCGID(), records[kHTTPCGIDIdx]->Get<types::Int64Value>(0).val);
   }
 }
 
@@ -256,6 +257,7 @@ TEST_P(IOVecSyscallTests, IOVecSyscalls) {
     EXPECT_THAT(std::string(records[kHTTPRespBodyIdx]->Get<types::StringValue>(1)), StrEq("bc"));
     EXPECT_THAT(std::string(records[kHTTPRespMessageIdx]->Get<types::StringValue>(1)),
                 StrEq("Not Found"));
+    EXPECT_EQ(system.ServerCGID(), records[kHTTPCGIDIdx]->Get<types::Int64Value>(0).val);
   }
 
   if (p.trace_role & kRoleClient) {
@@ -423,6 +425,7 @@ TEST_F(SocketTraceBPFTest, MultipleConnections) {
 
     ASSERT_THAT(records, RecordBatchSizeIs(1));
     EXPECT_THAT(records[kHTTPRespHeadersIdx]->Get<types::StringValue>(0), HasSubstr("msg1"));
+    EXPECT_EQ(system1.ServerCGID(), records[kHTTPCGIDIdx]->Get<types::Int64Value>(0).val);
   }
 
   {
@@ -431,6 +434,7 @@ TEST_F(SocketTraceBPFTest, MultipleConnections) {
 
     ASSERT_THAT(records, RecordBatchSizeIs(1));
     EXPECT_THAT(records[kHTTPRespHeadersIdx]->Get<types::StringValue>(0), HasSubstr("msg2"));
+    EXPECT_EQ(system2.ServerCGID(), records[kHTTPCGIDIdx]->Get<types::Int64Value>(0).val);
   }
 }
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1345,6 +1345,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   DataTable::RecordBuilder<&kMySQLTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1698,7 +1698,7 @@ void SocketTraceConnector::TransferConnStats(ConnectorContext* ctx, DataTable* d
 
       r.Append<idx::kTime>(time);
       r.Append<idx::kUPID>(upid.value());
-      r.Append<idx::kCGID>(UINT64_MAX);
+      r.Append<idx::kCGID>(stats.cgid_curr);
       r.Append<idx::kRemoteAddr>(key.remote_addr);
       r.Append<idx::kRemotePort>(key.remote_port);
       r.Append<idx::kAddrFamily>(static_cast<int>(stats.addr_family));

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1339,8 +1339,8 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::mysql::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   DataTable::RecordBuilder<&kMySQLTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
@@ -1362,12 +1362,13 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::cass::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   DataTable::RecordBuilder<&kCQLTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
@@ -1385,12 +1386,13 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::dns::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   DataTable::RecordBuilder<&kDNSTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
@@ -1408,12 +1410,13 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::pgsql::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   DataTable::RecordBuilder<&kPGSQLTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
@@ -1430,12 +1433,13 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::mux::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   DataTable::RecordBuilder<&kMuxTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
@@ -1450,13 +1454,15 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::amqp::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
+
   int64_t timestamp_ns = std::max(entry.req.timestamp_ns, entry.resp.timestamp_ns);
   DataTable::RecordBuilder<&kAMQPTable> r(data_table, timestamp_ns);
 
   r.Append<r.ColIndex("time_")>(timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
@@ -1497,8 +1503,8 @@ endpoint_role_t Swapendpoint_role_t(endpoint_role_t role) {
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::redis::Record entry, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   endpoint_role_t role = conn_tracker.role();
   if (entry.role_swapped) {
@@ -1508,6 +1514,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   DataTable::RecordBuilder<&kRedisTable> r(data_table, entry.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(entry.resp.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
@@ -1524,13 +1531,14 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 template <>
 void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
                                          protocols::nats::Record record, DataTable* data_table) {
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   endpoint_role_t role = conn_tracker.role();
   DataTable::RecordBuilder<&kNATSTable> r(data_table, record.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(record.req.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
@@ -1547,13 +1555,14 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
                                          protocols::kafka::Record record, DataTable* data_table) {
   constexpr size_t kMaxKafkaBodyBytes = 65536;
 
-  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
-                conn_tracker.conn_id().upid.start_time_ticks);
+  auto const& conn_id = conn_tracker.conn_id();
+  md::UPID upid(ctx->GetASID(), conn_id.upid.pid, conn_id.upid.start_time_ticks);
 
   endpoint_role_t role = conn_tracker.role();
   DataTable::RecordBuilder<&kKafkaTable> r(data_table, record.resp.timestamp_ns);
   r.Append<r.ColIndex("time_")>(record.req.timestamp_ns);
   r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("cgid")>(conn_id.cgid);
   r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
   r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
@@ -1586,6 +1595,7 @@ namespace {
 void SocketDataEventToPB(const SocketDataEvent& event, sockeventpb::SocketDataEvent* pb) {
   pb->mutable_attr()->set_timestamp_ns(event.attr.timestamp_ns);
   pb->mutable_attr()->mutable_conn_id()->set_pid(event.attr.conn_id.upid.pid);
+  pb->mutable_attr()->mutable_conn_id()->set_cgid(event.attr.conn_id.cgid);
   pb->mutable_attr()->mutable_conn_id()->set_start_time_ns(
       event.attr.conn_id.upid.start_time_ticks);
   pb->mutable_attr()->mutable_conn_id()->set_fd(event.attr.conn_id.fd);
@@ -1688,6 +1698,7 @@ void SocketTraceConnector::TransferConnStats(ConnectorContext* ctx, DataTable* d
 
       r.Append<idx::kTime>(time);
       r.Append<idx::kUPID>(upid.value());
+      r.Append<idx::kCGID>(UINT64_MAX);
       r.Append<idx::kRemoteAddr>(key.remote_addr);
       r.Append<idx::kRemotePort>(key.remote_port);
       r.Append<idx::kAddrFamily>(static_cast<int>(stats.addr_family));

--- a/src/stirling/source_connectors/socket_tracer/testing/client_server_system.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/client_server_system.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "src/common/system/tcp_socket.h"
+#include "src/shared/metadata/cgroup_path_resolver.h"
 
 static uint64_t getcgid() { return px::md::FindCgroupIDFromPID(getpid()).ValueOrDie(); }
 


### PR DESCRIPTION
Summary: Added Capturing of Cgroup ids to the ebpf probes in the socket tracer. This includes modifications to data structures for communicating that information to userspace and other data tables. It also includes some minimal testing for ensuring that cgroup ids are captured correctly. The reason for this change is given in the design document for the solution to this [issue](https://github.com/pixie-io/pixie/issues/1638): in short it is the first step in using cgids rather than pids to associate a particular piece of communication data with the correct pod.

Test Plan: Added Cgroup id capture checks to existing `socket_tracer` tests.

Type of change: /kind Feature expansion

Signed-off-as: AdityaAtulTewari [adityaatewari@gmail.com](mailto:adityaatewari@gmail.com)