### PR TITLE
[standalone_pem] Add examples and add option to fully static link.

### DIFF
--- a/bazel/pl_build_system.bzl
+++ b/bazel/pl_build_system.bzl
@@ -193,6 +193,7 @@ def pl_cc_binary(
         srcs = [],
         data = [],
         args = [],
+        features = [],
         testonly = 0,
         visibility = None,
         repository = "",
@@ -220,7 +221,7 @@ def pl_cc_binary(
         tags = tags,
         deps = deps + _default_external_deps() + _default_internal_deps(),
         defines = pl_defines() + defines,
-        features = pl_default_features(),
+        features = pl_default_features() + features,
     )
 
 def _default_empty_list(name, kwargs):

--- a/src/experimental/standalone_pem/BUILD.bazel
+++ b/src/experimental/standalone_pem/BUILD.bazel
@@ -14,11 +14,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library")
 
 package(default_visibility = ["//src/vizier:__subpackages__"])
+
+string_flag(
+    name = "full_static",
+    build_setting_default = "False",
+    values = [
+        "True",
+        "False",
+    ],
+)
+
+config_setting(
+    name = "full_static_is_set",
+    flag_values = {
+        ":full_static": "True",
+    },
+)
 
 pl_cc_library(
     name = "cc_library",
@@ -57,6 +74,10 @@ pl_cc_library(
 pl_cc_binary(
     name = "standalone_pem",
     srcs = ["standalone_pem_main.cc"],
+    features = select({
+        ":full_static_is_set": ["fully_static_link"],
+        "//conditions:default": [],
+    }),
     stamp = -1,
     tags = ["manual"],
     deps = [

--- a/src/experimental/standalone_pem/README.md
+++ b/src/experimental/standalone_pem/README.md
@@ -1,0 +1,32 @@
+Environment setup:
+```
+export PX_DIRECT_VIZIER_ADDR=localhost:12345
+export PX_DISABLE_SSL=true
+export PX_DIRECT_VIZIER_KEY=test
+```
+
+To run the standalone pem:
+```
+sudo bazel-bin/src/experimental/standalone_pem/standalone_pem
+```
+
+Using the `px` cli to query the standalone pem:
+```
+px run -f pxl/http.pxl
+```
+If you want data in other formats you can add `-o json`, etc to change the formats.
+
+If you want to export data to NR using OTEL you can use `otel.pxl` to do this.
+```
+px run -f pxl/otel.pxl
+```
+
+To access a sample of custom BPF code, you can run the included tp.pxl. This will snoop all process executions.
+```
+px run -f pxl/tp.pxl
+```
+
+To fully static link (experimental), invoke as follows:
+```
+bazel build //src/experimental/standalone_pem:standalone_pem --//src/experimental/standalone_pem:full_static=True
+```

--- a/src/experimental/standalone_pem/pxl/http.pxl
+++ b/src/experimental/standalone_pem/pxl/http.pxl
@@ -1,0 +1,28 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import px
+
+# Look at the http_events.
+df = px.DataFrame(table='http_events')
+
+# Grab the command line from the metadata.
+df.cmdline = px.upid_to_cmdline(df.upid)
+
+# Limit to the first 10.
+df = df.head(10)
+
+px.display(df)

--- a/src/experimental/standalone_pem/pxl/otel.pxl
+++ b/src/experimental/standalone_pem/pxl/otel.pxl
@@ -1,0 +1,81 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import px
+
+df = px.DataFrame('http_events', start_time='-10s')
+df.cmdline = px.upid_to_cmdline(df.upid)
+df.hostname = px._exec_hostname()
+
+df = df.head(15000)
+df.req_start_time = df.time_ - df.latency
+df.host = px.pluck(df.req_headers, 'Host')
+df.req_url = df.host + df.req_path
+
+df.user_agent = px.pluck(df.req_headers, 'User-Agent')
+df.trace_id = px.pluck(df.req_headers, 'X-B3-TraceId')
+df.span_id = px.pluck(df.req_headers, 'X-B3-SpanId')
+df.parent_span_id = px.pluck(df.req_headers, 'X-B3-ParentSpanId')
+
+# Strip out all but the actual path value from req_path
+df.req_path = px.uri_recompose('', '', '', 0, px.pluck(px.uri_parse(df.req_path), 'path'), '', '')
+
+# Replace any Hex IDS from the path with <id>
+# flake8: noqa:W605
+df.req_path = px.replace('/[a-fA-F0-9\-:]{6,}(/?)', df.req_path, '/<id>\\1')
+
+
+df.pixie = 'standalone_pixie'
+df.upidStr = px.upid_to_string(df.upid)
+
+px.export(
+    df, px.otel.Data(
+        endpoint=px.otel.Endpoint(
+            url='otlp.nr-data.net:443',
+            headers={
+                'api-key': '',
+            }
+        ),
+        resource={
+            'service.name': df.upidStr,
+            'instrumentation.provider': df.pixie,
+        },
+        data=[
+            px.otel.trace.Span(
+                name=df.req_path,
+                start_time=df.req_start_time,
+                end_time=df.time_,
+                trace_id=df.trace_id,
+                span_id=df.span_id,
+                parent_span_id=df.parent_span_id,
+                kind=px.otel.trace.SPAN_KIND_SERVER,
+                attributes={
+                    # NOTE: the integration handles splitting of services.
+                    'hostname': df.hostname,
+                    'cmdline': df.cmdline,
+                    'http.req_body': df.req_body,
+                    'http.resp_body': df.resp_body,
+                    'http.method': df.req_method,
+                    'http.url': df.req_url,
+                    'http.target': df.req_path,
+                    'http.host': df.host,
+                    'http.status_code': df.resp_status,
+                    'http.user_agent': df.user_agent,
+                },
+            ),
+        ],
+    ),
+)

--- a/src/experimental/standalone_pem/pxl/otel.pxl
+++ b/src/experimental/standalone_pem/pxl/otel.pxl
@@ -44,10 +44,8 @@ df.upidStr = px.upid_to_string(df.upid)
 px.export(
     df, px.otel.Data(
         endpoint=px.otel.Endpoint(
-            url='otlp.nr-data.net:443',
-            headers={
-                'api-key': '',
-            }
+            url='',
+            headers={}
         ),
         resource={
             'service.name': df.upidStr,

--- a/src/experimental/standalone_pem/pxl/tp.pxl
+++ b/src/experimental/standalone_pem/pxl/tp.pxl
@@ -1,0 +1,48 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pxtrace
+import px
+
+program = """
+#include <linux/sched.h>
+
+tracepoint:syscalls:sys_enter_exec*
+{
+    printf("time_:%u pid:%d pid_start_time:%d ppid:%d ppid_start_time:%d filename:%s argv0:%s argv1:%s",
+           nsecs,
+           pid,
+           ((struct task_struct*)curtask)->group_leader->start_time / 10000000,
+           ((struct task_struct*)curtask)->parent->pid,
+           ((struct task_struct*)curtask)->parent->group_leader->start_time / 10000000,
+           str(args->filename), str(args->argv[0]), str(args->argv[1]));
+}
+"""
+
+table_name = 'exec_table'
+pxtrace.UpsertTracepoint('exec_tracer', table_name, program, pxtrace.kprobe(), "5m")
+df = px.DataFrame(table=table_name)
+
+# Grab the node from exec_hostname instead of `ctx`, because not all PIDs have a pod.
+df.node = px._exec_hostname()
+
+# Filter for the requested commands.
+df = df[px.contains(df.filename, '')]
+
+# Try to add the pod name, if available. If pod is not matched, the field will be blank.
+df.asid = px.asid()
+df['time_', 'node', 'pid', 'ppid', 'filename', 'argv0', 'argv1']
+px.display(df)


### PR DESCRIPTION
Summary: We add some example scripts, a README.md file, and update the build file with an option to fully static link. Static linking may be desirable for deployment to non-containerized environments, but is an experimental feature since it statically links in glibc. We considered static linking with musl, but cannot figure out how to do that with C++.

Type of change: /kind feature

Test Plan: Existing tests. And, copied the standalone pem binary to a GKE node, then deleted all libs, then ran the binary. The binary ran (but could not find linux headers).