### PR TITLE
[Mongo] Clear the streamID from the request/response maps after stitching

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -183,7 +183,8 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
       ++erase_until_iter;
     }
 
-    // Determine whether to clear the StreamID from the map or only the frames that have been consumed.
+    // Determine whether to clear the StreamID from the map or only the frames that have been
+    // consumed.
     if (erase_until_iter == req_deque.end()) {
       reqs->erase(stream_id);
     } else {

--- a/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mongodb/stitcher.cc
@@ -183,7 +183,12 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
       ++erase_until_iter;
     }
 
-    req_deque.erase(req_deque.begin(), erase_until_iter);
+    // Determine whether to clear the StreamID from the map or only the frames that have been consumed.
+    if (erase_until_iter == req_deque.end()) {
+      reqs->erase(stream_id);
+    } else {
+      req_deque.erase(req_deque.begin(), erase_until_iter);
+    }
     stream_id_pair.second = true;
   }
 
@@ -195,8 +200,10 @@ RecordsWithErrorCount<mongodb::Record> StitchFrames(
         error_count++;
       }
     }
-    resp_deque.clear();
   }
+
+  // Clear the response map.
+  resps->clear();
 
   // Clear the state.
   auto it = state->stream_order.begin();


### PR DESCRIPTION
Summary: This PR modifies mongo's stitcher logic to clear streamID’s from request/response maps once all frames of a streamID have been consumed. We observed high CPU use allocated to `FramesSize()` & `EraseExpiredFrames()`, this was due to the size of the maps increasing with new streamIDs and having to continuously loop over those growing maps to cleanup. Clearing the streamID's from the maps after stitching significantly reduces the CPU allocated to the cleanup logic for mongo, the exact details for mongo's streamID reuse needs to be determined to further adapt the stitcher logic.

Type of change: /kind bug

Test Plan: Existing tests still pass, ran the px-mongo demo and observed lower CPU allocated to mongo in the PEM through flamegraph.