### PR TITLE
Add the px-mongo demo to the CLI

### DIFF
--- a/demos/BUILD.bazel
+++ b/demos/BUILD.bazel
@@ -52,12 +52,20 @@ pkg_tar(
     strip_prefix = "k8ssandra",
 )
 
+pkg_tar(
+    name = "px-mongo",
+    srcs = glob(["mongodb/*"]),
+    extension = "tar.gz",
+    strip_prefix = "mongodb",
+)
+
 ARCHIVES = [
     ":px-finagle",
     ":px-kafka",
     ":px-sock-shop",
     ":px-online-boutique",
     ":px-k8ssandra",
+    ":px-mongo",
 ]
 
 demo_upload(

--- a/demos/README.md
+++ b/demos/README.md
@@ -92,7 +92,7 @@ file describes the demo scenarios.
 
 ## Updating the `px-mongo` demo
 
-1. Clone `https://github.com/kpattaswamy/mern-k8s`
+1. Clone `https://github.com/pixie-io/mern-k8s`
 
 2. (optional) Build the container images & update the individual yaml files.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -99,7 +99,7 @@ file describes the demo scenarios.
 3. Build a single yaml file for the demo:
 
     ```shell
-    kustomize . > mongodb.yaml
+    kustomize build . > mongodb.yaml
     ```
 
 4. Copy the yaml file to `pixie/demos/mongodb`.

--- a/demos/README.md
+++ b/demos/README.md
@@ -90,6 +90,20 @@ file describes the demo scenarios.
 
 6. Replace all occurrences of the k8ssandra-operator namespace. At the time of this writing, the areas to search and replace include the namespace field for a given resource in addition to the cert-manager annotations (cert-manager.io/inject-ca-from). Note: there may be kustomize variables used for the cert-manager.io/inject-ca-from annotation, so ensure all usages reference the px-k8ssandra namespace.
 
+## Updating the `px-mongo` demo
+
+1. Clone `https://github.com/kpattaswamy/mern-k8s`
+
+2. (optional) Build the container images & update the individual yaml files.
+
+3. Build a single yaml file for the demo:
+
+    ```shell
+    kustomize . > mongodb.yaml
+    ```
+
+4. Copy the yaml file to `pixie/demos/mongodb`.
+
 ## Updating the `px-finagle` demo
 
 1. Clone `https://github.com/pixie-io/finagle-helloworld`

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -49,5 +49,14 @@
 	"dependencies": {
             "cert-manager": true
         }
+    },
+    "px-mongo": {
+        "description": "Microservice demo that generates traffic between the Mern-K8s demo app and MongoDB.",
+        "instructions": [
+            "Load testing has been automatically launched for px-mongo",
+            "",
+            " Use the px/mongodb_data and px/http_data scripts to view the backend API and MongoDB traffic",
+            " flowing through the demo app."
+        ]
     }
 }

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -58,7 +58,7 @@
             " Use the px/mongodb_data and px/http_data scripts to view the backend API and MongoDB traffic",
             " flowing through the demo app.",
             "",
-            " Note: The Vizier version must be later than v0.14.7."
+            " Note: The Vizier version must be v0.14.8 or later."
         ]
     }
 }

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -56,7 +56,9 @@
             "Load testing has been automatically launched for px-mongo",
             "",
             " Use the px/mongodb_data and px/http_data scripts to view the backend API and MongoDB traffic",
-            " flowing through the demo app."
+            " flowing through the demo app.",
+            "",
+            " Note: The Vizier version must be later than v0.14.7."
         ]
     }
 }

--- a/demos/mongodb/mongodb.yaml
+++ b/demos/mongodb/mongodb.yaml
@@ -1,0 +1,230 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: px-mongo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: back
+  name: back
+  namespace: px-mongo
+spec:
+  ports:
+  - name: "8085"
+    port: 8085
+    targetPort: 8085
+  selector:
+    io.kompose.service: back
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: front
+  name: front
+  namespace: px-mongo
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 8080
+  selector:
+    io.kompose.service: front
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+  namespace: px-mongo
+spec:
+  ports:
+  - name: "27017"
+    port: 27017
+    targetPort: 27017
+  selector:
+    io.kompose.service: mongodb
+status:
+  loadBalancer: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: back
+  name: back
+  namespace: px-mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: back
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: back
+    spec:
+      containers:
+      - env:
+        - name: CONN_STR
+          value: mongodb://mongodb:27017
+        - name: PORT
+          value: "8085"
+        image: gcr.io/pixie-prod/demos/px-mongo/backend:1.0.0
+        imagePullPolicy: ""
+        name: back
+        ports:
+        - containerPort: 8085
+        resources: {}
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - set -xe; while ! mongosh mongodb://mongodb:27017 --eval "db.serverStatus()"
+          ; do echo "waiting until mongodb is available"; sleep 2; done;
+        image: mongo:7.0
+        name: mongodb-wait
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: front
+  name: front
+  namespace: px-mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: front
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: front
+    spec:
+      containers:
+      - image: gcr.io/pixie-prod/demos/px-mongo/frontend:1.0.0
+        imagePullPolicy: ""
+        name: front
+        ports:
+        - containerPort: 8080
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: load
+  name: load
+  namespace: px-mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: load
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: load
+    spec:
+      containers:
+      - image: gcr.io/pixie-prod/demos/px-mongo/load:1.0.0
+        imagePullPolicy: ""
+        name: load
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+  namespace: px-mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb
+    spec:
+      containers:
+      - image: mongo:7.0
+        imagePullPolicy: ""
+        name: mongodb
+        ports:
+        - containerPort: 27017
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}


### PR DESCRIPTION
Summary: This PR adds a demo app to test the mongo protocol tracing feature.

Related issues: Closes https://github.com/pixie-io/pixie/issues/640

Type of change: /kind feature

Test Plan: Uploaded the `px-mongo` demo artifact to the GCS dev bucket. Tested the CLI and then deployed the demo to my cluster. Skaffolded Pixie with the latest mongo tracing changes and used the scratch pad to execute the mongo pxl script to verify data is being collected from the demo.

<img width="1401" alt="Screenshot 2023-12-06 at 1 29 39 PM" src="https://github.com/pixie-io/pixie/assets/62078498/57aba6ed-dce5-4721-8c55-c4cd23f9ed0d">

Changelog Message:
```
Adds the `px-mongo` demo to the CLI
```
