### PR TITLE
Don't fail GH action on empty XML test results

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -174,6 +174,7 @@ jobs:
         reporter: java-junit
         list-suites: all
         list-tests: failed
+        fail-on-empty: false
     - name: Buildbuddy URL
       if: always()
       run: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -170,7 +170,7 @@ jobs:
       if: always()
       with:
         name: testlogs-${{ matrix.name }} tests
-        path: 'bazel-testlogs/**/*.xml'
+        path: 'bazel-testlogs/**/test.xml'
         reporter: java-junit
         list-suites: all
         list-tests: failed


### PR DESCRIPTION
Summary: Our build and test avoidance sometimes runs no tests. This
is fine and we shouldn't fail the XML reporter in this scenario.

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Check the test reporter on a PR that triggers no tests.
