### PR TITLE
Ignore PR description linter when PR is created by dependabot

### DIFF
--- a/.github/workflows/pr_description_linter.yaml
+++ b/.github/workflows/pr_description_linter.yaml
@@ -7,6 +7,7 @@ permissions:
   contents: read
 jobs:
   lint-pr-description:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       PR_BODY: ${{github.event.pull_request.body}}


### PR DESCRIPTION
Summary: TSIA

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: This will prevent the GH actions from showing a failed run on
dependabot PRs.
