### PR TITLE
fix: add return on err to prevent nil pointer deref panic in goroutine

### DIFF
--- a/src/vizier/services/query_broker/script_runner/script_runner.go
+++ b/src/vizier/services/query_broker/script_runner/script_runner.go
@@ -282,6 +282,7 @@ func (r *runner) runScript(scriptPeriod time.Duration) {
 	})
 	if err != nil {
 		log.WithError(err).Error("Failed to execute cronscript")
+		return
 	}
 	for {
 		resp, err := execScriptClient.Recv()


### PR DESCRIPTION
Summary: If no execScriptClient is returned due to there being an err, the codebase still attempts to use the client to call execScriptClient.Recv() shortly thereafter. This can result in a runtime panic, which appears to be able to bubble up and crash the QB. This patch returns early if there is a detected error such that the QB will continue processing.

Type of change: /kind fix

Test Plan: Reuse existing unit tests