### PR TITLE
[Kernel scoping 4/5] Add TraceProgram object

### DIFF
--- a/src/carnot/planner/objects/qlobject.h
+++ b/src/carnot/planner/objects/qlobject.h
@@ -55,6 +55,7 @@ enum class QLObjectType {
   // General module type.
   kModule,
   kTraceModule,
+  kTraceProgram,
   kDict,
   kTracingVariable,
   kProbe,

--- a/src/carnot/planner/probes/probes.cc
+++ b/src/carnot/planner/probes/probes.cc
@@ -197,12 +197,17 @@ StatusOr<TracepointDeployment*> MutationsIR::CreateKProbeTracepointDeployment(
   return raw;
 }
 
-Status TracepointDeployment::AddBPFTrace(const std::string& bpftrace,
-                                         const std::string& output_name) {
+Status TracepointDeployment::AddBPFTrace(const std::string& bpftrace_str,
+                                         const std::string& output_name,
+                                         const std::vector<TracepointSelector>& selectors) {
   carnot::planner::dynamic_tracing::ir::logical::TracepointDeployment::TracepointProgram
       tracepoint_pb;
-  tracepoint_pb.mutable_bpftrace()->set_program(bpftrace);
+  tracepoint_pb.mutable_bpftrace()->set_program(bpftrace_str);
+  // set the output table to write program results to
   tracepoint_pb.set_table_name(output_name);
+  for (const auto& selector : selectors) {
+    *tracepoint_pb.add_selectors() = selector;
+  }
   tracepoints_.push_back(tracepoint_pb);
   return Status::OK();
 }

--- a/src/carnot/planner/probes/probes.h
+++ b/src/carnot/planner/probes/probes.h
@@ -36,6 +36,8 @@ namespace carnot {
 namespace planner {
 namespace compiler {
 
+using TracepointSelector = carnot::planner::dynamic_tracing::ir::logical::TracepointSelector;
+
 class ProbeOutput {
  public:
   ProbeOutput() = delete;
@@ -192,9 +194,11 @@ class TracepointDeployment {
    *
    * @param bpftrace_program the program in string format.
    * @param output_name the output table to write program results.
+   * @param selectors the selectors to use for the program.
    * @return Status
    */
-  Status AddBPFTrace(const std::string& bpftrace_program, const std::string& output_name);
+  Status AddBPFTrace(const std::string& bpftrace_str, const std::string& output_name,
+                     const std::vector<TracepointSelector>& selectors);
 
   std::string name() const { return name_; }
 

--- a/src/carnot/planner/probes/probes_test.cc
+++ b/src/carnot/planner/probes/probes_test.cc
@@ -706,10 +706,7 @@ TEST_F(ProbeCompilerTest, parse_single_bpftrace_program_object) {
   ASSERT_EQ(pb.mutations_size(), 1);
 
   std::string literal_bpf_trace_min = kBPFTraceProgramMinKernel;
-  literal_bpf_trace_min =
-      std::regex_replace(literal_bpf_trace_min, std::regex(R"(\\\n)"), R"(\\\\n)");
   literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\n"), "\\n");
-  literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\""), "\\\"");
 
   EXPECT_THAT(pb.mutations()[0].trace(),
               testing::proto::EqualsProto(
@@ -775,16 +772,10 @@ TEST_F(ProbeCompilerTest, parse_multiple_bpftrace_program_objects) {
   ASSERT_EQ(pb.mutations_size(), 1);
 
   std::string literal_bpf_trace_min = kBPFTraceProgramMinKernel;
-  literal_bpf_trace_min =
-      std::regex_replace(literal_bpf_trace_min, std::regex(R"(\\\n)"), R"(\\\\n)");
   literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\n"), "\\n");
-  literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\""), "\\\"");
 
   std::string literal_bpf_trace_max = kBPFTraceProgramMaxKernel;
-  literal_bpf_trace_max =
-      std::regex_replace(literal_bpf_trace_max, std::regex(R"(\\\n)"), R"(\\\\n)");
   literal_bpf_trace_max = std::regex_replace(literal_bpf_trace_max, std::regex("\n"), "\\n");
-  literal_bpf_trace_max = std::regex_replace(literal_bpf_trace_max, std::regex("\""), "\\\"");
 
   EXPECT_THAT(pb.mutations()[0].trace(),
               testing::proto::EqualsProto(absl::Substitute(

--- a/src/carnot/planner/probes/probes_test.cc
+++ b/src/carnot/planner/probes/probes_test.cc
@@ -648,6 +648,228 @@ TEST_F(ProbeCompilerTest, parse_bpftrace) {
               testing::proto::EqualsProto(absl::Substitute(kBPFTraceProgramPb, literal_bpf_trace)));
 }
 
+constexpr char kBPFTraceProgramMaxKernel[] = R"bpftrace(
+kprobe:tcp_drop
+{
+  ...
+}
+)bpftrace";
+
+constexpr char kBPFTraceProgramMinKernel[] = R"bpftrace(
+tracepoint:skb:kfree_skb
+{
+  ...
+}
+)bpftrace";
+
+// Test that we can compile/parse a single TraceProgram object with a valid selector
+constexpr char kBPFSingleTraceProgramObjectPxl[] = R"pxl(
+import pxtrace
+import px
+
+after_519_trace_program = pxtrace.TraceProgram(
+  program="""$0""",
+  min_kernel='5.19',
+)
+
+table_name = 'tcp_drop_table'
+pxtrace.UpsertTracepoint('tcp_drop_tracer',
+                          table_name,
+                          after_519_trace_program,
+                          pxtrace.kprobe(),
+                          '10m')
+)pxl";
+
+constexpr char kBPFSingleTraceProgramObjectPb[] = R"proto(
+name: "tcp_drop_tracer"
+ttl {
+  seconds: 600
+}
+programs {
+  table_name: "tcp_drop_table"
+  bpftrace {
+    program: "$0"
+  }
+  selectors {
+    selector_type: MIN_KERNEL
+    value: "5.19"
+  }
+}
+)proto";
+
+TEST_F(ProbeCompilerTest, parse_single_bpftrace_program_object) {
+  ASSERT_OK_AND_ASSIGN(auto probe_ir,
+                       CompileProbeScript(absl::Substitute(kBPFSingleTraceProgramObjectPxl,
+                                                           kBPFTraceProgramMinKernel)));
+  plannerpb::CompileMutationsResponse pb;
+  EXPECT_OK(probe_ir->ToProto(&pb));
+  ASSERT_EQ(pb.mutations_size(), 1);
+
+  std::string literal_bpf_trace_min = kBPFTraceProgramMinKernel;
+  literal_bpf_trace_min =
+      std::regex_replace(literal_bpf_trace_min, std::regex(R"(\\\n)"), R"(\\\\n)");
+  literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\n"), "\\n");
+  literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\""), "\\\"");
+
+  EXPECT_THAT(pb.mutations()[0].trace(),
+              testing::proto::EqualsProto(
+                  absl::Substitute(kBPFSingleTraceProgramObjectPb, literal_bpf_trace_min)));
+}
+
+// Test that we can compile a list of TraceProgram objects with valid selectors
+constexpr char kBPFTraceProgramObjectsPxl[] = R"pxl(
+import pxtrace
+import px
+
+before_518_trace_program = pxtrace.TraceProgram(
+  program="""$0""",
+  max_kernel='5.18',
+)
+
+after_519_trace_program = pxtrace.TraceProgram(
+  program="""$1""",
+  min_kernel='5.19',
+)
+
+table_name = 'tcp_drop_table'
+pxtrace.UpsertTracepoint('tcp_drop_tracer',
+                          table_name,
+                          [before_518_trace_program, after_519_trace_program],
+                          pxtrace.kprobe(),
+                          '10m')
+)pxl";
+
+constexpr char kBPFTraceProgramObjectsPb[] = R"proto(
+name: "tcp_drop_tracer"
+ttl {
+  seconds: 600
+}
+programs {
+  table_name: "tcp_drop_table"
+  bpftrace {
+    program: "$0"
+  }
+  selectors {
+    selector_type: MAX_KERNEL
+    value: "5.18"
+  }
+}
+programs {
+  table_name: "tcp_drop_table"
+  bpftrace {
+    program: "$1"
+  }
+  selectors {
+    selector_type: MIN_KERNEL
+    value: "5.19"
+  }
+}
+)proto";
+
+TEST_F(ProbeCompilerTest, parse_multiple_bpftrace_program_objects) {
+  ASSERT_OK_AND_ASSIGN(auto probe_ir, CompileProbeScript(absl::Substitute(
+                                          kBPFTraceProgramObjectsPxl, kBPFTraceProgramMinKernel,
+                                          kBPFTraceProgramMaxKernel)));
+  plannerpb::CompileMutationsResponse pb;
+  EXPECT_OK(probe_ir->ToProto(&pb));
+  ASSERT_EQ(pb.mutations_size(), 1);
+
+  std::string literal_bpf_trace_min = kBPFTraceProgramMinKernel;
+  literal_bpf_trace_min =
+      std::regex_replace(literal_bpf_trace_min, std::regex(R"(\\\n)"), R"(\\\\n)");
+  literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\n"), "\\n");
+  literal_bpf_trace_min = std::regex_replace(literal_bpf_trace_min, std::regex("\""), "\\\"");
+
+  std::string literal_bpf_trace_max = kBPFTraceProgramMaxKernel;
+  literal_bpf_trace_max =
+      std::regex_replace(literal_bpf_trace_max, std::regex(R"(\\\n)"), R"(\\\\n)");
+  literal_bpf_trace_max = std::regex_replace(literal_bpf_trace_max, std::regex("\n"), "\\n");
+  literal_bpf_trace_max = std::regex_replace(literal_bpf_trace_max, std::regex("\""), "\\\"");
+
+  EXPECT_THAT(pb.mutations()[0].trace(),
+              testing::proto::EqualsProto(absl::Substitute(
+                  kBPFTraceProgramObjectsPb, literal_bpf_trace_min, literal_bpf_trace_max)));
+}
+
+// Test that passing an unsupported selector type to TraceProgram throws a compiler error
+constexpr char kBPFUnsupportedTraceProgramObjectSelectorPxl[] = R"pxl(
+import pxtrace
+import px
+
+after_519_trace_program = pxtrace.TraceProgram(
+  program="""$0""",
+  min_kernel='5.19',
+  my_unsupported_selector='12345',
+)
+
+table_name = 'tcp_drop_table'
+pxtrace.UpsertTracepoint('tcp_drop_tracer',
+                          table_name,
+                          after_519_trace_program,
+                          pxtrace.kprobe(),
+                          '10m')
+)pxl";
+
+TEST_F(ProbeCompilerTest, parse_unsupported_selector_in_trace_program_object) {
+  auto probe_ir_or_s = CompileProbeScript(kBPFUnsupportedTraceProgramObjectSelectorPxl);
+  ASSERT_NOT_OK(probe_ir_or_s);
+  EXPECT_THAT(
+      probe_ir_or_s.status(),
+      HasCompilerError("Unsupported selector argument provided \'my_unsupported_selector\'"));
+}
+
+// Test that an invalid selector value throws a compiler error (currently needs to be a string)
+constexpr char kBPFInvalidTraceProgramObjectSelectorPxl[] = R"pxl(
+import pxtrace
+import px
+
+after_519_trace_program = pxtrace.TraceProgram(
+  program="""$0""",
+  min_kernel='5.19',
+  max_kernel=None,
+)
+
+table_name = 'tcp_drop_table'
+pxtrace.UpsertTracepoint('tcp_drop_tracer',
+                          table_name,
+                          after_519_trace_program,
+                          pxtrace.kprobe(),
+                          '10m')
+)pxl";
+
+TEST_F(ProbeCompilerTest, parse_invalid_trace_program_object) {
+  auto probe_ir_or_s = CompileProbeScript(kBPFInvalidTraceProgramObjectSelectorPxl);
+  ASSERT_NOT_OK(probe_ir_or_s);
+  EXPECT_THAT(probe_ir_or_s.status(),
+              HasCompilerError("Expected \'String\' in arg \'max_kernel\', got \'none\'"));
+}
+
+// Test that an empty selector value throws a compiler error
+constexpr char kBPFEmptyTraceProgramObjectSelectorPxl[] = R"pxl(
+import pxtrace
+import px
+
+after_519_trace_program = pxtrace.TraceProgram(
+  program="""$0""",
+  min_kernel='5.19',
+  max_kernel='',
+)
+
+table_name = 'tcp_drop_table'
+pxtrace.UpsertTracepoint('tcp_drop_tracer',
+                          table_name,
+                          after_519_trace_program,
+                          pxtrace.kprobe(),
+                          '10m')
+)pxl";
+
+TEST_F(ProbeCompilerTest, parse_empty_trace_program_object) {
+  auto probe_ir_or_s = CompileProbeScript(kBPFEmptyTraceProgramObjectSelectorPxl);
+  ASSERT_NOT_OK(probe_ir_or_s);
+  EXPECT_THAT(probe_ir_or_s.status(),
+              HasCompilerError("Empty selector value provided for \'max_kernel\'"));
+}
+
 constexpr char kConfigChangePxl[] = R"pxl(
 import pxconfig
 import px

--- a/src/carnot/planner/probes/tracing_module.h
+++ b/src/carnot/planner/probes/tracing_module.h
@@ -81,6 +81,30 @@ class ProbeObject : public QLObject {
   std::shared_ptr<TracepointIR> probe_;
 };
 
+class TraceProgramObject : public QLObject {
+ public:
+  static constexpr TypeDescriptor TracePointProgramType = {
+      /* name */ "TraceProgram",
+      /* type */ QLObjectType::kTraceProgram,
+  };
+
+  static bool IsTraceProgram(const QLObjectPtr& ptr) {
+    return ptr->type() == TracePointProgramType.type();
+  }
+  const std::string& program() const { return program_; }
+  const std::vector<TracepointSelector>& selectors() const { return selectors_; }
+
+  TraceProgramObject(const pypa::AstPtr& ast, ASTVisitor* visitor, const std::string& program,
+                     const std::vector<TracepointSelector>& selectors)
+      : QLObject(TracePointProgramType, ast, visitor),
+        program_(std::move(program)),
+        selectors_(selectors) {}
+
+ private:
+  std::string program_;
+  std::vector<TracepointSelector> selectors_;
+};
+
 class TraceModule : public QLObject {
  public:
   static constexpr TypeDescriptor TraceModuleType = {
@@ -171,6 +195,23 @@ class TraceModule : public QLObject {
       to trace as specified by unique Vizier PID.
     ttl (px.Duration): The length of time that a tracepoint will stay alive, after
       which it will be removed.
+  )doc";
+
+  inline static constexpr char kTraceProgramID[] = "TraceProgram";
+  inline static constexpr char kTraceProgramDocstring[] = R"doc(
+  Creates a trace program.
+
+  :topic: pixie_state_management
+
+  Args:
+    program (str): The BPFtrace program string.
+    min_kernel (str, optional): The minimum kernel version that the tracepoint is supported on. Format is <version>.<major>.<minor>.
+    max_kernel (str, optional): The maximum kernel version that the tracepoint is supported on. Format is <version>.<major>.<minor>.
+    (Additional selectors may be added in the future.)
+
+  Returns:
+    TraceProgram: A pointer to the TraceProgram that can be passed as a probe_fn
+    to UpsertTracepoint.
   )doc";
 
   inline static constexpr char kDeleteTracepointID[] = "DeleteTracepoint";

--- a/src/carnot/planner/probes/tracing_module.h
+++ b/src/carnot/planner/probes/tracing_module.h
@@ -207,6 +207,7 @@ class TraceModule : public QLObject {
     program (str): The BPFtrace program string.
     min_kernel (str, optional): The minimum kernel version that the tracepoint is supported on. Format is <version>.<major>.<minor>.
     max_kernel (str, optional): The maximum kernel version that the tracepoint is supported on. Format is <version>.<major>.<minor>.
+    host_name (str, optional): Restrict the tracepoint to a specific host.
     (Additional selectors may be added in the future.)
 
   Returns:


### PR DESCRIPTION
Summary: Adds new `TraceProgram` object to `pxtrace` which accepts a BPFtrace program and selectors to specify deployment restrictions as key value arguments. Also modifies the `probe_fn` argument to `pxtrace.UpsertTracepoint` to accept a single `TraceProgram` object or a list of them, extracting selectors and populating `TracepointDeployment` as required, so that the query broker can register tracepoints with agents that match those selectors.

Example usage

```
import pxtrace
import px

before_518_trace_program = pxtrace.TraceProgram(
  program="""$0""",
  max_kernel='5.18',
)
after_519_trace_program = pxtrace.TraceProgram(
  program="""$1""",
  min_kernel='5.19',
)

table_name = 'tcp_drop_table'
pxtrace.UpsertTracepoint('tcp_drop_tracer',
                          table_name,
                          [before_518_trace_program, after_519_trace_program],
                          pxtrace.kprobe(),
                          '10m')
)pxl";
```

Related issues: #1582. Closes #1659.

Type of change: /kind feature

Test Plan: Tested all existing targets, added compiler tests to `src/carnot/planner/logical_planner_test.cc` and `src/carnot/planner/probes/probes_test.cc`, and skaffolded changes to a cluster, verifying expected behavior and interoperability with selectors introduced in PR #1686.

Known issues
- Two or more programs on one PEM: If selectors are specified such that two or more bpftrace programs are deployed to a PEM as part of a single `TracepointDeployment`, stirling throws an error `stirling.cc:511` `error::Internal("Only one Tracepoint is currently supported.");`. This is an existing limitation, which is a little more exposed as a result of the selector feature introduced in this PR. To mitigate this, we could add documentation, improve the error message, and/or have just one of the bpftrace programs in the `TracepointDeployment` run.
- Schemas differ: If the schemas of two bpftrace programs passed to one `pxtrace.UpsertTracepoint` call differ, only one of the schemas will be used to the create the output table (currently the first one that is processed). When the program whose schema differs tries to push a record to the table, we get the error `source_connector.cc:64] Failed to push data. Message = Table_id ## doesn't exist.` The user has to manually create another table/make another call to `UpsertTracepoint` if they want to deploy bpftrace programs with different schemas.