### PR TITLE
Integrate mongo into the socket tracer pipeline

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -210,6 +210,9 @@ template void DataStream::ProcessBytesToFrames<protocols::nats::stream_id_t,
 template void DataStream::ProcessBytesToFrames<protocols::amqp::channel_id, protocols::amqp::Frame,
                                                protocols::NoState>(message_type_t type,
                                                                    protocols::NoState* state);
+template void
+DataStream::ProcessBytesToFrames<protocols::mongodb::Frame, protocols::mongodb::StateWrapper>(
+    message_type_t type, protocols::mongodb::StateWrapper* state);
 void DataStream::Reset() {
   data_buffer_.Reset();
   has_new_events_ = false;

--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -210,8 +210,8 @@ template void DataStream::ProcessBytesToFrames<protocols::nats::stream_id_t,
 template void DataStream::ProcessBytesToFrames<protocols::amqp::channel_id, protocols::amqp::Frame,
                                                protocols::NoState>(message_type_t type,
                                                                    protocols::NoState* state);
-template void
-DataStream::ProcessBytesToFrames<protocols::mongodb::Frame, protocols::mongodb::StateWrapper>(
+template void DataStream::ProcessBytesToFrames<
+    protocols::mongodb::stream_id_t, protocols::mongodb::Frame, protocols::mongodb::StateWrapper>(
     message_type_t type, protocols::mongodb::StateWrapper* state);
 void DataStream::Reset() {
   data_buffer_.Reset();

--- a/src/stirling/source_connectors/socket_tracer/mongodb_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mongodb_table.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <map>
+
+#include "src/stirling/core/output.h"
+#include "src/stirling/core/types.h"
+#include "src/stirling/source_connectors/socket_tracer/canonical_types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
+
+namespace px {
+namespace stirling {
+
+// clang-format off
+static constexpr DataElement kMongoDBElements[] = {
+        canonical_data_elements::kTime,
+        canonical_data_elements::kUPID,
+        canonical_data_elements::kRemoteAddr,
+        canonical_data_elements::kRemotePort,
+        canonical_data_elements::kTraceRole,
+        {"req_cmd", "MongoDB request command",
+         types::DataType::STRING,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL},
+        {"req_body", "MongoDB request body",
+         types::DataType::STRING,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL},
+        {"resp_status", "MongoDB response status",
+         types::DataType::STRING,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL},
+        {"resp_body", "MongoDB response body",
+         types::DataType::STRING,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL},
+         canonical_data_elements::kLatencyNS,
+#ifndef NDEBUG
+        canonical_data_elements::kPXInfo,
+#endif
+};
+// clang-format on
+
+static constexpr auto kMongoDBTable =
+    DataTableSchema("mongodb_events", "MongoDB request-response pair events", kMongoDBElements);
+DEFINE_PRINT_TABLE(MongoDB)
+
+constexpr int kMongoDBTimeIdx = kMongoDBTable.ColIndex("time_");
+constexpr int kMongoDBUPIDIdx = kMongoDBTable.ColIndex("upid");
+constexpr int kMongoDBReqCmdIdx = kMongoDBTable.ColIndex("req_cmd");
+constexpr int kMongoDBReqBodyIdx = kMongoDBTable.ColIndex("req_body");
+constexpr int kMongoDBRespStatusIdx = kMongoDBTable.ColIndex("resp_status");
+constexpr int kMongoDBRespBodyIdx = kMongoDBTable.ColIndex("resp_body");
+constexpr int kMongoDBLatencyIdx = kMongoDBTable.ColIndex("latency");
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/protocols/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/BUILD.bazel
@@ -40,6 +40,7 @@ pl_cc_library(
         "//src/stirling/source_connectors/socket_tracer/protocols/http:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/http2:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/kafka:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/protocols/mongodb:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/mux:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/mysql:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/nats:cc_library",

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
@@ -92,7 +92,8 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame
 }
 
 template <>
-size_t FindFrameBoundary<mongodb::Frame>(message_type_t, std::string_view, size_t, NoState*) {
+size_t FindFrameBoundary<mongodb::Frame>(message_type_t, std::string_view, size_t,
+                                         mongodb::StateWrapper*) {
   // Not implemented.
   return std::string::npos;
 }

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
@@ -38,7 +38,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame
 
 template <>
 size_t FindFrameBoundary<mongodb::Frame>(message_type_t type, std::string_view buf,
-                                         size_t start_pos, NoState*);
+                                         size_t start_pos, mongodb::StateWrapper* state);
 
 template <>
 mongodb::stream_id_t GetStreamID(mongodb::Frame* frame);

--- a/src/stirling/source_connectors/socket_tracer/protocols/stitchers.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/stitchers.h
@@ -25,6 +25,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/http2/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/kafka/stitcher.h"  // IWYU pragma: export
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/mux/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/mysql/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/nats/stitcher.h"  // IWYU pragma: export

--- a/src/stirling/source_connectors/socket_tracer/protocols/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/types.h
@@ -28,6 +28,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/http2/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/kafka/common/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mysql/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/nats/types.h"
@@ -51,7 +52,8 @@ using FrameDequeVariant = std::variant<std::monostate,
                                        absl::flat_hash_map<redis::stream_id_t, std::deque<redis::Message>>,
                                        absl::flat_hash_map<kafka::correlation_id_t, std::deque<kafka::Packet>>,
                                        absl::flat_hash_map<nats::stream_id_t, std::deque<nats::Message>>,
-                                       absl::flat_hash_map<amqp::channel_id, std::deque<amqp::Frame>>>;
+                                       absl::flat_hash_map<amqp::channel_id, std::deque<amqp::Frame>>,
+                                       absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>>;
 // clang-format off
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -112,7 +112,10 @@ DEFINE_int32(stirling_enable_mux_tracing,
 DEFINE_int32(stirling_enable_amqp_tracing,
              gflags::Int32FromEnv("PX_STIRLING_ENABLE_AMQP_TRACING", px::stirling::TraceMode::On),
              "If true, stirling will trace and process AMQP messages.");
-
+DEFINE_int32(stirling_enable_mongodb_tracing,
+             gflags::Int32FromEnv("PX_STIRLING_ENABLE_MONGODB_TRACING",
+                                  px::stirling::TraceMode::Off),
+             "If true, stirling will trace and process MongoDB messages");
 DEFINE_bool(stirling_disable_golang_tls_tracing,
             gflags::BoolFromEnv("PX_STIRLING_DISABLE_GOLANG_TLS_TRACING", false),
             "If true, stirling will not trace TLS traffic for Go applications. This implies "
@@ -262,11 +265,10 @@ void SocketTraceConnector::InitProtocolTransferSpecs() {
                                   kMuxTableNum,
                                   {kRoleClient, kRoleServer},
                                   TRANSFER_STREAM_PROTOCOL(mux)}},
-      // TODO(chengruizhe): Update Mongo after implementing protocol parsers.
-      {kProtocolMongo, TransferSpec{/* trace_mode */ px::stirling::TraceMode::Off,
-                                    /* table_num */ static_cast<uint32_t>(-1),
-                                    /* trace_roles */ {},
-                                    /* transfer_fn */ nullptr}},
+      {kProtocolMongo, TransferSpec{FLAGS_stirling_enable_mongodb_tracing,
+                                    kMongoDBTableNum,
+                                    {kRoleClient, kRoleServer},
+                                    TRANSFER_STREAM_PROTOCOL(mongodb)}},
       {kProtocolAMQP, TransferSpec{FLAGS_stirling_enable_amqp_tracing,
                                    kAMQPTableNum,
                                    {kRoleClient, kRoleServer},
@@ -442,7 +444,7 @@ Status SocketTraceConnector::InitBPF() {
       absl::StrCat("-DENABLE_REDIS_TRACING=", protocol_transfer_specs_[kProtocolRedis].enabled),
       absl::StrCat("-DENABLE_NATS_TRACING=", protocol_transfer_specs_[kProtocolNATS].enabled),
       absl::StrCat("-DENABLE_AMQP_TRACING=", protocol_transfer_specs_[kProtocolAMQP].enabled),
-      absl::StrCat("-DENABLE_MONGO_TRACING=", "true"),
+      absl::StrCat("-DENABLE_MONGO_TRACING=", protocol_transfer_specs_[kProtocolMongo].enabled),
   };
   PX_RETURN_IF_ERROR(bcc_->InitBPFProgram(socket_trace_bcc_script, defines));
 
@@ -1562,6 +1564,30 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("client_id")>(std::move(record.req.client_id), FLAGS_max_body_bytes);
   r.Append<r.ColIndex("req_body")>(std::move(record.req.msg), kMaxKafkaBodyBytes);
   r.Append<r.ColIndex("resp")>(std::move(record.resp.msg), kMaxKafkaBodyBytes);
+  r.Append<r.ColIndex("latency")>(
+      CalculateLatency(record.req.timestamp_ns, record.resp.timestamp_ns));
+#ifndef NDEBUG
+  r.Append<r.ColIndex("px_info_")>(PXInfoString(conn_tracker, record));
+#endif
+}
+
+template <>
+void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracker& conn_tracker,
+                                         protocols::mongodb::Record record, DataTable* data_table) {
+  md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
+                conn_tracker.conn_id().upid.start_time_ticks);
+
+  endpoint_role_t role = conn_tracker.role();
+  DataTable::RecordBuilder<&kMongoDBTable> r(data_table, record.resp.timestamp_ns);
+  r.Append<r.ColIndex("time_")>(record.req.timestamp_ns);
+  r.Append<r.ColIndex("upid")>(upid.value());
+  r.Append<r.ColIndex("remote_addr")>(conn_tracker.remote_endpoint().AddrStr());
+  r.Append<r.ColIndex("remote_port")>(conn_tracker.remote_endpoint().port());
+  r.Append<r.ColIndex("trace_role")>(role);
+  r.Append<r.ColIndex("req_cmd")>(std::move(record.req.op_msg_type));
+  r.Append<r.ColIndex("req_body")>(std::move(record.req.frame_body));
+  r.Append<r.ColIndex("resp_status")>(std::move(record.resp.op_msg_type));
+  r.Append<r.ColIndex("resp_body")>(std::move(record.resp.frame_body));
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(record.req.timestamp_ns, record.resp.timestamp_ns));
 #ifndef NDEBUG

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -114,7 +114,7 @@ DEFINE_int32(stirling_enable_amqp_tracing,
              "If true, stirling will trace and process AMQP messages.");
 DEFINE_int32(stirling_enable_mongodb_tracing,
              gflags::Int32FromEnv("PX_STIRLING_ENABLE_MONGODB_TRACING",
-                                  px::stirling::TraceMode::Off),
+                                  px::stirling::TraceMode::On),
              "If true, stirling will trace and process MongoDB messages");
 DEFINE_bool(stirling_disable_golang_tls_tracing,
             gflags::BoolFromEnv("PX_STIRLING_DISABLE_GOLANG_TLS_TRACING", false),
@@ -265,7 +265,7 @@ void SocketTraceConnector::InitProtocolTransferSpecs() {
                                   kMuxTableNum,
                                   {kRoleClient, kRoleServer},
                                   TRANSFER_STREAM_PROTOCOL(mux)}},
-      {kProtocolMongo, TransferSpec{FLAGS_stirling_enable_mongodb_tracing,
+      {kProtocolMongo, TransferSpec{px::stirling::TraceMode::Off,
                                     kMongoDBTableNum,
                                     {kRoleClient, kRoleServer},
                                     TRANSFER_STREAM_PROTOCOL(mongodb)}},

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -65,6 +65,7 @@ DECLARE_int32(stirling_enable_nats_tracing);
 DECLARE_int32(stirling_enable_kafka_tracing);
 DECLARE_int32(stirling_enable_mux_tracing);
 DECLARE_int32(stirling_enable_amqp_tracing);
+DECLARE_int32(stirling_enable_mongodb_tracing);
 DECLARE_bool(stirling_disable_self_tracing);
 DECLARE_string(stirling_role_to_trace);
 
@@ -95,7 +96,7 @@ class SocketTraceConnector : public BCCSourceConnector {
   static constexpr std::string_view kName = "socket_tracer";
   static constexpr auto kTables =
       MakeArray(kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable,
-                kRedisTable, kNATSTable, kKafkaTable, kMuxTable, kAMQPTable);
+                kRedisTable, kNATSTable, kKafkaTable, kMuxTable, kAMQPTable, kMongoDBTable);
 
   static constexpr uint32_t kConnStatsTableNum = TableNum(kTables, kConnStatsTable);
   static constexpr uint32_t kHTTPTableNum = TableNum(kTables, kHTTPTable);
@@ -108,6 +109,7 @@ class SocketTraceConnector : public BCCSourceConnector {
   static constexpr uint32_t kKafkaTableNum = TableNum(kTables, kKafkaTable);
   static constexpr uint32_t kMuxTableNum = TableNum(kTables, kMuxTable);
   static constexpr uint32_t kAMQPTableNum = TableNum(kTables, kAMQPTable);
+  static constexpr uint32_t kMongoDBTableNum = TableNum(kTables, kMongoDBTable);
 
   static constexpr auto kSamplingPeriod = std::chrono::milliseconds{200};
   // TODO(yzhao): This is not used right now. Eventually use this to control data push frequency.

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_tables.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_tables.h
@@ -26,6 +26,7 @@
 #include "src/stirling/source_connectors/socket_tracer/dns_table.h"
 #include "src/stirling/source_connectors/socket_tracer/http_table.h"
 #include "src/stirling/source_connectors/socket_tracer/kafka_table.h"
+#include "src/stirling/source_connectors/socket_tracer/mongodb_table.h"
 #include "src/stirling/source_connectors/socket_tracer/mux_table.h"
 #include "src/stirling/source_connectors/socket_tracer/mysql_table.h"
 #include "src/stirling/source_connectors/socket_tracer/nats_table.h"


### PR DESCRIPTION
Summary: This PR integrates the mongo protocol tracing functionality with the socket tracer pipeline. The trace mode is currently set to off and can be toggled later.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind feature

Test Plan: Tested these changes with the upcoming BPF test.