### PR TITLE
Integrate the mongo stitcher with the upstream map stitching interface

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
@@ -97,6 +97,15 @@ size_t FindFrameBoundary<mongodb::Frame>(message_type_t, std::string_view, size_
   return std::string::npos;
 }
 
+template <>
+mongodb::stream_id_t GetStreamID(mongodb::Frame* frame) {
+  if (frame->response_to == 0) {
+    return frame->request_id;
+  }
+
+  return frame->response_to;
+}
+
 }  // namespace protocols
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
@@ -40,6 +40,9 @@ template <>
 size_t FindFrameBoundary<mongodb::Frame>(message_type_t type, std::string_view buf,
                                          size_t start_pos, NoState*);
 
+template <>
+mongodb::stream_id_t GetStreamID(mongodb::Frame* frame);
+
 }  // namespace protocols
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -178,6 +178,7 @@ struct ProtocolTraits : public BaseProtocolTraits<Record> {
   using record_type = Record;
   using state_type = StateWrapper;
   using key_type = stream_id_t;
+  static constexpr StreamSupport stream_support = BaseProtocolTraits<Record>::UseStream;
 };
 
 }  // namespace mongodb


### PR DESCRIPTION
Summary: This PR integrates the mongo stitcher with the new upstream stitching interface using a map of `streamID` and deque of frames.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind feature

Test Plan: Tested these changes with the upcoming BPF test.