### PR TITLE
[stirling] Fix `netty_tls_trace_bpf_test.cc` mux protocol tracing option.

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/netty_tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/netty_tls_trace_bpf_test.cc
@@ -50,8 +50,12 @@ using ::testing::UnorderedElementsAre;
 
 class ThriftMuxServerContainerWrapper : public ::px::stirling::testing::ThriftMuxServerContainer {};
 
+namespace {
+constexpr bool kClientSideTracing = false;
+}
+
 template <typename TServerContainer>
-class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing */ false> {
+class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture<kClientSideTracing> {
  protected:
   void SetUp() override {
     FLAGS_stirling_enable_mux_tracing = true;
@@ -64,7 +68,7 @@ class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTrac
     // Enable the raw fptr fallback for determining ssl lib version.
     FLAGS_openssl_raw_fptrs_enabled = true;
 
-    SocketTraceBPFTestFixture<true>::SetUp();
+    SocketTraceBPFTestFixture<kClientSideTracing>::SetUp();
   }
 
   BaseOpenSSLTraceTest() {

--- a/src/stirling/source_connectors/socket_tracer/netty_tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/netty_tls_trace_bpf_test.cc
@@ -58,15 +58,15 @@ template <typename TServerContainer>
 class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture<kClientSideTracing> {
  protected:
   void SetUp() override {
-    FLAGS_stirling_enable_mux_tracing = true;
+    PX_SET_FOR_SCOPE(FLAGS_stirling_enable_mux_tracing, true);
 
     // We turn off CQL and NATS tracing to give some BPF instructions back for Mux.
     // This is required for older kernels with only 4096 BPF instructions.
-    FLAGS_stirling_enable_cass_tracing = false;
-    FLAGS_stirling_enable_nats_tracing = false;
+    PX_SET_FOR_SCOPE(FLAGS_stirling_enable_cass_tracing, false);
+    PX_SET_FOR_SCOPE(FLAGS_stirling_enable_nats_tracing, false);
 
     // Enable the raw fptr fallback for determining ssl lib version.
-    FLAGS_openssl_raw_fptrs_enabled = true;
+    PX_SET_FOR_SCOPE(FLAGS_openssl_raw_fptrs_enabled, true);
 
     SocketTraceBPFTestFixture<kClientSideTracing>::SetUp();
   }

--- a/src/stirling/source_connectors/socket_tracer/netty_tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/netty_tls_trace_bpf_test.cc
@@ -50,28 +50,23 @@ using ::testing::UnorderedElementsAre;
 
 class ThriftMuxServerContainerWrapper : public ::px::stirling::testing::ThriftMuxServerContainer {};
 
-// The Init() function is used to set flags for the entire test.
-// We can't do this in the MuxTraceTest constructor, because it will be too late
-// (SocketTraceBPFTestFixture will already have been constructed).
-bool Init() {
-  // Make sure Mux tracing is enabled.
-  FLAGS_stirling_enable_mux_tracing = true;
-
-  // We turn off CQL and NATS tracing to give some BPF instructions back for Mux.
-  // This is required for older kernels with only 4096 BPF instructions.
-  FLAGS_stirling_enable_cass_tracing = false;
-  FLAGS_stirling_enable_nats_tracing = false;
-
-  // Enable the raw fptr fallback for determining ssl lib version.
-  FLAGS_openssl_raw_fptrs_enabled = true;
-  return true;
-}
-
-bool kInit = Init();
-
 template <typename TServerContainer>
 class BaseOpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing */ false> {
  protected:
+  void SetUp() override {
+    FLAGS_stirling_enable_mux_tracing = true;
+
+    // We turn off CQL and NATS tracing to give some BPF instructions back for Mux.
+    // This is required for older kernels with only 4096 BPF instructions.
+    FLAGS_stirling_enable_cass_tracing = false;
+    FLAGS_stirling_enable_nats_tracing = false;
+
+    // Enable the raw fptr fallback for determining ssl lib version.
+    FLAGS_openssl_raw_fptrs_enabled = true;
+
+    SocketTraceBPFTestFixture<true>::SetUp();
+  }
+
   BaseOpenSSLTraceTest() {
     // Run the nginx HTTPS server.
     // The container runner will make sure it is in the ready state before unblocking.


### PR DESCRIPTION
Summary: To prevent older kernels from complaining about eBPF instruction count, mux protocol tracing is only enabled for "newer" kernels. In our test case, we want to enable mux tracing. We fix test `netty_tls_trace_bpf_test.cc` by enabling mux protocol tracing using the test `SetUp` method (and we simultaneously disable a few other protocols to save on eBPF instruction count). Previously, we used an init function, but that was rendered ineffective after we switched our flags from command line args. to env. args.

Type of change: /kind bug fix

Test Plan: Existing tests.
