### PR TITLE
Add cgroup bcc flag for compilation

### DIFF
--- a/src/stirling/bpf_tools/bcc_wrapper.cc
+++ b/src/stirling/bpf_tools/bcc_wrapper.cc
@@ -153,11 +153,15 @@ Status BCCWrapperImpl::InitBPFProgram(std::string_view bpf_program, std::vector<
       }
     }
 
+    KernelVersionOrder cgroup_order= CompareKernelVersion(KernelVersion{4, 18, 0}, GetKernelVersion);
+    uint8_t cgroup_id_enabled = (KernelVersionOrder::kOlder == cgroup_order) ? 0 : 1;
+
     cflags.push_back(absl::Substitute("-DSTART_BOOTTIME_VARNAME=$0", boottime_varname));
     cflags.push_back(
         absl::Substitute("-DGROUP_LEADER_OFFSET_OVERRIDE=$0", offsets.group_leader_offset));
     cflags.push_back(
         absl::Substitute("-DSTART_BOOTTIME_OFFSET_OVERRIDE=$0", offsets.real_start_time_offset));
+    cflags.push_back(absl::Substitute("-DGET_CGROUP_ID_ENABLED=$0", cgroup_id_enabled));
   }
 
   PX_RETURN_IF_ERROR(MountDebugFS());

--- a/src/stirling/bpf_tools/testdata/BUILD.bazel
+++ b/src/stirling/bpf_tools/testdata/BUILD.bazel
@@ -27,6 +27,15 @@ pl_bpf_cc_resource(
     ],
 )
 
+pl_bpf_cc_resource(
+    name = "get_current_cgroup_id",
+    src = "get_current_cgroup_id.c",
+    deps = [
+        "//src/stirling/bpf_tools/bcc_bpf:headers",
+        "//src/stirling/bpf_tools/bcc_bpf/system-headers",
+    ],
+)
+
 pl_cc_resource(
     name = "test_txt_cc_resource",
     src = "test.txt",

--- a/src/stirling/bpf_tools/testdata/get_current_cgroup_id.c
+++ b/src/stirling/bpf_tools/testdata/get_current_cgroup_id.c
@@ -1,0 +1,15 @@
+
+#include "src/stirling/bpf_tools/bcc_bpf/task_struct_utils.h"
+
+BPF_ARRAY(cgroup_id_output, uint64_t, 1);
+
+int probe_bpf_get_current_cgroup_id(struct pt_regs* ctx) {
+  uint64_t cgroup_id = UINT64_MAX;
+#if GET_CGROUP_ID_ENABLED
+  cgroup_id = bpf_get_current_cgroup_id();
+#endif
+  int kZero = 0;
+  cgroup_id_ouptut.update(&kZero, &cgroup_id);
+  return 0;
+}
+


### PR DESCRIPTION
This is to ensure that the reversions in #1738 are not necessary for #1638.