### PR TITLE
Enforce monotonicity for timestamps in event parser

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer.h
@@ -20,7 +20,6 @@
 
 #include <gflags/gflags.h>
 
-#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer.h
@@ -104,7 +104,7 @@ class DataStreamBuffer {
     if (current_timestamp_ns < prev_timestamp_ns) {
       LOG(WARNING) << "Detected non-monotonically increasing timestamp " << current_timestamp_ns
                    << ". Adjusting to previous timestamp + 1: " << prev_timestamp_ns + 1;
-      return prev_timestamp_ns + 1;
+      current_timestamp_ns = prev_timestamp_ns + 1;
     }
     SetPrevTimestamp(current_timestamp_ns);
     return current_timestamp_ns;

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer_test.cc
@@ -146,6 +146,12 @@ TEST_P(DataStreamBufferTest, Timestamp) {
   EXPECT_OK_AND_EQ(stream_buffer.GetTimestamp(4), 4);
   EXPECT_OK_AND_EQ(stream_buffer.GetTimestamp(7), 4);
   EXPECT_NOT_OK(stream_buffer.GetTimestamp(8));
+
+  // Test automatic adjustment of non-monotonic timestamp
+  stream_buffer.Add(8, "89", 3);  // timestamp is 3, which is less than previous timestamp 4
+  EXPECT_EQ(stream_buffer.Head(), "123456789");
+  EXPECT_OK_AND_EQ(stream_buffer.GetTimestamp(8),
+                   5);  // timestamp is adjusted to previous timestamp + 1
 }
 
 TEST_P(DataStreamBufferTest, TimestampWithGap) {


### PR DESCRIPTION
Summary: Ensures that timestamps in the event parser are monotonically increasing.

The current stitching logic for CQL relies on the assumption that frame deques are chronologically sorted based on their timestamps. Timestamps from eBPF, however, may not always be monotonic due to CPU variances, with potential discrepancies of [up to 880 usec](https://lore.kernel.org/bpf/CAJD7tkYOs4LKa=j+xNRMRiK=ors7_uCBtAjp6axRNQo0NHQqWA@mail.gmail.com/). This change catches potential anomalies due to non-monotonic timestamps by ensuring that the next frame's timestamp will always be greater than the previous one.

The DataStreamBuffer itself relies on byte positions, not timestamps, for its internal ordering so it won't be affected by this timestamp issue directly. Although DataTables are sorted before being pushed to the TableStore, the timestamp variance from eBPF might still have implications. More experiments will be required to determine how frequently this condition is hit in the wild.

Type of change: /kind bug

Test Plan: Existing targets.