### PR TITLE
Add support to stitch MongoDB frames

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/BUILD.bazel
@@ -46,3 +46,9 @@ pl_cc_test(
     srcs = ["parse_test.cc"],
     deps = [":cc_library"],
 )
+
+pl_cc_test(
+    name = "stitcher_test",
+    srcs = ["stitcher_test.cc"],
+    deps = [":cc_library"],
+)

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h"
+
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/strings/str_replace.h>
+#include "src/common/base/base.h"
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/interface.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
+#include "src/stirling/utils/binary_decoder.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mongodb {
+
+RecordsWithErrorCount<mongodb::Record> StitchFrames(
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps, State* state) {
+
+  std::vector<mongodb::Record> records;
+  int error_count = 0;
+
+  for (const auto& [idx, stream_id] : Enumerate(state->transaction_stream_order)) {
+    // Find the stream ID's response deque.
+    auto resp_it = resps->find(stream_id);
+    if (resp_it == resps->end()) {
+      VLOG(1) << absl::Substitute(
+          "Did not find a response deque with the stream ID: $0",
+          stream_id);
+      error_count++;
+      continue;
+    }
+
+    // Response deque for the stream ID.
+    auto& resp_deque = resp_it->second;
+
+    // Find the stream ID's response deque.
+    auto req_it = reqs->find(stream_id);
+    if (req_it == reqs->end()) {
+      VLOG(1) << absl::Substitute(
+          "Did not find a request with the stream ID = $0",
+          stream_id);
+      error_count++;
+      continue;
+    }
+
+    // Request deque for the stream ID.
+    auto& req_deque = req_it->second;
+
+    // Track the latest response timestamp to compare against request frame's timestamp later.
+    uint64_t latest_resp_ts = 0;
+
+    // Loop over each frame in the response deque and match the oldest response frame with the oldest request that occured just before the response.
+    for (const auto& [idx, resp_frame] : Enumerate(resp_deque)) {
+      if (resp_frame.consumed) {
+        continue;
+      }
+
+      latest_resp_ts = resp_frame.timestamp_ns;
+
+      auto curr_resp = resp_frame;
+
+      // Find and insert all of the moreToCome frame(s)' section data to the head response frame.
+      while (curr_resp.more_to_come) {
+        // Find the next response's deque.
+        auto next_resp_deque_it = resps->find(curr_resp.request_id);
+        if (next_resp_deque_it == resps->end()) {
+          VLOG(1) << absl::Substitute(
+              "Did not find a response deque with extending the prior more to come response. responseTo: $0",
+              curr_resp.request_id);
+          error_count++;
+          break;
+        }
+
+        // Response deque containg the next more to come response frame.
+        auto& next_resp_deque = next_resp_deque_it->second;
+
+        // Find the next response frame from the deque with a timestamp just greater than the current response frame's timestamp.
+        auto next_resp_it =
+        std::upper_bound(next_resp_deque.begin(), next_resp_deque.end(), latest_resp_ts,
+                        [](const uint64_t ts, const mongodb::Frame& frame) {
+                          return ts < frame.timestamp_ns;
+                        });
+        if (next_resp_it->timestamp_ns < latest_resp_ts) {
+          VLOG(1) << absl::Substitute("Did not find a response extending the prior more to come response. RequestID: $0", curr_resp.request_id);
+          error_count++;
+          continue;
+        }
+
+        mongodb::Frame& next_resp = *next_resp_it;
+        resp_frame.sections.insert(std::end(resp_frame.sections), std::begin(next_resp.sections),
+                                  std::end(next_resp.sections));
+        next_resp.consumed = true;
+        latest_resp_ts = next_resp.timestamp_ns;
+        curr_resp = next_resp;
+        next_resp_deque.erase(next_resp_it);
+      }
+
+      // Find the corresponding request frame for the head response frame.
+      auto req_frame_it =
+          std::upper_bound(req_deque.begin(), req_deque.end(), latest_resp_ts,
+                          [](const uint64_t ts, const mongodb::Frame& frame) {
+                            return ts < frame.timestamp_ns;
+                          }) -
+          1;
+      if (req_frame_it == req_deque.begin() &&
+          req_frame_it->timestamp_ns > resp_frame.timestamp_ns) {
+        VLOG(1) << absl::Substitute("Did not find a request frame that is earlier than the response. Response's responseTo: $0", resp_frame.response_to);
+        error_count++;
+        continue;
+      }
+
+      mongodb::Frame& req_frame = *req_frame_it;
+      req_frame.consumed = true;
+      resp_frame.consumed = true;
+      records.push_back({std::move(req_frame), std::move(resp_frame)});
+      resp_deque.erase(resp_deque.begin() + idx);
+    }
+
+    size_t delete_idx = req_deque.size();
+    bool found_unconsumed = false;
+    for (const auto& [idx, frame] : Enumerate(req_deque)) {
+      if (frame.consumed) {
+        continue;
+      }
+
+      if (frame.discarded || frame.timestamp_ns < latest_resp_ts) {
+        error_count++;
+        frame.discarded = true;
+      } else if (!found_unconsumed) {
+        delete_idx = idx;
+        found_unconsumed = true;
+        break;
+      }
+    }
+    req_deque.erase(req_deque.begin(), req_deque.begin() + delete_idx);
+  }
+
+  for (auto it = resps->begin(); it != resps->end(); it++) {
+    auto& resp_deque = it->second;
+    if (resp_deque.size() > 0) {
+      error_count += resp_deque.size();
+      resp_deque.clear();
+    }
+  }
+  state->transaction_stream_order.clear();
+
+  return {records, error_count};
+}
+
+}  // namespace mongodb
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <deque>
+// #include <map>
+#include <absl/container/flat_hash_map.h>
+
+#include <vector>
+
+#include "src/common/base/base.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/interface.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mongodb {
+
+RecordsWithErrorCount<mongodb::Record> StitchFrames(
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps, State* state);
+}  // namespace mongodb
+
+// Uncomment this when the upstream stitching interface is done
+// template <>
+// inline RecordsWithErrorCount<mongodb::Record> StitchFrames(
+//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,
+//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* resps,
+//     NoState* /*state*/) {
+//   return mongodb::StitchFrames(reqs, resps);
+// }
+
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -18,10 +18,9 @@
 
 #pragma once
 
-#include <deque>
-// #include <map>
 #include <absl/container/flat_hash_map.h>
-
+#include <deque>
+#include <utility>
 #include <vector>
 
 #include "src/common/base/base.h"
@@ -33,6 +32,8 @@ namespace stirling {
 namespace protocols {
 namespace mongodb {
 
+void FlattenSections(mongodb::Frame* frame);
+
 RecordsWithErrorCount<mongodb::Record> StitchFrames(
     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps, State* state);
@@ -41,10 +42,10 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
 // Uncomment this when the upstream stitching interface is done
 // template <>
 // inline RecordsWithErrorCount<mongodb::Record> StitchFrames(
-//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* reqs,
-//     std::map<mongodb::stream_id, std::deque<mongodb::Frame>>* resps,
-//     NoState* /*state*/) {
-//   return mongodb::StitchFrames(reqs, resps);
+//     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
+//     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps,
+//     State* state) {
+//   return mongodb::StitchFrames(reqs, resps, state);
 // }
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -43,14 +43,13 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps, State* state);
 }  // namespace mongodb
 
-// Uncomment this when the upstream stitching interface is done
-// template <>
-// inline RecordsWithErrorCount<mongodb::Record> StitchFrames(
-//     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
-//     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps,
-//     State* state) {
-//   return mongodb::StitchFrames(reqs, resps, &state->global);
-// }
+template <>
+inline RecordsWithErrorCount<mongodb::Record> StitchFrames(
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps,
+    mongodb::StateWrapper* state) {
+  return mongodb::StitchFrames(reqs, resps, &state->global);
+}
 
 }  // namespace protocols
 }  // namespace stirling

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -45,7 +45,7 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
 //     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* reqs,
 //     absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps,
 //     State* state) {
-//   return mongodb::StitchFrames(reqs, resps, state);
+//   return mongodb::StitchFrames(reqs, resps, &state->global);
 // }
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h
@@ -32,6 +32,10 @@ namespace stirling {
 namespace protocols {
 namespace mongodb {
 
+void FindMoreToComeResponses(
+    absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>* resps, int* error_count,
+    mongodb::Frame* resp_frame, uint64_t* latest_resp_ts);
+
 void FlattenSections(mongodb::Frame* frame);
 
 RecordsWithErrorCount<mongodb::Record> StitchFrames(

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h"
+
+#include <absl/container/flat_hash_map.h>
+
+#include <string>
+#include <utility>
+
+#include "src/common/testing/testing.h"
+
+namespace px {
+namespace stirling {
+namespace protocols {
+namespace mongodb {
+
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
+class MongoDBStitchFramesTest : public ::testing::Test {};
+
+Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id, int32_t response_to, bool more_to_come,
+                         std::string doc = "") {
+  mongodb::Frame frame;
+  frame.timestamp_ns = ts_ns;
+  frame.request_id = request_id;
+  frame.response_to = response_to;
+  frame.more_to_come = more_to_come;
+
+  mongodb::Section section;
+  section.documents.push_back(doc);
+
+  frame.sections.push_back(section);
+  return frame;
+}
+
+bool areAllDequesEmpty(
+    const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
+  for (const auto& pair : frame_map) {
+    if (!pair.second.empty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+size_t totalDequeSize(
+    const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
+  size_t total_size = 0;
+  for (const auto& pair : frame_map) {
+    total_size += pair.second.size();
+  }
+  return total_size;
+}
+
+TEST_F(MongoDBStitchFramesTest, VerifyOnetoOneStitching) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[3].push_back(CreateMongoDBFrame(2, 3, 0, false));
+  reqs[5].push_back(CreateMongoDBFrame(4, 5, 0, false));
+  reqs[7].push_back(CreateMongoDBFrame(6, 7, 0, false));
+  reqs[9].push_back(CreateMongoDBFrame(8, 9, 0, false));
+  reqs[11].push_back(CreateMongoDBFrame(10, 11, 0, false));
+  reqs[13].push_back(CreateMongoDBFrame(12, 13, 0, false));
+  reqs[15].push_back(CreateMongoDBFrame(14, 15, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, false));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, false));
+  resps[5].push_back(CreateMongoDBFrame(5, 6, 5, false));
+  resps[7].push_back(CreateMongoDBFrame(7, 8, 7, false));
+  resps[9].push_back(CreateMongoDBFrame(9, 10, 9, false));
+  resps[11].push_back(CreateMongoDBFrame(11, 12, 11, false));
+  resps[13].push_back(CreateMongoDBFrame(13, 14, 13, false));
+  resps[15].push_back(CreateMongoDBFrame(15, 16, 15, false));
+
+  // Add the order in which the transactions's streamID's were found.
+  State state = {};
+  state.transaction_stream_order.push_back(1);
+  state.transaction_stream_order.push_back(3);
+  state.transaction_stream_order.push_back(5);
+  state.transaction_stream_order.push_back(7);
+  state.transaction_stream_order.push_back(9);
+  state.transaction_stream_order.push_back(11);
+  state.transaction_stream_order.push_back(13);
+  state.transaction_stream_order.push_back(15);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_THAT(result.records, SizeIs(8));
+  EXPECT_EQ(totalDequeSize(reqs), 0);
+  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+TEST_F(MongoDBStitchFramesTest, VerifyOnetoNStitching) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[3].push_back(CreateMongoDBFrame(2, 3, 0, false));
+
+  // Request frame corresponding to multi frame response message.
+  reqs[5].push_back(CreateMongoDBFrame(4, 5, 0, false));
+
+  reqs[9].push_back(CreateMongoDBFrame(8, 9, 0, false));
+  reqs[11].push_back(CreateMongoDBFrame(10, 11, 0, false));
+  reqs[13].push_back(CreateMongoDBFrame(12, 13, 0, false));
+  reqs[15].push_back(CreateMongoDBFrame(14, 15, 0, false));
+  reqs[17].push_back(CreateMongoDBFrame(16, 17, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, false));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, false));
+
+  // Multi frame response message.
+  resps[5].push_back(CreateMongoDBFrame(5, 6, 5, true, "1"));
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, true, "2"));
+  resps[7].push_back(CreateMongoDBFrame(7, 8, 7, false, "3"));
+
+  resps[9].push_back(CreateMongoDBFrame(9, 10, 9, false));
+  resps[11].push_back(CreateMongoDBFrame(11, 12, 11, false));
+  resps[13].push_back(CreateMongoDBFrame(13, 14, 13, false));
+  resps[15].push_back(CreateMongoDBFrame(15, 16, 15, false));
+  resps[17].push_back(CreateMongoDBFrame(17, 18, 17, false));
+
+  // Add the order in which the transactions's streamID's were found.
+  State state = {};
+  state.transaction_stream_order.push_back(1);
+  state.transaction_stream_order.push_back(3);
+  state.transaction_stream_order.push_back(5);
+  state.transaction_stream_order.push_back(9);
+  state.transaction_stream_order.push_back(11);
+  state.transaction_stream_order.push_back(13);
+  state.transaction_stream_order.push_back(15);
+  state.transaction_stream_order.push_back(17);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_EQ(result.records[2].resp.sections[0].documents[0], "1");
+  EXPECT_EQ(result.records[2].resp.sections[1].documents[0], "2");
+  EXPECT_EQ(result.records[2].resp.sections[2].documents[0], "3");
+  EXPECT_THAT(result.records, SizeIs(8));
+
+  EXPECT_EQ(totalDequeSize(reqs), 0);
+  EXPECT_EQ(totalDequeSize(resps), 0);
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+TEST_F(MongoDBStitchFramesTest, UnmatchedResponsesAreHandled) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  // Missing request frame
+  reqs[2].push_back(CreateMongoDBFrame(1, 2, 0, false));
+
+  // Add responses to map;
+  resps[10].push_back(CreateMongoDBFrame(0, 1, 10, false));
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, false));
+
+  // Add the order in which the transactions's streamID's were found.
+  State state = {};
+  state.transaction_stream_order.push_back(2);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+
+  EXPECT_EQ(result.error_count, 1);
+  EXPECT_EQ(result.records.size(), 1);
+  EXPECT_EQ(result.records[0].req.request_id, 2);
+  EXPECT_EQ(result.records[0].resp.response_to, 2);
+
+  EXPECT_EQ(totalDequeSize(reqs), 0);
+  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+TEST_F(MongoDBStitchFramesTest, UnmatchedRequestsAreCleanedUp) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[2].push_back(CreateMongoDBFrame(1, 2, 0, false));
+  reqs[4].push_back(CreateMongoDBFrame(3, 4, 0, false));
+
+  // Add responses to map.
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, false));
+  resps[4].push_back(CreateMongoDBFrame(4, 5, 4, false));
+
+  State state = {};
+  state.transaction_stream_order.push_back(1);
+  state.transaction_stream_order.push_back(2);
+  state.transaction_stream_order.push_back(4);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+
+  EXPECT_EQ(result.error_count, 0);
+  EXPECT_THAT(result.records, SizeIs(2));
+  EXPECT_EQ(result.records[0].req.request_id, 2);
+  EXPECT_EQ(result.records[1].req.request_id, 4);
+
+  EXPECT_TRUE(areAllDequesEmpty(reqs));
+  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+TEST_F(MongoDBStitchFramesTest, MissingHeadFrameInNResponses) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[6].push_back(CreateMongoDBFrame(5, 6, 0, false));
+
+  // Add responses to map.
+  // Missing head frame in the N responses
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, true));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, false));
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
+
+  State state = {};
+  state.transaction_stream_order.push_back(1);
+  state.transaction_stream_order.push_back(6);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+
+  EXPECT_EQ(result.error_count, 3);
+  EXPECT_EQ(result.records.size(), 1);
+
+  EXPECT_EQ(totalDequeSize(reqs), 1);
+  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+TEST_F(MongoDBStitchFramesTest, MissingFrameInNResponses) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[6].push_back(CreateMongoDBFrame(5, 6, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, true));
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, true));
+  // Missing middle frame in the N responses.
+  resps[4].push_back(CreateMongoDBFrame(4, 5, 4, false));
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
+
+  State state = {};
+  state.transaction_stream_order.push_back(1);
+  state.transaction_stream_order.push_back(6);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+
+  EXPECT_EQ(result.error_count, 2);
+  EXPECT_EQ(result.records.size(), 2);
+
+  EXPECT_EQ(totalDequeSize(reqs), 0);
+  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+TEST_F(MongoDBStitchFramesTest, MissingTailFrameInNResponses) {
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> reqs;
+  absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>> resps;
+
+  // Add requests to map.
+  reqs[1].push_back(CreateMongoDBFrame(0, 1, 0, false));
+  reqs[6].push_back(CreateMongoDBFrame(5, 6, 0, false));
+
+  // Add responses to map.
+  resps[1].push_back(CreateMongoDBFrame(1, 2, 1, true));
+  resps[2].push_back(CreateMongoDBFrame(2, 3, 2, true));
+  resps[3].push_back(CreateMongoDBFrame(3, 4, 3, true));
+  // Missing tail frame in the N responses
+  resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
+
+  State state = {};
+  state.transaction_stream_order.push_back(1);
+  state.transaction_stream_order.push_back(6);
+
+  RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
+
+  EXPECT_EQ(result.error_count, 1);
+  EXPECT_EQ(result.records.size(), 2);
+
+  EXPECT_EQ(totalDequeSize(reqs), 0);
+  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_THAT(state.transaction_stream_order, SizeIs(0));
+}
+
+}  // namespace mongodb
+}  // namespace protocols
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
@@ -52,7 +52,7 @@ Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id, int32_t response_to
 }
 
 // Uncomment following two functions once upstream testing functions are merged.
-bool areAllDequesEmpty(
+bool AreAllDequesEmpty(
     const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
   for (const auto& pair : frame_map) {
     if (!pair.second.empty()) {
@@ -62,7 +62,7 @@ bool areAllDequesEmpty(
   return true;
 }
 
-size_t totalDequeSize(
+size_t TotalDequeSize(
     const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
   size_t total_size = 0;
   for (const auto& pair : frame_map) {
@@ -97,13 +97,13 @@ TEST_F(MongoDBStitchFramesTest, VerifyStitchingWithReusedStreams) {
 
   // Add the order in which the transactions's streamID's were found.
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(3, false));
-  state.stream_order.push_back(std::pair(5, false));
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(3, false));
-  state.stream_order.push_back(std::pair(5, false));
-  state.stream_order.push_back(std::pair(5, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({3, false});
+  state.stream_order.push_back({5, false});
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({3, false});
+  state.stream_order.push_back({5, false});
+  state.stream_order.push_back({5, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
   EXPECT_EQ(result.error_count, 1);
@@ -113,8 +113,8 @@ TEST_F(MongoDBStitchFramesTest, VerifyStitchingWithReusedStreams) {
   EXPECT_EQ(result.records[5].req.timestamp_ns, 10);
   EXPECT_EQ(result.records[5].resp.timestamp_ns, 11);
 
-  EXPECT_EQ(totalDequeSize(reqs), 1);
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_EQ(TotalDequeSize(reqs), 1);
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(0));
 }
 
@@ -144,20 +144,20 @@ TEST_F(MongoDBStitchFramesTest, VerifyOnetoOneStitching) {
 
   // Add the order in which the transactions's streamID's were found.
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(3, false));
-  state.stream_order.push_back(std::pair(5, false));
-  state.stream_order.push_back(std::pair(7, false));
-  state.stream_order.push_back(std::pair(9, false));
-  state.stream_order.push_back(std::pair(11, false));
-  state.stream_order.push_back(std::pair(13, false));
-  state.stream_order.push_back(std::pair(15, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({3, false});
+  state.stream_order.push_back({5, false});
+  state.stream_order.push_back({7, false});
+  state.stream_order.push_back({9, false});
+  state.stream_order.push_back({11, false});
+  state.stream_order.push_back({13, false});
+  state.stream_order.push_back({15, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
   EXPECT_EQ(result.error_count, 0);
   EXPECT_THAT(result.records, SizeIs(8));
-  EXPECT_TRUE(areAllDequesEmpty(reqs));
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_TRUE(AreAllDequesEmpty(reqs));
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(0));
 }
 
@@ -195,14 +195,14 @@ TEST_F(MongoDBStitchFramesTest, VerifyOnetoNStitching) {
 
   // Add the order in which the transactions's streamID's were found.
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(3, false));
-  state.stream_order.push_back(std::pair(5, false));
-  state.stream_order.push_back(std::pair(9, false));
-  state.stream_order.push_back(std::pair(11, false));
-  state.stream_order.push_back(std::pair(13, false));
-  state.stream_order.push_back(std::pair(15, false));
-  state.stream_order.push_back(std::pair(17, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({3, false});
+  state.stream_order.push_back({5, false});
+  state.stream_order.push_back({9, false});
+  state.stream_order.push_back({11, false});
+  state.stream_order.push_back({13, false});
+  state.stream_order.push_back({15, false});
+  state.stream_order.push_back({17, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
 
@@ -211,8 +211,8 @@ TEST_F(MongoDBStitchFramesTest, VerifyOnetoNStitching) {
   EXPECT_EQ(result.records[2].resp.frame_body, "response frame body ");
   EXPECT_THAT(result.records, SizeIs(8));
 
-  EXPECT_TRUE(areAllDequesEmpty(reqs));
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_TRUE(AreAllDequesEmpty(reqs));
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(0));
 }
 
@@ -230,7 +230,7 @@ TEST_F(MongoDBStitchFramesTest, UnmatchedResponsesAreHandled) {
 
   // Add the order in which the streamID's were found.
   State state = {};
-  state.stream_order.push_back(std::pair(2, false));
+  state.stream_order.push_back({2, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
 
@@ -239,8 +239,8 @@ TEST_F(MongoDBStitchFramesTest, UnmatchedResponsesAreHandled) {
   EXPECT_EQ(result.records[0].req.request_id, 2);
   EXPECT_EQ(result.records[0].resp.response_to, 2);
 
-  EXPECT_TRUE(areAllDequesEmpty(reqs));
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_TRUE(AreAllDequesEmpty(reqs));
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(0));
 }
 
@@ -258,9 +258,9 @@ TEST_F(MongoDBStitchFramesTest, UnmatchedRequestsAreNotCleanedUp) {
   resps[4].push_back(CreateMongoDBFrame(4, 5, 4, false));
 
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(2, false));
-  state.stream_order.push_back(std::pair(4, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({2, false});
+  state.stream_order.push_back({4, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
 
@@ -269,8 +269,8 @@ TEST_F(MongoDBStitchFramesTest, UnmatchedRequestsAreNotCleanedUp) {
   EXPECT_EQ(result.records[0].req.request_id, 2);
   EXPECT_EQ(result.records[1].req.request_id, 4);
 
-  EXPECT_EQ(totalDequeSize(reqs), 1);
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_EQ(TotalDequeSize(reqs), 1);
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(1));
 }
 
@@ -289,16 +289,16 @@ TEST_F(MongoDBStitchFramesTest, MissingHeadFrameInNResponses) {
   resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
 
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(6, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({6, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
 
   EXPECT_EQ(result.error_count, 2);
   EXPECT_EQ(result.records.size(), 1);
 
-  EXPECT_EQ(totalDequeSize(reqs), 1);
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_EQ(TotalDequeSize(reqs), 1);
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(1));
 }
 
@@ -318,8 +318,8 @@ TEST_F(MongoDBStitchFramesTest, MissingFrameInNResponses) {
   resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
 
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(6, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({6, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
 
@@ -327,8 +327,8 @@ TEST_F(MongoDBStitchFramesTest, MissingFrameInNResponses) {
   EXPECT_EQ(result.records.size(), 2);
   EXPECT_EQ(result.records[0].resp.frame_body, "frame 1 frame 2 ");
 
-  EXPECT_TRUE(areAllDequesEmpty(reqs));
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_TRUE(AreAllDequesEmpty(reqs));
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(0));
 }
 
@@ -348,8 +348,8 @@ TEST_F(MongoDBStitchFramesTest, MissingTailFrameInNResponses) {
   resps[6].push_back(CreateMongoDBFrame(6, 7, 6, false));
 
   State state = {};
-  state.stream_order.push_back(std::pair(1, false));
-  state.stream_order.push_back(std::pair(6, false));
+  state.stream_order.push_back({1, false});
+  state.stream_order.push_back({6, false});
 
   RecordsWithErrorCount<mongodb::Record> result = mongodb::StitchFrames(&reqs, &resps, &state);
 
@@ -357,8 +357,8 @@ TEST_F(MongoDBStitchFramesTest, MissingTailFrameInNResponses) {
   EXPECT_EQ(result.records.size(), 2);
   EXPECT_EQ(result.records[0].resp.frame_body, "frame 1 frame 2 frame 3 ");
 
-  EXPECT_TRUE(areAllDequesEmpty(reqs));
-  EXPECT_TRUE(areAllDequesEmpty(resps));
+  EXPECT_TRUE(AreAllDequesEmpty(reqs));
+  EXPECT_TRUE(AreAllDequesEmpty(resps));
   EXPECT_THAT(state.stream_order, SizeIs(0));
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "src/common/testing/testing.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/common/test_utils.h"
 
 namespace px {
 namespace stirling {
@@ -49,26 +50,6 @@ Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id, int32_t response_to
   frame.sections.push_back(section);
 
   return frame;
-}
-
-// Uncomment following two functions once upstream testing functions are merged.
-bool AreAllDequesEmpty(
-    const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
-  for (const auto& pair : frame_map) {
-    if (!pair.second.empty()) {
-      return false;
-    }
-  }
-  return true;
-}
-
-size_t TotalDequeSize(
-    const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
-  size_t total_size = 0;
-  for (const auto& pair : frame_map) {
-    total_size += pair.second.size();
-  }
-  return total_size;
 }
 
 TEST_F(MongoDBStitchFramesTest, VerifyStitchingWithReusedStreams) {

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher_test.cc
@@ -51,6 +51,7 @@ Frame CreateMongoDBFrame(uint64_t ts_ns, int32_t request_id, int32_t response_to
   return frame;
 }
 
+// Uncomment following two functions once upstream testing functions are merged.
 bool areAllDequesEmpty(
     const absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>& frame_map) {
   for (const auto& pair : frame_map) {

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -137,6 +137,7 @@ struct Frame : public FrameBase {
   uint32_t checksum = 0;
 
   bool consumed = false;
+  bool discarded = false;
   size_t ByteSize() const override { return sizeof(Frame); }
 
   std::string ToString() const override {

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -20,7 +20,6 @@
 
 #include <string>
 #include <utility>
-
 #include <vector>
 
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"
@@ -134,10 +133,10 @@ struct Frame : public FrameBase {
   bool exhaust_allowed = false;
   std::vector<Section> sections;
   std::string op_msg_type;
+  std::string frame_body;
   uint32_t checksum = 0;
 
   bool consumed = false;
-  bool discarded = false;
   size_t ByteSize() const override { return sizeof(Frame); }
 
   std::string ToString() const override {


### PR DESCRIPTION
Summary: This PR adds functionality to stitch MongoDB frames together. It relies on state to iterate over the order of streamIDs parsed and uses a response led matching approach.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind feature

Test Plan: Added tests