### PR TITLE
[MongoDB Parsing 1/3] Add bazel repo for the Mongo C Driver

### DIFF
--- a/bazel/external/mongo_c_driver.BUILD
+++ b/bazel/external/mongo_c_driver.BUILD
@@ -26,19 +26,25 @@ filegroup(
 )
 
 cmake(
-    name = "mongo_c_driver",
+    name = "libbson",
     build_args = [
         "--",  # <- Pass remaining options to the native tool.
         "-j`nproc`",
         "-l`nproc`",
     ],
     cache_entries = {
+        "BUILD_TESTING": "OFF",
         "BUILD_VERSION": "1.24.0",
+        "ENABLE_EXAMPLES": "OFF",
+        "ENABLE_MONGOC": "OFF",
+        "ENABLE_TESTS": "OFF",
+        "ENABLE_UNINSTALL": "OFF",
     },
     lib_source = ":all",
     out_static_libs = [
         "libbson-static-1.0.a",
     ],
+    targets = ["bson_static", "bson_shared"],
     visibility = ["//visibility:public"],
     working_directory = "",
 )

--- a/bazel/external/mongo_c_driver.BUILD
+++ b/bazel/external/mongo_c_driver.BUILD
@@ -1,0 +1,44 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+)
+
+cmake(
+    name = "mongo_c_driver",
+    build_args = [
+        "--",  # <- Pass remaining options to the native tool.
+        "-j`nproc`",
+        "-l`nproc`",
+    ],
+    cache_entries = {
+        "BUILD_VERSION": "1.24.0",
+    },
+    lib_source = ":all",
+    out_static_libs = [
+        "libbson-static-1.0.a",
+    ],
+    visibility = ["//visibility:public"],
+    working_directory = "",
+)

--- a/bazel/external/mongo_c_driver.BUILD
+++ b/bazel/external/mongo_c_driver.BUILD
@@ -44,7 +44,10 @@ cmake(
     out_static_libs = [
         "libbson-static-1.0.a",
     ],
-    targets = ["bson_static", "bson_shared"],
+    targets = [
+        "bson_static",
+        "bson_shared",
+    ],
     visibility = ["//visibility:public"],
     working_directory = "",
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -92,7 +92,7 @@ def _local_repo_impl(name, **kwargs):
 def _git_repo(name, **kwargs):
     _git_repo_impl(name, **kwargs)
 
-def _local_repo(name, **kwargs):
+def _local_repo(name, **kwargs):  # buildifier: disable=unused-variable
     _local_repo_impl(name, **kwargs)
 
 # For bazel repos do not require customization.
@@ -204,7 +204,7 @@ def _java_deps():
 
 def _list_pl_deps(name):
     modules = dict()
-    for repo_name, repo_config in REPOSITORY_LOCATIONS.items():
+    for _, repo_config in REPOSITORY_LOCATIONS.items():
         if "manual_license_name" in repo_config:
             modules["#manual-license-name:" + repo_config["manual_license_name"]] = True
             continue
@@ -215,7 +215,7 @@ def _list_pl_deps(name):
                 best_url = url
         modules[best_url] = True
 
-    for repo_name, repo_config in GIT_REPOSITORY_LOCATIONS.items():
+    for _, repo_config in GIT_REPOSITORY_LOCATIONS.items():
         remote = repo_config["remote"]
         if remote.endswith(".git"):
             remote = remote[:-len(".git")]

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,6 +167,7 @@ def _cc_deps():
     _bazel_repo("com_github_opentelemetry_proto", build_file = "//bazel/external:opentelemetry.BUILD")
     _bazel_repo("com_github_uriparser_uriparser", build_file = "//bazel/external:uriparser.BUILD")
     _bazel_repo("com_github_libbpf_libbpf", build_file = "//bazel/external:libbpf.BUILD")
+    _bazel_repo("com_github_mongodb_mongo_c_driver", build_file = "//bazel/external:mongo_c_driver.BUILD")
 
     # Uncomment these to develop bcc and/or bpftrace locally. Should also comment out the corresponding _bazel_repo lines.
     # _local_repo("com_github_iovisor_bcc", build_file = "//bazel/external/local_dev:bcc.BUILD")

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -157,6 +157,11 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "libuv-1.42.0",
         urls = ["https://github.com/libuv/libuv/archive/refs/tags/v1.42.0.tar.gz"],
     ),
+    com_github_mongodb_mongo_c_driver = dict(
+        sha256 = "fdb9de045efabedf67b0ac8d7e77006705b22d954579567af75d440fd0a2c5e1",
+        strip_prefix = "mongo-c-driver-1.24.0",
+        urls = ["https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.24.0.tar.gz"],
+    ),
     com_github_nats_io_natsc = dict(
         sha256 = "16e700d912034faefb235a955bd920cfe4d449a260d0371b9694d722eb617ae1",
         strip_prefix = "nats.c-3.3.0",


### PR DESCRIPTION
Summary: This PR adds the external Bazel repo for the mongo-c-driver. This driver is used to help parse BSON documents from a MongoDB frame to type JSON strings.

Related issues: #640

Type of change: /kind feature

Test Plan: `bazel build @com_github_mongodb_mongo_c_driver//...`