### PR TITLE
Add support to ignore MongoDB handshaking frames

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/decode.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/decode.cc
@@ -126,6 +126,13 @@ ParseState ProcessOpMsg(BinaryDecoder* decoder, Frame* frame) {
         if ((op_msg_type == insert || op_msg_type == delete_ || op_msg_type == update ||
              op_msg_type == find || op_msg_type == cursor)) {
           frame->op_msg_type = op_msg_type;
+
+        } else if (op_msg_type == kHello || op_msg_type == kIsMaster ||
+                   op_msg_type == kIsMasterAlternate) {
+          // The frame is a handshaking message.
+          frame->op_msg_type = op_msg_type;
+          frame->is_handshake = true;
+
         } else {
           // The frame is a response message, find the "ok" key and its value.
           auto itr = doc.FindMember("ok");

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/decode.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/decode.cc
@@ -123,8 +123,8 @@ ParseState ProcessOpMsg(BinaryDecoder* decoder, Frame* frame) {
         // The type of all request commands and the response to all find command requests
         // will always be the first key.
         auto op_msg_type = doc.MemberBegin()->name.GetString();
-        if ((op_msg_type == insert || op_msg_type == delete_ || op_msg_type == update ||
-             op_msg_type == find || op_msg_type == cursor)) {
+        if ((op_msg_type == kInsert || op_msg_type == kDelete || op_msg_type == kUpdate ||
+             op_msg_type == kFind || op_msg_type == kCursor)) {
           frame->op_msg_type = op_msg_type;
 
         } else if (op_msg_type == kHello || op_msg_type == kIsMaster ||

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -162,6 +162,12 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
       resp_frame.consumed = true;
       FlattenSections(&req_frame);
       FlattenSections(&resp_frame);
+
+      // Ignore stitching the request/response if either one is a handshaking frame.
+      if (req_frame.is_handshake || resp_frame.is_handshake) {
+        break;
+      }
+
       records.push_back({std::move(req_frame), std::move(resp_frame)});
       break;
     }

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -165,6 +165,8 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
 
       // Ignore stitching the request/response if either one is a handshaking frame.
       if (req_frame.is_handshake || resp_frame.is_handshake) {
+        req_frame.consumed = true;
+        resp_frame.consumed = true;
         break;
       }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -75,6 +75,11 @@ constexpr std::string_view find = "find";
 constexpr std::string_view cursor = "cursor";
 constexpr std::string_view ok = "ok";
 
+// Types of top level keys for handshaking messages
+constexpr std::string_view kHello = "hello";
+constexpr std::string_view kIsMaster = "isMaster";
+constexpr std::string_view kIsMasterAlternate = "ismaster";
+
 constexpr int32_t kMaxBSONObjSize = 16000000;
 
 /**
@@ -116,6 +121,9 @@ constexpr int32_t kMaxBSONObjSize = 16000000;
  * https://github.com/mongodb/specifications/blob/e09b41df206f9efaa36ba4c332c47d04ddb7d6d1/source/message/OP_MSG.rst#command-arguments-as-payload
  *
  * There can be 0 or more documents in a section of kind 1 without a separator between them.
+ *
+ * Information about MongoDB handshaking messages can be found here:
+ * https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst
  */
 
 struct Frame : public FrameBase {
@@ -135,6 +143,7 @@ struct Frame : public FrameBase {
   std::string op_msg_type;
   std::string frame_body;
   uint32_t checksum = 0;
+  bool is_handshake = false;
 
   bool consumed = false;
   size_t ByteSize() const override { return sizeof(Frame); }

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -68,12 +68,12 @@ enum class SectionKind : uint8_t {
 };
 
 // Types of OP_MSG requests/responses
-constexpr std::string_view insert = "insert";
-constexpr std::string_view delete_ = "delete";
-constexpr std::string_view update = "update";
-constexpr std::string_view find = "find";
-constexpr std::string_view cursor = "cursor";
-constexpr std::string_view ok = "ok";
+constexpr std::string_view kInsert = "insert";
+constexpr std::string_view kDelete = "delete";
+constexpr std::string_view kUpdate = "update";
+constexpr std::string_view kFind = "find";
+constexpr std::string_view kCursor = "cursor";
+constexpr std::string_view kOk = "ok";
 
 // Types of top level keys for handshaking messages
 constexpr std::string_view kHello = "hello";

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h
@@ -123,7 +123,7 @@ constexpr int32_t kMaxBSONObjSize = 16000000;
  * There can be 0 or more documents in a section of kind 1 without a separator between them.
  *
  * Information about MongoDB handshaking messages can be found here:
- * https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst
+ * https://github.com/mongodb/specifications/blob/022fbf64fb36c80b9295ba93acec150c94362767/source/mongodb-handshake/handshake.rst
  */
 
 struct Frame : public FrameBase {


### PR DESCRIPTION
Summary: When end to end testing MongoDB tracing, the parser encountered `OP_MSG` handshaking frames and was not able to parse them. This was due to the old parser searching for a CRUD command in the `OP_MSG` frame's top level key in the payload and `OP_MSG` handshaking frames not containing a key the old parser could interpret.

This PR adds support to parse top level handshaking keys and discards those frames at stitching time. It also correctly prefixes `const` variables in the `types.h` file.

The motivation to parse these frames instead of immediately ignoring them at parsing time is to account for the different possibilities of responses for a handshaking request. A handshaking request could lead to a `more_to_come` response where each frame in the `more_to_come` response may not be identifiable as a handshaking frame. It's also possible that the response of a handshaking request may contain an `ok` key which can be misidentified as a non handshaking response and left stale in the map of response deques. Identifying all of the handshaking request/response frames at stitching time but not inserting it to the records would ensure that all handshaking frames are cleared from the map and not pushed to the data table.

Related issues: https://github.com/pixie-io/pixie/issues/640

Type of change: /kind bug

Test Plan: Added a stitcher test