### PR TITLE
Update AMQP's code generation README

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/README.md
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/amqp_code_generator/README.md
@@ -1,10 +1,5 @@
 # AMQP Protocol Parsing
 
-Install the requirements via pip install and run
-```bash
-    python3 amqp_decode_gen.py run
-```
-
 The function takes in the `amqp-0-9-1.stripped.xml` from the AMQP specification and generates header and c files for pixie.
 The stripped version of xml from https://www.amqp.org/specification/0-9-1/amqp-org-download
 


### PR DESCRIPTION
Summary: The steps to run AMQP's code generation involve running the python files with `bazel` and not `python3`. I experienced the confusion in the readme when I was following the steps to produce AMQP's protocol parsing code when testing out the `ExtractBEInt` functionality in #1698.

Related issues: N/A

Type of change: /kind cleanup

Test Plan: N/A