### PR TITLE
feat: add udf for returning a namespace ID from a namespace name

### DIFF
--- a/src/carnot/funcs/metadata/metadata_ops.cc
+++ b/src/carnot/funcs/metadata/metadata_ops.cc
@@ -131,6 +131,7 @@ void RegisterMetadataOpsOrDie(px::carnot::udf::Registry* registry) {
   registry->RegisterOrDie<VizierNameUDF>("vizier_name");
   registry->RegisterOrDie<VizierNamespaceUDF>("vizier_namespace");
   registry->RegisterOrDie<GetClusterCIDRRangeUDF>("get_cidrs");
+  registry->RegisterOrDie<NamespaceNameToNamespaceIDUDF>("namespace_name_to_namespace_id");
 
   /*****************************************
    * Aggregate UDFs.

--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -3262,6 +3262,24 @@ class GetClusterCIDRRangeUDF : public udf::ScalarUDF {
   std::string cidrs_str_;
 };
 
+class NamespaceNameToNamespaceIDUDF : public ScalarUDF {
+ public:
+  StringValue Exec(FunctionContext* ctx, StringValue namespace_name) {
+    auto md = GetMetadataState(ctx);
+    auto namespace_id =
+        md->k8s_metadata_state().NamespaceIDByName(std::make_pair(namespace_name, namespace_name));
+    return namespace_id;
+  }
+
+  static udf::ScalarUDFDocBuilder Doc() {
+    return udf::ScalarUDFDocBuilder("Get the Kubernetes UID of the given namespace name.")
+        .Details("Get the Kubernetes UID of the given namespace name.")
+        .Example("df.kube_system_namespace_uid = px.namespace_name_to_namespace_id('kube-system')")
+        .Arg("arg1", "The name of the namespace to get the UID of.")
+        .Returns("The Kubernetes UID of the given namespace name");
+  }
+};
+
 void RegisterMetadataOpsOrDie(px::carnot::udf::Registry* registry);
 
 }  // namespace metadata

--- a/src/shared/k8s/metadatapb/test_proto.h
+++ b/src/shared/k8s/metadatapb/test_proto.h
@@ -362,6 +362,30 @@ conditions: {
 }
 )";
 
+/*
+ * Templates for namespace updates.
+ */
+const char* kRunningNamespaceUpdatePbTxt = R"(
+uid: "namespace_uid"
+name: "namespace1"
+start_timestamp_ns: 101
+stop_timestamp_ns: 0
+)";
+
+const char* kTerminatingNamespaceUpdatePbTxt = R"(
+uid: "terminating_namespace_uid"
+name: "terminating_namespace1"
+start_timestamp_ns: 123
+stop_timestamp_ns: 0
+)";
+
+const char* kTerminatedNamespaceUpdatePbTxt = R"(
+uid: "terminating_namespace_uid"
+name: "terminating_namespace1"
+start_timestamp_ns: 123
+stop_timestamp_ns: 150
+)";
+
 std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateRunningPodUpdatePB() {
   auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
   auto update_proto = absl::Substitute(kResourceUpdateTmpl, "pod_update", kRunningPodUpdatePbTxt);
@@ -525,6 +549,33 @@ std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateTerminatedDep
   auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
   auto update_proto =
       absl::Substitute(kResourceUpdateTmpl, "deployment_update", kTerminatedDeploymentUpdatePbTxt);
+  CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
+      << "Failed to parse proto";
+  return update;
+}
+
+std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateRunningNamespaceUpdatePB() {
+  auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
+  auto update_proto =
+      absl::Substitute(kResourceUpdateTmpl, "namespace_update", kRunningNamespaceUpdatePbTxt);
+  CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
+      << "Failed to parse proto";
+  return update;
+}
+
+std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateTerminatingNamespaceUpdatePB() {
+  auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
+  auto update_proto =
+      absl::Substitute(kResourceUpdateTmpl, "namespace_update", kTerminatingNamespaceUpdatePbTxt);
+  CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
+      << "Failed to parse proto";
+  return update;
+}
+
+std::unique_ptr<px::shared::k8s::metadatapb::ResourceUpdate> CreateTerminatedNamespaceUpdatePB() {
+  auto update = std::make_unique<px::shared::k8s::metadatapb::ResourceUpdate>();
+  auto update_proto =
+      absl::Substitute(kResourceUpdateTmpl, "namespace_update", kTerminatedNamespaceUpdatePbTxt);
   CHECK(google::protobuf::TextFormat::MergeFromString(update_proto, update.get()))
       << "Failed to parse proto";
   return update;


### PR DESCRIPTION
Summary: Adds a UDF for returning the Kubernetes ID (uid in the resource) of a Namespace given that Namespaces Name

Type of change: /kind feat

Test Plan: Added CRUD tests for namespace creation, update and deletion similar to other tests in the metadata_ops_test file.