### PR TITLE
Update vizier yaml to handle case where deployKey is not specified.

### DIFF
--- a/k8s/operator/helm/templates/04_vizier.yaml
+++ b/k8s/operator/helm/templates/04_vizier.yaml
@@ -7,7 +7,9 @@ spec:
   {{- if .Values.version }}
   version: {{ .Values.version }}
   {{- end }}
+  {{- if .Values.deployKey }}
   deployKey: {{ .Values.deployKey }}
+  {{- end }}
   {{- if .Values.customDeployKeySecret }}
   customDeployKeySecret: {{ .Values.customDeployKeySecret }}
   {{- end }}


### PR DESCRIPTION
Summary: We update the vizier yaml inside of operator/helm to handle a case where `deployKey` is not specified. This can happen (e.g.) when a user has `customDeployKeySecret` set instead.

Type of change: /kind bug fix

Test Plan: Not sure.
1. Need some help on figuring out how to test this.
2. Is there a yaml template style that can require one of these two fields to be set, i.e. they should be required but mutually exclusive.
