### PR TITLE
Bump urllib to 1.26.18, closing #1745

### DIFF
--- a/src/datagen/pii/privy/requirements.bazel.txt
+++ b/src/datagen/pii/privy/requirements.bazel.txt
@@ -2203,9 +2203,9 @@ tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \
     --hash=sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda
     # via pandas
-urllib3==1.26.16 \
-    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
-    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
+urllib3==1.26.18 \
+    --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07 \
+    --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
Summary: Bumps urllib dependency for PII generation library Privy.

Relevant Issues: Closes https://github.com/pixie-io/pixie/pull/1745

Type of change: /kind cleanup

Test Plan: bazel build and tests inside privy work. Datagen works.