### PR TITLE
Fix and re-enable partial aggregates.

### DIFF
--- a/src/carnot/funcs/builtins/collections.h
+++ b/src/carnot/funcs/builtins/collections.h
@@ -88,7 +88,7 @@ class AnyUDA : public udf::UDA {
   void Merge(FunctionContext*, const AnyUDA& other) { SetValue(other.val_); }
 
   TArg Finalize(FunctionContext*) {
-    DCHECK(picked);
+    DCHECK(picked) << "AnyUDA uninitialized.";
     return val_;
   }
 
@@ -97,7 +97,7 @@ class AnyUDA : public udf::UDA {
   }
 
   StringValue Serialize(FunctionContext*) {
-    DCHECK(picked);
+    DCHECK(picked) << "AnyUDA uninitialized.";
     return SerializeScalar(&val_);
   }
 

--- a/src/carnot/funcs/builtins/collections.h
+++ b/src/carnot/funcs/builtins/collections.h
@@ -103,7 +103,6 @@ class AnyUDA : public udf::UDA {
 
   Status Deserialize(FunctionContext*, const StringValue& data) {
     SetValue(DeserializeScalar<TArg>(data));
-    DCHECK(picked);
     return Status::OK();
   }
 

--- a/src/carnot/funcs/builtins/collections.h
+++ b/src/carnot/funcs/builtins/collections.h
@@ -82,26 +82,28 @@ class AnyUDA : public udf::UDA {
   void Update(FunctionContext*, TArg val) {
     // TODO(zasgar): We should find a way to short-circuit the agg since we only care
     // about one value.
-    if (!picked) {
-      val_ = val;
-      picked = true;
-    }
+    SetValue(val);
   }
 
-  void Merge(FunctionContext*, const AnyUDA&) {
-    // Does nothing.
-  }
+  void Merge(FunctionContext*, const AnyUDA& other) { SetValue(other.val_); }
 
-  TArg Finalize(FunctionContext*) { return val_; }
+  TArg Finalize(FunctionContext*) {
+    DCHECK(picked);
+    return val_;
+  }
 
   static udf::InfRuleVec SemanticInferenceRules() {
     return {udf::InheritTypeFromArgs<AnyUDA>::CreateGeneric()};
   }
 
-  StringValue Serialize(FunctionContext*) { return SerializeScalar(&val_); }
+  StringValue Serialize(FunctionContext*) {
+    DCHECK(picked);
+    return SerializeScalar(&val_);
+  }
 
   Status Deserialize(FunctionContext*, const StringValue& data) {
-    val_ = DeserializeScalar<TArg>(data);
+    SetValue(DeserializeScalar<TArg>(data));
+    DCHECK(picked);
     return Status::OK();
   }
 
@@ -119,6 +121,14 @@ class AnyUDA : public udf::UDA {
  protected:
   TArg val_;
   bool picked = false;
+
+ private:
+  void SetValue(TArg val) {
+    if (!picked) {
+      val_ = val;
+      picked = true;
+    }
+  }
 };
 
 }  // namespace builtins

--- a/src/carnot/funcs/builtins/collections.h
+++ b/src/carnot/funcs/builtins/collections.h
@@ -85,7 +85,11 @@ class AnyUDA : public udf::UDA {
     SetValue(val);
   }
 
-  void Merge(FunctionContext*, const AnyUDA& other) { SetValue(other.val_); }
+  void Merge(FunctionContext*, const AnyUDA& other) {
+    if (other.picked) {
+      SetValue(other.val_);
+    }
+  }
 
   TArg Finalize(FunctionContext*) {
     DCHECK(picked) << "AnyUDA uninitialized.";

--- a/src/carnot/funcs/builtins/collections_test.cc
+++ b/src/carnot/funcs/builtins/collections_test.cc
@@ -30,7 +30,7 @@ namespace builtins {
 
 TEST(CollectionsTest, AnyUDA) {
   auto uda_tester = udf::UDATester<AnyUDA<types::Float64Value>>();
-  std::vector<types::Float64Value> vals = {
+  const std::vector<types::Float64Value> vals = {
       1.234, 2.442, 1.04, 5.322, 6.333,
   };
 
@@ -39,6 +39,59 @@ TEST(CollectionsTest, AnyUDA) {
   }
 
   EXPECT_THAT(vals, ::testing::Contains(uda_tester.Result()));
+}
+
+TEST(CollectionsTest, MergeAnyUDA) {
+  using DataType = types::Int64Value;
+  auto uda_tester_a = udf::UDATester<AnyUDA<DataType>>();
+  auto uda_tester_b = udf::UDATester<AnyUDA<DataType>>();
+  auto uda_tester_merge = udf::UDATester<AnyUDA<DataType>>();
+  const std::vector<DataType> vals_a = {1, 2, 3};
+  const std::vector<DataType> vals_b = {4, 5, 6};
+  std::vector<DataType> all_vals;
+
+  for (const auto& val : vals_a) {
+    uda_tester_a.ForInput(val);
+    all_vals.push_back(val);
+  }
+  for (const auto& val : vals_b) {
+    uda_tester_b.ForInput(val);
+    all_vals.push_back(val);
+  }
+
+  // Merge A & B UDAs into the final "merge" UDA.
+  uda_tester_merge.Merge(&uda_tester_a);
+  uda_tester_merge.Merge(&uda_tester_b);
+  const auto final = uda_tester_merge.Result();
+
+  EXPECT_THAT(all_vals, ::testing::Contains(final));
+}
+
+TEST(CollectionsTest, SerDesAnyUDA) {
+  using DataType = types::Int64Value;
+  auto uda_tester_a = udf::UDATester<AnyUDA<DataType>>();
+  auto uda_tester_b = udf::UDATester<AnyUDA<DataType>>();
+  auto uda_tester_merge = udf::UDATester<AnyUDA<DataType>>();
+  const std::vector<DataType> vals_a = {1, 2, 3};
+  const std::vector<DataType> vals_b = {4, 5, 6};
+  std::vector<DataType> all_vals;
+
+  for (const auto& val : vals_a) {
+    uda_tester_a.ForInput(val);
+    all_vals.push_back(val);
+  }
+  for (const auto& val : vals_b) {
+    uda_tester_b.ForInput(val);
+    all_vals.push_back(val);
+  }
+
+  // Merge A & B UDAs into the final "merge" UDA.
+  EXPECT_OK(uda_tester_merge.Deserialize(uda_tester_a.Serialize()));
+  EXPECT_OK(uda_tester_merge.Deserialize(uda_tester_b.Serialize()));
+
+  const auto final = uda_tester_merge.Result();
+
+  EXPECT_THAT(all_vals, ::testing::Contains(final));
 }
 
 TEST(CollectionsTest, CanSerializeDeserialize_Float64) {
@@ -52,7 +105,6 @@ TEST(CollectionsTest, CanSerializeDeserialize_Float64) {
   }
 
   auto any_uda = AnyUDA<types::Float64Value>();
-  EXPECT_NE(uda_tester.Result(), any_uda.Finalize(nullptr));
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
 
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
@@ -69,7 +121,6 @@ TEST(CollectionsTest, CanSerializeDeserialize_String) {
   }
 
   auto any_uda = AnyUDA<types::StringValue>();
-  EXPECT_NE(uda_tester.Result(), any_uda.Finalize(nullptr));
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
 
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
@@ -86,7 +137,6 @@ TEST(CollectionsTest, CanSerializeDeserialize_UInt128) {
   }
 
   auto any_uda = AnyUDA<types::UInt128Value>();
-  EXPECT_NE(uda_tester.Result(), any_uda.Finalize(nullptr));
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
 
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
@@ -103,7 +153,6 @@ TEST(CollectionsTest, CanSerializeDeserialize_Float) {
   }
 
   auto any_uda = AnyUDA<types::Float64Value>();
-  EXPECT_NE(uda_tester.Result(), any_uda.Finalize(nullptr));
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
 
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));

--- a/src/carnot/funcs/builtins/collections_test.cc
+++ b/src/carnot/funcs/builtins/collections_test.cc
@@ -28,6 +28,12 @@ namespace px {
 namespace carnot {
 namespace builtins {
 
+#ifndef NDEBUG
+#define EXPECT_DEATH_DBG(x, y) EXPECT_DEATH(x, y)
+#else
+#define EXPECT_DEATH_DBG(x, y)
+#endif
+
 TEST(CollectionsTest, AnyUDA) {
   auto uda_tester = udf::UDATester<AnyUDA<types::Float64Value>>();
   const std::vector<types::Float64Value> vals = {
@@ -105,7 +111,7 @@ TEST(CollectionsTest, CanSerializeDeserialize_Float64) {
   }
 
   auto any_uda = AnyUDA<types::Float64Value>();
-  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
+  EXPECT_DEATH_DBG(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
@@ -121,7 +127,7 @@ TEST(CollectionsTest, CanSerializeDeserialize_String) {
   }
 
   auto any_uda = AnyUDA<types::StringValue>();
-  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
+  EXPECT_DEATH_DBG(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
@@ -137,7 +143,7 @@ TEST(CollectionsTest, CanSerializeDeserialize_UInt128) {
   }
 
   auto any_uda = AnyUDA<types::UInt128Value>();
-  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
+  EXPECT_DEATH_DBG(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
@@ -153,7 +159,7 @@ TEST(CollectionsTest, CanSerializeDeserialize_Float) {
   }
 
   auto any_uda = AnyUDA<types::Float64Value>();
-  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
+  EXPECT_DEATH_DBG(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }

--- a/src/carnot/funcs/builtins/collections_test.cc
+++ b/src/carnot/funcs/builtins/collections_test.cc
@@ -105,8 +105,8 @@ TEST(CollectionsTest, CanSerializeDeserialize_Float64) {
   }
 
   auto any_uda = AnyUDA<types::Float64Value>();
+  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
-
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
 
@@ -121,8 +121,8 @@ TEST(CollectionsTest, CanSerializeDeserialize_String) {
   }
 
   auto any_uda = AnyUDA<types::StringValue>();
+  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
-
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
 
@@ -137,8 +137,8 @@ TEST(CollectionsTest, CanSerializeDeserialize_UInt128) {
   }
 
   auto any_uda = AnyUDA<types::UInt128Value>();
+  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
-
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
 
@@ -153,8 +153,8 @@ TEST(CollectionsTest, CanSerializeDeserialize_Float) {
   }
 
   auto any_uda = AnyUDA<types::Float64Value>();
+  EXPECT_DEATH(any_uda.Finalize(nullptr), "AnyUDA uninitialized.");
   ASSERT_OK(any_uda.Deserialize(nullptr, uda_tester.Serialize()));
-
   EXPECT_EQ(uda_tester.Result(), any_uda.Finalize(nullptr));
 }
 

--- a/src/carnot/funcs/builtins/collections_test.cc
+++ b/src/carnot/funcs/builtins/collections_test.cc
@@ -24,15 +24,15 @@
 #include "src/carnot/funcs/builtins/collections.h"
 #include "src/carnot/udf/test_utils.h"
 
-namespace px {
-namespace carnot {
-namespace builtins {
-
 #ifndef NDEBUG
 #define EXPECT_DEATH_DBG(x, y) EXPECT_DEATH(x, y)
 #else
 #define EXPECT_DEATH_DBG(x, y)
 #endif
+
+namespace px {
+namespace carnot {
+namespace builtins {
 
 TEST(CollectionsTest, AnyUDA) {
   auto uda_tester = udf::UDATester<AnyUDA<types::Float64Value>>();

--- a/src/carnot/planner/distributed/coordinator/coordinator.cc
+++ b/src/carnot/planner/distributed/coordinator/coordinator.cc
@@ -179,7 +179,7 @@ StatusOr<SchemaToAgentsMap> LoadSchemaMap(
 
 StatusOr<std::unique_ptr<DistributedPlan>> CoordinatorImpl::CoordinateImpl(const IR* logical_plan) {
   PX_ASSIGN_OR_RETURN(std::unique_ptr<Splitter> splitter,
-                      Splitter::Create(compiler_state_, /* support_partial_agg */ false));
+                      Splitter::Create(compiler_state_, /* support_partial_agg */ true));
   PX_ASSIGN_OR_RETURN(std::unique_ptr<BlockingSplitPlan> split_plan,
                       splitter->SplitKelvinAndAgents(logical_plan));
   auto distributed_plan = std::make_unique<DistributedPlan>();

--- a/src/carnot/planner/distributed/splitter/partial_op_mgr/partial_op_mgr.h
+++ b/src/carnot/planner/distributed/splitter/partial_op_mgr/partial_op_mgr.h
@@ -97,7 +97,8 @@ class AggOperatorMgr : public PartialOperatorMgr {
     if (!Match(op, BlockingAgg())) {
       return false;
     }
-    BlockingAggIR* agg = static_cast<BlockingAggIR*>(op);
+    BlockingAggIR* agg = dynamic_cast<BlockingAggIR*>(op);
+    ECHECK_NE(agg, nullptr);
     for (const auto& col_expr : agg->aggregate_expressions()) {
       if (!Match(col_expr.node, PartialUDA())) {
         return false;

--- a/src/carnot/planner/distributed/splitter/partial_op_mgr/partial_op_mgr.h
+++ b/src/carnot/planner/distributed/splitter/partial_op_mgr/partial_op_mgr.h
@@ -97,8 +97,7 @@ class AggOperatorMgr : public PartialOperatorMgr {
     if (!Match(op, BlockingAgg())) {
       return false;
     }
-    BlockingAggIR* agg = dynamic_cast<BlockingAggIR*>(op);
-    ECHECK_NE(agg, nullptr);
+    BlockingAggIR* agg = static_cast<BlockingAggIR*>(op);
     for (const auto& col_expr : agg->aggregate_expressions()) {
       if (!Match(col_expr.node, PartialUDA())) {
         return false;


### PR DESCRIPTION
Summary: The implementation of the "any" UDA was broken for partial aggregates. In this PR, we fix that and re-enable partial aggregates.

Type of change: /kind bug fix

Test Plan: We add two new test cases: `MergeAnyUDA` and `SerDesAnyUDA`.
- [x] Both new test cases fail with the original UDA impl.
- [x] Both new test cases pass with the fixed UDA impl. (this PR).
- [x] Skaffolded up the new impl. and verified that flamegraphs render correctly.
