### PR TITLE
Prevent vizier yaml uploads during pre-release builds

### DIFF
--- a/ci/vizier_build_release.sh
+++ b/ci/vizier_build_release.sh
@@ -56,8 +56,8 @@ bazel run -c opt //src/utils/template_generator:template_generator -- \
 tmpl_path="${tmp_dir}/yamls.tar"
 upload_artifact_to_mirrors "vizier" "${release_tag}" "${tmpl_path}" "vizier_template_yamls.tar" AT_CONTAINER_SET_TEMPLATE_YAMLS
 
-# Update helm chart if it is a release.
-if [[ $VERSION != *"-"* ]]; then
+# Check to see if it's production build. If so we should also write it to the latest directory.
+if [[ ! $release_tag == *"-"* ]]; then
   # Update Vizier YAMLS in latest.
   upload_artifact_to_mirrors "vizier" "latest" "${yamls_tar}" "vizier_yamls.tar"
 


### PR DESCRIPTION
Summary: Prevent vizier yaml uploads during pre-release builds

A Pixie user that was trying to use a custom registry was attempting to install a pre-release found from the URL mentioned in our docs (`curl https://storage.googleapis.com/pixie-dev-public/vizier/latest/vizier_yamls.tar`).
<img width="1130" alt="Screenshot 2023-09-10 at 8 12 22 PM" src="https://github.com/pixie-io/pixie/assets/5855593/75a67cfc-3239-4a1a-b1a4-7162a1baca88">

This led me to realize that there is a bug that causes our vizier "latest" yamls to be updated on every vizier release instead of filtering out pre release builds.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Compared the various build release scripts and noticed that `$release_tag` is used for these checks
- [x] `ci/cli_build_release.sh` uses the same check as introduced in this PR ([source](https://github.com/pixie-io/pixie/blob/97d13beb734c8a5be8eacd38757b1b7a1e421caa/ci/cli_build_release.sh#L103))
- [x] `ci/cloud_build_release.sh` uses the same check as introduced in this PR ([here](https://github.com/pixie-io/pixie/blob/97d13beb734c8a5be8eacd38757b1b7a1e421caa/ci/cloud_build_release.sh#L32) and [here](https://github.com/pixie-io/pixie/blob/97d13beb734c8a5be8eacd38757b1b7a1e421caa/ci/cloud_build_release.sh#L89))
- [x] Verified that `$VERSION` is set in a different job of the GitHub action for it to take effect for `ci/vizier_build_release.sh` ([source](https://github.com/pixie-io/pixie/blob/97d13beb734c8a5be8eacd38757b1b7a1e421caa/.github/workflows/vizier_release.yaml#L62-L151))

After this is merged, we should attempt a pre-release build and verify that `https://storage.googleapis.com/pixie-dev-public/vizier/latest/vizier_yamls.tar` isn't updated.