### PR TITLE
Increase kFileSizeLimit for dbg builds in stirling wrapper size test

### DIFF
--- a/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
+++ b/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
@@ -30,7 +30,7 @@ namespace stirling {
 #ifdef __OPTIMIZE__
 constexpr uint64_t kFileSizeLimitMB = 118;
 #else
-constexpr uint64_t kFileSizeLimitMB = 295;
+constexpr uint64_t kFileSizeLimitMB = 300;
 #endif
 
 TEST(StirlingWrapperSizeTest, ExecutableSizeLimit) {


### PR DESCRIPTION
Summary: Raises the stirling size limit for `dbg` builds by 5 MiB (to 300mb) to accommodate upcoming changes and additions, including mongodb parsing/stitching and `StitchFrames` interface changes (#1716).

Type of change: /kind cleanup

Test Plan: Existing targets