### PR TITLE
Decode http request bodies that contain x-www-form-urlencoded data

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -203,6 +203,7 @@ pl_cc_bpf_test(
         ":cc_library",
         "//src/common/exec:cc_library",
         "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:curl_container",
         "//src/stirling/testing:cc_library",
         "//src/stirling/testing/demo_apps/go_http:go_http_fixture",
     ],

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/stitcher.cc
@@ -68,6 +68,11 @@ void PreProcessMessage(Message* message) {
     }
   }
 
+  if (message->type == message_type_t::kRequest &&
+      content_type_iter->second == "application/x-www-form-urlencoded") {
+    message->body = HTTPUrlDecode(message->body);
+  }
+
   auto content_encoding_iter = message->headers.find(kContentEncoding);
   // Replace body with decompressed version, if required.
   if (content_encoding_iter != message->headers.end() && content_encoding_iter->second == "gzip") {

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/stitcher.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/stitcher.h
@@ -45,7 +45,8 @@ namespace http {
 RecordsWithErrorCount<Record> ProcessMessages(std::deque<Message>* req_messages,
                                               std::deque<Message>* resp_messages);
 
-void PreProcessMessage(Message* message);
+void PreProcessRespMessage(Message* message);
+void PreProcessReqMessage(Message* message);
 
 }  // namespace http
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/utils.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/utils.cc
@@ -74,6 +74,45 @@ HTTPHeaderFilter ParseHTTPHeaderFilters(std::string_view filters) {
   return result;
 }
 
+// Lookup table for fast conversion of hex character to decimal value
+static constexpr unsigned char hextable[] = {
+    0, 1,  2,  3,  4,  5,  6,  7, 8, 9, 0, 0, 0, 0, 0, 0, /* 0x30 - 0x3f */
+    0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x40 - 0x4f */
+    0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x50 - 0x5f */
+    0, 10, 11, 12, 13, 14, 15                             /* 0x60 - 0x66 */
+};
+
+#define HEX_TO_DEC(x) hextable[x - '0']
+
+// Checks to see if the char is a valid hex digit [A-Fa-f0-9]
+// Used to check that HEX_TO_DEC is safe to apply for the given char
+bool IsHexDigit(char c) {
+  return (c >= 0x30 && c <= 0x39) || (c >= 0x41 && c <= 0x46) || (c >= 0x61 && c <= 0x66);
+}
+
+std::string HTTPUrlDecode(const std::string_view input) {
+  std::string output;
+  output.reserve(input.size());
+  size_t pos = 0;
+  size_t end = input.size();
+  while (pos < end) {
+    auto c = input.at(pos);
+    if (c == '+') {
+      output.push_back(' ');
+      pos += 1;
+    } else if (c == '%' && (end - pos >= 2) && IsHexDigit(input[pos + 1]) &&
+               IsHexDigit(input[pos + 2])) {
+      output.push_back((unsigned char)(HEX_TO_DEC(input[pos + 1]) << 4) |
+                       HEX_TO_DEC(input[pos + 2]));
+      pos += 3;
+    } else {
+      output.push_back(c);
+      pos += 1;
+    }
+  }
+  return output;
+}
+
 bool IsJSONContent(const Message& message) {
   auto content_type_iter = message.headers.find(kContentType);
   if (content_type_iter == message.headers.end()) {

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/utils.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/utils.h
@@ -59,6 +59,8 @@ HTTPHeaderFilter ParseHTTPHeaderFilters(std::string_view filters);
  */
 bool MatchesHTTPHeaders(const HeadersMap& http_headers, const HTTPHeaderFilter& filter);
 
+std::string HTTPUrlDecode(std::string_view input);
+
 /**
  * Detects the content-type of an HTTP message. Currently only checks for JSON.
  */

--- a/src/stirling/source_connectors/socket_tracer/protocols/http/utils_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/http/utils_test.cc
@@ -76,6 +76,29 @@ TEST(ParseHTTPHeaderFiltersAndMatchTest, FiltersAreAsExpectedAndMatchesWork) {
   }
 }
 
+TEST(HTTPUrlDecode, Decode) {
+  std::string input =
+      "action=%7B%0A++%22commands%22%3A+%5B%0A++++%7B%0A++++++%22server%22%3A+%22api.use-case.svc."
+      "cluster.local%3A5011%22%2C%0A++++++%22action%22%3A+%22req2%22%2C%0A++++++%22telemetry";
+  std::string expected = R"(action={
+  "commands": [
+    {
+      "server": "api.use-case.svc.cluster.local:5011",
+      "action": "req2",
+      "telemetry)";
+  EXPECT_EQ(HTTPUrlDecode(input), expected);
+}
+
+TEST(HTTPUrlDecode, DecodeTruncatedInput) {
+  // Use input that has its first % encoded hex digit removed
+  std::string truncated_first_digit = "action=%";
+  EXPECT_EQ(HTTPUrlDecode(truncated_first_digit), truncated_first_digit);
+
+  // Use input that has its second % encoded hex digit removed
+  std::string truncated_second_digit = "action=%7";
+  EXPECT_EQ(HTTPUrlDecode(truncated_second_digit), truncated_second_digit);
+}
+
 }  // namespace http
 }  // namespace protocols
 }  // namespace stirling

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1255,6 +1255,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   // Currently decompresses gzip content, but could handle other transformations too.
   // Note that we do this after filtering to avoid burning CPU cycles unnecessarily.
   protocols::http::PreProcessMessage(&resp_message);
+  protocols::http::PreProcessMessage(&req_message);
 
   md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
                 conn_tracker.conn_id().upid.start_time_ticks);

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1254,8 +1254,8 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
 
   // Currently decompresses gzip content, but could handle other transformations too.
   // Note that we do this after filtering to avoid burning CPU cycles unnecessarily.
-  protocols::http::PreProcessMessage(&resp_message);
-  protocols::http::PreProcessMessage(&req_message);
+  protocols::http::PreProcessRespMessage(&resp_message);
+  protocols::http::PreProcessReqMessage(&req_message);
 
   md::UPID upid(ctx->GetASID(), conn_tracker.conn_id().upid.pid,
                 conn_tracker.conn_id().upid.start_time_ticks);


### PR DESCRIPTION
Summary: Decode http request bodies that contain x-www-form-urlencoded data

This change enhances the request body in a `http_events` protocol trace for services that accept HTML form submissions.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: New unit tests and trace bpf test verify decoding works

Changelog Message: Decode `x-www-form-urlencoded` payloads within HTTP requests