### PR TITLE
[Parse incomplete chunks 1/9] Raise kFileSizeLimit for dbg builds in stirling wrapper size test

### DIFF
--- a/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
+++ b/src/stirling/e2e_tests/stirling_wrapper_size_test.cc
@@ -30,7 +30,7 @@ namespace stirling {
 #ifdef __OPTIMIZE__
 constexpr uint64_t kFileSizeLimitMB = 118;
 #else
-constexpr uint64_t kFileSizeLimitMB = 300;
+constexpr uint64_t kFileSizeLimitMB = 305;
 #endif
 
 TEST(StirlingWrapperSizeTest, ExecutableSizeLimit) {


### PR DESCRIPTION
Summary: Raises the stirling size limit for `dbg` builds by 5 MiB (to
305 MiB) to accommodate upcoming changes and additions related to tracking gaps from bpf and lazily parsing incomplete chunks in the data stream buffer.

Type of change: /kind cleanup

Test Plan: Existing targets