### PR TITLE
Add encrypted field to all protocol data tables

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/amqp_table.h
+++ b/src/stirling/source_connectors/socket_tracer/amqp_table.h
@@ -36,6 +36,7 @@ static constexpr DataElement kAMQPElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {
         "frame_type", "AMQP request command",
         types::DataType::INT64,

--- a/src/stirling/source_connectors/socket_tracer/canonical_types.h
+++ b/src/stirling/source_connectors/socket_tracer/canonical_types.h
@@ -78,6 +78,14 @@ constexpr DataElement kLatencyNS = {
     types::PatternType::METRIC_GAUGE,
 };
 
+constexpr DataElement kEncrypted = {
+    "encrypted",
+    "If the protocol trace happened over an encrypted connection",
+    types::DataType::BOOLEAN,
+    types::SemanticType::ST_NONE,
+    types::PatternType::GENERAL_ENUM,
+};
+
 constexpr DataElement kPXInfo = {
     "px_info_",
     "Pixie messages regarding the record (e.g. warnings)",

--- a/src/stirling/source_connectors/socket_tracer/cass_table.h
+++ b/src/stirling/source_connectors/socket_tracer/cass_table.h
@@ -42,6 +42,7 @@ static constexpr DataElement kCQLElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_op", "Request opcode",
          types::DataType::INT64,
          types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/dns_table.h
+++ b/src/stirling/source_connectors/socket_tracer/dns_table.h
@@ -37,6 +37,7 @@ static constexpr DataElement kDNSElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_header", "Request header",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/http_table.h
+++ b/src/stirling/source_connectors/socket_tracer/http_table.h
@@ -46,6 +46,7 @@ constexpr DataElement kHTTPElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"major_version", "HTTP major version, can be 1 or 2",
          types::DataType::INT64,
          types::SemanticType::ST_NONE,
@@ -117,6 +118,7 @@ constexpr int kHTTPRemotePortIdx = kHTTPTable.ColIndex("remote_port");
 constexpr int kHTTPLocalAddrIdx = kHTTPTable.ColIndex("local_addr");
 constexpr int kHTTPLocalPortIdx = kHTTPTable.ColIndex("local_port");
 constexpr int kHTTPTraceRoleIdx = kHTTPTable.ColIndex("trace_role");
+constexpr int kHTTPEncryptedIdx = kHTTPTable.ColIndex("encrypted");
 constexpr int kHTTPMajorVersionIdx = kHTTPTable.ColIndex("major_version");
 constexpr int kHTTPMinorVersionIdx = kHTTPTable.ColIndex("minor_version");
 constexpr int kHTTPContentTypeIdx = kHTTPTable.ColIndex("content_type");

--- a/src/stirling/source_connectors/socket_tracer/kafka_table.h
+++ b/src/stirling/source_connectors/socket_tracer/kafka_table.h
@@ -40,6 +40,7 @@ static constexpr DataElement kKafkaElements[] = {
       canonical_data_elements::kLocalAddr,
       canonical_data_elements::kLocalPort,
       canonical_data_elements::kTraceRole,
+      canonical_data_elements::kEncrypted,
       {"req_cmd", "Kafka request command",
        types::DataType::INT64,
        types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/mongodb_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mongodb_table.h
@@ -37,6 +37,7 @@ static constexpr DataElement kMongoDBElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_cmd", "MongoDB request command",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/mux_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mux_table.h
@@ -37,6 +37,7 @@ static constexpr DataElement kMuxElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_type", "Mux message request type",
          types::DataType::INT64,
          types::SemanticType::ST_NONE,
@@ -59,6 +60,7 @@ DEFINE_PRINT_TABLE(Mux)
 
 static constexpr int kMuxUPIDIdx = kMuxTable.ColIndex("upid");
 static constexpr int kMuxReqTypeIdx = kMuxTable.ColIndex("req_type");
+static constexpr int kMuxEncryptedIdx = kMuxTable.ColIndex("encrypted");
 
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/mysql_table.h
+++ b/src/stirling/source_connectors/socket_tracer/mysql_table.h
@@ -42,6 +42,7 @@ static constexpr DataElement kMySQLElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_cmd", "MySQL request command",
          types::DataType::INT64,
          types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/nats_table.h
+++ b/src/stirling/source_connectors/socket_tracer/nats_table.h
@@ -34,6 +34,7 @@ constexpr DataElement kNATSElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"cmd", "The name of the command.",
          types::DataType::STRING, types::SemanticType::ST_NONE, types::PatternType::GENERAL},
         // For PUB, MSG commands, the parameters and the paylod are included in the 'body' as

--- a/src/stirling/source_connectors/socket_tracer/pgsql_table.h
+++ b/src/stirling/source_connectors/socket_tracer/pgsql_table.h
@@ -34,6 +34,7 @@ static constexpr DataElement kPGSQLElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_cmd", "PostgreSQL request command code",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/redis_table.h
+++ b/src/stirling/source_connectors/socket_tracer/redis_table.h
@@ -37,6 +37,7 @@ static constexpr DataElement kRedisElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
+        canonical_data_elements::kEncrypted,
         {"req_cmd", "Request command. See https://redis.io/commands.",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1274,6 +1274,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("major_version")>(1);
   r.Append<r.ColIndex("minor_version")>(resp_message.minor_version);
   r.Append<r.ColIndex("content_type")>(static_cast<uint64_t>(content_type));
@@ -1338,6 +1339,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("major_version")>(2);
   // HTTP2 does not define minor version.
   r.Append<r.ColIndex("minor_version")>(0);
@@ -1381,6 +1383,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_cmd")>(static_cast<uint64_t>(entry.req.cmd));
   r.Append<r.ColIndex("req_body")>(std::move(entry.req.msg), FLAGS_max_body_bytes);
   r.Append<r.ColIndex("resp_status")>(static_cast<uint64_t>(entry.resp.status));
@@ -1406,6 +1409,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_op")>(static_cast<uint64_t>(entry.req.op));
   r.Append<r.ColIndex("req_body")>(std::move(entry.req.msg), FLAGS_max_body_bytes);
   r.Append<r.ColIndex("resp_op")>(static_cast<uint64_t>(entry.resp.op));
@@ -1431,6 +1435,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_header")>(entry.req.header);
   r.Append<r.ColIndex("req_body")>(entry.req.query);
   r.Append<r.ColIndex("resp_header")>(entry.resp.header);
@@ -1456,6 +1461,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req")>(std::move(entry.req.payload));
   r.Append<r.ColIndex("resp")>(std::move(entry.resp.payload));
   r.Append<r.ColIndex("latency")>(
@@ -1480,6 +1486,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_type")>(entry.req.type);
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(entry.req.timestamp_ns, entry.resp.timestamp_ns));
@@ -1503,6 +1510,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
 
   size_t frame_type = std::max(entry.req.frame_type, entry.resp.frame_type);
   r.Append<r.ColIndex("frame_type")>(frame_type);
@@ -1556,6 +1564,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_cmd")>(std::string(entry.req.command));
   r.Append<r.ColIndex("req_args")>(std::string(entry.req.payload));
   r.Append<r.ColIndex("resp")>(std::string(entry.resp.payload));
@@ -1581,6 +1590,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("cmd")>(record.req.command);
   r.Append<r.ColIndex("body")>(record.req.options);
   r.Append<r.ColIndex("resp")>(record.resp.command);
@@ -1606,6 +1616,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_cmd")>(static_cast<int64_t>(record.req.api_key));
   r.Append<r.ColIndex("client_id")>(std::move(record.req.client_id), FLAGS_max_body_bytes);
   r.Append<r.ColIndex("req_body")>(std::move(record.req.msg), kMaxKafkaBodyBytes);
@@ -1632,6 +1643,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(role);
+  r.Append<r.ColIndex("encrypted")>(conn_tracker.ssl());
   r.Append<r.ColIndex("req_cmd")>(std::move(record.req.op_msg_type));
   r.Append<r.ColIndex("req_body")>(std::move(record.req.frame_body));
   r.Append<r.ColIndex("resp_status")>(std::move(record.resp.op_msg_type));

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -126,6 +126,15 @@ inline std::vector<std::string> GetLocalAddrs(const types::ColumnWrapperRecordBa
   return addrs;
 }
 
+inline std::vector<bool> GetEncrypted(const types::ColumnWrapperRecordBatch& rb,
+                                      const int encrypted_idx, const std::vector<size_t>& indices) {
+  std::vector<bool> encrypted;
+  for (size_t idx : indices) {
+    encrypted.push_back(rb[encrypted_idx]->Get<types::BoolValue>(idx).val);
+  }
+  return encrypted;
+}
+
 inline std::vector<int64_t> GetRemotePorts(const types::ColumnWrapperRecordBatch& rb,
                                            const std::vector<size_t>& indices) {
   std::vector<int64_t> addrs;


### PR DESCRIPTION
Summary: Add encrypted field to all protocol data tables

The goal of this column is to ease the ability of identifying connections that are plaintext that are ingressing from or egressing to the Internet.

Relevant Issues: #1865

Type of change: /kind feature

Test Plan: Additional test logic verifies new behavior

Changelog Message: Add `encrypted` boolean field to all protocol/L7 data tables