### PR TITLE
[Parse incomplete chunks 9/9] Add bpf test for loop limit exceeded

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -475,6 +475,27 @@ pl_cc_bpf_test(
 )
 
 pl_cc_bpf_test(
+    name = "nodejs_trace_bpf_test",
+    timeout = "long",
+    srcs = ["nodejs_trace_bpf_test.cc"],
+    flaky = True,
+    shard_count = 2,
+    tags = [
+        "cpu:16",
+        "no_asan",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/common/testing/test_utils:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:acorn_node14_container",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:curl_container",
+        "//src/stirling/testing:cc_library",
+    ],
+)
+
+pl_cc_bpf_test(
     name = "boringssl_trace_bpf_test",
     timeout = "long",
     srcs = ["boringssl_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/socket_tracer/nodejs_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/nodejs_trace_bpf_test.cc
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <prometheus/text_serializer.h>
+#include "src/common/base/base.h"
+#include "src/common/exec/exec.h"
+#include "src/common/testing/test_environment.h"
+#include "src/shared/types/column_wrapper.h"
+#include "src/shared/types/types.h"
+#include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images/curl_container.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images/acorn_node14_container.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
+#include "src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.h"
+#include "src/stirling/testing/common.h"
+
+namespace px {
+namespace stirling {
+
+namespace http = protocols::http;
+
+using ::px::stirling::testing::EqHTTPRecord;
+using ::px::stirling::testing::EqHTTPRecordWithBodyRegex;
+using ::px::stirling::testing::FindRecordIdxMatchesPID;
+using ::px::stirling::testing::GetTargetRecords;
+using ::px::stirling::testing::SocketTraceBPFTestFixture;
+using ::px::stirling::testing::ToRecordVector;
+
+using ::testing::StrEq;
+using ::testing::Types;
+using ::testing::UnorderedElementsAre;
+
+class AcornNode14ContainerWrapper : public ::px::stirling::testing::AcornNode14Container {
+ public:
+  int32_t PID() const { return process_pid(); }
+};
+
+// Includes all information we need to extract from the trace records, which are used to verify
+// against the expected results.
+struct TraceRecords {
+  std::vector<http::Record> http_records;
+  std::vector<std::string> remote_address;
+};
+
+template <typename TServerContainer>
+class NodeJSTraceTest : public SocketTraceBPFTestFixture</* TClientSideTracing */ false> {
+ protected:
+  NodeJSTraceTest() {
+    // The container runner will make sure it is in the ready state before unblocking.
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60});
+    PX_CHECK_OK(run_result);
+
+    // Sleep an additional second, just to be safe.
+    sleep(1);
+  }
+
+  // Returns the trace records of the process specified by the input pid.
+  TraceRecords GetTraceRecords(int pid) {
+    std::vector<TaggedRecordBatch> tablets =
+        this->ConsumeRecords(SocketTraceConnector::kHTTPTableNum);
+    if (tablets.empty()) {
+      return {};
+    }
+    types::ColumnWrapperRecordBatch record_batch = tablets[0].records;
+    std::vector<size_t> server_record_indices =
+        FindRecordIdxMatchesPID(record_batch, kHTTPUPIDIdx, pid);
+    std::vector<http::Record> http_records =
+        ToRecordVector<http::Record>(record_batch, server_record_indices);
+    std::vector<std::string> remote_addresses =
+        testing::GetRemoteAddrs(record_batch, server_record_indices);
+    return {std::move(http_records), std::move(remote_addresses)};
+  }
+
+  TServerContainer server_;
+};
+
+//-----------------------------------------------------------------------------
+// Test Scenarios
+//-----------------------------------------------------------------------------
+
+std::string_view kPartialRespBody = R"delimiter(
+295885c4 200 4096 8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280582f5105914c333144
+8eee8a560fc1b68e046e9cb5de9a4c64b146667c93280... [TRUNCATED])delimiter";
+
+http::Record GetExpectedHTTPRecord() {
+  http::Record expected_record;
+  expected_record.req.req_method = "GET";
+  expected_record.req.req_path = "/";
+  expected_record.req.body = "";
+
+  expected_record.resp.resp_status = 200;
+  expected_record.resp.resp_message = "OK";
+  return expected_record;
+}
+
+using NodeJSServerImplementations = Types<AcornNode14ContainerWrapper>;
+
+TYPED_TEST_SUITE(NodeJSTraceTest, NodeJSServerImplementations);
+
+TYPED_TEST(NodeJSTraceTest, simple_curl_client) {
+  FLAGS_stirling_conn_trace_pid = this->server_.process_pid();
+  this->StartTransferDataThread();
+
+  // Run the client in the network of the server, so they can connect to each other.
+  ::px::stirling::testing::CurlContainer client;
+  ASSERT_OK(client.Run(std::chrono::seconds{60},
+                       {absl::Substitute("--network=container:$0", this->server_.container_name())},
+                       {"-s", "-S", "localhost:8080"}));
+  client.Wait();
+  this->StopTransferDataThread();
+
+  TraceRecords records = this->GetTraceRecords(this->server_.PID());
+
+  http::Record expected_record = GetExpectedHTTPRecord();
+
+  if (LazyParsingEnabled()) {
+    // We lazily parse the incomplete chunk with a partial body.
+    // only the consistent part of the response body is checked
+    EXPECT_THAT(records.http_records,
+                UnorderedElementsAre(EqHTTPRecordWithBodyRegex(expected_record, ".*200 4096.*")));
+
+    EXPECT_THAT(records.remote_address, UnorderedElementsAre(StrEq("127.0.0.1")));
+  } else {
+    // No records should be captured because we exceeded the loop limit (iovec has length 257) 
+    // and lazy parsing was disabled.
+    EXPECT_THAT(records.http_records, UnorderedElementsAre());
+  }
+
+  auto& registry = GetMetricsRegistry();  // retrieves global var keeping metrics
+  auto metrics = registry.Collect();      // samples all metrics
+  auto metrics_text = prometheus::TextSerializer().Serialize(metrics);  // serializes to text
+  LOG(WARNING) << absl::Substitute("with metric text: $0", metrics_text);
+}
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
@@ -231,6 +231,16 @@ pl_cc_test_library(
 )
 
 pl_cc_test_library(
+    name = "acorn_node14_container",
+    srcs = [],
+    hdrs = ["acorn_node14_container.h"],
+    data = [
+        "//src/stirling/source_connectors/socket_tracer/testing/containers:nodejs_acorn_image.tar",
+    ],
+    deps = ["//src/common/testing/test_utils:cc_library"],
+)
+
+pl_cc_test_library(
     name = "node_client_container",
     srcs = [],
     hdrs = ["node_client_container.h"],

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images/acorn_node14_container.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images/acorn_node14_container.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string>
+
+#include "src/common/testing/test_environment.h"
+#include "src/common/testing/test_utils/container_runner.h"
+
+namespace px {
+namespace stirling {
+namespace testing {
+
+class AcornNode14Container : public ContainerRunner {
+ public:
+  AcornNode14Container()
+      : ContainerRunner(::px::testing::BazelRunfilePath(kBazelImageTar), kContainerNamePrefix,
+                        kReadyMessage) {}
+
+ private:
+  static constexpr std::string_view kBazelImageTar =
+      "src/stirling/source_connectors/socket_tracer/testing/containers/"
+      "nodejs_acorn_image.tar";
+  static constexpr std::string_view kContainerNamePrefix = "acorn_node_server";
+  static constexpr std::string_view kReadyMessage = "listening on 8080";
+};
+
+// bazel run image to test for same behavior
+
+}  // namespace testing
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/BUILD.bazel
@@ -132,6 +132,18 @@ container_image(
 ]
 
 container_image(
+    name = "nodejs_acorn_image",
+    base = "@node_14_18_1_alpine_linux_amd64_image//image",
+    cmd = [
+        "node",
+        "/etc/node/acorn_server.js",
+    ],
+    layers = [
+        "//src/stirling/source_connectors/socket_tracer/testing/containers/acornjs:acorn_client_server_layer",
+    ],
+)
+
+container_image(
     name = "amqp_image",
     base = "@rabbitmq_3_management//image",
 )

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_layer")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//src/stirling:__subpackages__"])
+
+pkg_tar(
+    name = "acorn_client_server",
+    srcs = [
+        "acorn_client.js",
+        "acorn_server.js",
+    ],
+    mode = "0755",
+    strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs",
+)
+
+container_layer(
+    name = "acorn_client_server_layer",
+    directory = "/etc/node",
+    tars = [":acorn_client_server"],
+)

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs/acorn_client.js
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs/acorn_client.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const https = require('https');
+
+const options = {
+  hostname: 'localhost',
+  port: 443,
+  path: '/index.html',
+  method: 'GET'
+};
+
+// Allows self-signed certs.
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
+
+const req = https.request(options, (res) => {
+  console.log('statusCode:', res.statusCode);
+  console.log('headers:', res.headers);
+
+  res.on('data', (d) => {
+    process.stdout.write(d);
+  });
+});
+
+req.on('error', (e) => {
+  console.error(e);
+});
+req.end();

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs/acorn_server.js
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/acornjs/acorn_server.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const http = require('http')
+const url = require('url')
+const port = process.env.PORT || 8080
+const crypto = require('crypto')
+
+const id = crypto.randomBytes(4).toString('hex')
+const message = crypto.randomBytes(32).toString('hex').substr(0,63)+"\n"
+const len = message.length
+const targets = []
+const isDebug = process.env.DEBUG === 'true'
+const success = parseInt(process.env.SUCCESS_PERCENT,10) || 90
+const errorCodes = [400, 401, 403, 418, 422, 500]
+
+for ( const k of Object.keys(process.env) ) {
+  if ( k.startsWith('TARGET_') ) {
+    let [host, port, bytes, seconds] = process.env[k].split(/[:,]/)
+    targets.push({host, port, bytes, seconds})
+  }
+}
+
+console.log(`[${id}] listening on ${port}`)
+for ( const t of targets ) {
+  debug(`Request ${t.bytes} from ${t.host}:${t.port} every ${t.seconds} seconds`)
+  setInterval(() => {
+    const req = http.request(`http://${t.host}:${t.port}/${id}/${t.bytes}`, (res) => {
+      let received = 0
+      let fromId = ''
+
+      res.on('data', (chunk) => {
+        if ( !received ) {
+          fromId = chunk.toString().split(' ')[0]
+        }
+        received += chunk.length
+      })
+
+      res.on('end', () => {
+        debug(`[${id}] Received ${received} from ${fromId} (${t.host}:${t.port})`)
+      })
+    })
+
+    req.on('error', (err) => {
+      console.error(`[${id}] Error: ${err}`)
+    })
+
+    req.end()
+  }, t.seconds * 1000)
+}
+console.log('===============================')
+
+http.createServer((req, res) => {
+  const parsed = url.parse(req.url)
+  const parts = parsed.path.substring(1).split('/')
+  let target = parts[0]
+  let bytes = parseInt(parts[1],10) || 4096
+  let status = 200
+
+  if ( crypto.randomInt(0, 101) > success ) {
+    status = errorCodes[crypto.randomInt(0,errorCodes.length)]
+  }
+
+  res.writeHead(status, {'Content-Type': 'text/plain'})
+  const intro = `${id} ${status} ${bytes} ${message}\n`
+  bytes -= intro.length
+  res.write(intro)
+
+  while ( bytes > len ) {
+    res.write(message)
+    bytes -= len
+  }
+
+  if ( bytes > 0 ) {
+    res.write(message.substring(0,bytes))
+  }
+
+  debug(`[${id}] Sent ${bytes} to ${target}`)
+  res.end()
+}).listen(port)
+
+function debug(...msg) {
+  if ( isDebug ) {
+    console.log(...msg)
+  }
+}

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_layer")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//src/stirling:__subpackages__"])
+
+pkg_tar(
+    name = "node_client_server",
+    srcs = [
+        "https_client.js",
+        "https_server.js",
+    ],
+    mode = "0755",
+    strip_prefix = "/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs",
+)
+
+container_layer(
+    name = "node_client_server_layer",
+    directory = "/etc/node",
+    tars = [":node_client_server"],
+)

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs/https_client.js
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs/https_client.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const https = require('https');
+
+const options = {
+  hostname: 'localhost',
+  port: 443,
+  path: '/index.html',
+  method: 'GET'
+};
+
+// Allows self-signed certs.
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
+
+const req = https.request(options, (res) => {
+  console.log('statusCode:', res.statusCode);
+  console.log('headers:', res.headers);
+
+  res.on('data', (d) => {
+    process.stdout.write(d);
+  });
+});
+
+req.on('error', (e) => {
+  console.error(e);
+});
+req.end();

--- a/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs/https_server.js
+++ b/src/stirling/source_connectors/socket_tracer/testing/containers/nodejs/https_server.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const http = require('http')
+const url = require('url')
+const port = process.env.PORT || 8080
+const crypto = require('crypto')
+
+const id = crypto.randomBytes(4).toString('hex')
+const message = crypto.randomBytes(32).toString('hex').substr(0,63)+"\n"
+const len = message.length
+const targets = []
+const isDebug = process.env.DEBUG === 'true'
+const success = parseInt(process.env.SUCCESS_PERCENT,10) || 90
+const errorCodes = [400, 401, 403, 418, 422, 500]
+
+for ( const k of Object.keys(process.env) ) {
+  if ( k.startsWith('TARGET_') ) {
+    let [host, port, bytes, seconds] = process.env[k].split(/[:,]/)
+    targets.push({host, port, bytes, seconds})
+  }
+}
+
+console.log(`[${id}] listening on ${port}`)
+for ( const t of targets ) {
+  debug(`Request ${t.bytes} from ${t.host}:${t.port} every ${t.seconds} seconds`)
+  setInterval(() => {
+    const req = http.request(`http://${t.host}:${t.port}/${id}/${t.bytes}`, (res) => {
+      let received = 0
+      let fromId = ''
+
+      res.on('data', (chunk) => {
+        if ( !received ) {
+          fromId = chunk.toString().split(' ')[0]
+        }
+        received += chunk.length
+      })
+
+      res.on('end', () => {
+        debug(`[${id}] Received ${received} from ${fromId} (${t.host}:${t.port})`)
+      })
+    })
+
+    req.on('error', (err) => {
+      console.error(`[${id}] Error: ${err}`)
+    })
+
+    req.end()
+  }, t.seconds * 1000)
+}
+console.log('===============================')
+
+http.createServer((req, res) => {
+  const parsed = url.parse(req.url)
+  const parts = parsed.path.substring(1).split('/')
+  let target = parts[0]
+  let bytes = parseInt(parts[1],10) || 4096
+  let status = 200
+
+  if ( crypto.randomInt(0, 101) > success ) {
+    status = errorCodes[crypto.randomInt(0,errorCodes.length)]
+  }
+
+  res.writeHead(status, {'Content-Type': 'text/plain'})
+  const intro = `${id} ${status} ${bytes} ${message}\n`
+  bytes -= intro.length
+  res.write(intro)
+
+  while ( bytes > len ) {
+    res.write(message)
+    bytes -= len
+  }
+
+  if ( bytes > 0 ) {
+    res.write(message.substring(0,bytes))
+  }
+
+  debug(`[${id}] Sent ${bytes} to ${target}`)
+  res.end()
+}).listen(port)
+
+function debug(...msg) {
+  if ( isDebug ) {
+    console.log(...msg)
+  }
+}

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -93,6 +93,21 @@ inline auto EqHTTPRecord(const protocols::http::Record& x) {
                Field(&protocols::http::Record::resp, EqHTTPResp(x.resp)));
 }
 
+inline auto EqHTTPRecordWithBodyRegex(const protocols::http::Record& x,
+                                      const std::string& body_regex) {
+  using ::testing::Field;
+  using ::testing::MatchesRegex;
+
+  auto EqHTTPRespWithRegex = [&x, &body_regex]() {
+    return AllOf(Field(&protocols::http::Message::resp_status, x.resp.resp_status),
+                 Field(&protocols::http::Message::resp_message, x.resp.resp_message),
+                 Field(&protocols::http::Message::body, MatchesRegex(body_regex)));
+  };
+
+  return AllOf(Field(&protocols::http::Record::req, EqHTTPReq(x.req)),
+               Field(&protocols::http::Record::resp, EqHTTPRespWithRegex()));
+}
+
 inline auto EqMux(const protocols::mux::Frame& x) {
   using ::testing::Field;
 


### PR DESCRIPTION
Summary: Adds a bpf test for HTTP that triggers the gap condition `LoopLimitExceeded` based on a NodeJS application submitted in community slack. It submits an iovec with 257 elements, which is greater than our loop limit of 42. Our current behavior is that we merge 41 events into the data stream buffer, getting us to 878 bytes. Then on 42nd iov we reach loop limit, record the gap in metadata, and pad the rest with filler (or leave a gap if lazy parsing is enabled).

Type of change: /kind feature

Test Plan: Tested for both lazy and non-lazy HTTP parsing. Checked that metrics consistently show the loop limit exceeded condition for an iovec with length 257.