### PR TITLE
added flag '-s' to grep to suppress 'No such file or directory' error

### DIFF
--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -71,7 +71,7 @@ fi
 
 # Check if build buddy cache exists. If so, add the appropriate arguments.
 build_buddy_args=()
-if grep -q "^build.*remote_cache.*grpc.*9998" /etc/bazelrc; then
+if grep -sq "^build.*remote_cache.*grpc.*9998" /etc/bazelrc; then
   build_buddy_args=(
     "--add-host=$(hostname -f):127.0.0.1"
     "--volume=/etc/bazelrc:/etc/bazelrc")


### PR DESCRIPTION
in case '/etc/bazelrc' does not exist the script displays:
_grep: /etc/bazelrc: No such file or directory_