### PR TITLE
[record & replay] Add `rr` for per-cpu array table and for stack table.

### DIFF
--- a/src/stirling/bpf_tools/bcc_wrapper.cc
+++ b/src/stirling/bpf_tools/bcc_wrapper.cc
@@ -485,9 +485,9 @@ std::unique_ptr<WrappedBCCStackTable> WrappedBCCStackTable::Create(bpf_tools::BC
                                                                    const std::string& name) {
   using BaseT = WrappedBCCStackTable;
   using ImplT = WrappedBCCStackTableImpl;
-
-  // TODO(jps): Impl. rr for stack table.
-  return CreateBCCWrappedMapOrArray<BaseT, ImplT, ImplT, ImplT>(bcc, name);
+  using RecordingT = RecordingWrappedBCCStackTableImpl;
+  using ReplayingT = ReplayingWrappedBCCStackTableImpl;
+  return CreateBCCWrappedMapOrArray<BaseT, ImplT, RecordingT, ReplayingT>(bcc, name);
 }
 
 }  // namespace bpf_tools

--- a/src/stirling/bpf_tools/rr/rr.cc
+++ b/src/stirling/bpf_tools/rr/rr.cc
@@ -140,7 +140,7 @@ void RecordPerfBufferLoss(void* cb_cookie, uint64_t lost) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Replay.
 void BPFReplayer::ReplayPerfBufferEvents(const PerfBufferSpec& perf_buffer_spec) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     LOG_FIRST_N(INFO, 1) << "BPFReplayer::ReplayPerfBufferEvents(), plaback complete.";
     return;
   }
@@ -171,7 +171,7 @@ void BPFReplayer::ReplayPerfBufferEvents(const PerfBufferSpec& perf_buffer_spec)
 
 Status BPFReplayer::ReplayArrayGetValue(const std::string& name, const int32_t idx,
                                         const uint32_t data_size, void* value) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 
@@ -203,7 +203,7 @@ Status BPFReplayer::ReplayArrayGetValue(const std::string& name, const int32_t i
 
 Status BPFReplayer::ReplayMapGetValue(const std::string& name, const uint32_t key_size,
                                       void const* const key, const uint32_t val_size, void* value) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 
@@ -238,7 +238,7 @@ Status BPFReplayer::ReplayMapGetValue(const std::string& name, const uint32_t ke
 
 Status BPFReplayer::ReplayMapGetKeyAndValue(const std::string& name, const uint32_t key_size,
                                             void* key, const uint32_t val_size, void* val) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 
@@ -269,7 +269,7 @@ Status BPFReplayer::ReplayMapGetKeyAndValue(const std::string& name, const uint3
 }
 
 StatusOr<int32_t> BPFReplayer::ReplayBPFMapCapacityEvent(const std::string& name) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 
@@ -290,7 +290,7 @@ StatusOr<int32_t> BPFReplayer::ReplayBPFMapCapacityEvent(const std::string& name
 }
 
 StatusOr<int32_t> BPFReplayer::ReplayBPFMapGetTableOfflineEvent(const std::string& name) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 
@@ -312,7 +312,7 @@ StatusOr<int32_t> BPFReplayer::ReplayBPFMapGetTableOfflineEvent(const std::strin
 
 StatusOr<std::vector<uintptr_t>> BPFReplayer::ReplayBPFStackTableGetStackAddrEvent(
     const std::string& name, const int32_t stack_id) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 
@@ -345,7 +345,7 @@ StatusOr<std::vector<uintptr_t>> BPFReplayer::ReplayBPFStackTableGetStackAddrEve
 StatusOr<std::string> BPFReplayer::ReplayBPFStackTableGetAddrSymbolEvent(const std::string& name,
                                                                          const uint64_t addr,
                                                                          const uint32_t pid) {
-  if (PlabackComplete()) {
+  if (PlaybackComplete()) {
     return error::Internal("Playback complete.");
   }
 

--- a/src/stirling/bpf_tools/rr/rr.h
+++ b/src/stirling/bpf_tools/rr/rr.h
@@ -38,6 +38,10 @@ class BPFRecorder : public NotCopyMoveable {
                                  void const* const value);
   void RecordBPFMapGetTableOfflineEvent(const std::string& name, const uint32_t size);
   void RecordBPFMapCapacityEvent(const std::string& name, const int32_t n);
+  void RecordBPFStackTableGetStackAddrEvent(const std::string& name, const int32_t stack_id,
+                                            const std::vector<uintptr_t>& addrs);
+  void RecordBPFStackTableGetAddrSymbolEvent(const std::string& name, const uint64_t addr,
+                                             const uint32_t pid, const std::string symbol);
   void RecordPerfBufferEvent(PerfBufferSpec* pb_spec, void const* const data, const int data_size);
   void WriteProto(const std::string& proto_buf_file_path);
 
@@ -57,6 +61,11 @@ class BPFReplayer : public NotCopyMoveable {
                                  const uint32_t val_size, void* value);
   StatusOr<int32_t> ReplayBPFMapCapacityEvent(const std::string& name);
   StatusOr<int32_t> ReplayBPFMapGetTableOfflineEvent(const std::string& name);
+  StatusOr<std::vector<uintptr_t>> ReplayBPFStackTableGetStackAddrEvent(const std::string& name,
+                                                                        const int32_t stack_id);
+  StatusOr<std::string> ReplayBPFStackTableGetAddrSymbolEvent(const std::string& name,
+                                                              const uint64_t addr,
+                                                              const uint32_t pid);
   Status OpenReplayProtobuf(const std::string& replay_events_pb_file_path);
   bool PlabackComplete() const { return playback_event_idx_ >= events_proto_.event_size(); }
 

--- a/src/stirling/bpf_tools/rr/rr.h
+++ b/src/stirling/bpf_tools/rr/rr.h
@@ -67,7 +67,7 @@ class BPFReplayer : public NotCopyMoveable {
                                                               const uint64_t addr,
                                                               const uint32_t pid);
   Status OpenReplayProtobuf(const std::string& replay_events_pb_file_path);
-  bool PlabackComplete() const { return playback_event_idx_ >= events_proto_.event_size(); }
+  bool PlaybackComplete() const { return playback_event_idx_ >= events_proto_.event_size(); }
 
   ::px::stirling::rr::BPFEvents& events_proto() { return events_proto_; }
 

--- a/src/stirling/bpf_tools/rr/rr_bpf_test.cc
+++ b/src/stirling/bpf_tools/rr/rr_bpf_test.cc
@@ -147,6 +147,77 @@ class BasicRecorderTest : public ::testing::Test {
   std::unique_ptr<bpf_tools::ReplayingBCCWrapperImpl> replaying_bcc_;
 };
 
+class StackTableRecorderTest : public ::testing::Test {
+ public:
+  StackTableRecorderTest() {}
+
+ protected:
+  void SetUp() override {
+    test::gold_data.clear();
+    test::test_idx = 0;
+
+    recording_bcc_ = std::make_unique<bpf_tools::RecordingBCCWrapperImpl>();
+    replaying_bcc_ = std::make_unique<bpf_tools::ReplayingBCCWrapperImpl>();
+
+    // Register our BPF program in the kernel, for real (recording), and for fake (replaying).
+    ASSERT_OK(recording_bcc_->InitBPFProgram(rr_test_bcc_script));
+    ASSERT_OK(replaying_bcc_->InitBPFProgram(rr_test_bcc_script));
+
+    const auto recording_perf_buffer_specs = MakeArray<bpf_tools::PerfBufferSpec>({
+        .name = std::string("stack_ids"),
+        .probe_output_fn = test::PerfBufferRecordingDataFn,
+        .probe_loss_fn = test::PerfBufferLossFn,
+        .cb_cookie = this,
+    });
+    const auto replaying_perf_buffer_specs = MakeArray<bpf_tools::PerfBufferSpec>({
+        .name = std::string("stack_ids"),
+        .probe_output_fn = test::PerfBufferReplayingDataFn,
+        .probe_loss_fn = test::PerfBufferLossFn,
+        .cb_cookie = this,
+    });
+
+    // Open perf buffers for real (recording), and for fake (replaying).
+    ASSERT_OK(recording_bcc_->OpenPerfBuffers(recording_perf_buffer_specs));
+    ASSERT_OK(replaying_bcc_->OpenPerfBuffers(replaying_perf_buffer_specs));
+
+    const int64_t self_pid = getpid();
+    const std::filesystem::path self_path = GetSelfPath().ValueOrDie();
+    ASSERT_OK_AND_ASSIGN(auto elf_reader, ElfReader::Create(self_path.string()));
+    ASSERT_OK_AND_ASSIGN(auto converter, ElfAddressConverter::Create(elf_reader.get(), self_pid));
+
+    // For the uprobe spec.
+    const uint64_t foo_virt_addr = reinterpret_cast<uint64_t>(&::test::Foo);
+    const uint64_t bar_virt_addr = reinterpret_cast<uint64_t>(&::test::Bar);
+    const uint64_t foo_bin_addr = converter->VirtualAddrToBinaryAddr(foo_virt_addr);
+    const uint64_t bar_bin_addr = converter->VirtualAddrToBinaryAddr(bar_virt_addr);
+
+    const UProbeSpec kFooUprobe{.binary_path = self_path,
+                                .symbol = {},
+                                .address = foo_bin_addr,
+                                .attach_type = BPFProbeAttachType::kEntry,
+                                .probe_fn = "sample_a_stack_trace"};
+    const UProbeSpec kBarUprobe{.binary_path = self_path,
+                                .symbol = {},
+                                .address = bar_bin_addr,
+                                .attach_type = BPFProbeAttachType::kEntry,
+                                .probe_fn = "sample_a_stack_trace"};
+
+    // Attach uprobes for this test case:
+    ASSERT_OK(recording_bcc_->AttachUProbe(kFooUprobe));
+    ASSERT_OK(recording_bcc_->AttachUProbe(kBarUprobe));
+    ASSERT_OK(replaying_bcc_->AttachUProbe(kFooUprobe));
+    ASSERT_OK(replaying_bcc_->AttachUProbe(kBarUprobe));
+  }
+
+  void TearDown() override {
+    recording_bcc_->Close();
+    replaying_bcc_->Close();
+  }
+
+  std::unique_ptr<bpf_tools::RecordingBCCWrapperImpl> recording_bcc_;
+  std::unique_ptr<bpf_tools::ReplayingBCCWrapperImpl> replaying_bcc_;
+};
+
 TEST_F(BasicRecorderTest, PerfBufferRRTest) {
   constexpr uint32_t kLoopIters = 16;
 
@@ -285,6 +356,72 @@ TEST_F(BasicRecorderTest, BPFMapRRTest) {
     EXPECT_EQ(r100, 100);
     EXPECT_EQ(r200, 200);
   }
+}
+
+TEST_F(StackTableRecorderTest, BPFStackTableRRTest) {
+  auto recording_stack_table = WrappedBCCStackTable::Create(recording_bcc_.get(), "stack_table");
+
+  // Invoking Foo() or Bar() triggers our eBPF profiling probe.
+  // Args to Foo() and Bar() will be totally ignored in this test case.
+  constexpr int kIgnoredArg = 0;
+  PX_UNUSED(::test::Foo(kIgnoredArg));
+  PX_UNUSED(::test::Bar(kIgnoredArg));
+
+  // Polling perf buffers will cause the recording BCC wrapper to record each perf buffer event.
+  recording_bcc_->PollPerfBuffers();
+
+  EXPECT_EQ(test::gold_data.size(), 2);
+  const int stack_id_0 = test::gold_data[0];
+  const int stack_id_1 = test::gold_data[1];
+
+  constexpr bool kClearStackId = false;
+  const auto gold_foo_stack_trace = recording_stack_table->GetStackAddr(stack_id_0, kClearStackId);
+  const auto gold_bar_stack_trace = recording_stack_table->GetStackAddr(stack_id_1, kClearStackId);
+  const uint64_t gold_foo_addr = gold_foo_stack_trace[0];
+  const uint64_t gold_bar_addr = gold_bar_stack_trace[0];
+  const auto gold_foo_symbol = recording_stack_table->GetAddrSymbol(gold_foo_addr, getpid());
+  const auto gold_bar_symbol = recording_stack_table->GetAddrSymbol(gold_bar_addr, getpid());
+  EXPECT_EQ(gold_foo_symbol, "test::Foo(unsigned int)");
+  EXPECT_EQ(gold_bar_symbol, "test::Bar(unsigned int)");
+
+  const std::string pb_file_name = "bpf_stack_table_replay_test.pb";
+
+  // Write out the protobuf file and close the recording BCC wrapper.
+  recording_bcc_->WriteProto(pb_file_name);
+  recording_bcc_->Close();
+
+  // Open the protobuf file in the replaying BCC wrapper.
+  ASSERT_OK(replaying_bcc_->OpenReplayProtobuf(pb_file_name));
+
+  // Create the replaying stack table.
+  auto replaying_stack_table = WrappedBCCStackTable::Create(recording_bcc_.get(), "stack_table");
+
+  // Replay perf buffer events. The callback fn. will invoke EXPECT vs. the gold data.
+  replaying_bcc_->PollPerfBuffers();
+
+  // Replay calls to GetStackAddr() and GetAddrSymbol().
+  const auto test_foo_stack_trace = replaying_stack_table->GetStackAddr(stack_id_0, kClearStackId);
+  const auto test_bar_stack_trace = replaying_stack_table->GetStackAddr(stack_id_1, kClearStackId);
+  const uint64_t test_foo_addr = test_foo_stack_trace[0];
+  const uint64_t test_bar_addr = test_bar_stack_trace[0];
+  const auto test_foo_symbol = replaying_stack_table->GetAddrSymbol(test_foo_addr, getpid());
+  const auto test_bar_symbol = replaying_stack_table->GetAddrSymbol(test_bar_addr, getpid());
+
+  // Expect test & gold stack traces and symbols to match.
+  EXPECT_EQ(test_foo_stack_trace.size(), gold_foo_stack_trace.size());
+  EXPECT_EQ(test_bar_stack_trace.size(), gold_bar_stack_trace.size());
+
+  for (uint32_t i = 0; i < test_foo_stack_trace.size(); ++i) {
+    EXPECT_EQ(test_foo_stack_trace[i], gold_foo_stack_trace[i]);
+  }
+  for (uint32_t i = 0; i < test_bar_stack_trace.size(); ++i) {
+    EXPECT_EQ(test_bar_stack_trace[i], gold_bar_stack_trace[i]);
+  }
+
+  EXPECT_EQ(gold_foo_addr, test_foo_addr);
+  EXPECT_EQ(gold_bar_addr, test_bar_addr);
+  EXPECT_EQ(gold_foo_symbol, test_foo_symbol);
+  EXPECT_EQ(gold_bar_symbol, test_bar_symbol);
 }
 
 }  // namespace stirling

--- a/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
+++ b/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
@@ -30,7 +30,7 @@ namespace stirling {
 #ifdef __OPTIMIZE__
 constexpr uint64_t kFileSizeLimitMB = 118;
 #else
-constexpr uint64_t kFileSizeLimitMB = 305;
+constexpr uint64_t kFileSizeLimitMB = 310;
 #endif
 
 TEST(StirlingWrapperSizeTest, ExecutableSizeLimit) {


### PR DESCRIPTION
Summary: We add the record & replay capability for per-cpu array tables and for stack tables.

Type of change: /kind feature

Test Plan: We extend the test case: `rr_bpf_test`.
