### PR TITLE
Add the Mongo image and mirror it across registries

### DIFF
--- a/scripts/regclient/deps.lua
+++ b/scripts/regclient/deps.lua
@@ -22,6 +22,7 @@ local images = {
   "docker.io/curlimages/curl@sha256:5594e102d5da87f8a3a6b16e5e9b0e40292b5404c12f9b6962fd6b056d2a4f82",
   "docker.io/datastax/dse-server@sha256:a98e1a877f9c1601aa6dac958d00e57c3f6eaa4b48d4f7cac3218643a4bfb36e",
   "docker.io/ibmjava@sha256:78e2dd462373b3c5631183cc927a54aef1b114c56fe2fb3e31c4b39ba2d919dc",
+  "docker.io/mongo@sha256:19b2e5c91f92c7b18113a1501c5a5fe52b71a6c6d2a5232eeebb4f2abacae04a",
   "docker.io/mysql/mysql-server@sha256:3d50c733cc42cbef715740ed7b4683a8226e61911e3a80c3ed8a30c2fbd78e9a",
   "docker.io/nginx@sha256:0f2ab24c6aba5d96fcf6e7a736333f26dca1acf5fa8def4c276f6efc7d56251f",
   "docker.io/nginx@sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad",


### PR DESCRIPTION
Summary: This PR adds the Mongo docker [image](https://hub.docker.com/layers/library/mongo/7.0.0/images/sha256-19b2e5c91f92c7b18113a1501c5a5fe52b71a6c6d2a5232eeebb4f2abacae04a?context=explore) to the image dependencies so that it can be mirrored to the various container registries for later use, specifically for the upcoming BPF test.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind test-infra

Test Plan: Used this image through docker.io with the upcoming Mongo BPF test