### PR TITLE
Use State to track the order of MongoDB transactions

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
@@ -91,8 +91,6 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame
 }
 
 template <>
-// size_t FindFrameBoundary<mongodb::Frame>(message_type_t, std::string_view, size_t,
-// mongodb::State*) {
 size_t FindFrameBoundary<mongodb::Frame>(message_type_t, std::string_view, size_t, NoState*) {
   // Not implemented.
   return std::string::npos;

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
@@ -28,12 +28,13 @@ namespace stirling {
 namespace protocols {
 namespace mongodb {
 
-ParseState ParseFrame(BinaryDecoder* decoder, Frame* frame);
+ParseState ParseFrame(BinaryDecoder* decoder, Frame* frame, State* state);
 
 }  // namespace mongodb
 
 template <>
-ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame* frame, NoState*);
+ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame* frame,
+                      mongodb::StateWrapper* state);
 
 template <>
 size_t FindFrameBoundary<mongodb::Frame>(message_type_t type, std::string_view buf,

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse_test.cc
@@ -577,8 +577,8 @@ TEST_F(MongoDBParserTest, ValidateStateOrderFromFrames) {
       CreateStringView<char>(CharArrayStringView<uint8_t>(mongoDBValidRequestTwoSections));
 
   // Initialize what the state's stream order should look like after the first insertion.
-  std::vector<std::pair<mongodb::stream_id_t, mongodb::order_consumed_t>> stream_order{
-      std::pair(917, false)};
+  std::vector<std::pair<mongodb::stream_id_t, mongodb::stream_id_consumed_t>> stream_order{
+      {917, false}};
 
   StateWrapper state_order{};
 
@@ -588,14 +588,14 @@ TEST_F(MongoDBParserTest, ValidateStateOrderFromFrames) {
   EXPECT_EQ(state_order.global.stream_order, stream_order);
   EXPECT_EQ(state_1, ParseState::kSuccess);
 
-  stream_order.push_back(std::pair(444, false));
+  stream_order.push_back({444, false});
   mongodb::Frame frame_2;
   ParseState state_2 = ParseFrame(message_type_t::kRequest, &frame_view_2, &frame_2, &state_order);
   EXPECT_EQ(frame_2.request_id, 444);
   EXPECT_EQ(state_order.global.stream_order, stream_order);
   EXPECT_EQ(state_2, ParseState::kSuccess);
 
-  stream_order.push_back(std::pair(1144108930, false));
+  stream_order.push_back({1144108930, false});
   mongodb::Frame frame_3;
   ParseState state_3 = ParseFrame(message_type_t::kRequest, &frame_view_3, &frame_3, &state_order);
   EXPECT_EQ(frame_3.request_id, 1144108930);

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse_test.cc
@@ -577,8 +577,7 @@ TEST_F(MongoDBParserTest, ValidateStateOrderFromFrames) {
       CreateStringView<char>(CharArrayStringView<uint8_t>(mongoDBValidRequestTwoSections));
 
   // Initialize what the state's stream order should look like after the first insertion.
-  std::vector<std::pair<mongodb::stream_id_t, mongodb::stream_id_consumed_t>> stream_order{
-      {917, false}};
+  std::vector<std::pair<mongodb::stream_id_t, bool>> stream_order{{917, false}};
 
   StateWrapper state_order{};
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -19,6 +19,8 @@
 #pragma once
 
 #include <string>
+#include <utility>
+
 #include <vector>
 
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"
@@ -153,11 +155,29 @@ struct Record {
   }
 };
 
+using stream_id_t = int32_t;
+using order_consumed_t = bool;
+struct State {
+  std::vector<std::pair<mongodb::stream_id_t, order_consumed_t>> stream_order;
+};
+
+struct StateWrapper {
+  State global;
+  std::monostate send;
+  std::monostate recv;
+};
 struct ProtocolTraits : public BaseProtocolTraits<Record> {
   using frame_type = Frame;
   using record_type = Record;
-  using state_type = NoState;
+  using state_type = StateWrapper;
+  using key_type = stream_id_t;
 };
+
+// struct ProtocolTraits : public BaseProtocolTraits<Record> {
+//   using frame_type = Frame;
+//   using record_type = Record;
+//   using state_type = NoState;
+// };
 
 }  // namespace mongodb
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -156,9 +156,8 @@ struct Record {
 };
 
 using stream_id_t = int32_t;
-using stream_id_consumed_t = bool;
 struct State {
-  std::vector<std::pair<mongodb::stream_id_t, stream_id_consumed_t>> stream_order;
+  std::vector<std::pair<mongodb::stream_id_t, bool>> stream_order;
 };
 
 struct StateWrapper {

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -156,9 +156,9 @@ struct Record {
 };
 
 using stream_id_t = int32_t;
-using order_consumed_t = bool;
+using stream_id_consumed_t = bool;
 struct State {
-  std::vector<std::pair<mongodb::stream_id_t, order_consumed_t>> stream_order;
+  std::vector<std::pair<mongodb::stream_id_t, stream_id_consumed_t>> stream_order;
 };
 
 struct StateWrapper {

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -173,12 +173,6 @@ struct ProtocolTraits : public BaseProtocolTraits<Record> {
   using key_type = stream_id_t;
 };
 
-// struct ProtocolTraits : public BaseProtocolTraits<Record> {
-//   using frame_type = Frame;
-//   using record_type = Record;
-//   using state_type = NoState;
-// };
-
 }  // namespace mongodb
 }  // namespace protocols
 }  // namespace stirling

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -155,6 +155,13 @@ struct Record {
   }
 };
 
+// The stream_order state tracks which stream_id to stitch first.
+// In more detail, the MongoDB wire protocol can link responses together in a more_to_come scenario
+// where each response points to a new response via the streamID. To stitch correctly, we record the
+// first streamID on the request side in each such sequence during frame parsing and store that in
+// the stream_order vector. The second item in the pair is a boolean flag that is initially false,
+// but set to true during the stitching process to indicate that the transaction has been processsed
+// and can be removed from the vector.
 using stream_id_t = int32_t;
 struct State {
   std::vector<std::pair<mongodb::stream_id_t, bool>> stream_order;
@@ -165,6 +172,7 @@ struct StateWrapper {
   std::monostate send;
   std::monostate recv;
 };
+
 struct ProtocolTraits : public BaseProtocolTraits<Record> {
   using frame_type = Frame;
   using record_type = Record;


### PR DESCRIPTION
Summary: This PR adds functionality to track the order of transactions as they are parsed. It adds the streamID of each request to the state vector at parsing time which will then be used to iterate over at stitching time. Adding this will mainly help the stitching process when trying to stitch a request with N `moreToCome` responses.

**Motivation behind this change:**
The stitching implementation relies on the new interface using `absl::flat_hash_map` to store the `streamID` and a deque of request/response frames. We then use a response led matching algorithm where we loop through the response map and stitch the first response frame in a deque with its corresponding request frame. A response pairs with a request when both frames share the same `streamID`, the response frame's `streamID` is its `responseTo` and the request frame's `streamID` is its `requestID`.

MongoDB's `OP_MSG` wire protocol has the concept of `more_to_come` which means that the server could send `N` responses back to a singular request by the client. Each frame in the series of the `N` responses are linked by the `responseTo` of the frame matching the `requestID` of the previous response frame, similar to a singly linked list. The head response frame's `responseTo` will be the `requestID` of the request frame. Note: the `requestID` of each frame in the `N more_to_come` frames is random and unique.

At the time of stitching, if we do not use state to track the order of transactions we would iterate over the response map in a "random" order and could iterate over the `more_to_come` response frames out of order. We could lose context on how the `more_to_come` frames are linked due to not knowing the head response frame and if we were to iterate over the end of the `more_to_come` message before looping through all prior `more_to_come` frames in the message they would be dropped since we do not know which request those frames are responding to. To solve this issue, tracking the order of transactions' `streamIDs` to iterate over would ensure that could use the response led stitching approach and find the complete `more_to_come` message for a given request.

**New test case:**
The new test case checks to make sure the state's `stream_order` vector is correctly populated with the order of `streamIDs` as we parse new request frames (transactions). The test case parses 3 frames and expects that the state's `stream_order` after parsing the first frame to contain `std::pair<917, false>` since the first frame's `requestID` is 917. It expects the `stream_order` to contain `std::pair<917, false>`, `std::pair<444, false>` after parsing the second request frame since that frame's requestID is 444 and so on.

Related issues: #640

Type of change: /kind feature

Test Plan: Modified the existing tests and added another test to make sure the vector is populated correctly.