### PR TITLE
Make sure altstack_size_ is a multiple of the system page size

### DIFF
--- a/src/common/signal/signal_action.h
+++ b/src/common/signal/signal_action.h
@@ -73,15 +73,13 @@ class SignalAction : public NotCopyable {
   const size_t altstack_size_;
   /**
    * Determine the number of bytes to allocate to altstack_size_.
-   * Makes sure that it is a multiple of the system page size.
    */
   size_t DetermineAltStackSize() const {
-    // The size of altstack_ should be at least 4 * page size or size MINSIGSTKSZ if it is
+    // The size of altstack_size_ should be at least 4 * guard size or size MINSIGSTKSZ if it is
     // greater. This size needs to be a multiple of the system page size.
-    const size_t page_size = px::system::Config::GetInstance().PageSizeBytes();
-    const size_t min_altstack_size = 4 * page_size;
-    const size_t sig_page_count = IntRoundUpDivide(static_cast<size_t>(MINSIGSTKSZ), page_size);
-    const size_t sig_stack_size = sig_page_count * page_size;
+    const size_t min_altstack_size = 4 * guard_size_;
+    const size_t sig_page_count = IntRoundUpDivide(static_cast<size_t>(MINSIGSTKSZ), guard_size_);
+    const size_t sig_stack_size = sig_page_count * guard_size_;
 
     return std::max(min_altstack_size, sig_stack_size);
   }


### PR DESCRIPTION
Summary: This PR modifies the logic that sets the value of `altstack_size_`. When deploying Pixie on a 7th gen AMI running bottle rocket, the value of `altstack_size_` was set to `MINSIGSTKSZ`. This value was 39616 and was not a multiple of the system page size.

In this [line of code](https://github.com/pixie-io/pixie/blob/0888c38df2dc414a36cc84198c7b159c39eea0e0/src/common/signal/signal_action.cc#L149) `mprotect` was then applied on a non page aligned region since its address was set as `altstack_ + guard_size_ + altstack_size_` leading to an error. This region in `altstack_` was also not the tailing `guard_size_` area as [mmap](https://github.com/pixie-io/pixie/blob/0888c38df2dc414a36cc84198c7b159c39eea0e0/src/common/signal/signal_action.cc#L145) would have added extra bytes to `altstack_` in order to page align it.

As per the docs, the address passed to `mprotect` needs to be aligned to a page boundary. The function in this PR makes sure that the value of `altstack_size_` is a multiple of the page size so that the address calculated/passed to `mprotect` is aligned to a page boundary and that it protects the tailing `guard_size_` region of `altstack_`

Relevant Issues: Fixes #1882

Type of change: /kind bug

Test Plan: Skaffolded pixie on EKS clusters with m7i.large, r7i.large instances and on a GKE cluster with e2-standard-4 nodes and saw the PEM start up