### PR TITLE
[Parse incomplete chunks 3/9] Add `ChunkInfo` metadata to DS buffer to record (un)filled gap locations

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -47,11 +47,14 @@ namespace px {
 namespace stirling {
 
 void DataStream::AddData(std::unique_ptr<SocketDataEvent> event) {
+  // Note that msg.size() includes filler \0 bytes under certain circumstances. See socket_trace.hpp
+  // for details.
   LOG_IF(WARNING, event->attr.msg_size > event->msg.size() && !event->msg.empty())
       << absl::Substitute("Message truncated, original size: $0, transferred size: $1",
                           event->attr.msg_size, event->msg.size());
 
-  data_buffer_.Add(event->attr.pos, event->msg, event->attr.timestamp_ns);
+  data_buffer_.Add(event->attr.pos, event->msg, event->attr.timestamp_ns,
+                   event->attr.incomplete_chunk, event->attr.bytes_missed);
 
   has_new_events_ = true;
 }

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/data_stream_buffer.h
@@ -23,8 +23,10 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "src/common/base/base.h"
+#include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.hpp"
 
 DECLARE_bool(stirling_data_stream_buffer_always_contiguous_buffer);
 
@@ -32,13 +34,146 @@ namespace px {
 namespace stirling {
 namespace protocols {
 
+// IncompleteChunkInfo keeps track of the chunks we know to be incomplete from bpf for the
+// DataStreamBuffer. This metadata is updated during merging of contiguous events in Add(). If gaps
+// are present, we should tell the event parser to treat this data as incomplete and lazily parse as
+// many bytes as possible. Each contiguous section (without filler) will have at most one incomplete
+// chunk that ends with a gap, containing n >= 0 valid frames and at most one partial frame. For
+// example:
+//
+//      event   event   incomplete_event
+//        v       v       v
+//  _______________________________________
+// |      |       |       |       |       |
+// |      |       |       |       |       |
+// |      |       |       |       |       |
+// |      |       |       |       |       |
+// |      |       |       |       |  gap  |
+// |      |       |       |       |       |
+// |      |       |       |       |       |
+// |      |       |       |       |       |
+// |______|_______|_______|_______|_______|
+//     n valid frames     ^ n valid frames and at most 1 partial frame in this chunk before the gap
+//
+// Chunks grow when adjacent events are merged, so we keep track of the start position of the event
+// for which we know there is an upcoming gap. The gap start in these cases is the end of head_.
+//
+// ------- Chained Incomplete Chunks -------
+// We currently add filler \0 bytes to the end of incomplete events (up to 1MB), so it is possible
+// that a filler event will bridge the gap between two incomplete events.
+//
+// incomplete_event     incomplete_event     event
+// v                    v                     v
+// ____________________________________________________
+// |         |          |          |          |       |
+// |         |          |          |          |       |
+// |         |          |          |          |       |
+// |         |    gap   |          |    gap   |       |
+// |         |  filled  |          |  filled  |       |
+// |         |   with   |          |   with   |       |
+// |         |    \0    |          |    \0    |       |
+// |         |          |          |          |       |
+// |_________|__________|__________|__________|_______|
+// ^                    ^                     ^ n valid frames
+//  n valid frames and at most
+//  1 partial frame in each incomplete chunk before the filled gaps.
+
+// Because of this, we may have any number of incomplete events joined together by filler in
+// a contiguous section of the buffer. If the filler event fails to plug the entire gap
+// (i.e. the gap is larger than 1MB), then we end up with an actual gap.
+struct IncompleteChunkInfo {
+  // What is the reason for the gap (should not be kFullyFormed)
+  chunk_t incomplete_chunk;  // todo: rename to reason, also rename event->incomplete_chunk to
+                             // chunk_type
+
+  // Where does the event start for which we know there is an upcoming gap
+  size_t incomplete_event_start;
+
+  // How large is the gap (whether filled or not)
+  size_t gap_size;
+
+  // Where does the gap start (should be the end of the contiguous section if unfilled)
+  size_t gap_start;
+
+  // If the gap is filled, where does the gap end
+  // TODO(@benkilimnik): consider making this gap_start + gap_size instead of std::optional
+  std::optional<size_t> gap_end = std::nullopt;
+
+  // Was this gap plugged by filler \0 bytes
+  bool gap_filled;
+
+  // Bytes rendered unparseable because they were cut off by the gap (filled or not)
+  size_t unparseable_bytes_before_gap = 0;
+
+  void MarkGapAsFilled(size_t filler_start, size_t filler_end) {
+    DCHECK(filler_start == gap_start);
+    gap_filled = true;
+    this->gap_end = filler_end;
+  }
+
+  IncompleteChunkInfo(chunk_t inc, size_t inc_event_start, size_t gap_size, size_t gap_start,
+                      bool gap_filled = false)
+      : incomplete_chunk(inc),
+        incomplete_event_start(inc_event_start),
+        gap_size(gap_size),
+        gap_start(gap_start),
+        gap_filled(gap_filled) {
+    DCHECK(inc != chunk_t::kFullyFormed);
+  }
+
+  ~IncompleteChunkInfo() {
+    LOG(WARNING) << absl::Substitute(
+        "IncompleteChunkInfo destructor called for incomplete chunk of type $0, gap located at "
+        "[$1, $2] with $3 bytes of unparseable data before the gap",
+        incomplete_chunk, gap_start, gap_start + gap_size, unparseable_bytes_before_gap);
+  }
+};
+struct ChunkInfo {
+  size_t size;
+  // A contiguous section of the buffer may have multiple incomplete chunks joined together by
+  // filler.
+  // TODO(benkilimnik): eventually, we should replace filler events with lazy parsing for all
+  // protocols. At that point, we can remove the vector below because we will only have one
+  // incomplete chunk per contiguous section.
+  std::vector<IncompleteChunkInfo> incomplete_chunks = {};
+
+  void AddIncompleteChunkInfo(IncompleteChunkInfo inc) { incomplete_chunks.emplace_back(inc); }
+
+  // Rightmost in the buffer
+  IncompleteChunkInfo& MostRecentIncompleteChunkInfo() {
+    DCHECK(!incomplete_chunks.empty());
+    return incomplete_chunks.back();
+  }
+
+  // Leftmost in the buffer
+  IncompleteChunkInfo& OldestIncompleteChunkInfo() {
+    DCHECK(!incomplete_chunks.empty());
+    return incomplete_chunks.front();
+  }
+
+  // Sum of all gaps/filler in this contiguous chunk
+  size_t TotalGapSize() const {
+    size_t total_gap_size = 0;
+    for (const auto& inc : incomplete_chunks) {
+      total_gap_size += inc.gap_size;
+    }
+    return total_gap_size;
+  }
+
+  bool HasIncompleteChunks() const { return !incomplete_chunks.empty(); }
+
+  explicit ChunkInfo(size_t sz = 0) : size(sz) {}
+};
+
 // TODO(james): switch back to concrete DataStreamBuffer (or standard abstract class) once we've
 // settled on a DataStreamBuffer implementation.
 class DataStreamBufferImpl {
  public:
   virtual ~DataStreamBufferImpl() = default;
-  virtual void Add(size_t pos, std::string_view data, uint64_t timestamp) = 0;
+  virtual void Add(size_t pos, std::string_view data, uint64_t timestamp,
+                   chunk_t incomplete_chunk = chunk_t::kFullyFormed, size_t gap_size = 0) = 0;
   virtual std::string_view Head() = 0;
+  virtual ChunkInfo GetChunkInfoForHead() = 0;
   virtual StatusOr<uint64_t> GetTimestamp(size_t pos) const = 0;
   virtual void RemovePrefix(ssize_t n) = 0;
   virtual void Trim() = 0;
@@ -80,8 +215,9 @@ class DataStreamBuffer {
    * @param data The data to insert.
    * @param timestamp Timestamp to associate with the data.
    */
-  void Add(size_t pos, std::string_view data, uint64_t timestamp) {
-    impl_->Add(pos, data, timestamp);
+  void Add(size_t pos, std::string_view data, uint64_t timestamp,
+           chunk_t incomplete_chunk = chunk_t::kFullyFormed, size_t gap_size = 0) {
+    impl_->Add(pos, data, timestamp, incomplete_chunk, gap_size);
   }
 
   /**
@@ -89,6 +225,12 @@ class DataStreamBuffer {
    * @return A string_view to the data.
    */
   std::string_view Head() { return impl_->Head(); }
+
+  /**
+   * Get the chunk info for the head of the buffer.
+   * @return The chunk info.
+   */
+  ChunkInfo GetChunkInfoForHead() { return impl_->GetChunkInfoForHead(); }
 
   /**
    * Get timestamp recorded for the data at the specified position.

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/lazy_contiguous_data_stream_buffer_impl.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/lazy_contiguous_data_stream_buffer_impl.cc
@@ -60,8 +60,12 @@ uint8_t* FixedSizeContiguousBuffer::Data() {
 size_t FixedSizeContiguousBuffer::Size() const { return capacity_ - offset_; }
 size_t FixedSizeContiguousBuffer::Capacity() const { return capacity_; }
 
-void LazyContiguousDataStreamBufferImpl::Add(size_t pos, std::string_view data,
-                                             uint64_t timestamp) {
+// TODO(@benkilimnik): If we switch to using the lazy contiguous buffer implementation,
+// implement the gap metadata.
+ChunkInfo LazyContiguousDataStreamBufferImpl::GetChunkInfoForHead() { return ChunkInfo(); }
+
+void LazyContiguousDataStreamBufferImpl::Add(size_t pos, std::string_view data, uint64_t timestamp,
+                                             chunk_t /*incomplete_chunk*/, size_t /*gap_size*/) {
   if (data.size() == 0) {
     // Ignore empty events.
     return;

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/lazy_contiguous_data_stream_buffer_impl.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/lazy_contiguous_data_stream_buffer_impl.h
@@ -68,7 +68,10 @@ class LazyContiguousDataStreamBufferImpl : public DataStreamBufferImpl {
   explicit LazyContiguousDataStreamBufferImpl(size_t max_capacity)
       : LazyContiguousDataStreamBufferImpl(max_capacity, 0, 0) {}
 
-  void Add(size_t pos, std::string_view data, uint64_t timestamp) override;
+  void Add(size_t pos, std::string_view data, uint64_t timestamp,
+           chunk_t incomplete_chunk = chunk_t::kFullyFormed, size_t gap_size = 0) override;
+
+  ChunkInfo GetChunkInfoForHead() override;
 
   std::string_view Head() override;
 


### PR DESCRIPTION
Summary: Adds metadata to the `always_contiguous_data_stream_buffer` to keep track of gap and filler locations. This forms the basis of tracking the number of bytes rendered unparseable due to the presence of a gap (i.e. the bytes cut off before the gap). It is also used to lazily parse as far as possible up to the gap in a future PR.

A `TODO` is added to the `lazy_contiguous` implementation in case we switch to that at some point in the future.

Type of change: /kind feature

Test Plan: Test cases added to `data_stream_buffer_test.cc`