### PR TITLE
Add rr sub-tree, impl. perf buffer record & replay.

### DIFF
--- a/src/stirling/bpf_tools/BUILD.bazel
+++ b/src/stirling/bpf_tools/BUILD.bazel
@@ -39,6 +39,7 @@ pl_cc_library(
         "//src/stirling/bpf_tools/bcc_bpf:task_struct_mem_read",
         "//src/stirling/bpf_tools/bcc_bpf_intf:cc_library",
         "//src/stirling/bpf_tools/probe_specs:cc_library",
+        "//src/stirling/bpf_tools/rr:cc_library",
         "//src/stirling/obj_tools:cc_library",
         "//src/stirling/utils:cc_library",
         "@com_github_iovisor_bcc//:bcc",

--- a/src/stirling/bpf_tools/probe_specs/probe_specs.h
+++ b/src/stirling/bpf_tools/probe_specs/probe_specs.h
@@ -44,6 +44,8 @@ namespace px {
 namespace stirling {
 namespace bpf_tools {
 
+class BPFRecorder;
+
 enum class BPFProbeAttachType {
   // Attach to function entry.
   kEntry = BPF_PROBE_ENTRY,
@@ -179,6 +181,9 @@ struct PerfBufferSpec {
   // We specify a maximum total size per PerfBufferSizeCategory, this specifies which size category
   // to count this buffer's size against.
   PerfBufferSizeCategory size_category = PerfBufferSizeCategory::kUncategorized;
+
+  // This will be populated and used only if the BPF recording BCC wrapper is used.
+  BPFRecorder* recorder = nullptr;
 
   std::string ToString() const {
     return absl::Substitute("name=$0 size_bytes=$1 size_category=$2", name, size_bytes,

--- a/src/stirling/bpf_tools/rr/BUILD.bazel
+++ b/src/stirling/bpf_tools/rr/BUILD.bazel
@@ -1,0 +1,65 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:pl_build_system.bzl", "pl_cc_bpf_test", "pl_cc_library")
+load("//bazel:proto_compile.bzl", "pl_cc_proto_library", "pl_proto_library")
+
+package(default_visibility = ["//src/stirling:__subpackages__"])
+
+pl_proto_library(
+    name = "rr_pl_proto",
+    srcs = ["rr.proto"],
+    deps = [],
+)
+
+pl_cc_proto_library(
+    name = "rr_pl_cc_proto",
+    proto = ":rr_pl_proto",
+    deps = [],
+)
+
+pl_cc_library(
+    name = "cc_library",
+    srcs = glob(
+        ["*.cc"],
+        exclude = [
+            "**/*_test.cc",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "*.h",
+        ],
+    ),
+    deps = [
+        "//src/stirling/bpf_tools/probe_specs:cc_library",
+        "//src/stirling/bpf_tools/rr:rr_pl_cc_proto",
+    ],
+)
+
+pl_cc_bpf_test(
+    name = "rr_bpf_test",
+    srcs = ["rr_bpf_test.cc"],
+    tags = [
+        "cpu:16",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/stirling/bpf_tools:cc_library",
+        "//src/stirling/bpf_tools/rr/testing/bpf:rr_test_bpf_text",
+    ],
+)

--- a/src/stirling/bpf_tools/rr/rr.cc
+++ b/src/stirling/bpf_tools/rr/rr.cc
@@ -80,12 +80,15 @@ void BPFReplayer::ReplayPerfBufferEvents(const PerfBufferSpec& perf_buffer_spec)
   while (playback_event_idx_ < n_events) {
     const auto event = events_proto_.event(playback_event_idx_);
     if (!event.has_perf_buffer_event()) {
+      // Return control to calling context. Replay will continue with a different eBPF data
+      // type, e.g. map or array.
       break;
     }
     const auto perf_buffer_event = event.perf_buffer_event();
     const auto data = perf_buffer_event.data();
     const auto name = perf_buffer_event.name();
     if (name != perf_buffer_spec.name) {
+      // Return control to calling context. Replay will continue with a different perf buffer.
       break;
     }
     const void* const_data = static_cast<const void*>(data.data());

--- a/src/stirling/bpf_tools/rr/rr.cc
+++ b/src/stirling/bpf_tools/rr/rr.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/bpf_tools/rr/rr.h"
+
+#include <fstream>
+
+namespace px {
+namespace stirling {
+namespace bpf_tools {
+
+void BPFRecorder::WriteProto(const std::string& proto_buf_file_path) {
+  if (!recording_written_) {
+    LOG(INFO) << "Writing BPF events pb to file: " << proto_buf_file_path;
+
+    std::fstream outfile(proto_buf_file_path, std::ios::out | std::ios::trunc | std::ios::binary);
+    if (!outfile.is_open()) {
+      return;
+    }
+
+    if (!events_proto_.SerializeToOstream(&outfile)) {
+      return;
+    }
+  }
+  recording_written_ = true;
+}
+
+void BPFRecorder::RecordPerfBufferEvent(PerfBufferSpec* pb_spec, void const* const data,
+                                        const int data_size) {
+  auto event = events_proto_.add_event()->mutable_perf_buffer_event();
+  auto pb_name = event->mutable_name();
+  auto pb_data = event->mutable_data();
+
+  const std::string data_as_string(static_cast<char const*>(data), data_size);
+
+  *pb_name = pb_spec->name;
+  *pb_data = data_as_string;
+}
+
+void RecordPerfBufferEvent(void* cb_cookie, void* data, int data_size) {
+  PerfBufferSpec* pb_spec = static_cast<PerfBufferSpec*>(cb_cookie);
+  BPFRecorder* recorder = pb_spec->recorder;
+  ECHECK(recorder != nullptr);
+
+  recorder->RecordPerfBufferEvent(pb_spec, data, data_size);
+  pb_spec->probe_output_fn(pb_spec->cb_cookie, data, data_size);
+}
+
+void RecordPerfBufferLoss(void* cb_cookie, uint64_t lost) {
+  PerfBufferSpec* pb_spec = static_cast<PerfBufferSpec*>(cb_cookie);
+  pb_spec->probe_loss_fn(pb_spec->cb_cookie, lost);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Replay.
+void BPFReplayer::ReplayPerfBufferEvents(const PerfBufferSpec& perf_buffer_spec) {
+  if (PlabackComplete()) {
+    LOG_FIRST_N(INFO, 1) << "BPFReplayer::ReplayPerfBufferEvents(), plaback complete.";
+    return;
+  }
+
+  const auto n_events = events_proto_.event_size();
+
+  while (playback_event_idx_ < n_events) {
+    const auto event = events_proto_.event(playback_event_idx_);
+    if (!event.has_perf_buffer_event()) {
+      break;
+    }
+    const auto perf_buffer_event = event.perf_buffer_event();
+    const auto data = perf_buffer_event.data();
+    const auto name = perf_buffer_event.name();
+    if (name != perf_buffer_spec.name) {
+      break;
+    }
+    const void* const_data = static_cast<const void*>(data.data());
+    void* data_ptr = const_cast<void*>(static_cast<const void*>(const_data));
+    auto f = perf_buffer_spec.probe_output_fn;
+    f(perf_buffer_spec.cb_cookie, data_ptr, data.size());
+    ++playback_event_idx_;
+  }
+}
+
+Status BPFReplayer::OpenReplayProtobuf(const std::string& replay_events_pb_file_path) {
+  LOG(INFO) << absl::Substitute("replay_events_pb_file_path: $0.", replay_events_pb_file_path);
+  std::fstream input(replay_events_pb_file_path, std::ios::in | std::ios::binary);
+
+  if (!input) {
+    return error::Internal("Could not open file: $0.", replay_events_pb_file_path);
+  } else if (!events_proto_.ParseFromIstream(&input)) {
+    return error::Internal("Could not parse file: $0.", replay_events_pb_file_path);
+  }
+  LOG(INFO) << absl::Substitute("events_proto_.size(): $0.", events_proto_.event_size());
+  return Status::OK();
+}
+
+}  // namespace bpf_tools
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/bpf_tools/rr/rr.h
+++ b/src/stirling/bpf_tools/rr/rr.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "src/stirling/bpf_tools/probe_specs/probe_specs.h"
+#include "src/stirling/bpf_tools/rr/rr.pb.h"
+
+namespace px {
+namespace stirling {
+namespace bpf_tools {
+
+class BPFRecorder : public NotCopyMoveable {
+ public:
+  void RecordPerfBufferEvent(PerfBufferSpec* pb_spec, void const* const data, const int data_size);
+  void WriteProto(const std::string& proto_buf_file_path);
+
+ private:
+  bool recording_written_ = false;
+  ::px::stirling::rr::BPFEvents events_proto_;
+};
+
+class BPFReplayer : public NotCopyMoveable {
+ public:
+  void ReplayPerfBufferEvents(const PerfBufferSpec& perf_buffer_spec);
+  Status OpenReplayProtobuf(const std::string& replay_events_pb_file_path);
+  bool PlabackComplete() const { return playback_event_idx_ >= events_proto_.event_size(); }
+
+  ::px::stirling::rr::BPFEvents& events_proto() { return events_proto_; }
+
+ private:
+  int64_t playback_event_idx_ = 0;
+  ::px::stirling::rr::BPFEvents events_proto_;
+};
+
+void RecordPerfBufferEvent(void* cb_cookie, void* data, int data_size);
+void RecordPerfBufferLoss(void* cb_cookie, uint64_t lost);
+
+}  // namespace bpf_tools
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/bpf_tools/rr/rr.proto
+++ b/src/stirling/bpf_tools/rr/rr.proto
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto3";
+
+package px.stirling.rr;
+
+// The request message containing the user's name.
+message BPFEvents {
+  repeated BPFEvent event = 1;
+}
+
+message BPFEvent {
+  oneof event {
+    PerfBufferEvent perf_buffer_event = 1;
+    BPFArrayTableGetValueEvent array_table_get_value_event = 2;
+    BPFMapGetValueEvent map_get_value_event = 3;
+    BPFMapGetTableOfflineEvent map_get_table_offline_event = 4;
+    BPFMapCapacityEvent map_capacity_event = 5;
+    BPFStackTableGetStackAddrEvent get_stack_addr_event = 6;
+    BPFStackTableGetAddrSymbolEvent get_addr_symbol_event = 7;
+  }
+}
+
+message PerfBufferEvent {
+  string name = 1;
+  bytes data = 2;
+}
+
+message BPFArrayTableGetValueEvent {
+  string name = 1;
+  int32 idx = 2;
+  bytes data = 3;
+}
+
+message BPFMapGetValueEvent {
+  string name = 1;
+  bytes key = 2;
+  bytes value = 3;
+}
+
+// BPFMapGetTableOfflineEvent stores the number of table entries in "size".
+// Then the recorder (or replayer) writes (reads) N key value pairs using BPFMapGetValueEvent.
+message BPFMapGetTableOfflineEvent {
+  string name = 1;
+  int32 size = 2;
+}
+
+message BPFMapCapacityEvent {
+  string name = 1;
+  int32 capacity = 2;
+}
+
+message BPFStackTableGetStackAddrEvent {
+  string name = 1;
+  int32 stack_id = 2;
+  repeated uint64 addr = 3;
+}
+
+message BPFStackTableGetAddrSymbolEvent {
+  string name = 1;
+  uint32 pid = 2;
+  uint64 addr = 3;
+  string symbol = 4;
+}

--- a/src/stirling/bpf_tools/rr/rr_bpf_test.cc
+++ b/src/stirling/bpf_tools/rr/rr_bpf_test.cc
@@ -173,8 +173,6 @@ TEST_F(BasicRecorderTest, PerfBufferRRTest) {
   ASSERT_OK(replaying_bcc_->OpenReplayProtobuf(pb_file_name));
   replaying_bcc_->PollPerfBuffers();
   EXPECT_EQ(test::test_idx, test::gold_data.size());
-
-  // TODO(jps): add the expectations.
 }
 
 }  // namespace stirling

--- a/src/stirling/bpf_tools/rr/rr_bpf_test.cc
+++ b/src/stirling/bpf_tools/rr/rr_bpf_test.cc
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/syscall.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "src/common/testing/testing.h"
+#include "src/stirling/bpf_tools/bcc_wrapper.h"
+#include "src/stirling/bpf_tools/macros.h"
+#include "src/stirling/bpf_tools/rr/rr.h"
+#include "src/stirling/obj_tools/address_converter.h"
+#include "src/stirling/utils/proc_path_tools.h"
+
+using px::stirling::obj_tools::ElfAddressConverter;
+using px::stirling::obj_tools::ElfReader;
+
+// Create a std::string_view named rr_test_bcc_script based on the bazel target :rr_test_bpf_text.
+// This is the BPF program we will invoke for this test.
+OBJ_STRVIEW(rr_test_bcc_script, rr_test_bpf_text);
+
+namespace test {
+
+// We attach an eBPF user space probe to Foo() and Bar(). Later, we invoke Foo() and Bar()
+// and expect that the eBPF recording mechanism records the perf buffer traffic generated
+// by our eBPF probe.
+NO_OPT_ATTR uint32_t Foo(const uint32_t arg) { return 1 + arg; }
+NO_OPT_ATTR uint32_t Bar(const uint32_t arg) { return 2 + arg; }
+
+std::vector<int> gold_data;
+uint32_t test_idx = 0;
+
+void PerfBufferRecordingDataFn(void* cb_cookie, void* data, int data_size) {
+  DCHECK(cb_cookie != nullptr) << "Perf buffer callback not set-up properly. Missing cb_cookie.";
+  EXPECT_EQ(data_size, sizeof(int));
+  int v = *static_cast<int*>(data);
+  gold_data.push_back(v);
+}
+
+void PerfBufferReplayingDataFn(void* cb_cookie, void* data, int data_size) {
+  DCHECK(cb_cookie != nullptr) << "Perf buffer callback not set-up properly. Missing cb_cookie.";
+  EXPECT_EQ(data_size, sizeof(int));
+  int v = *static_cast<int*>(data);
+  EXPECT_EQ(gold_data[test_idx], v);
+  ++test_idx;
+}
+
+void PerfBufferLossFn(void* cb_cookie, uint64_t /*lost*/) {
+  DCHECK(cb_cookie != nullptr) << "Perf buffer callback not set-up properly. Missing cb_cookie.";
+}
+
+}  // namespace test
+
+namespace px {
+namespace stirling {
+
+using bpf_tools::BPFProbeAttachType;
+using bpf_tools::UProbeSpec;
+using bpf_tools::WrappedBCCArrayTable;
+using bpf_tools::WrappedBCCMap;
+using bpf_tools::WrappedBCCStackTable;
+
+class BasicRecorderTest : public ::testing::Test {
+ public:
+  BasicRecorderTest() {}
+
+ protected:
+  void SetUp() override {
+    recording_bcc_ = std::make_unique<bpf_tools::RecordingBCCWrapperImpl>();
+    replaying_bcc_ = std::make_unique<bpf_tools::ReplayingBCCWrapperImpl>();
+
+    // Register our BPF program in the kernel, for real (recording), and for fake (replaying).
+    ASSERT_OK(recording_bcc_->InitBPFProgram(rr_test_bcc_script));
+    ASSERT_OK(replaying_bcc_->InitBPFProgram(rr_test_bcc_script));
+
+    const auto recording_perf_buffer_specs = MakeArray<bpf_tools::PerfBufferSpec>({
+        .name = std::string("perf_buffer"),
+        .probe_output_fn = test::PerfBufferRecordingDataFn,
+        .probe_loss_fn = test::PerfBufferLossFn,
+        .cb_cookie = this,
+    });
+    const auto replaying_perf_buffer_specs = MakeArray<bpf_tools::PerfBufferSpec>({
+        .name = std::string("perf_buffer"),
+        .probe_output_fn = test::PerfBufferReplayingDataFn,
+        .probe_loss_fn = test::PerfBufferLossFn,
+        .cb_cookie = this,
+    });
+
+    // Open perf buffers for real (recording), and for fake (replaying).
+    ASSERT_OK(recording_bcc_->OpenPerfBuffers(recording_perf_buffer_specs));
+    ASSERT_OK(replaying_bcc_->OpenPerfBuffers(replaying_perf_buffer_specs));
+
+    const int64_t self_pid = getpid();
+    const std::filesystem::path self_path = GetSelfPath().ValueOrDie();
+    ASSERT_OK_AND_ASSIGN(auto elf_reader, ElfReader::Create(self_path.string()));
+    ASSERT_OK_AND_ASSIGN(auto converter, ElfAddressConverter::Create(elf_reader.get(), self_pid));
+
+    // For the uprobe spec.
+    const uint64_t foo_virt_addr = reinterpret_cast<uint64_t>(&::test::Foo);
+    const uint64_t bar_virt_addr = reinterpret_cast<uint64_t>(&::test::Bar);
+    const uint64_t foo_bin_addr = converter->VirtualAddrToBinaryAddr(foo_virt_addr);
+    const uint64_t bar_bin_addr = converter->VirtualAddrToBinaryAddr(bar_virt_addr);
+
+    const UProbeSpec kFooUprobe{.binary_path = self_path,
+                                .symbol = {},
+                                .address = foo_bin_addr,
+                                .attach_type = BPFProbeAttachType::kEntry,
+                                .probe_fn = "push_something_into_a_perf_buffer"};
+    const UProbeSpec kBarUprobe{.binary_path = self_path,
+                                .symbol = {},
+                                .address = bar_bin_addr,
+                                .attach_type = BPFProbeAttachType::kEntry,
+                                .probe_fn = "push_something_into_a_perf_buffer"};
+
+    // Attach uprobes for this test case:
+    ASSERT_OK(recording_bcc_->AttachUProbe(kFooUprobe));
+    ASSERT_OK(recording_bcc_->AttachUProbe(kBarUprobe));
+    ASSERT_OK(replaying_bcc_->AttachUProbe(kFooUprobe));
+    ASSERT_OK(replaying_bcc_->AttachUProbe(kBarUprobe));
+  }
+
+  void TearDown() override {
+    recording_bcc_->Close();
+    replaying_bcc_->Close();
+  }
+
+  std::unique_ptr<bpf_tools::RecordingBCCWrapperImpl> recording_bcc_;
+  std::unique_ptr<bpf_tools::ReplayingBCCWrapperImpl> replaying_bcc_;
+};
+
+TEST_F(BasicRecorderTest, PerfBufferRRTest) {
+  constexpr uint32_t kLoopIters = 16;
+
+  for (uint32_t i = 0; i < kLoopIters; ++i) {
+    // Invoking Foo() or Bar() triggers our eBPF uprobe, which will capture the function argument.
+    PX_UNUSED(::test::Foo(2 * i + 0));
+    PX_UNUSED(::test::Bar(2 * i + 1));
+  }
+
+  const std::string pb_file_name = "perf_buffer_replay_test.pb";
+
+  // Polling perf buffers will cause the recording BCC wrapper to record each perf buffer event.
+  recording_bcc_->PollPerfBuffers();
+
+  // Write out the protobuf file and close the recording BCC wrapper.
+  recording_bcc_->WriteProto(pb_file_name);
+  recording_bcc_->Close();
+
+  // Open the protobuf file in the replaying BCC wrapper.
+  // The "replaying" data callback will check "test" (replay) data vs. "gold" data (captured
+  // on the side during original recording when we invoked functions Foo() and Bar()).
+  // Finally, we check that the "test" event count (from replay)
+  // is the same as the "gold" event count (from recording).
+  ASSERT_OK(replaying_bcc_->OpenReplayProtobuf(pb_file_name));
+  replaying_bcc_->PollPerfBuffers();
+  EXPECT_EQ(test::test_idx, test::gold_data.size());
+
+  // TODO(jps): add the expectations.
+}
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/bpf_tools/rr/testing/bpf/BUILD.bazel
+++ b/src/stirling/bpf_tools/rr/testing/bpf/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+load("//bazel:cc_resource.bzl", "pl_bpf_cc_resource")
+
+package(default_visibility = ["//src/stirling:__subpackages__"])
+
+pl_bpf_cc_resource(
+    name = "rr_test_bpf_text",
+    src = "rr_test.c",
+    deps = [
+        "//src/stirling/bpf_tools/bcc_bpf:headers",
+        "//src/stirling/bpf_tools/bcc_bpf/system-headers",
+        "//src/stirling/bpf_tools/bcc_bpf_intf:headers",
+    ],
+)

--- a/src/stirling/bpf_tools/rr/testing/bpf/rr_test.c
+++ b/src/stirling/bpf_tools/rr/testing/bpf/rr_test.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// LINT_C_FILE: Do not remove this line. It ensures cpplint treats this as a C file.
+#include <linux/ptrace.h>
+
+BPF_PERF_OUTPUT(perf_buffer);
+BPF_HASH(map, int, int);
+BPF_ARRAY(state, int, 1);
+BPF_ARRAY(results, int, 1024);
+BPF_STACK_TRACE(stack_table, 1024);
+BPF_PERF_OUTPUT(stack_ids);
+
+// A minimal BPF program to:
+// 1. Push something into a perf buffer.
+// 2. Populate a BPF array.
+// 3. Populate a BPF hash map.
+int push_something_into_a_perf_buffer(struct pt_regs* ctx) {
+  int count_idx = 0;
+  int* pcount = state.lookup(&count_idx);
+  if (pcount == NULL) {
+    return -1;
+  }
+  int count = *pcount;
+
+  int arg_val = PT_REGS_PARM1(ctx);
+  perf_buffer.perf_submit(ctx, &arg_val, sizeof(int));
+  map.update(&count, &arg_val);
+  results.update(&count, &arg_val);
+
+  ++count;
+  state.update(&count_idx, &count);
+  return 0;
+}
+
+// A minimal BPF program to sample a stack trace.
+int sample_a_stack_trace(struct pt_regs* ctx) {
+  int stack_id = stack_table.get_stackid(ctx, BPF_F_USER_STACK);
+  stack_ids.perf_submit(ctx, &stack_id, sizeof(int));
+  return 0;
+}


### PR DESCRIPTION
Summary: We add the `rr` sub-tree to implement BPF record & replay. In this PR, we include _only_ perf buffer record and replay. BPF maps & arrays will be included in a subsequent PR.

Type of change: /kind feature

Test Plan: We add a new test case: `rr_bpf_test`.