### PR TITLE
Fix duplicate `/proc/<pid>/root` prefix bug that formed wrong path to `libssl.so` files.

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -170,10 +170,10 @@ http::Record GetExpectedHTTPRecord() {
   return expected_record;
 }
 
-using OpenSSLServerImplementations = Types<NginxOpenSSL_3_0_8_ContainerWrapper>;
-// Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1_ContainerWrapper,
-//       NginxOpenSSL_3_0_8_ContainerWrapper, Python310ContainerWrapper,
-//       Node12_3_1ContainerWrapper, Node14_18_1AlpineContainerWrapper>;
+using OpenSSLServerImplementations =
+    Types<NginxOpenSSL_1_1_0_ContainerWrapper, NginxOpenSSL_1_1_1_ContainerWrapper,
+          NginxOpenSSL_3_0_8_ContainerWrapper, Python310ContainerWrapper,
+          Node12_3_1ContainerWrapper, Node14_18_1AlpineContainerWrapper>;
 
 TYPED_TEST_SUITE(OpenSSLTraceTest, OpenSSLServerImplementations);
 

--- a/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/openssl_trace_bpf_test.cc
@@ -104,7 +104,8 @@ class OpenSSLTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing 
     // Run the nginx HTTPS server.
     // The container runner will make sure it is in the ready state before unblocking.
     // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
-    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60}, {}, {}, false);
+    constexpr bool kHostPid = false;
+    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60}, {}, {}, kHostPid);
     PX_CHECK_OK(run_result);
 
     // Sleep an additional second, just to be safe.
@@ -187,9 +188,10 @@ TYPED_TEST(OpenSSLTraceTest, ssl_capture_curl_client) {
 
   // Run the client in the network of the server, so they can connect to each other.
   ::px::stirling::testing::CurlContainer client;
+  constexpr bool kHostPid = false;
   ASSERT_OK(client.Run(std::chrono::seconds{60},
                        {absl::Substitute("--network=container:$0", this->server_.container_name())},
-                       {"--insecure", "-s", "-S", "https://127.0.0.1:443/index.html"}, false));
+                       {"--insecure", "-s", "-S", "https://127.0.0.1:443/index.html"}, kHostPid));
   client.Wait();
   this->StopTransferDataThread();
 
@@ -227,9 +229,10 @@ TYPED_TEST(OpenSSLTraceTest, ssl_capture_ruby_client) {
   // Make an SSL request with the client.
   // Run the client in the network of the server, so they can connect to each other.
   ::px::stirling::testing::RubyContainer client;
+  constexpr bool kHostPid = false;
   ASSERT_OK(client.Run(std::chrono::seconds{60},
                        {absl::Substitute("--network=container:$0", this->server_.container_name())},
-                       {"ruby", "-e", rb_script}, false));
+                       {"ruby", "-e", rb_script}, kHostPid));
   client.Wait();
   this->StopTransferDataThread();
 
@@ -249,9 +252,10 @@ TYPED_TEST(OpenSSLTraceTest, ssl_capture_node_client) {
   // Make an SSL request with the client.
   // Run the client in the network of the server, so they can connect to each other.
   ::px::stirling::testing::NodeClientContainer client;
+  constexpr bool kHostPid = false;
   ASSERT_OK(client.Run(std::chrono::seconds{60},
                        {absl::Substitute("--network=container:$0", this->server_.container_name())},
-                       {"node", "/etc/node/https_client.js"}, false));
+                       {"node", "/etc/node/https_client.js"}, kHostPid));
   client.Wait();
   this->StopTransferDataThread();
 


### PR DESCRIPTION
Summary: Fixes a bug that prevented SSL tracing on dynamically loaded SSL libraries. When probing open ssl libs found from a pod's mapped libraries, we erroneously prefixed library paths with `/proc/<pid>/root` twice, i.e. such that a target library might look like this:
```
/proc/<pid>/root/proc/<pid>/root/<path>/some-lib.so
```
Normal target processes run in their own pid namespace. This meant that the *second* instance of `<pid>` in the path above would not exist in the target process namespace. Hence probing dynamic libraries using this path failed.

We also update the open-ssl test case to not use host pid namespace, i.e. such that those tests expose this bug. Previously, this bug was masked in those test cases because the test container processes ran with host pid namespace.

Related issues: #1736.

Type of change: /kind bug fix.

Test Plan: Show that tests fail when we disable use of host pid namespace in SSL test containers, see #1744.

Changelog Message:
```release-note
Fixed a bug that prevented SSL tracing on dynamically linked SSL libraries. 
```