### PR TITLE
Extend ExtractUVarInt to support customizable kMaxVarintLen64

### DIFF
--- a/src/stirling/utils/binary_decoder.h
+++ b/src/stirling/utils/binary_decoder.h
@@ -25,7 +25,6 @@
 namespace px {
 namespace stirling {
 
-constexpr int kMaxVarintLen64 = 10;
 
 /**
  * Provides functions to extract bytes from a bytes buffer.
@@ -75,7 +74,7 @@ class BinaryDecoder {
   // Extract UVarInt encoded value and return result as uint64_t. The details of this encoding's
   // specification can be see in the following link:
   // https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/encoding/binary/varint.go;l=7-25
-  StatusOr<uint64_t> ExtractUVarInt() {
+  StatusOr<uint64_t> ExtractUVarInt(int kMaxVarintLen64 = 10, bool cap_final_byte_val = true) {
     uint64_t x = 0;
     uint bits = 0;
     int i = 0;
@@ -85,7 +84,7 @@ class BinaryDecoder {
       buf_.remove_prefix(1);
 
       if (b < 0x80) {
-        if (i == kMaxVarintLen64 - 1 && b > 1) {
+        if (cap_final_byte_val && i == kMaxVarintLen64 - 1 && b > 1) {
           return error::ResourceUnavailable("Insufficient number of bytes.");
         }
         return x | uint64_t(b) << bits;


### PR DESCRIPTION
ExtractUVarInt in Binary Decoder currently uses a definite value for kMaxVarintLen64, which can be a problem while parsing the variable encoding in protocols such as MQTT. which has the maximum limit set as 4 bytes. This PR makes a slight modification to support this functionality.