### PR TITLE
Fix bug that threw an error while searching for linux headers through a symlink

### DIFF
--- a/src/stirling/utils/linux_headers.cc
+++ b/src/stirling/utils/linux_headers.cc
@@ -214,7 +214,8 @@ StatusOr<std::filesystem::path> ResolvePossibleSymlinkToHostPath(const std::file
   std::error_code ec;
   const bool is_symlink = std::filesystem::is_symlink(p, ec);
   if (ec) {
-    return error::Internal(ec.message());
+    return error::NotFound(absl::Substitute("Did not find the host headers at path: $0, $1.",
+                                            p.string(), ec.message()));
   }
 
   if (!is_symlink) {

--- a/src/stirling/utils/linux_headers.cc
+++ b/src/stirling/utils/linux_headers.cc
@@ -210,11 +210,6 @@ Status FindLinuxHeadersDirectory(const std::filesystem::path& lib_modules_dir) {
 }
 
 StatusOr<std::filesystem::path> ResolvePossibleSymlinkToHostPath(const std::filesystem::path p) {
-  // The rest of this won't work if "p" does not exist. Go ahead and error out early if needed.
-  if (!fs::Exists(p)) {
-    return error::NotFound(absl::Substitute("Did not find host headers at path: $0.", p.string()));
-  }
-
   // Check if "p" is a symlink.
   std::error_code ec;
   const bool is_symlink = std::filesystem::is_symlink(p, ec);


### PR DESCRIPTION
Summary: This PR removes a condition which checks to see if a host path exists in the filesystem of a process when trying to resolve symlinks.

The function `fs::Exists()` returned false for a broken symlink when the expectation was to return true because the path existed although it was a broken symlink. This function would later on fix the broken symlink path by reading its target host and converting the broken path into the actual path. This makes the code removal safe as the next check: `is_symlink` will return an error code if there is no file.

Type of change: /kind bug

Test Plan: Existing tests pass and deployed the PEM with the updated fix and saw that the Linux header files were found.