### PR TITLE
[Fix CQL Stitcher 2/4] Update StitchFrames to use new interface

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/common/test_utils.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/test_utils.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <absl/container/flat_hash_map.h>
+#include <deque>
 #include <string>
 #include <vector>
 
@@ -63,6 +65,25 @@ std::vector<SocketDataEvent> CreateEvents(const std::vector<TStrType>& msgs) {
     pos += msgs[i].size();
   }
   return events;
+}
+
+template <typename TKey, typename TFrameType>
+bool AreAllDequesEmpty(const absl::flat_hash_map<TKey, std::deque<TFrameType>>& frame_map) {
+  for (const auto& pair : frame_map) {
+    if (!pair.second.empty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename TKey, typename TFrameType>
+size_t TotalDequeSize(const absl::flat_hash_map<TKey, std::deque<TFrameType>>& frame_map) {
+  size_t total_size = 0;
+  for (const auto& pair : frame_map) {
+    total_size += pair.second.size();
+  }
+  return total_size;
 }
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.cc
@@ -333,19 +333,16 @@ Status ProcessResp(Frame* resp_frame, Response* resp) {
   }
 }
 
-StatusOr<Record> ProcessReqRespPair(Frame* req_frame, Frame* resp_frame) {
+Status ProcessReqRespPair(Frame* req_frame, Frame* resp_frame, Record* r) {
   CTX_ECHECK_LT(req_frame->timestamp_ns, resp_frame->timestamp_ns);
 
-  Record r;
-  PX_RETURN_IF_ERROR(ProcessReq(req_frame, &r.req));
-  PX_RETURN_IF_ERROR(ProcessResp(resp_frame, &r.resp));
+  PX_RETURN_IF_ERROR(ProcessReq(req_frame, &r->req));
+  PX_RETURN_IF_ERROR(ProcessResp(resp_frame, &r->resp));
 
-  return r;
+  return Status::OK();
 }
 
-StatusOr<Record> ProcessSolitaryResp(Frame* resp_frame) {
-  Record r;
-
+Status ProcessSolitaryResp(Frame* resp_frame, Record* r) {
   // For now, Event is the only supported solitary response.
   // If this ever changes, the code below needs to be adapted.
   CTX_DCHECK(resp_frame->hdr.opcode == Opcode::kEvent);
@@ -353,15 +350,13 @@ StatusOr<Record> ProcessSolitaryResp(Frame* resp_frame) {
   // Make a fake request to go along with the response.
   // - Use REGISTER op, since that was what set up the events in the first place.
   // - Use response timestamp, so any calculated latencies are reported as 0.
-  r.req.op = ReqOp::kRegister;
-  r.req.msg = "-";
-  r.req.timestamp_ns = resp_frame->timestamp_ns;
+  r->req.op = ReqOp::kRegister;
+  r->req.msg = "-";
+  r->req.timestamp_ns = resp_frame->timestamp_ns;
 
   // A little inefficient because it will go through a switch statement again,
   // when we actually know the op. But keep it this way for consistency.
-  PX_RETURN_IF_ERROR(ProcessResp(resp_frame, &r.resp));
-
-  return r;
+  return ProcessResp(resp_frame, &r->resp);
 }
 
 // Currently StitchFrames() uses a response-led matching algorithm.
@@ -372,76 +367,100 @@ StatusOr<Record> ProcessSolitaryResp(Frame* resp_frame) {
 //  - Request and response deques are likely (confirm?) to be mostly ordered.
 //  - Stream values can be re-used, so sorting would have to consider times too.
 //  - Stream values need not be in any sequential order.
-RecordsWithErrorCount<Record> StitchFrames(std::deque<Frame>* req_frames,
-                                           std::deque<Frame>* resp_frames) {
+RecordsWithErrorCount<Record> StitchFrames(
+    absl::flat_hash_map<cass::stream_id_t, std::deque<cass::Frame>>* requests,
+    absl::flat_hash_map<cass::stream_id_t, std::deque<cass::Frame>>* responses) {
   std::vector<Record> entries;
   int error_count = 0;
 
-  for (auto& resp_frame : *resp_frames) {
-    bool found_match = false;
+  // iterate through all deques of responses associated with a specific streamID and find the
+  // matching request
+  for (auto& [stream_id, resp_deque] : *responses) {
+    bool event_handled = false;
+    for (cass::Frame& resp_frame : resp_deque) {
+      // Event responses are special: they have no request.
+      if (resp_frame.hdr.opcode == Opcode::kEvent) {
+        event_handled = true;
+        Record record;
+        Status record_status = ProcessSolitaryResp(&resp_frame, &record);
+        if (record_status.ok()) {
+          entries.push_back(std::move(record));
+        } else {
+          VLOG(1) << record_status.ToString();
+          ++error_count;
+        }
+      }
+    }
 
-    // Event responses are special: they have no request.
-    if (resp_frame.hdr.opcode == Opcode::kEvent) {
-      StatusOr<Record> record_status = ProcessSolitaryResp(&resp_frame);
-      if (record_status.ok()) {
-        entries.push_back(record_status.ConsumeValueOrDie());
-      } else {
-        VLOG(1) << record_status.msg();
+    auto pos = requests->find(stream_id);
+    if (pos == requests->end()) {
+      VLOG(1) << absl::Substitute("Could not find any requests for stream = $0", stream_id);
+      // if we don't find a matching request, we can't do anything with this response
+      // so clean it up
+      resp_deque.clear();
+      if (!event_handled) {
         ++error_count;
       }
       continue;
     }
 
-    // Search for matching req frame
-    for (auto& req_frame : *req_frames) {
-      if (resp_frame.hdr.stream == req_frame.hdr.stream) {
-        VLOG(2) << absl::Substitute("req_op=$0 msg=$1", magic_enum::enum_name(req_frame.hdr.opcode),
-                                    req_frame.msg);
+    // we found a potential set of requests for this stream ID
+    std::deque<cass::Frame>& req_deque = pos->second;
 
-        StatusOr<Record> record_status = ProcessReqRespPair(&req_frame, &resp_frame);
-        if (record_status.ok()) {
-          entries.push_back(record_status.ConsumeValueOrDie());
-        } else {
-          VLOG(1) << record_status.ToString();
-          ++error_count;
-        }
+    uint64_t latest_resp_ts = 0;
+    auto req_deque_begin_iter = req_deque.begin();
+    // go through the responses for this stream ID and check for requests
+    for (cass::Frame& resp_frame : resp_deque) {
+      latest_resp_ts = resp_frame.timestamp_ns;
+      // Find the first request timestamp that is strictly greater than the response timestamp.
+      // Then decrement the iterator to get the request timestamp that is just before the response
+      // timestamp.
+      auto stream_it =
+          std::upper_bound(
+              req_deque_begin_iter, req_deque.end(), resp_frame.timestamp_ns,
+              [](const uint64_t ts, const cass::Frame& frame) { return ts < frame.timestamp_ns; }) -
+          1;
+      req_deque_begin_iter = stream_it;
 
-        // Found a match, so remove both request and response.
-        // We don't remove request frames on the fly, however,
-        // because it could otherwise cause unnecessary churn/copying in the deque.
-        // This is due to the fact that responses can come out-of-order.
-        // Just mark the request as consumed, and clean-up when they reach the head of the queue.
-        // Note that responses are always head-processed, so they don't require this optimization.
-        found_match = true;
-        req_frame.consumed = true;
-        break;
+      // Responses should always have a more recent timestamp than the first request. If this
+      // condition is triggered we should not attempt to match this frame. Since responses are
+      // cleared during StitchFrames this will get cleaned up during the current iteration.
+      if (stream_it == req_deque.begin() && stream_it->timestamp_ns > resp_frame.timestamp_ns) {
+        VLOG(1) << "Warning: Unable to find request that is earlier than response: "
+                << resp_frame.ToString();
+        continue;
       }
-    }
 
-    if (!found_match) {
-      VLOG(1) << absl::Substitute("Did not find a request matching the response. Stream = $0",
-                                  resp_frame.hdr.stream);
-      ++error_count;
-    }
+      cass::Frame& req_frame = *stream_it;  // dereference the iterator to get the frame
 
-    // Clean-up consumed frames at the head.
-    // Do this inside the resp loop to aggressively clean-out req_frames whenever a frame consumed.
-    // Should speed up the req_frames search for the next iteration.
-    auto it = req_frames->begin();
-    while (it != req_frames->end()) {
-      if (!(*it).consumed) {
-        break;
+      VLOG(2) << absl::Substitute("req_op=$0 msg=$1", magic_enum::enum_name(req_frame.hdr.opcode),
+                                  req_frame.msg);
+      Record record;
+      Status record_status = ProcessReqRespPair(&req_frame, &resp_frame, &record);
+      if (record_status.ok()) {
+        entries.push_back(std::move(record));
+      } else {
+        VLOG(1) << record_status.ToString();
+        ++error_count;
       }
-      it++;
+      // Record that the req and response pair are consumed
+      req_frame.consumed = true;
     }
-    req_frames->erase(req_frames->begin(), it);
 
-    // TODO(oazizi): Consider removing requests that are too old, otherwise a lost response can mean
-    // the are never processed. This would result in a memory leak until the more drastic connection
-    // tracker clean-up mechanisms kick in.
+    // Loop through req_deque and stop at the first request that isn't consumed
+    // and has a timestamp newer than the latest response's timestamp.
+    auto erase_until_iter = req_deque.begin();
+    while (erase_until_iter != req_deque.end() &&
+           (erase_until_iter->consumed || erase_until_iter->timestamp_ns < latest_resp_ts)) {
+      if (!erase_until_iter->consumed) {
+        error_count++;  // This is an unmatched (discarded) request.
+      }
+      ++erase_until_iter;
+    }
+
+    req_deque.erase(req_deque.begin(), erase_until_iter);  // Erase consumed or unmatched requests.
+    resp_deque.clear();                                    // Clear all processed responses.
   }
-
-  resp_frames->clear();
 
   return {entries, error_count};
 }

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.cc
@@ -415,17 +415,17 @@ RecordsWithErrorCount<Record> StitchFrames(
       // Find the first request timestamp that is strictly greater than the response timestamp.
       // Then decrement the iterator to get the request timestamp that is just before the response
       // timestamp.
-      auto stream_it =
-          std::upper_bound(
-              req_deque_begin_iter, req_deque.end(), resp_frame.timestamp_ns,
-              [](const uint64_t ts, const cass::Frame& frame) { return ts < frame.timestamp_ns; }) -
-          1;
+      auto stream_it = std::upper_bound(
+          req_deque_begin_iter, req_deque.end(), resp_frame.timestamp_ns,
+          [](const uint64_t ts, const cass::Frame& frame) { return ts < frame.timestamp_ns; });
+      if (stream_it != req_deque.begin()) {
+        --stream_it;
+      }
       req_deque_begin_iter = stream_it;
-
       // Responses should always have a more recent timestamp than the first request. If this
       // condition is triggered we should not attempt to match this frame. Since responses are
       // cleared during StitchFrames this will get cleaned up during the current iteration.
-      if (stream_it == req_deque.begin() && stream_it->timestamp_ns > resp_frame.timestamp_ns) {
+      if (stream_it->timestamp_ns > resp_frame.timestamp_ns) {
         VLOG(1) << "Warning: Unable to find request that is earlier than response: "
                 << resp_frame.ToString();
         continue;

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.h
@@ -20,7 +20,6 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <deque>
-#include <map>
 #include <string>
 #include <vector>
 
@@ -40,8 +39,9 @@ namespace cass {
  * @param resp_frames: deque of all response frames.
  * @return A vector of entries to be appended to table store.
  */
-RecordsWithErrorCount<Record> StitchFrames(std::deque<Frame>* req_frames,
-                                           std::deque<Frame>* resp_frames);
+RecordsWithErrorCount<Record> StitchFrames(
+    absl::flat_hash_map<stream_id_t, std::deque<Frame>>* req_frames,
+    absl::flat_hash_map<stream_id_t, std::deque<Frame>>* resp_frames);
 
 }  // namespace cass
 
@@ -50,7 +50,7 @@ inline RecordsWithErrorCount<cass::Record> StitchFrames(
     absl::flat_hash_map<cass::stream_id_t, std::deque<cass::Frame>>* req_messages,
     absl::flat_hash_map<cass::stream_id_t, std::deque<cass::Frame>>* res_messages,
     NoState* /* state */) {
-  return cass::StitchFrames(&((*req_messages)[0]), &((*res_messages)[0]));
+  return cass::StitchFrames(req_messages, res_messages);
 }
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher_test.cc
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/test_utils.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/cql/parse.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/cql/stitcher.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/cql/test_utils.h"
@@ -173,71 +174,101 @@ constexpr uint8_t kEventResp[] = {0x00, 0x0d, 0x53, 0x43, 0x48, 0x45, 0x4d, 0x41
 // Test Cases
 //-----------------------------------------------------------------------------
 
-TEST(CassStitcherTest, OutOfOrderMatching) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+TEST(CassStitcherTest, OutOfOrderMatchingWithMissingResponses) {
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
   int t = 0;
 
-  Frame req0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
-  Frame resp0_frame = CreateFrame(0, Opcode::kError, kBadQueryErrorResp, ++t);
-  Frame req1_frame = CreateFrame(1, Opcode::kQuery, kBadQueryReq, ++t);
-  Frame resp1_frame = CreateFrame(1, Opcode::kError, kBadQueryErrorResp, ++t);
-  Frame req2_frame = CreateFrame(2, Opcode::kQuery, kBadQueryReq, ++t);
-  Frame resp2_frame = CreateFrame(2, Opcode::kError, kBadQueryErrorResp, ++t);
+  Frame req0_s0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame resp0_s0_frame = CreateFrame(0, Opcode::kError, kBadQueryErrorResp, ++t);
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  Frame req0_s1_frame = CreateFrame(1, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame resp0_s1_frame = CreateFrame(1, Opcode::kError, kBadQueryErrorResp, ++t);
+  Frame req0_s2_frame = CreateFrame(2, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame resp0_s2_frame = CreateFrame(2, Opcode::kError, kBadQueryErrorResp, ++t);
+
+  Frame req1_s0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame req1_s1_frame = CreateFrame(1, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame req1_s2_frame = CreateFrame(2, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame resp1_s1_frame = CreateFrame(1, Opcode::kError, kBadQueryErrorResp, ++t);
+  Frame resp1_s2_frame = CreateFrame(2, Opcode::kError, kBadQueryErrorResp, ++t);
+
+  Frame req2_s0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame resp2_s0_frame = CreateFrame(0, Opcode::kError, kBadQueryErrorResp, ++t);
+
+  Frame req3_s0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame req4_s0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
+
+  Frame req5_s0_frame = CreateFrame(0, Opcode::kQuery, kBadQueryReq, ++t);
+  Frame resp5_s0_frame = CreateFrame(0, Opcode::kError, kBadQueryErrorResp, ++t);
+
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   EXPECT_EQ(result.records.size(), 0);
 
-  req_frames.push_back(req0_frame);
-  req_frames.push_back(req1_frame);
+  // create deque for stream0 on the stack
+  req_map[0].push_back(req0_s0_frame);
+  req_map[1].push_back(req0_s1_frame);
+  req_map[2].push_back(req0_s2_frame);
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 2);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 3);
   EXPECT_EQ(result.error_count, 0);
   EXPECT_EQ(result.records.size(), 0);
 
-  resp_frames.push_back(resp1_frame);
+  req_map[0].push_back(req1_s0_frame);
+  req_map[1].push_back(req1_s1_frame);
+  req_map[2].push_back(req1_s2_frame);
+  req_map[0].push_back(req2_s0_frame);
+  req_map[0].push_back(req3_s0_frame);
+  req_map[0].push_back(req4_s0_frame);
+  req_map[0].push_back(req5_s0_frame);
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 2);
-  EXPECT_EQ(result.error_count, 0);
-  EXPECT_EQ(result.records.size(), 1);
+  resp_map[0].push_back(resp0_s0_frame);
+  resp_map[1].push_back(resp0_s1_frame);
+  resp_map[2].push_back(resp0_s2_frame);
+  resp_map[0].push_back(resp2_s0_frame);
+  resp_map[0].push_back(resp5_s0_frame);
 
-  req_frames.push_back(req2_frame);
-  resp_frames.push_back(resp0_frame);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 2);
+  EXPECT_EQ(req_map[1].front().timestamp_ns, req1_s1_frame.timestamp_ns);
+  EXPECT_EQ(req_map[2].front().timestamp_ns, req1_s2_frame.timestamp_ns);
+  EXPECT_EQ(result.error_count, 3);
+  EXPECT_EQ(result.records.size(), 5);
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 1);
-  EXPECT_EQ(result.error_count, 0);
-  EXPECT_EQ(result.records.size(), 1);
-
-  resp_frames.push_back(resp2_frame);
-
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(resp_frames.size(), 0);
-  EXPECT_EQ(result.error_count, 0);
-  EXPECT_EQ(result.records.size(), 1);
-
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(resp_frames.size(), 0);
+  // No requests or responses should be deleted when streams of
+  // the head of requests are inactive
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 2);
+  EXPECT_EQ(req_map[1].front().timestamp_ns, req1_s1_frame.timestamp_ns);
+  EXPECT_EQ(req_map[2].front().timestamp_ns, req1_s2_frame.timestamp_ns);
   EXPECT_EQ(result.error_count, 0);
   EXPECT_EQ(result.records.size(), 0);
+
+  resp_map[1].push_back(resp1_s1_frame);
+  resp_map[2].push_back(resp1_s2_frame);
+
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_EQ(result.records.size(), 2);
 }
 
 // To test that, if a request of a response is missing, then the response is popped off.
 TEST(CassStitcherTest, MissingRequest) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
   int t = 0;
@@ -245,21 +276,23 @@ TEST(CassStitcherTest, MissingRequest) {
   Frame resp0_frame = CreateFrame(0, Opcode::kError, kBadQueryErrorResp, ++t);
   Frame resp1_frame = CreateFrame(1, Opcode::kError, kBadQueryErrorResp, ++t);
 
-  req_frames.push_back(req1_frame);
-  resp_frames.push_back(resp0_frame);
-  resp_frames.push_back(resp1_frame);
+  req_map[1].push_back(req1_frame);
+  resp_map[0].push_back(resp0_frame);
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  resp_map[1].push_back(resp1_frame);
+
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 1);
   EXPECT_EQ(result.records.size(), 1);
 }
 
 // To test that mis-classified frames are caught by stitcher.
 TEST(CassStitcherTest, NonCQLFrames) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
   int t = 0;
@@ -269,26 +302,29 @@ TEST(CassStitcherTest, NonCQLFrames) {
   Frame req1_frame = CreateFrame(0, Opcode::kQuery, {0x23, 0xa8, 0xf3}, ++t);
   Frame resp1_frame = CreateFrame(0, Opcode::kError, {0x35, 0x9e, 0x1b, 0x77}, ++t);
 
-  req_frames = {req0_frame, req1_frame};
-  resp_frames = {resp0_frame, resp1_frame};
+  req_map[0].push_back(req0_frame);
+  req_map[0].push_back(req1_frame);
+  resp_map[0].push_back(resp0_frame);
+  resp_map[0].push_back(resp1_frame);
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 2);
   EXPECT_EQ(result.records.size(), 0);
 }
 
 TEST(CassStitcherTest, OpEvent) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  resp_frames.push_back(CreateFrame(-1, Opcode::kEvent, kEventResp, 3));
+  resp_map[1].push_back(CreateFrame(1, Opcode::kEvent, kEventResp, 3));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -305,16 +341,17 @@ TEST(CassStitcherTest, OpEvent) {
 }
 
 TEST(CassStitcherTest, StartupReady) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kStartup, kStartupReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kReady, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kStartup, kStartupReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kReady, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -328,16 +365,17 @@ TEST(CassStitcherTest, StartupReady) {
 }
 
 TEST(CassStitcherTest, RegisterReady) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kRegister, kRegisterReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kReady, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kRegister, kRegisterReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kReady, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -351,16 +389,17 @@ TEST(CassStitcherTest, RegisterReady) {
 }
 
 TEST(CassStitcherTest, OptionsSupported) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kOptions, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kSupported, kSupportedResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kOptions, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kSupported, kSupportedResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -376,16 +415,17 @@ TEST(CassStitcherTest, OptionsSupported) {
 }
 
 TEST(CassStitcherTest, QueryResult) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kQuery, kQueryReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kResult, kResultResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kQuery, kQueryReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kResult, kResultResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -405,22 +445,23 @@ TEST(CassStitcherTest, QueryResult) {
 }
 
 TEST(CassStitcherTest, QueryError) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   EXPECT_EQ(result.records.size(), 0);
 
-  req_frames.push_back(CreateFrame(0, Opcode::kQuery, kBadQueryReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kError, kBadQueryErrorResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kQuery, kBadQueryReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kError, kBadQueryErrorResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -434,16 +475,17 @@ TEST(CassStitcherTest, QueryError) {
 }
 
 TEST(CassStitcherTest, PrepareResult) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kPrepare, kPrepareReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kResult, kPrepareResultResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kPrepare, kPrepareReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kResult, kPrepareResultResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -460,16 +502,17 @@ TEST(CassStitcherTest, PrepareResult) {
 }
 
 TEST(CassStitcherTest, ExecuteResult) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kExecute, kExecuteReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kResult, kExecuteResultResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kExecute, kExecuteReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kResult, kExecuteResultResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -489,16 +532,17 @@ TEST(CassStitcherTest, ExecuteResult) {
 }
 
 TEST(CassStitcherTest, StartupAuthenticate) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kStartup, kStartupReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kAuthenticate, kAuthenticateResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kStartup, kStartupReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kAuthenticate, kAuthenticateResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 
@@ -512,16 +556,17 @@ TEST(CassStitcherTest, StartupAuthenticate) {
 }
 
 TEST(CassStitcherTest, AuthResponseAuthSuccess) {
-  std::deque<Frame> req_frames;
-  std::deque<Frame> resp_frames;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> req_map;
+  absl::flat_hash_map<stream_id_t, std::deque<Frame>> resp_map;
+
   RecordsWithErrorCount<Record> result;
 
-  req_frames.push_back(CreateFrame(0, Opcode::kAuthResponse, kAuthResponseReq, 1));
-  resp_frames.push_back(CreateFrame(0, Opcode::kAuthSuccess, kAuthSuccessResp, 2));
+  req_map[0].push_back(CreateFrame(0, Opcode::kAuthResponse, kAuthResponseReq, 1));
+  resp_map[0].push_back(CreateFrame(0, Opcode::kAuthSuccess, kAuthSuccessResp, 2));
 
-  result = StitchFrames(&req_frames, &resp_frames);
-  EXPECT_TRUE(resp_frames.empty());
-  EXPECT_EQ(req_frames.size(), 0);
+  result = StitchFrames(&req_map, &resp_map);
+  EXPECT_TRUE(AreAllDequesEmpty(resp_map));
+  EXPECT_EQ(TotalDequeSize(req_map), 0);
   EXPECT_EQ(result.error_count, 0);
   ASSERT_EQ(result.records.size(), 1);
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/types.h
@@ -177,6 +177,10 @@ struct ProtocolTraits : public BaseProtocolTraits<Record> {
 };
 
 }  // namespace cass
+
+template <>
+cass::stream_id_t GetStreamID(cass::Frame* frame);
+
 }  // namespace protocols
 }  // namespace stirling
 }  // namespace px


### PR DESCRIPTION
Summary: Fixes the head of line blocking issue discussed in #1375  by using a map of stream_ids to deque of frames, which we populate in the `conn_tracker`. CQL stitcher tests are updated to reflect the bug fix and new interface.

Related issues: #1375

Type of change: /kind bug

Test Plan: Tested all existing targets and updated the unittests for the CQL stitcher. `Note`: this PR relies on changes introduced in #1689.