### PR TITLE
Temporarily disable partial aggregates.

### DIFF
--- a/src/carnot/planner/distributed/coordinator/coordinator.cc
+++ b/src/carnot/planner/distributed/coordinator/coordinator.cc
@@ -179,7 +179,7 @@ StatusOr<SchemaToAgentsMap> LoadSchemaMap(
 
 StatusOr<std::unique_ptr<DistributedPlan>> CoordinatorImpl::CoordinateImpl(const IR* logical_plan) {
   PX_ASSIGN_OR_RETURN(std::unique_ptr<Splitter> splitter,
-                      Splitter::Create(compiler_state_, /* support_partial_agg */ true));
+                      Splitter::Create(compiler_state_, /* support_partial_agg */ false));
   PX_ASSIGN_OR_RETURN(std::unique_ptr<BlockingSplitPlan> split_plan,
                       splitter->SplitKelvinAndAgents(logical_plan));
   auto distributed_plan = std::make_unique<DistributedPlan>();


### PR DESCRIPTION
Summary: Enabling partial aggregates appears to break flamegraphs in the UI. Below, we show a screen capture with partial aggregates enabled, and disabled. In this PR, we temporarily disable partial aggregates, i.e. until the underlying issue that breaks flamegraphs is resolved.


**Partial aggregates enabled (flamegraphs broken):**
<img width="2478" alt="broken" src="https://github.com/pixie-io/pixie/assets/809015/641e762a-ac7b-4242-8e25-0b72231da2f9">



**Partial aggregates disabled (this PR):**
<img width="2484" alt="fixed" src="https://github.com/pixie-io/pixie/assets/809015/f4c3e08d-7ff5-4b5f-ad62-8dad60b59b97">


Type of change: /kind bug fix

Test Plan: Existing tests one off deploy testing.
