### PR TITLE
[Parse incomplete chunks 4/9] Add HTTP lazy parsing

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.cc
@@ -127,7 +127,7 @@ size_t FindFrameBoundary<amqp::Frame>(message_type_t /*type*/, std::string_view 
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, amqp::Frame* msg,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   return amqp::ParseFrame(type, buf, msg);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/amqp/parse.h
@@ -29,14 +29,15 @@ namespace px {
 namespace stirling {
 namespace protocols {
 namespace amqp {
-ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* result, NoState* state);
+ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* result, NoState* state,
+                      bool lazy_parsing_enabled);
 
 size_t FindFrameBoundary(std::string_view buf, size_t start);
 }  // namespace amqp
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, amqp::Frame* packet,
-                      NoState* state);
+                      NoState* state, bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<amqp::Frame>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/event_parser_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/event_parser_test.cc
@@ -48,7 +48,7 @@ struct TestFrame : public FrameBase {
 
 template <>
 ParseState ParseFrame(message_type_t /* type */, std::string_view* buf, TestFrame* frame,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   size_t pos = buf->find(",");
   if (pos == buf->npos) {
     return ParseState::kNeedsMoreData;

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/interface.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/interface.h
@@ -110,7 +110,7 @@ size_t FindFrameBoundary(message_type_t type, std::string_view buf, size_t start
  */
 template <typename TFrameType, typename TStateType = NoState>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, TFrameType* frame,
-                      TStateType* state = nullptr);
+                      TStateType* state = nullptr, bool lazy_parsing_enabled = false);
 
 /**
  * Returns the stream ID of the given frame.

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/parse.cc
@@ -85,7 +85,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* result)
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, cass::Frame* result,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   return cass::ParseFrame(type, buf, result);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/parse.h
@@ -34,7 +34,7 @@ namespace protocols {
  */
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, cass::Frame* frame,
-                      NoState* state);
+                      NoState* state, bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<cass::Frame>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/dns/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/dns/parse.cc
@@ -87,7 +87,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* result)
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, dns::Frame* result,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   return dns::ParseFrame(type, buf, result);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/dns/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/dns/parse.h
@@ -33,8 +33,8 @@ namespace protocols {
  * Parses the input string as a DNS protocol frame.
  */
 template <>
-ParseState ParseFrame(message_type_t type, std::string_view* buf, dns::Frame* frame,
-                      NoState* state);
+ParseState ParseFrame(message_type_t type, std::string_view* buf, dns::Frame* frame, NoState* state,
+                      bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<dns::Frame>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/body_decoder.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/body_decoder.h
@@ -20,6 +20,7 @@
 
 #include <string>
 
+#include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
 #include "src/stirling/utils/parse_state.h"
 
 // Choose either the pico or custom implementation of the chunked HTTP body decoder.
@@ -41,7 +42,7 @@ namespace http {
  *         ParseState::kSuccess if the chunk length was extracted and chunk header is well-formed.
  */
 ParseState ParseChunked(std::string_view* buf, size_t body_size_limit_bytes, std::string* result,
-                        size_t* body_size);
+                        size_t* body_size, bool lazy_parsing_enabled = false);
 
 /**
  * Parse an HTTP body based on Content-Length.
@@ -55,7 +56,8 @@ ParseState ParseChunked(std::string_view* buf, size_t body_size_limit_bytes, std
  *         ParseState::kSuccess if the entire body is present and well-formed.
  */
 ParseState ParseContent(std::string_view content_len_str, std::string_view* data,
-                        size_t body_size_limit_bytes, std::string* result, size_t* body_size);
+                        size_t body_size_limit_bytes, std::string* result, size_t* body_size,
+                        bool lazy_parsing_enabled = false);
 
 }  // namespace http
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/parse.h
@@ -32,10 +32,18 @@ namespace protocols {
 
 /**
  * Parses a single HTTP message from the input string.
+ * A note on the lazy_parsing_enabled flag:
+ * It signals to the http protocol parser to parse lazily.
+ * Currently only used when we know that a contiguous section of the data stream buffer
+ * (the head passed to the parser) ends with a gap due to an incomplete event from bpf.
+ * Note that the http parser consumes bytes from the input buffer when parsing a partial frame
+ * even if it is not pushed in the event parser. To preserve the behavior of kNeedsMoreData
+ * for non-incomplete heads where we expect more data to arrive, we implement this flag in
+ * conjunction with tracking whether a head contains a gap.
  */
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, http::Message* frame,
-                      http::StateWrapper* state);
+                      http::StateWrapper* state, bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<http::Message>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.cc
@@ -162,7 +162,8 @@ template <>
 ParseState ParseFrame<kafka::Packet, kafka::StateWrapper>(message_type_t type,
                                                           std::string_view* buf,
                                                           kafka::Packet* packet,
-                                                          kafka::StateWrapper* state) {
+                                                          kafka::StateWrapper* state,
+                                                          bool /*lazy_parsing_enabled*/) {
   return kafka::ParseFrame(type, buf, packet, &state->global);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/kafka/parse.h
@@ -36,7 +36,7 @@ size_t FindFrameBoundary(message_type_t type, std::string_view buf, size_t start
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, kafka::Packet* packet,
-                      kafka::StateWrapper* state);
+                      kafka::StateWrapper* state, bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<kafka::Packet>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.cc
@@ -87,7 +87,7 @@ ParseState ParseFrame(message_type_t type, std::string_view* buf, Frame* frame, 
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame* frame,
-                      mongodb::StateWrapper* state) {
+                      mongodb::StateWrapper* state, bool /*lazy_parsing_enabled*/) {
   return mongodb::ParseFrame(type, buf, frame, &state->global);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/parse.h
@@ -34,7 +34,7 @@ ParseState ParseFrame(BinaryDecoder* decoder, Frame* frame, State* state);
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, mongodb::Frame* frame,
-                      mongodb::StateWrapper* state);
+                      mongodb::StateWrapper* state, bool /*lazy_parsing_enabled*/);
 
 template <>
 size_t FindFrameBoundary<mongodb::Frame>(message_type_t type, std::string_view buf,

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.cc
@@ -114,7 +114,8 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
 }  // namespace mux
 
 template <>
-ParseState ParseFrame(message_type_t, std::string_view* buf, mux::Frame* frame, NoState*) {
+ParseState ParseFrame(message_type_t, std::string_view* buf, mux::Frame* frame, NoState*,
+                      bool /*lazy_parsing_enabled*/) {
   BinaryDecoder decoder(*buf);
 
   PX_ASSIGN_OR(frame->length, decoder.ExtractBEInt<int32_t>(), return ParseState::kInvalid);

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/parse.h
@@ -33,7 +33,8 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame);
 }
 
 template <>
-ParseState ParseFrame(message_type_t type, std::string_view* buf, mux::Frame* frame, NoState*);
+ParseState ParseFrame(message_type_t type, std::string_view* buf, mux::Frame* frame, NoState*,
+                      bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<mux::Frame>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/mysql/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mysql/parse.cc
@@ -118,7 +118,7 @@ size_t FindFrameBoundary(message_type_t type, std::string_view buf, size_t start
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, mysql::Packet* result,
-                      mysql::StateWrapper* /*state*/) {
+                      mysql::StateWrapper* /*state*/, bool /*lazy_parsing_enabled*/) {
   return mysql::ParseFrame(type, buf, result);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/mysql/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mysql/parse.h
@@ -34,7 +34,7 @@ namespace protocols {
  */
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, mysql::Packet* frame,
-                      mysql::StateWrapper* state);
+                      mysql::StateWrapper* state, bool lazy_parsing_enabled);
 
 template <>
 size_t FindFrameBoundary<mysql::Packet>(message_type_t type, std::string_view buf, size_t start_pos,

--- a/src/stirling/source_connectors/socket_tracer/protocols/nats/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/nats/parse.cc
@@ -227,7 +227,7 @@ size_t FindFrameBoundary<nats::Message>(message_type_t /*type*/, std::string_vie
 
 template <>
 ParseState ParseFrame(message_type_t /*type*/, std::string_view* buf, nats::Message* msg,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   return TranslateStatus(nats::ParseMessage(buf, msg));
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/nats/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/nats/parse.h
@@ -33,7 +33,7 @@ size_t FindFrameBoundary<nats::Message>(message_type_t /*type*/, std::string_vie
 
 template <>
 ParseState ParseFrame(message_type_t /*type*/, std::string_view* buf, nats::Message* msg,
-                      NoState* /*state*/);
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/);
 
 }  // namespace protocols
 }  // namespace stirling

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/parse.cc
@@ -311,7 +311,7 @@ Status ParseDesc(const RegularMessage& msg, Desc* desc) {
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, pgsql::RegularMessage* frame,
-                      pgsql::StateWrapper* /*state*/) {
+                      pgsql::StateWrapper* /*state*/, bool /*lazy_parsing_enabled*/) {
   PX_UNUSED(type);
 
   std::string_view buf_copy = *buf;

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/parse.h
@@ -53,7 +53,7 @@ size_t FindFrameBoundary(std::string_view buf, size_t start);
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, pgsql::RegularMessage* frame,
-                      pgsql::StateWrapper* /*state*/);
+                      pgsql::StateWrapper* /*state*/, bool /*lazy_parsing_enabled*/);
 
 template <>
 size_t FindFrameBoundary<pgsql::RegularMessage>(message_type_t type, std::string_view buf,

--- a/src/stirling/source_connectors/socket_tracer/protocols/redis/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/redis/parse.cc
@@ -218,7 +218,7 @@ size_t FindFrameBoundary<redis::Message>(message_type_t /*type*/, std::string_vi
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, redis::Message* msg,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   return redis::ParseMessage(type, buf, msg);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/redis/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/redis/parse.h
@@ -33,7 +33,7 @@ size_t FindFrameBoundary<redis::Message>(message_type_t /*type*/, std::string_vi
 
 template <>
 ParseState ParseFrame(message_type_t type, std::string_view* buf, redis::Message* msg,
-                      NoState* /*state*/);
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/);
 
 }  // namespace protocols
 }  // namespace stirling

--- a/src/stirling/utils/parse_state.h
+++ b/src/stirling/utils/parse_state.h
@@ -37,6 +37,10 @@ enum class ParseState {
   // Input buffer may be partially consumed and the parsed output element is not fully populated.
   kNeedsMoreData,
 
+  // Header/Metadata parsing succeeded, but the payload is partial.
+  // We have enough for stitching.
+  kMetadataComplete,
+
   // The parse succeeded, but the data is ignored.
   // Input buffer is consumed, but the parsed output element is invalid.
   kIgnored,


### PR DESCRIPTION
Summary: Instead of relying on filler events with large null byte allocations, we should parse as far as possible up to the gap for incomplete events. Such lazy parsing lets us capture partial frames if we know from bpf that a gap is coming.

This PR modifies the HTTP protocol parser to support lazy parsing. This behavior is controlled by a flag, which is disabled by default (hence these changes should be a no-op). The following PRs integrate this into the event parser and add a feature flag.

To avoid masking unrelated errors, we push a partial frame only if we know there is a gap coming. In those cases, the parser returns a new `ParseState` `kMetadataComplete` indicating that we successfully parsed the minimum amount of information needed to successfully stitch a frame.

Type of change: /kind feature

Test Plan: Added unittests to `http/body_decoder_test.cc`. `http/parse_test.cc` is updated in a following PR where lazy parsing is integrated in the event parser.

Additional Context: #1755