### PR TITLE
Relax a the overflow `DCHECK` in `perf_profile_connector.cc`.

### DIFF
--- a/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
+++ b/src/stirling/source_connectors/perf_profiler/perf_profile_connector.cc
@@ -368,7 +368,13 @@ void PerfProfileConnector::CheckProfilerState(const uint64_t num_stack_traces) {
   const uint64_t error_code =
       profiler_state_->GetValue(kErrorStatusIdx).ValueOr(kPerfProfilerStatusOk);
 
-  DCHECK_EQ(error_code, kPerfProfilerStatusOk);
+  // The overflow error is expected during pem startup, i.e. while other source connectors are
+  // being brough up. During pem startup, the profiler transfer data method is starved and so
+  // we do expect a few overflow count errors.
+  constexpr int64_t max_overflow_error_count = 10;
+  constexpr int64_t max_map_read_error_count = 0;
+  DCHECK_LE(profiler_state_overflow_counter_.Value(), max_overflow_error_count);
+  DCHECK_LE(profiler_state_map_read_error_counter_.Value(), max_map_read_error_count);
 
   switch (error_code) {
     case kOverflowError: {


### PR DESCRIPTION
Summary: during `pem` startup, the transfer data method for various source connectors can get starved i.e. not called at the correct periodicity. This will cause the overflow `DCHECK` in the perf profiler to fire. In this PR, we relax that condition.

Relevant Issues: #1683 

Type of change: /kind bug fix

Test Plan: Existing tests.