### PR TITLE
Raise loop and chunk limit for newer kernels

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/socket_trace.c
@@ -35,7 +35,7 @@
 #include "src/stirling/upid/upid.h"
 
 // This keeps instruction count below BPF's limit of 4096 per probe.
-#define LOOP_LIMIT 42
+#define LOOP_LIMIT BPF_LOOP_LIMIT
 #define PROTOCOL_VEC_LIMIT 3
 
 const int32_t kInvalidFD = -1;

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/socket_trace.h
@@ -128,7 +128,7 @@ struct close_event_t {
 // This defines how many chunks a perf_submit can support.
 // This applies to messages that are over MAX_MSG_SIZE,
 // and effectively makes the maximum message size to be CHUNK_LIMIT*MAX_MSG_SIZE.
-#define CHUNK_LIMIT 4
+#define CHUNK_LIMIT BPF_CHUNK_LIMIT
 
 // Unique ID to all syscalls and a few other notable functions.
 // This applies to events sent to user-space.

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
@@ -491,8 +491,7 @@ TEST_F(SocketTraceBPFTest, LargeMessages) {
   std::string large_response =
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: application/json; msg2\r\n"
-      // "Content-Length: 131072\r\n"
-      "Content-Length: 3512768\r\n"  // 21x it
+      "Content-Length: 3512768\r\n"
       "\r\n";
   large_response += std::string(3512768, '+');
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -176,6 +176,15 @@ DEFINE_bool(
     stirling_debug_tls_sources, gflags::BoolFromEnv("PX_DEBUG_TLS_SOURCES", false),
     "If true, stirling will add additional prometheus metrics regarding the traced tls sources");
 
+DEFINE_uint32(stirling_bpf_loop_limit, 42,
+              "The maximum number of iovecs to capture for syscalls. "
+              "Set conservatively for older kernels by default to keep the instruction count below "
+              "BPF's limit for version 4 kernels (4096 per probe).");
+
+DEFINE_uint32(stirling_bpf_chunk_limit, 4,
+              "The maximum number of chunks a perf_submit can support. "
+              "This applies to messages that are over MAX_MSG_SIZE.");
+
 OBJ_STRVIEW(socket_trace_bcc_script, socket_trace);
 
 namespace px {
@@ -434,17 +443,15 @@ auto SocketTraceConnector::InitPerfBufferSpecs() {
 Status SocketTraceConnector::InitBPF() {
   // set BPF loop limit and chunk limit based on kernel version
   auto kernel = system::GetCachedKernelVersion();
-  int loop_limit = 42;
-  int chunk_limit = 4;
   if (kernel.version >= 5 || (kernel.version == 5 && kernel.major_rev >= 1)) {
     // Kernels >= 5.1 have higher BPF instruction limits (1 million for verifier).
     // This enables a 21x increase to our loop and chunk limits
-    loop_limit = 882;
-    chunk_limit = 84;
+    FLAGS_stirling_bpf_loop_limit = 882;
+    FLAGS_stirling_bpf_chunk_limit = 84;
     LOG(INFO) << absl::Substitute(
         "Kernel version greater than V5.1 detected ($0), raised loop limit to $1 and chunk limit "
         "to $2",
-        kernel.ToString(), loop_limit, chunk_limit);
+        kernel.ToString(), FLAGS_stirling_bpf_loop_limit, FLAGS_stirling_bpf_chunk_limit);
   }
   // PROTOCOL_LIST: Requires update on new protocols.
   std::vector<std::string> defines = {
@@ -460,8 +467,8 @@ Status SocketTraceConnector::InitBPF() {
       absl::StrCat("-DENABLE_NATS_TRACING=", protocol_transfer_specs_[kProtocolNATS].enabled),
       absl::StrCat("-DENABLE_AMQP_TRACING=", protocol_transfer_specs_[kProtocolAMQP].enabled),
       absl::StrCat("-DENABLE_MONGO_TRACING=", protocol_transfer_specs_[kProtocolMongo].enabled),
-      absl::StrCat("-DBPF_LOOP_LIMIT=", loop_limit),
-      absl::StrCat("-DBPF_CHUNK_LIMIT=", chunk_limit),
+      absl::StrCat("-DBPF_LOOP_LIMIT=", FLAGS_stirling_bpf_loop_limit),
+      absl::StrCat("-DBPF_CHUNK_LIMIT=", FLAGS_stirling_bpf_chunk_limit),
   };
   PX_RETURN_IF_ERROR(bcc_->InitBPFProgram(socket_trace_bcc_script, defines));
 


### PR DESCRIPTION
Summary: Dynamically increase the loop limit for newer kernels with higher instruction limits (1 million for kernels > 5.1) by 21x to reduce data loss and raise ingest. More details in #1755.

One open question is whether we want to add vizier flag to toggle this behavior in case there are unforseen performance bottlenecks for certain clusters.

Type of change: /kind feature

Test Plan: Existing targets + perf/demo tests outlined in #1755.