### PR TITLE
Clear the frame contents from the buffer in the case that we return k…

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse_test.cc
@@ -391,6 +391,7 @@ TEST_F(MongoDBParserTest, ParseFrameWhenUnsupportedType) {
   ParseState state = ParseFrame(message_type_t::kRequest, &frame_view, &frame, &state_order);
 
   EXPECT_EQ(state, ParseState::kIgnored);
+  EXPECT_EQ(frame_view.length(), 0);
 }
 
 TEST_F(MongoDBParserTest, ParseFrameInvalidFlagBits) {


### PR DESCRIPTION
Summary: This PR removes the frame's contents from the buffer in the case we return `kIgnored` when the frame is a type (opcode) we do not parse. When running the BPF test we noticed that the program would stall when the parser encountered a frame with an opcode it does not support. This was due to to the parser returning `kIgnored` to `ParseFramesLoop` and it not moving the buffer forward before calling `ParseFrame` again. This change will update the buffer position before returning `kIgnored` to `ParseFramesLoop` so that the remaining frames in the buffer can be parsed.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind bug

Test Plan: Modified the existing test checking for the unsupported opcode type.