### PR TITLE
[standalone pem] Fix execution stats.

### DIFF
--- a/src/experimental/standalone_pem/sink_server.h
+++ b/src/experimental/standalone_pem/sink_server.h
@@ -173,7 +173,6 @@ class StandaloneResultSinkServer final : public carnotpb::ResultSinkService::Ser
     auto timing_info = rb->execution_and_timing_info();
     auto stats = resp->mutable_data()->mutable_execution_stats();
     stats->set_bytes_processed(timing_info.execution_stats().bytes_processed());
-    stats->set_bytes_processed(314);
     stats->set_records_processed(timing_info.execution_stats().records_processed());
     auto timing = stats->mutable_timing();
     timing->set_execution_time_ns(timing_info.execution_stats().timing().execution_time_ns());

--- a/src/experimental/standalone_pem/sink_server.h
+++ b/src/experimental/standalone_pem/sink_server.h
@@ -171,12 +171,13 @@ class StandaloneResultSinkServer final : public carnotpb::ResultSinkService::Ser
   void HandleExecutionAndTimingInfo(::px::api::vizierpb::ExecuteScriptResponse* resp,
                                     carnotpb::TransferResultChunkRequest* rb) {
     auto timing_info = rb->execution_and_timing_info();
-    auto stats = resp->mutable_data()->execution_stats();
-    stats.set_bytes_processed(timing_info.execution_stats().bytes_processed());
-    stats.set_records_processed(timing_info.execution_stats().records_processed());
-    auto timing = stats.timing();
-    timing.set_execution_time_ns(timing_info.execution_stats().timing().execution_time_ns());
-    timing.set_compilation_time_ns(timing_info.execution_stats().timing().compilation_time_ns());
+    auto stats = resp->mutable_data()->mutable_execution_stats();
+    stats->set_bytes_processed(timing_info.execution_stats().bytes_processed());
+    stats->set_bytes_processed(314);
+    stats->set_records_processed(timing_info.execution_stats().records_processed());
+    auto timing = stats->mutable_timing();
+    timing->set_execution_time_ns(timing_info.execution_stats().timing().execution_time_ns());
+    timing->set_compilation_time_ns(timing_info.execution_stats().timing().compilation_time_ns());
   }
 
   absl::flat_hash_map<sole::uuid, ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>*>


### PR DESCRIPTION
Summary: We update the code to populate the execution stats data using `mutable` so that the data is written into message that will be sent on the wire. Previously, our code created a copy of the execution stats and updated that. The copy left the upstream message empty and consequently nothing was sent on the wire.

Type of change: /kind bug fix.

Test Plan: We discovered this bug when testing with the px go api. Standalone pem would work when using streaming, but the client api program would fail for batched. The cause of the failure was an unidentified message data type, i.e. a completely empty execution stats data field. We successfully re-tested the batched query with a standalone pem and the go px api.