### PR TITLE
Clear stale test output xml

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -146,6 +146,9 @@ jobs:
       with:
         dev: ${{ github.event_name == 'push' && 'false' || 'true' }}
         BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
+    - name: Clear stale test.xml
+      shell: bash
+      run: rm -rf "$(bazel info ${{ matrix.args }} bazel-testlogs --noshow_progress 2>/dev/null)"
     - name: Build ${{ matrix.name }}
       shell: bash
       # yamllint disable rule:indentation


### PR DESCRIPTION
Summary: The XML testlogs aren't always cleaned between runs.
This ensures that we don't fail due to stale test output.

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Check github actions runs on this PR.
