### PR TITLE
[Parse incomplete chunks 8/9] Add prometheus metrics for bytes rendered unparseable before gap

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/metrics.h
+++ b/src/stirling/source_connectors/socket_tracer/metrics.h
@@ -23,20 +23,26 @@
 
 #include "src/common/metrics/metrics.h"
 #include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h"
+#include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.h"
 
 namespace px {
 namespace stirling {
 
 struct SocketTracerMetrics {
   SocketTracerMetrics(prometheus::Registry* registry, traffic_protocol_t protocol,
-                      ssl_source_t tls_source);
+                      ssl_source_t tls_source, chunk_t chunk_type, bool lazy_parsing_enabled);
   prometheus::Counter& data_loss_bytes;
   prometheus::Counter& conn_stats_bytes;
+  prometheus::Counter& unparseable_bytes_before_gap;
 
   static SocketTracerMetrics& GetProtocolMetrics(traffic_protocol_t protocol,
-                                                 ssl_source_t tls_source);
+                                                 ssl_source_t tls_source,
+                                                 chunk_t chunk_type = chunk_t::kFullyFormed,
+                                                 bool lazy_parsing_enabled = false);
 
-  static void TestOnlyResetProtocolMetrics(traffic_protocol_t protocol, ssl_source_t tls_source);
+  static void TestOnlyResetProtocolMetrics(traffic_protocol_t protocol, ssl_source_t tls_source,
+                                           chunk_t chunk_type = chunk_t::kFullyFormed,
+                                           bool lazy_parsing_enabled = false);
 };
 
 }  // namespace stirling


### PR DESCRIPTION
Summary: Adds metric to keep track of the number of bytes rendered unparseable due to the presence of a gap (i.e. the bytes we discard because we can't process the incomplete chunk). This is used in a future PR to lazily parse up until the gap only if we know there is a gap coming (to avoid masking unrelated errors).

Type of change: /kind feature

Test Plan: Tested that metrics work in a bpf test introduced in # and that they show up in BigQuery.