### PR TITLE
[Parse incomplete chunks 7/9] Add prometheus metric for gap sizes and reasons

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -242,6 +242,7 @@ class SocketTraceConnector : public BCCSourceConnector {
       openssl_trace_state_debug_;
   prometheus::Family<prometheus::Counter>& openssl_trace_mismatched_fds_counter_family_;
   prometheus::Family<prometheus::Counter>& openssl_trace_tls_source_counter_family_;
+  prometheus::Family<prometheus::Counter>& incomplete_chunk_counter_family_;
 
   absl::flat_hash_set<int> pids_to_trace_disable_;
 


### PR DESCRIPTION
Summary: Adds prometheus counter to record the bytes lost due to gaps from bpf and the reason for the gap on a per protocol basis.

Type of change: /kind feature

Test Plan: Existing targets + tested in bpf test triggering a gap condition in # + tested that metrics show up in bigQuery.