### PR TITLE
[Parse incomplete chunks 5/9] Add feature flag for lazy parsing, integrate into event parser

### DIFF
--- a/src/cloud/config_manager/controllers/vizier_feature_flags.go
+++ b/src/cloud/config_manager/controllers/vizier_feature_flags.go
@@ -52,6 +52,11 @@ var availableFeatureFlags = []*featureFlag{
 		VizierFlagName:  "PX_DEBUG_TLS_SOURCES",
 		DefaultValue:    false,
 	},
+	{
+		FeatureFlagName: "lazy-parsing",
+		VizierFlagName:  "PX_LAZY_PARSING",
+		DefaultValue:    false,
+	},
 }
 
 // NewVizierFeatureFlagClient creates a LaunchDarkly feature flag client if the SDK key is provided,

--- a/src/stirling/source_connectors/socket_tracer/common.h
+++ b/src/stirling/source_connectors/socket_tracer/common.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <unordered_set>
+#include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h"
+
+DECLARE_bool(stirling_enable_lazy_parsing);
+
+namespace px {
+
+namespace stirling {
+
+// Define the set of protocols which currently support lazy parsing
+const std::unordered_set<traffic_protocol_t> kLazyParsingProtocols = {
+    kProtocolHTTP,
+    // kProtocolHTTP2,
+    // kProtocolCQL,
+    // kProtocolMySQL,
+    // kProtocolPGSQL,
+    // kProtocolDNS,
+    // kProtocolRedis,
+    // kProtocolNATS,
+    // kProtocolKafka,
+    // kProtocolMux,
+    // kProtocolMongo,
+    // kProtocolAMQP,
+};
+
+/**
+ * Check if lazy parsing is enabled and supported for the given protocol.
+ * @param protocol The protocol to check
+ *
+ * @return true if lazy parsing is enabled and supported for the given protocol.
+ */
+inline bool LazyParsingEnabled(traffic_protocol_t protocol) {
+  return FLAGS_stirling_enable_lazy_parsing &&
+         (kLazyParsingProtocols.find(protocol) != kLazyParsingProtocols.end());
+}
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
@@ -522,8 +522,9 @@ bool ConnTracker::SetProtocol(traffic_protocol_t protocol, std::string_view reas
   CONN_TRACE(2) << absl::Substitute("Protocol changed: $0->$1, reason=[$2]",
                                     magic_enum::enum_name(old_protocol),
                                     magic_enum::enum_name(protocol), reason);
-  send_data_.set_protocol(protocol);
-  recv_data_.set_protocol(protocol);
+  bool lazy_parsing_enabled = LazyParsingEnabled(protocol);
+  send_data_.set_protocol(protocol, lazy_parsing_enabled);
+  recv_data_.set_protocol(protocol, lazy_parsing_enabled);
   return true;
 }
 

--- a/src/stirling/source_connectors/socket_tracer/data_stream.h
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.h
@@ -227,7 +227,10 @@ class DataStream : NotCopyMoveable {
     }
   }
 
-  void set_protocol(traffic_protocol_t protocol) { protocol_ = protocol; }
+  void set_protocol(traffic_protocol_t protocol, bool lazy_parsing_enabled = false) {
+    protocol_ = protocol;
+    lazy_parsing_enabled_ = lazy_parsing_enabled;
+  }
 
   /**
    * Cleanup frames that are parsed from the BPF events, when the condition is right.
@@ -340,6 +343,7 @@ class DataStream : NotCopyMoveable {
   size_t last_processed_pos_ = 0;
   // Keep track of the protocol for this DataStream so that data loss can be reported per protocol.
   traffic_protocol_t protocol_ = traffic_protocol_t::kProtocolUnknown;
+  bool lazy_parsing_enabled_ = false;
 
   template <typename TKey, typename TFrameType>
   friend std::string DebugString(const DataStream& d, std::string_view prefix);

--- a/src/stirling/source_connectors/socket_tracer/protocols/common/event_parser_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/common/event_parser_test.cc
@@ -48,7 +48,7 @@ struct TestFrame : public FrameBase {
 
 template <>
 ParseState ParseFrame(message_type_t /* type */, std::string_view* buf, TestFrame* frame,
-                      NoState* /*state*/) {
+                      NoState* /*state*/, bool /*lazy_parsing_enabled*/) {
   size_t pos = buf->find(",");
   if (pos == buf->npos) {
     return ParseState::kNeedsMoreData;


### PR DESCRIPTION
Summary: Adds vizier feature flag for lazy parsing (off by default) which enables lazy parsing and disables adding filler events to incomplete chunks for supported protocols. Currently only HTTP lazy parsing is supported. Also updates the HTTP `parse_test`.

Type of change: /kind feature

Test Plan: Tested E2E + unittests added in next PR.