### PR TITLE
Add support to stitch MongoDB frames

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/BUILD.bazel
@@ -46,3 +46,9 @@ pl_cc_test(
     srcs = ["parse_test.cc"],
     deps = [":cc_library"],
 )
+
+pl_cc_test(
+    name = "stitcher_test",
+    srcs = ["stitcher_test.cc"],
+    deps = [":cc_library"],
+)

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h"
+
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <absl/strings/str_replace.h>
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/interface.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
+#include "src/stirling/utils/binary_decoder.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mongodb {
+
+RecordsWithErrorCount<mongodb::Record> StitchFrames(
+    std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,
+    std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* resps) {
+  // The reqs map's key will be the requestID and value will be the deque containing the request frame.
+  // The resps map's key will be the responseTo and value will be the deque containing the response frame. 
+  std::vector<mongodb::Record> records;
+  int error_count = 0;
+
+  for (auto& [request_id, req_deque] : *reqs) {
+    // Find the response frame that corresponds to the request frame.
+    // There will only be one frame in each deque for each requestID/responseTo.
+    auto& req = req_deque[0];
+    auto itr = resps->find(request_id);
+    if (itr == resps->end()) {
+      VLOG(1) << absl::Substitute(
+          "Did not find a response frame matching the request. Request's RequestID = $0",
+          req.request_id);
+      continue;
+    }
+
+    auto curr_resp = itr->second[0];
+    if (req.timestamp_ns > curr_resp.timestamp_ns) {
+      VLOG(1) << absl::Substitute(
+          "The request occured after the response was recorded, Request's time stamp = $0 "
+          "Response's time stamp = $1",
+          req.timestamp_ns, curr_resp.timestamp_ns);
+      error_count++;
+    }
+
+    // Keep track of the head of the response frame(s) for a potential more to come scenario.
+    auto& head_resp_frame = itr->second[0];
+
+    // Find the remaining frames that comprise of the full response message and insert their
+    // sections to the head response frame's section vector.
+    while (curr_resp.more_to_come) {
+      auto itr = resps->find(curr_resp.request_id);
+      if (itr == resps->end()) {
+        VLOG(1) << "Did not find a response frame extending the prior more to come response";
+        error_count++;
+        break;
+      }
+
+      auto& next_resp = itr->second[0];
+      if (curr_resp.timestamp_ns > next_resp.timestamp_ns) {
+        VLOG(1) << absl::Substitute(
+            "The response occured before the prior response was recorded. Prior response's time "
+            "stamp = $0, current response's time stamp = $1",
+            curr_resp.timestamp_ns, next_resp.timestamp_ns);
+        error_count++;
+        break;
+      }
+      
+      // Insert the next response's sections to the head response frame.
+      head_resp_frame.sections.insert(std::end(head_resp_frame.sections),
+                                      std::begin(next_resp.sections), std::end(next_resp.sections));
+      next_resp.consumed = true;
+      curr_resp = next_resp;
+      resps->erase(next_resp.response_to);
+    }
+
+    // Stitch the request frame with the response frame(s).
+    req.consumed = true;
+    head_resp_frame.consumed = true;
+    records.push_back({std::move(req), std::move(head_resp_frame)});
+
+    resps->erase(head_resp_frame.response_to);
+  }
+
+  for (const auto& [response_to, resp] : *resps) {
+    VLOG(1) << absl::Substitute("Did not find a request matching the response. responseTo = $0",
+                                response_to);
+    error_count++;
+  }
+
+  // TODO (kpattaswamy) Cleanup stale requests.
+  auto itr = reqs->begin();
+  while (itr != reqs->end()) {
+    auto& req = itr->second[0];
+    if (req.consumed) {
+      reqs->erase(itr++);
+    } else {
+      break;
+    }
+  }
+  resps->clear();
+
+  return {records, error_count};
+}
+
+}  // namespace mongodb
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -37,8 +37,8 @@ namespace mongodb {
 RecordsWithErrorCount<mongodb::Record> StitchFrames(
     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,
     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* resps) {
-  // The reqs map's key will be the requestID and value will be the deque containing the request frame.
-  // The resps map's key will be the responseTo and value will be the deque containing the response frame. 
+  // The reqs key will be the requestID, value will be the deque containing the request frame.
+  // The resps key will be the responseTo, value will be the deque containing the response frame.
   std::vector<mongodb::Record> records;
   int error_count = 0;
 
@@ -85,7 +85,7 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
         error_count++;
         break;
       }
-      
+
       // Insert the next response's sections to the head response frame.
       head_resp_frame.sections.insert(std::end(head_resp_frame.sections),
                                       std::begin(next_resp.sections), std::end(next_resp.sections));
@@ -108,7 +108,7 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
     error_count++;
   }
 
-  // TODO (kpattaswamy) Cleanup stale requests.
+  // TODO(kpattaswamy) Cleanup stale requests.
   auto itr = reqs->begin();
   while (itr != reqs->end()) {
     auto& req = itr->second[0];

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <deque>
+#include <map>
+#include <vector>
+
+#include "src/common/base/base.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/interface.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mongodb {
+
+RecordsWithErrorCount<mongodb::Record> StitchFrames(
+    std::map<mongodb::stream_id, std::deque<Frame>>* reqs,
+    std::map<mongodb::stream_id, std::deque<Frame>>* resps);
+}  // namespace mongodb
+
+// Uncomment this when the upstream stitching interface is done
+// template <>
+// inline RecordsWithErrorCount<mongodb::Record> StitchFrames(
+//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,                                                   
+//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* resps,
+//     NoState* /*state*/) {
+//   return mongodb::StitchFrames(reqs, resps);
+// }
+
+
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -39,12 +39,11 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
 // Uncomment this when the upstream stitching interface is done
 // template <>
 // inline RecordsWithErrorCount<mongodb::Record> StitchFrames(
-//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,                                                   
+//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,
 //     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* resps,
 //     NoState* /*state*/) {
 //   return mongodb::StitchFrames(reqs, resps);
 // }
-
 
 }  // namespace protocols
 }  // namespace stirling

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
@@ -33,8 +33,8 @@ using ::testing::SizeIs;
 
 class MongoDBStitchFramesTest : public ::testing::Test {};
 
-Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id,
-                         int32_t response_to, bool more_to_come, std::string doc = "") {
+Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id, int32_t response_to, bool more_to_come,
+                         std::string doc = "") {
   mongodb::Frame frame;
   frame.timestamp_ns = ts_ns;
   frame.request_id = request_id;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h"
+
+#include <map>
+#include <string>
+
+#include "src/common/testing/testing.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mongodb {
+
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
+class MongoDBStitchFramesTest : public ::testing::Test {};
+
+Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id,
+                         int32_t response_to, bool more_to_come, std::string doc = "") {
+  mongodb::Frame frame;
+  frame.timestamp_ns = ts_ns;
+  frame.request_id = request_id;
+  frame.response_to = response_to;
+  frame.more_to_come = more_to_come;
+
+  mongodb::Section section;
+  section.documents.push_back(doc);
+
+  frame.sections.push_back(section);
+  return frame;
+}
+
+TEST_F(MongoDBStitchFramesTest, VerifyOnetoOneStitching) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[3].push_back(CreateMongoDBFrame(2, 3, 0, false));
+  reqs[5].push_back(CreateMongoDBFrame(4, 5, 0, false));
+  reqs[7].push_back(CreateMongoDBFrame(6, 7, 0, false));
+  reqs[9].push_back(CreateMongoDBFrame(8, 9, 0, false));
+  reqs[11].push_back(CreateMongoDBFrame(10, 11, 0, false));
+  reqs[13].push_back(CreateMongoDBFrame(12, 13, 0, false));
+  reqs[15].push_back(CreateMongoDBFrame(14, 15, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, false));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, false));
+  resps[5].push_back(CreateMongoDBFrame(5, 6, 5, false));
+  resps[7].push_back(CreateMongoDBFrame(7, 8, 7, false));
+  resps[9].push_back(CreateMongoDBFrame(9, 10, 9, false));
+  resps[11].push_back(CreateMongoDBFrame(11, 12, 11, false));
+  resps[13].push_back(CreateMongoDBFrame(13, 14, 13, false));
+  resps[15].push_back(CreateMongoDBFrame(15, 16, 15, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_THAT(result.records, SizeIs(8));
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(MongoDBStitchFramesTest, VerifyOnetoNStitching) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[3].push_back(CreateMongoDBFrame(2, 3, 0, false));
+
+  // Request frame corresponding to multi frame response message.
+  reqs[5].push_back(CreateMongoDBFrame(4, 5, 0, false));
+
+  reqs[9].push_back(CreateMongoDBFrame(8, 9, 0, false));
+  reqs[11].push_back(CreateMongoDBFrame(10, 11, 0, false));
+  reqs[13].push_back(CreateMongoDBFrame(12, 13, 0, false));
+  reqs[15].push_back(CreateMongoDBFrame(14, 15, 0, false));
+  reqs[17].push_back(CreateMongoDBFrame(16, 17, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, false));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, false));
+
+  // Multi frame response message.
+  resps[5].push_back(CreateMongoDBFrame(5, 6, 5, true, "1"));
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, true, "2"));
+  resps[7].push_back(CreateMongoDBFrame(7, 8, 7, false, "3"));
+
+  resps[9].push_back(CreateMongoDBFrame(9, 10, 9, false));
+  resps[11].push_back(CreateMongoDBFrame(11, 12, 11, false));
+  resps[13].push_back(CreateMongoDBFrame(13, 14, 13, false));
+  resps[15].push_back(CreateMongoDBFrame(15, 16, 15, false));
+  resps[17].push_back(CreateMongoDBFrame(17, 18, 17, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_EQ(result.records[2].resp.sections[0].documents[0], "1");
+  EXPECT_EQ(result.records[2].resp.sections[1].documents[0], "2");
+  EXPECT_EQ(result.records[2].resp.sections[2].documents[0], "3");
+  EXPECT_THAT(result.records, SizeIs(8));
+
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(MongoDBStitchFramesTest, UnmatchedResponsesAreHandled) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add request to map.
+  // Missing request frame
+  reqs[2].push_back(CreateMongoDBFrame(1, 2, 0, false));
+
+  // Add responses to map;
+  resps[10].push_back(CreateMongoDBFrame(0, 1, 10, false));
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+
+  EXPECT_EQ(result.error_count, 1);
+  EXPECT_EQ(result.records.size(), 1);
+
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(MongoDBStitchFramesTest, UnmatchedRequestsAreNotCleanedUp) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[2].push_back(CreateMongoDBFrame(1, 2, 0, false));
+  reqs[4].push_back(CreateMongoDBFrame(3, 4, 0, false));
+
+  // Add responses to map.
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, false));
+  resps[4].push_back(CreateMongoDBFrame(4, 5, 4, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_THAT(result.records, SizeIs(2));
+  EXPECT_EQ(result.records[0].req.request_id, 2);
+  EXPECT_EQ(result.records[1].req.request_id, 4);
+
+  // Stale requests are not yet cleaned up.
+  EXPECT_THAT(reqs, SizeIs(3));
+  EXPECT_THAT(reqs[1][0].consumed, false);
+  EXPECT_THAT(reqs[2][0].consumed, true);
+  EXPECT_THAT(reqs[4][0].consumed, true);
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(MongoDBStitchFramesTest, MissingHeadFrameInNResponses) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[6].push_back(CreateMongoDBFrame(5, 6, 0, false));
+
+  // Add responses to map.
+  // Missing head frame in the N responses
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, true));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, false));
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+
+  EXPECT_EQ(result.error_count, 2);
+  EXPECT_EQ(result.records.size(), 1);
+
+  EXPECT_THAT(reqs, SizeIs(2));
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(MongoDBStitchFramesTest, MissingFrameInNResponses) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[6].push_back(CreateMongoDBFrame(5, 6, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, true));
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, true));
+  // Missing middle frame in the N responses.
+  resps[4].push_back(CreateMongoDBFrame(4, 5, 4, false));
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+
+  EXPECT_EQ(result.error_count, 2);
+  EXPECT_EQ(result.records.size(), 2);
+
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+TEST_F(MongoDBStitchFramesTest, MissingTailFrameInNResponses) {
+  std::map<mongodb::stream_id, std::deque<Frame>> reqs;
+  std::map<mongodb::stream_id, std::deque<Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[6].push_back(CreateMongoDBFrame(5, 6, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, true));
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, true));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, true));
+  // Missing tail frame in the N responses
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps);
+
+  EXPECT_EQ(result.error_count, 1);
+  EXPECT_EQ(result.records.size(), 2);
+
+  EXPECT_THAT(reqs, IsEmpty());
+  EXPECT_THAT(resps, IsEmpty());
+}
+
+}  // namespace mongodb
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -153,7 +153,7 @@ struct Record {
   }
 };
 
-using stream_id = uint32_t;
+using stream_id = int32_t;
 struct ProtocolTraits : public BaseProtocolTraits<Record> {
   using frame_type = Frame;
   using record_type = Record;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -153,10 +153,12 @@ struct Record {
   }
 };
 
+using stream_id = uint32_t;
 struct ProtocolTraits : public BaseProtocolTraits<Record> {
   using frame_type = Frame;
   using record_type = Record;
   using state_type = NoState;
+  using key_type = stream_id;
 };
 
 }  // namespace mongodb


### PR DESCRIPTION
Summary: This PR adds support to stitch MongoDB frames. It relies on the new/upcoming stitching interface with maps.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind feature

Test Plan: Included tests