### PR TITLE
Add support to extract LE Ints in BinaryDecoder & rename the existing ExtractInt function to ExtractBEInt

### DIFF
--- a/src/stirling/obj_tools/go_syms.cc
+++ b/src/stirling/obj_tools/go_syms.cc
@@ -83,8 +83,8 @@ StatusOr<std::string> ReadGoBuildVersion(ElfReader* elf_reader) {
   BinaryDecoder binary_decoder(buildInfoByteCode);
 
   PX_CHECK_OK(binary_decoder.ExtractStringUntil(kGoBuildInfoMagic));
-  PX_ASSIGN_OR_RETURN(uint8_t ptr_size, binary_decoder.ExtractInt<uint8_t>());
-  PX_ASSIGN_OR_RETURN(uint8_t endianness, binary_decoder.ExtractInt<uint8_t>());
+  PX_ASSIGN_OR_RETURN(uint8_t ptr_size, binary_decoder.ExtractBEInt<uint8_t>());
+  PX_ASSIGN_OR_RETURN(uint8_t endianness, binary_decoder.ExtractBEInt<uint8_t>());
 
   // If the endianness has its second bit set, then the go version immediately follows the 32 bit
   // header specified by the varint encoded string data

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/amqp_code_gen.py
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/amqp_code_gen.py
@@ -68,13 +68,13 @@ class FieldType(Enum):
     def get_field_extract_function(field_type):
         extract_function_c_mapping = {
             FieldType.octet: "decoder->ExtractChar<uint8_t>()",
-            FieldType.short: "decoder->ExtractInt<uint16_t>()",
-            FieldType.long: "decoder->ExtractInt<uint32_t>()",
-            FieldType.longlong: "decoder->ExtractInt<uint64_t>()",
+            FieldType.short: "decoder->ExtractBEInt<uint16_t>()",
+            FieldType.long: "decoder->ExtractBEInt<uint32_t>()",
+            FieldType.longlong: "decoder->ExtractBEInt<uint64_t>()",
             FieldType.shortstr: "ExtractShortString(decoder)",
             FieldType.longstr: "ExtractLongString(decoder)",
             FieldType.table: "ExtractLongString(decoder)",
-            FieldType.timestamp: "decoder->ExtractInt<time_t>()",
+            FieldType.timestamp: "decoder->ExtractBEInt<time_t>()",
         }
         return extract_function_c_mapping[field_type]
 
@@ -304,8 +304,8 @@ class AMQPMethod:
         return f"""
             Status Extract{self.c_struct_name}(BinaryDecoder* decoder, Frame* frame) {{
                 {self.c_struct_name} r;
-                PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-                PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
                 r.property_flags = property_flags;
                 {field_buffer_extractions}
                 frame->msg = ToString(r);
@@ -671,8 +671,8 @@ class CodeGenerator:
         amqp_extract_class_case_str = "\n".join(amqp_extract_class_case)
         return f"""
         Status ProcessFrameMethod(BinaryDecoder* decoder, Frame* req) {{
-            PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractInt<uint16_t>());
-            PX_ASSIGN_OR_RETURN(uint16_t method_id, decoder->ExtractInt<uint16_t>());
+            PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractBEInt<uint16_t>());
+            PX_ASSIGN_OR_RETURN(uint16_t method_id, decoder->ExtractBEInt<uint16_t>());
 
             req->class_id = class_id;
             req->method_id = method_id;
@@ -726,8 +726,8 @@ class CodeGenerator:
         amqp_extract_class_case_str = "\n".join(amqp_extract_class_case)
         return f"""
         Status ProcessContentHeader(BinaryDecoder* decoder, Frame* req) {{
-            PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractInt<uint16_t>());
-            PX_ASSIGN_OR_RETURN(uint16_t weight, decoder->ExtractInt<uint16_t>());
+            PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractBEInt<uint16_t>());
+            PX_ASSIGN_OR_RETURN(uint16_t weight, decoder->ExtractBEInt<uint16_t>());
             req->class_id = class_id;
 
             if(weight != 0) {{

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/amqp_code_gen_test.py
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/amqp_code_gen_test.py
@@ -61,7 +61,7 @@ class TestAMQPField(BaseTestCase):
         sample_field = Field("sample_field", FieldType.short)
         self.assertEqual(
             sample_field.gen_buffer_extract(),
-            "PX_ASSIGN_OR_RETURN(r.sample_field, decoder->ExtractInt<uint16_t>());",
+            "PX_ASSIGN_OR_RETURN(r.sample_field, decoder->ExtractBEInt<uint16_t>());",
         )
 
     def test_gen_buffer_extract_bit(self):
@@ -149,8 +149,8 @@ class TestAMQPMethod(BaseTestCase):
             """
             Status ExtractAMQPSampleClassSampleMethod(BinaryDecoder* decoder, Frame* frame) {
                 AMQPSampleClassSampleMethod r;
-                PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-                PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
                 r.property_flags = property_flags;
 
                 frame->msg = ToString(r);
@@ -548,8 +548,8 @@ class TestAMQPCodeGeneratorGen(BaseTestCase):
             }
             Status ExtractAMQPConnectionContentHeader(BinaryDecoder* decoder, Frame* frame) {
                 AMQPConnectionContentHeader r;
-                PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-                PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
                 r.property_flags = property_flags;
                 frame->msg = ToString(r);
                 frame->synchronous = 0;
@@ -579,8 +579,8 @@ class TestAMQPCodeGeneratorGen(BaseTestCase):
             self.code_generator_single_class.gen_class_select(),
             """
             Status ProcessFrameMethod(BinaryDecoder* decoder, Frame* req) {
-                PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractInt<uint16_t>());
-                PX_ASSIGN_OR_RETURN(uint16_t method_id, decoder->ExtractInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractBEInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t method_id, decoder->ExtractBEInt<uint16_t>());
 
                 req->class_id = class_id;
                 req->method_id = method_id;
@@ -602,8 +602,8 @@ class TestAMQPCodeGeneratorGen(BaseTestCase):
             self.code_generator_single_class.gen_process_content_header_select(),
             """
             Status ProcessContentHeader(BinaryDecoder* decoder, Frame* req) {
-                PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractInt<uint16_t>());
-                PX_ASSIGN_OR_RETURN(uint16_t weight, decoder->ExtractInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractBEInt<uint16_t>());
+                PX_ASSIGN_OR_RETURN(uint16_t weight, decoder->ExtractBEInt<uint16_t>());
                 req->class_id = class_id;
                 if(weight != 0) {
                     return error::Internal("AMQP content header weight should be 0");

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/gen_templates/decode.cc.jinja_template
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/gen_templates/decode.cc.jinja_template
@@ -30,13 +30,13 @@ namespace amqp {
 
 StatusOr<std::string> ExtractShortString(BinaryDecoder* decoder) {
   // Short string defined as 2*OCTET(short-uint)
-  PX_ASSIGN_OR_RETURN(uint8_t len, decoder->ExtractInt<uint8_t>());
+  PX_ASSIGN_OR_RETURN(uint8_t len, decoder->ExtractBEInt<uint8_t>());
   return decoder->ExtractString(len);
 }
 
 StatusOr<std::string> ExtractLongString(BinaryDecoder* decoder) {
   // Long string defined as 4*OCTET(short-uint)
-  PX_ASSIGN_OR_RETURN(uint32_t len, decoder->ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(uint32_t len, decoder->ExtractBEInt<uint32_t>());
   return decoder->ExtractString(len);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/decode.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/decode.cc
@@ -35,13 +35,13 @@ namespace amqp {
 
 StatusOr<std::string> ExtractShortString(BinaryDecoder* decoder) {
   // Short string defined as 2*OCTET(short-uint)
-  PX_ASSIGN_OR_RETURN(uint8_t len, decoder->ExtractInt<uint8_t>());
+  PX_ASSIGN_OR_RETURN(uint8_t len, decoder->ExtractBEInt<uint8_t>());
   return decoder->ExtractString(len);
 }
 
 StatusOr<std::string> ExtractLongString(BinaryDecoder* decoder) {
   // Long string defined as 4*OCTET(short-uint)
-  PX_ASSIGN_OR_RETURN(uint32_t len, decoder->ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(uint32_t len, decoder->ExtractBEInt<uint32_t>());
   return decoder->ExtractString(len);
 }
 StatusOr<bool> ExtractNthBit(BinaryDecoder* decoder, int n) {
@@ -90,9 +90,9 @@ Status ExtractAMQPConnectionSecureOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPConnectionTune(BinaryDecoder* decoder, Frame* frame) {
   AMQPConnectionTune r;
-  PX_ASSIGN_OR_RETURN(r.channel_max, decoder->ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN(r.frame_max, decoder->ExtractInt<uint32_t>());
-  PX_ASSIGN_OR_RETURN(r.heartbeat, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.channel_max, decoder->ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.frame_max, decoder->ExtractBEInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.heartbeat, decoder->ExtractBEInt<uint16_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -100,9 +100,9 @@ Status ExtractAMQPConnectionTune(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPConnectionTuneOk(BinaryDecoder* decoder, Frame* frame) {
   AMQPConnectionTuneOk r;
-  PX_ASSIGN_OR_RETURN(r.channel_max, decoder->ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN(r.frame_max, decoder->ExtractInt<uint32_t>());
-  PX_ASSIGN_OR_RETURN(r.heartbeat, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.channel_max, decoder->ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.frame_max, decoder->ExtractBEInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.heartbeat, decoder->ExtractBEInt<uint16_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -129,10 +129,10 @@ Status ExtractAMQPConnectionOpenOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPConnectionClose(BinaryDecoder* decoder, Frame* frame) {
   AMQPConnectionClose r;
-  PX_ASSIGN_OR_RETURN(r.reply_code, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reply_code, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.reply_text, ExtractShortString(decoder));
-  PX_ASSIGN_OR_RETURN(r.class_id, decoder->ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN(r.method_id, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.class_id, decoder->ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.method_id, decoder->ExtractBEInt<uint16_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -148,8 +148,8 @@ Status ExtractAMQPConnectionCloseOk([[maybe_unused]] BinaryDecoder* decoder, Fra
 
 Status ExtractAMQPConnectionContentHeader(BinaryDecoder* decoder, Frame* frame) {
   AMQPConnectionContentHeader r;
-  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
   r.property_flags = property_flags;
 
   frame->msg = ToString(r);
@@ -193,10 +193,10 @@ Status ExtractAMQPChannelFlowOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPChannelClose(BinaryDecoder* decoder, Frame* frame) {
   AMQPChannelClose r;
-  PX_ASSIGN_OR_RETURN(r.reply_code, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reply_code, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.reply_text, ExtractShortString(decoder));
-  PX_ASSIGN_OR_RETURN(r.class_id, decoder->ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN(r.method_id, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.class_id, decoder->ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.method_id, decoder->ExtractBEInt<uint16_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -212,8 +212,8 @@ Status ExtractAMQPChannelCloseOk([[maybe_unused]] BinaryDecoder* decoder, Frame*
 
 Status ExtractAMQPChannelContentHeader(BinaryDecoder* decoder, Frame* frame) {
   AMQPChannelContentHeader r;
-  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
   r.property_flags = property_flags;
 
   frame->msg = ToString(r);
@@ -223,7 +223,7 @@ Status ExtractAMQPChannelContentHeader(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPExchangeDeclare(BinaryDecoder* decoder, Frame* frame) {
   AMQPExchangeDeclare r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.type, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.passive, ExtractNthBit(decoder, 0));
@@ -248,7 +248,7 @@ Status ExtractAMQPExchangeDeclareOk([[maybe_unused]] BinaryDecoder* decoder, Fra
 
 Status ExtractAMQPExchangeDelete(BinaryDecoder* decoder, Frame* frame) {
   AMQPExchangeDelete r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.if_unused, ExtractNthBit(decoder, 0));
   PX_ASSIGN_OR_RETURN(r.no_wait, ExtractNthBit(decoder, 1));
@@ -268,8 +268,8 @@ Status ExtractAMQPExchangeDeleteOk([[maybe_unused]] BinaryDecoder* decoder, Fram
 
 Status ExtractAMQPExchangeContentHeader(BinaryDecoder* decoder, Frame* frame) {
   AMQPExchangeContentHeader r;
-  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
   r.property_flags = property_flags;
 
   frame->msg = ToString(r);
@@ -279,7 +279,7 @@ Status ExtractAMQPExchangeContentHeader(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPQueueDeclare(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueDeclare r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.passive, ExtractNthBit(decoder, 0));
   PX_ASSIGN_OR_RETURN(r.durable, ExtractNthBit(decoder, 1));
@@ -296,8 +296,8 @@ Status ExtractAMQPQueueDeclare(BinaryDecoder* decoder, Frame* frame) {
 Status ExtractAMQPQueueDeclareOk(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueDeclareOk r;
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
-  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractInt<uint32_t>());
-  PX_ASSIGN_OR_RETURN(r.consumer_count, decoder->ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractBEInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.consumer_count, decoder->ExtractBEInt<uint32_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -305,7 +305,7 @@ Status ExtractAMQPQueueDeclareOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPQueueBind(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueBind r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.routing_key, ExtractShortString(decoder));
@@ -327,7 +327,7 @@ Status ExtractAMQPQueueBindOk([[maybe_unused]] BinaryDecoder* decoder, Frame* fr
 
 Status ExtractAMQPQueueUnbind(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueUnbind r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.routing_key, ExtractShortString(decoder));
@@ -347,7 +347,7 @@ Status ExtractAMQPQueueUnbindOk([[maybe_unused]] BinaryDecoder* decoder, Frame* 
 
 Status ExtractAMQPQueuePurge(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueuePurge r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.no_wait, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
@@ -358,7 +358,7 @@ Status ExtractAMQPQueuePurge(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPQueuePurgeOk(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueuePurgeOk r;
-  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractBEInt<uint32_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -366,7 +366,7 @@ Status ExtractAMQPQueuePurgeOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPQueueDelete(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueDelete r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.if_unused, ExtractNthBit(decoder, 0));
   PX_ASSIGN_OR_RETURN(r.if_empty, ExtractNthBit(decoder, 1));
@@ -379,7 +379,7 @@ Status ExtractAMQPQueueDelete(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPQueueDeleteOk(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueDeleteOk r;
-  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractBEInt<uint32_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -387,8 +387,8 @@ Status ExtractAMQPQueueDeleteOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPQueueContentHeader(BinaryDecoder* decoder, Frame* frame) {
   AMQPQueueContentHeader r;
-  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
   r.property_flags = property_flags;
 
   frame->msg = ToString(r);
@@ -398,8 +398,8 @@ Status ExtractAMQPQueueContentHeader(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicQos(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicQos r;
-  PX_ASSIGN_OR_RETURN(r.prefetch_size, decoder->ExtractInt<uint32_t>());
-  PX_ASSIGN_OR_RETURN(r.prefetch_count, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.prefetch_size, decoder->ExtractBEInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.prefetch_count, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.global, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
   frame->msg = ToString(r);
@@ -417,7 +417,7 @@ Status ExtractAMQPBasicQosOk([[maybe_unused]] BinaryDecoder* decoder, Frame* fra
 
 Status ExtractAMQPBasicConsume(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicConsume r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.consumer_tag, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.no_local, ExtractNthBit(decoder, 0));
@@ -459,7 +459,7 @@ Status ExtractAMQPBasicCancelOk(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicPublish(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicPublish r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.routing_key, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.mandatory, ExtractNthBit(decoder, 0));
@@ -472,7 +472,7 @@ Status ExtractAMQPBasicPublish(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicReturn(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicReturn r;
-  PX_ASSIGN_OR_RETURN(r.reply_code, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reply_code, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.reply_text, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.routing_key, ExtractShortString(decoder));
@@ -484,7 +484,7 @@ Status ExtractAMQPBasicReturn(BinaryDecoder* decoder, Frame* frame) {
 Status ExtractAMQPBasicDeliver(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicDeliver r;
   PX_ASSIGN_OR_RETURN(r.consumer_tag, ExtractShortString(decoder));
-  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractBEInt<uint64_t>());
   PX_ASSIGN_OR_RETURN(r.redelivered, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
@@ -496,7 +496,7 @@ Status ExtractAMQPBasicDeliver(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicGet(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicGet r;
-  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.reserved_1, decoder->ExtractBEInt<uint16_t>());
   PX_ASSIGN_OR_RETURN(r.queue, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.no_ack, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
@@ -507,12 +507,12 @@ Status ExtractAMQPBasicGet(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicGetOk(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicGetOk r;
-  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractBEInt<uint64_t>());
   PX_ASSIGN_OR_RETURN(r.redelivered, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
   PX_ASSIGN_OR_RETURN(r.exchange, ExtractShortString(decoder));
   PX_ASSIGN_OR_RETURN(r.routing_key, ExtractShortString(decoder));
-  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN(r.message_count, decoder->ExtractBEInt<uint32_t>());
   frame->msg = ToString(r);
   frame->synchronous = 1;
   return Status::OK();
@@ -528,7 +528,7 @@ Status ExtractAMQPBasicGetEmpty(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicAck(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicAck r;
-  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractBEInt<uint64_t>());
   PX_ASSIGN_OR_RETURN(r.multiple, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
   frame->msg = ToString(r);
@@ -538,7 +538,7 @@ Status ExtractAMQPBasicAck(BinaryDecoder* decoder, Frame* frame) {
 
 Status ExtractAMQPBasicReject(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicReject r;
-  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(r.delivery_tag, decoder->ExtractBEInt<uint64_t>());
   PX_ASSIGN_OR_RETURN(r.requeue, ExtractNthBit(decoder, 0));
   decoder->ExtractChar<uint8_t>();
   frame->msg = ToString(r);
@@ -574,8 +574,8 @@ Status ExtractAMQPBasicRecoverOk([[maybe_unused]] BinaryDecoder* decoder, Frame*
 
 Status ExtractAMQPBasicContentHeader(BinaryDecoder* decoder, Frame* frame) {
   AMQPBasicContentHeader r;
-  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
   r.property_flags = property_flags;
 
   if ((property_flags >> 15) & 1) {
@@ -615,7 +615,7 @@ Status ExtractAMQPBasicContentHeader(BinaryDecoder* decoder, Frame* frame) {
   }
 
   if ((property_flags >> 6) & 1) {
-    PX_ASSIGN_OR_RETURN(r.timestamp, decoder->ExtractInt<time_t>());
+    PX_ASSIGN_OR_RETURN(r.timestamp, decoder->ExtractBEInt<time_t>());
   }
 
   if ((property_flags >> 5) & 1) {
@@ -689,8 +689,8 @@ Status ExtractAMQPTxRollbackOk([[maybe_unused]] BinaryDecoder* decoder, Frame* f
 
 Status ExtractAMQPTxContentHeader(BinaryDecoder* decoder, Frame* frame) {
   AMQPTxContentHeader r;
-  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractInt<uint64_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(r.body_size, decoder->ExtractBEInt<uint64_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t property_flags, decoder->ExtractBEInt<uint16_t>());
   r.property_flags = property_flags;
 
   frame->msg = ToString(r);
@@ -699,8 +699,8 @@ Status ExtractAMQPTxContentHeader(BinaryDecoder* decoder, Frame* frame) {
 }
 
 Status ProcessContentHeader(BinaryDecoder* decoder, Frame* req) {
-  PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t weight, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t weight, decoder->ExtractBEInt<uint16_t>());
   req->class_id = class_id;
 
   if (weight != 0) {
@@ -939,8 +939,8 @@ Status ProcessTx(BinaryDecoder* decoder, Frame* req, uint16_t method_id) {
 }
 
 Status ProcessFrameMethod(BinaryDecoder* decoder, Frame* req) {
-  PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN(uint16_t method_id, decoder->ExtractInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t class_id, decoder->ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN(uint16_t method_id, decoder->ExtractBEInt<uint16_t>());
 
   req->class_id = class_id;
   req->method_id = method_id;

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
@@ -73,7 +73,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* packet)
     return ParseState::kNeedsMoreData;
   }
 
-  PX_ASSIGN_OR_RETURN_INVALID(uint8_t frame_type, decoder.ExtractInt<uint8_t>());
+  PX_ASSIGN_OR_RETURN_INVALID(uint8_t frame_type, decoder.ExtractBEInt<uint8_t>());
   AMQPFrameTypes frame_type_header = static_cast<AMQPFrameTypes>(frame_type);
   if (!(frame_type_header == AMQPFrameTypes::kFrameHeader ||
         frame_type_header == AMQPFrameTypes::kFrameBody ||
@@ -82,8 +82,8 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* packet)
     return ParseState::kInvalid;
   }
 
-  PX_ASSIGN_OR_RETURN_INVALID(uint16_t channel, decoder.ExtractInt<uint16_t>());
-  PX_ASSIGN_OR_RETURN_INVALID(uint32_t payload_size, decoder.ExtractInt<uint32_t>());
+  PX_ASSIGN_OR_RETURN_INVALID(uint16_t channel, decoder.ExtractBEInt<uint16_t>());
+  PX_ASSIGN_OR_RETURN_INVALID(uint32_t payload_size, decoder.ExtractBEInt<uint32_t>());
   if (frame_type_header == AMQPFrameTypes::kFrameHeartbeat && payload_size != 0) {
     return ParseState::kInvalid;
   }

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/frame_body_decoder.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/frame_body_decoder.cc
@@ -34,7 +34,7 @@ namespace cass {
 
 template <typename TIntType>
 StatusOr<TIntType> FrameBodyDecoder::ExtractIntCore() {
-  return binary_decoder_.ExtractInt<TIntType>();
+  return binary_decoder_.ExtractBEInt<TIntType>();
 }
 
 template <typename TFloatType>

--- a/src/stirling/source_connectors/socket_tracer/protocols/dns/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/dns/parse.cc
@@ -64,12 +64,12 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* result)
   // DnsParser ensures there is a complete header.
   DCHECK_GT(buf->size(), sizeof(DNSHeader));
   BinaryDecoder decoder(*buf);
-  result->header.txid = decoder.ExtractInt<uint16_t>().ValueOr(0xffff);
-  result->header.flags = decoder.ExtractInt<uint16_t>().ValueOr(0xffff);
-  result->header.num_queries = decoder.ExtractInt<uint16_t>().ValueOr(0xffff);
-  result->header.num_answers = decoder.ExtractInt<uint16_t>().ValueOr(0xffff);
-  result->header.num_auth = decoder.ExtractInt<uint16_t>().ValueOr(0xffff);
-  result->header.num_addl = decoder.ExtractInt<uint16_t>().ValueOr(0xffff);
+  result->header.txid = decoder.ExtractBEInt<uint16_t>().ValueOr(0xffff);
+  result->header.flags = decoder.ExtractBEInt<uint16_t>().ValueOr(0xffff);
+  result->header.num_queries = decoder.ExtractBEInt<uint16_t>().ValueOr(0xffff);
+  result->header.num_answers = decoder.ExtractBEInt<uint16_t>().ValueOr(0xffff);
+  result->header.num_auth = decoder.ExtractBEInt<uint16_t>().ValueOr(0xffff);
+  result->header.num_addl = decoder.ExtractBEInt<uint16_t>().ValueOr(0xffff);
 
   // The ValueOr(0xffff) conditions should never trigger, since there are enough bytes.
   DCHECK_NE(result->header.flags, 0xffff);

--- a/src/stirling/source_connectors/socket_tracer/protocols/http2/grpc.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http2/grpc.cc
@@ -81,7 +81,7 @@ Status GRPCPBWireToText(std::string_view message, bool is_gzipped, std::string* 
   Status status;
 
   while (!decoder.eof()) {
-    PX_ASSIGN_OR_RETURN(uint8_t compressed_flag, decoder.ExtractInt<uint8_t>());
+    PX_ASSIGN_OR_RETURN(uint8_t compressed_flag, decoder.ExtractBEInt<uint8_t>());
     // gRPC spec states that it's OK to *not* compress even if grpc-encoding header has specified
     // compression algorithm, which is indicated by is_gzipped.
     bool is_compressed = compressed_flag == 1;
@@ -90,7 +90,7 @@ Status GRPCPBWireToText(std::string_view message, bool is_gzipped, std::string* 
       continue;
     }
 
-    PX_ASSIGN_OR_RETURN(uint32_t len, decoder.ExtractInt<uint32_t>());
+    PX_ASSIGN_OR_RETURN(uint32_t len, decoder.ExtractBEInt<uint32_t>());
     // Only extract remaining data if the data is truncated. Protobuf parsing produces a partial
     // result if the data is incomplete, so potential truncation could be tolerated.
     PX_ASSIGN_OR_RETURN(std::string_view data, decoder.ExtractString<char>(std::min(

--- a/src/stirling/source_connectors/socket_tracer/protocols/kafka/decoder/packet_decoder.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/kafka/decoder/packet_decoder.cc
@@ -63,15 +63,15 @@ StatusOr<int64_t> PacketDecoder::ExtractVarintCore() {
 /*
  * Primitive Type Parsers
  */
-StatusOr<bool> PacketDecoder::ExtractBool() { return binary_decoder_.ExtractInt<bool>(); }
+StatusOr<bool> PacketDecoder::ExtractBool() { return binary_decoder_.ExtractBEInt<bool>(); }
 
-StatusOr<int8_t> PacketDecoder::ExtractInt8() { return binary_decoder_.ExtractInt<int8_t>(); }
+StatusOr<int8_t> PacketDecoder::ExtractInt8() { return binary_decoder_.ExtractBEInt<int8_t>(); }
 
-StatusOr<int16_t> PacketDecoder::ExtractInt16() { return binary_decoder_.ExtractInt<int16_t>(); }
+StatusOr<int16_t> PacketDecoder::ExtractInt16() { return binary_decoder_.ExtractBEInt<int16_t>(); }
 
-StatusOr<int32_t> PacketDecoder::ExtractInt32() { return binary_decoder_.ExtractInt<int32_t>(); }
+StatusOr<int32_t> PacketDecoder::ExtractInt32() { return binary_decoder_.ExtractBEInt<int32_t>(); }
 
-StatusOr<int64_t> PacketDecoder::ExtractInt64() { return binary_decoder_.ExtractInt<int64_t>(); }
+StatusOr<int64_t> PacketDecoder::ExtractInt64() { return binary_decoder_.ExtractBEInt<int64_t>(); }
 
 StatusOr<int32_t> PacketDecoder::ExtractUnsignedVarint() {
   constexpr uint8_t kVarintMaxLength = 35;

--- a/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.cc
@@ -61,7 +61,8 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Packet* result
   APIKey request_api_key;
   int16_t request_api_version;
   if (type == message_type_t::kRequest) {
-    PX_ASSIGN_OR_RETURN_INVALID(int16_t request_api_key_int, binary_decoder.ExtractBEInt<int16_t>());
+    PX_ASSIGN_OR_RETURN_INVALID(int16_t request_api_key_int,
+                                binary_decoder.ExtractBEInt<int16_t>());
     if (!IsValidAPIKey(request_api_key_int)) {
       return ParseState::kInvalid;
     }

--- a/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.cc
@@ -50,7 +50,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Packet* result
 
   BinaryDecoder binary_decoder(*buf);
 
-  PX_ASSIGN_OR_RETURN_INVALID(int32_t payload_length, binary_decoder.ExtractInt<int32_t>());
+  PX_ASSIGN_OR_RETURN_INVALID(int32_t payload_length, binary_decoder.ExtractBEInt<int32_t>());
 
   if (payload_length + kafka::kMessageLengthBytes <= min_packet_length) {
     return ParseState::kInvalid;
@@ -61,13 +61,13 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Packet* result
   APIKey request_api_key;
   int16_t request_api_version;
   if (type == message_type_t::kRequest) {
-    PX_ASSIGN_OR_RETURN_INVALID(int16_t request_api_key_int, binary_decoder.ExtractInt<int16_t>());
+    PX_ASSIGN_OR_RETURN_INVALID(int16_t request_api_key_int, binary_decoder.ExtractBEInt<int16_t>());
     if (!IsValidAPIKey(request_api_key_int)) {
       return ParseState::kInvalid;
     }
     request_api_key = static_cast<APIKey>(request_api_key_int);
 
-    PX_ASSIGN_OR_RETURN_INVALID(request_api_version, binary_decoder.ExtractInt<int16_t>());
+    PX_ASSIGN_OR_RETURN_INVALID(request_api_version, binary_decoder.ExtractBEInt<int16_t>());
 
     if (!IsSupportedAPIVersion(request_api_key, request_api_version)) {
       return ParseState::kInvalid;
@@ -75,7 +75,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Packet* result
     // TODO(chengruizhe): Add length range checks for each api key x version.
   }
 
-  PX_ASSIGN_OR_RETURN_INVALID(int32_t correlation_id, binary_decoder.ExtractInt<int32_t>());
+  PX_ASSIGN_OR_RETURN_INVALID(int32_t correlation_id, binary_decoder.ExtractBEInt<int32_t>());
   if (correlation_id < 0) {
     return ParseState::kInvalid;
   }
@@ -115,7 +115,7 @@ size_t FindFrameBoundary(message_type_t type, std::string_view buf, size_t start
     std::string_view cur_buf = buf.substr(i);
     BinaryDecoder binary_decoder(cur_buf);
 
-    PX_ASSIGN_OR_RETURN_NPOS(int32_t packet_length, binary_decoder.ExtractInt<int32_t>());
+    PX_ASSIGN_OR_RETURN_NPOS(int32_t packet_length, binary_decoder.ExtractBEInt<int32_t>());
 
     if (packet_length <= 0 || (size_t)packet_length + kMessageLengthBytes > buf.size() ||
         (size_t)packet_length + kMessageLengthBytes < min_length) {
@@ -124,18 +124,18 @@ size_t FindFrameBoundary(message_type_t type, std::string_view buf, size_t start
 
     // Check for valid api_key and api_version in requests.
     if (type == message_type_t::kRequest) {
-      PX_ASSIGN_OR_RETURN_NPOS(int16_t request_api_key, binary_decoder.ExtractInt<int16_t>());
+      PX_ASSIGN_OR_RETURN_NPOS(int16_t request_api_key, binary_decoder.ExtractBEInt<int16_t>());
       if (!IsValidAPIKey(request_api_key)) {
         continue;
       }
 
-      PX_ASSIGN_OR_RETURN_NPOS(int16_t request_api_version, binary_decoder.ExtractInt<int16_t>());
+      PX_ASSIGN_OR_RETURN_NPOS(int16_t request_api_version, binary_decoder.ExtractBEInt<int16_t>());
       if (!IsSupportedAPIVersion(static_cast<APIKey>(request_api_key), request_api_version)) {
         continue;
       }
     }
 
-    PX_ASSIGN_OR_RETURN_NPOS(int32_t correlation_id, binary_decoder.ExtractInt<int32_t>());
+    PX_ASSIGN_OR_RETURN_NPOS(int32_t correlation_id, binary_decoder.ExtractBEInt<int32_t>());
     if (correlation_id < 0) {
       continue;
     }

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.cc
@@ -53,7 +53,8 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
   }
 
   if (frame_type == Type::kRdispatch) {
-    PX_ASSIGN_OR(frame->reply_status, decoder->ExtractBEInt<uint8_t>(), return ParseState::kInvalid);
+    PX_ASSIGN_OR(frame->reply_status, decoder->ExtractBEInt<uint8_t>(),
+                 return ParseState::kInvalid);
   }
 
   PX_ASSIGN_OR(int16_t num_ctx, decoder->ExtractBEInt<int16_t>(), return ParseState::kInvalid);
@@ -68,11 +69,13 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
     PX_ASSIGN_OR(std::string_view ctx_key, decoder->ExtractString(ctx_key_len),
                  return ParseState::kInvalid);
 
-    PX_ASSIGN_OR(size_t ctx_value_len, decoder->ExtractBEInt<int16_t>(), return ParseState::kInvalid);
+    PX_ASSIGN_OR(size_t ctx_value_len, decoder->ExtractBEInt<int16_t>(),
+                 return ParseState::kInvalid);
 
     absl::flat_hash_map<std::string, std::string> unpacked_value;
     if (ctx_key == "com.twitter.finagle.Deadline") {
-      PX_ASSIGN_OR(int64_t timestamp, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t timestamp, decoder->ExtractBEInt<int64_t>(),
+                   return ParseState::kInvalid);
       PX_ASSIGN_OR(int64_t deadline, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
 
       unpacked_value["timestamp"] = std::to_string(timestamp / 1000);
@@ -80,7 +83,8 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
 
     } else if (ctx_key == "com.twitter.finagle.tracing.TraceContext") {
       PX_ASSIGN_OR(int64_t span_id, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
-      PX_ASSIGN_OR(int64_t parent_id, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t parent_id, decoder->ExtractBEInt<int64_t>(),
+                   return ParseState::kInvalid);
       PX_ASSIGN_OR(int64_t trace_id, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
       PX_ASSIGN_OR(int64_t flags, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.cc
@@ -28,7 +28,7 @@ namespace protocols {
 namespace mux {
 
 ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
-  PX_ASSIGN_OR(frame->tag, decoder->ExtractInt<uint24_t>(), return ParseState::kInvalid);
+  PX_ASSIGN_OR(frame->tag, decoder->ExtractBEInt<uint24_t>(), return ParseState::kInvalid);
 
   if (frame->tag < 1 || frame->tag > ((1 << 23) - 1)) {
     return ParseState::kInvalid;
@@ -53,36 +53,36 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
   }
 
   if (frame_type == Type::kRdispatch) {
-    PX_ASSIGN_OR(frame->reply_status, decoder->ExtractInt<uint8_t>(), return ParseState::kInvalid);
+    PX_ASSIGN_OR(frame->reply_status, decoder->ExtractBEInt<uint8_t>(), return ParseState::kInvalid);
   }
 
-  PX_ASSIGN_OR(int16_t num_ctx, decoder->ExtractInt<int16_t>(), return ParseState::kInvalid);
+  PX_ASSIGN_OR(int16_t num_ctx, decoder->ExtractBEInt<int16_t>(), return ParseState::kInvalid);
   absl::flat_hash_map<std::string, absl::flat_hash_map<std::string, std::string>> context;
 
   // Parse the key, value context pairs supplied in the Rdispatch/Tdispatch messages.
   // These entries pass distributed tracing context, request deadlines, client id context
   // and retries among others.
   for (int i = 0; i < num_ctx; i++) {
-    PX_ASSIGN_OR(size_t ctx_key_len, decoder->ExtractInt<int16_t>(), return ParseState::kInvalid);
+    PX_ASSIGN_OR(size_t ctx_key_len, decoder->ExtractBEInt<int16_t>(), return ParseState::kInvalid);
 
     PX_ASSIGN_OR(std::string_view ctx_key, decoder->ExtractString(ctx_key_len),
                  return ParseState::kInvalid);
 
-    PX_ASSIGN_OR(size_t ctx_value_len, decoder->ExtractInt<int16_t>(), return ParseState::kInvalid);
+    PX_ASSIGN_OR(size_t ctx_value_len, decoder->ExtractBEInt<int16_t>(), return ParseState::kInvalid);
 
     absl::flat_hash_map<std::string, std::string> unpacked_value;
     if (ctx_key == "com.twitter.finagle.Deadline") {
-      PX_ASSIGN_OR(int64_t timestamp, decoder->ExtractInt<int64_t>(), return ParseState::kInvalid);
-      PX_ASSIGN_OR(int64_t deadline, decoder->ExtractInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t timestamp, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t deadline, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
 
       unpacked_value["timestamp"] = std::to_string(timestamp / 1000);
       unpacked_value["deadline"] = std::to_string(deadline / 1000);
 
     } else if (ctx_key == "com.twitter.finagle.tracing.TraceContext") {
-      PX_ASSIGN_OR(int64_t span_id, decoder->ExtractInt<int64_t>(), return ParseState::kInvalid);
-      PX_ASSIGN_OR(int64_t parent_id, decoder->ExtractInt<int64_t>(), return ParseState::kInvalid);
-      PX_ASSIGN_OR(int64_t trace_id, decoder->ExtractInt<int64_t>(), return ParseState::kInvalid);
-      PX_ASSIGN_OR(int64_t flags, decoder->ExtractInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t span_id, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t parent_id, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t trace_id, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
+      PX_ASSIGN_OR(int64_t flags, decoder->ExtractBEInt<int64_t>(), return ParseState::kInvalid);
 
       unpacked_value["span id"] = std::to_string(span_id);
       unpacked_value["parent id"] = std::to_string(parent_id);
@@ -113,12 +113,12 @@ template <>
 ParseState ParseFrame(message_type_t, std::string_view* buf, mux::Frame* frame, NoState*) {
   BinaryDecoder decoder(*buf);
 
-  PX_ASSIGN_OR(frame->length, decoder.ExtractInt<int32_t>(), return ParseState::kInvalid);
+  PX_ASSIGN_OR(frame->length, decoder.ExtractBEInt<int32_t>(), return ParseState::kInvalid);
   if (frame->length > buf->length()) {
     return ParseState::kNeedsMoreData;
   }
 
-  PX_ASSIGN_OR(frame->type, decoder.ExtractInt<int8_t>(), return ParseState::kInvalid);
+  PX_ASSIGN_OR(frame->type, decoder.ExtractBEInt<int8_t>(), return ParseState::kInvalid);
   if (!mux::IsMuxType(frame->type)) {
     return ParseState::kInvalid;
   }

--- a/src/stirling/utils/binary_decoder.h
+++ b/src/stirling/utils/binary_decoder.h
@@ -63,7 +63,7 @@ class BinaryDecoder {
   }
 
   template <typename TIntType>
-  StatusOr<TIntType> ExtractIntFromLEndianBytes() {
+  StatusOr<TIntType> ExtractLEInt() {
     if (buf_.size() < sizeof(TIntType)) {
       return error::ResourceUnavailable("Insufficient number of bytes.");
     }

--- a/src/stirling/utils/binary_decoder.h
+++ b/src/stirling/utils/binary_decoder.h
@@ -53,7 +53,7 @@ class BinaryDecoder {
   }
 
   template <typename TIntType>
-  StatusOr<TIntType> ExtractInt() {
+  StatusOr<TIntType> ExtractBEInt() {
     if (buf_.size() < sizeof(TIntType)) {
       return error::ResourceUnavailable("Insufficient number of bytes.");
     }

--- a/src/stirling/utils/binary_decoder.h
+++ b/src/stirling/utils/binary_decoder.h
@@ -62,6 +62,16 @@ class BinaryDecoder {
     return val;
   }
 
+  template <typename TIntType>
+  StatusOr<TIntType> ExtractIntFromLEndianBytes() {
+    if (buf_.size() < sizeof(TIntType)) {
+      return error::ResourceUnavailable("Insufficient number of bytes.");
+    }
+    TIntType val = ::px::utils::LEndianBytesToInt<TIntType>(buf_);
+    buf_.remove_prefix(sizeof(TIntType));
+    return val;
+  }
+
   // Extract UVarInt encoded value and return result as uint64_t. The details of this encoding's
   // specification can be see in the following link:
   // https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/encoding/binary/varint.go;l=7-25

--- a/src/stirling/utils/binary_decoder_test.cc
+++ b/src/stirling/utils/binary_decoder_test.cc
@@ -42,14 +42,14 @@ TEST(BinaryDecoderTest, ExtractChar) {
   EXPECT_EQ(0, bin_decoder.BufSize());
 }
 
-TEST(BinaryDecoderTest, ExtractInt) {
+TEST(BinaryDecoderTest, ExtractBEInt) {
   std::string_view data("\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01");
   BinaryDecoder bin_decoder(data);
 
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractInt<int8_t>(), 1);
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractInt<int16_t>(), 257);
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractInt<int24_t>(), 65793);
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractInt<int32_t>(), 16843009);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractBEInt<int8_t>(), 1);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractBEInt<int16_t>(), 257);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractBEInt<int24_t>(), 65793);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractBEInt<int32_t>(), 16843009);
   EXPECT_EQ(0, bin_decoder.BufSize());
 }
 

--- a/src/stirling/utils/binary_decoder_test.cc
+++ b/src/stirling/utils/binary_decoder_test.cc
@@ -53,6 +53,17 @@ TEST(BinaryDecoderTest, ExtractInt) {
   EXPECT_EQ(0, bin_decoder.BufSize());
 }
 
+TEST(BinaryDecoderTest, ExtractIntFromLEndianBytes) {
+  std::string_view data("\x10\x10\x01\x10\x01\x01\x10\x01\x01\x01");
+  BinaryDecoder bin_decoder(data);
+
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int8_t>(), 16);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int16_t>(), 272);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int24_t>(), 65808);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int32_t>(), 16843024);
+  EXPECT_EQ(0, bin_decoder.BufSize());
+}
+
 TEST(BinaryDecoderTest, ExtractUVarInt) {
   std::vector<std::pair<std::vector<uint8_t>, uint64_t>> uVarInts = {
       {{}, 0},

--- a/src/stirling/utils/binary_decoder_test.cc
+++ b/src/stirling/utils/binary_decoder_test.cc
@@ -53,14 +53,14 @@ TEST(BinaryDecoderTest, ExtractInt) {
   EXPECT_EQ(0, bin_decoder.BufSize());
 }
 
-TEST(BinaryDecoderTest, ExtractIntFromLEndianBytes) {
+TEST(BinaryDecoderTest, ExtractLEInt) {
   std::string_view data("\x10\x10\x01\x10\x01\x01\x10\x01\x01\x01");
   BinaryDecoder bin_decoder(data);
 
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int8_t>(), 16);
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int16_t>(), 272);
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int24_t>(), 65808);
-  ASSERT_OK_AND_EQ(bin_decoder.ExtractIntFromLEndianBytes<int32_t>(), 16843024);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractLEInt<int8_t>(), 16);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractLEInt<int16_t>(), 272);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractLEInt<int24_t>(), 65808);
+  ASSERT_OK_AND_EQ(bin_decoder.ExtractLEInt<int32_t>(), 16843024);
   EXPECT_EQ(0, bin_decoder.BufSize());
 }
 


### PR DESCRIPTION
Summary: This PR adds a function to the BinaryDecoder class to extract little endian encoded integers from the buffer and renames the existing `ExtractInt` function to `ExtractBEInt` to make naming reflect the type of integer. There are several protocol parsing implementations, MongoDB included, which are little endian encoded but have been directly using its relevant functions within utils namespace. Adding this to BinaryDecoder would make it consistent with the existing extract integer functions that deals with big endian encoded integers.

Ran `git grep ExtractInt | cut -d : -f1 | uniq | xargs -I{} sed -i 's/ExtractInt(/ExtractBEInt(/g' {}` and `git grep ExtractInt | cut -d : -f1 | uniq | xargs -I{} sed -i 's/ExtractInt</ExtractBEInt</g' {}` to make the naming changes and reran AMQP's code generation to verify changes were done right.

Related issues: #640

Type of change: /kind feature

Test Plan: `bazel build //...` and `bazel test //...`