### PR TITLE
[Add Local Addr & Port 3/3] Add simple test for capturing local IP

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/http_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/http_trace_bpf_test.cc
@@ -93,6 +93,10 @@ TEST_F(GoHTTPTraceTest, RequestAndResponse) {
       std::string(record_batch[kHTTPRemoteAddrIdx]->Get<types::StringValue>(target_record_idx)),
       // On IPv6 host, localhost is resolved to ::1.
       AnyOf(HasSubstr("127.0.0.1"), HasSubstr("::1")));
+  EXPECT_THAT(
+      std::string(record_batch[kHTTPLocalAddrIdx]->Get<types::StringValue>(target_record_idx)),
+      // Due to loopback, the local address is the same as the remote address.
+      AnyOf(HasSubstr("127.0.0.1"), HasSubstr("::1")));
   EXPECT_THAT(record_batch[kHTTPRespBodyIdx]->Get<types::StringValue>(target_record_idx),
               StrEq(absl::StrCat(R"({"greeter":"Hello PixieLabs!"})", "\n")));
   // This test currently performs client-side tracing because of the cluster CIDR in

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -117,6 +117,15 @@ inline std::vector<std::string> GetRemoteAddrs(const types::ColumnWrapperRecordB
   return addrs;
 }
 
+inline std::vector<std::string> GetLocalAddrs(const types::ColumnWrapperRecordBatch& rb,
+                                              const std::vector<size_t>& indices) {
+  std::vector<std::string> addrs;
+  for (size_t idx : indices) {
+    addrs.push_back(rb[kHTTPLocalAddrIdx]->Get<types::StringValue>(idx));
+  }
+  return addrs;
+}
+
 inline std::vector<int64_t> GetRemotePorts(const types::ColumnWrapperRecordBatch& rb,
                                            const std::vector<size_t>& indices) {
   std::vector<int64_t> addrs;


### PR DESCRIPTION
Summary: Add simple test for capturing local IP. This is in addition to E2E testing with demo apps done previously.

Type of change: /kind feature

Test Plan: Adapted http and openssl bpf tests. Note that the remote and local address are the same because the client and server are running on the same host and communicating via loopback.