### PR TITLE
Optimize TCP Stats Connector

### DIFF
--- a/src/stirling/source_connectors/tcp_stats/tcp_stats.cc
+++ b/src/stirling/source_connectors/tcp_stats/tcp_stats.cc
@@ -41,7 +41,7 @@ TCPStats::AggKey BuildAggKey(const upid_t& upid, const SockAddr& local_endpoint,
 }  // namespace
 
 absl::flat_hash_map<TCPStats::AggKey, TCPStats::Stats>* TCPStats::UpdateStats(
-    const std::vector<tcp_event_t> events) {
+    const std::vector<tcp_event_t>& events) {
   for (auto& event : events) {
     SockAddr laddr, raddr;
     auto la = event.local_addr;

--- a/src/stirling/source_connectors/tcp_stats/tcp_stats.h
+++ b/src/stirling/source_connectors/tcp_stats/tcp_stats.h
@@ -88,7 +88,7 @@ class TCPStats {
    * @return A mutable reference to all the aggregated connection stats. The reference is mutable
    *         for the purposes of removing stats that are no longer needed.
    */
-  absl::flat_hash_map<AggKey, Stats>* UpdateStats(const std::vector<tcp_event_t> events);
+  absl::flat_hash_map<AggKey, Stats>* UpdateStats(const std::vector<tcp_event_t>& events);
 
  private:
   absl::flat_hash_map<AggKey, Stats> tcp_agg_stats_;

--- a/src/stirling/source_connectors/tcp_stats/tcp_stats_connector.cc
+++ b/src/stirling/source_connectors/tcp_stats/tcp_stats_connector.cc
@@ -124,7 +124,6 @@ void TCPStatsConnector::TransferDataImpl(ConnectorContext* ctx) {
     iter++;
   }
   agg_stats->clear();
-
 }
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/tcp_stats/tcp_stats_connector.cc
+++ b/src/stirling/source_connectors/tcp_stats/tcp_stats_connector.cc
@@ -99,6 +99,7 @@ void TCPStatsConnector::TransferDataImpl(ConnectorContext* ctx) {
 
   DataTable* data_table = data_tables_[0];
   auto* agg_stats = tcp_stats_.UpdateStats(events_);
+  events_.clear();
   uint64_t time = AdjustedSteadyClockNowNS();
   absl::flat_hash_set<md::UPID> upids = ctx->GetUPIDs();
 
@@ -120,10 +121,10 @@ void TCPStatsConnector::TransferDataImpl(ConnectorContext* ctx) {
     r.Append<tcp_stats::kTCPBytesSentIdx>(stats.bytes_sent);
     r.Append<tcp_stats::kTCPRetransmitsIdx>(stats.retransmissions);
 
-    agg_stats->erase(iter++);
+    iter++;
   }
+  agg_stats->clear();
 
-  events_.clear();
 }
 }  // namespace stirling
 }  // namespace px


### PR DESCRIPTION
Summary: Makes a couple of optimizations to the TCP stats connector. In particular, we pass by reference instead of copy in `TCPStats::UpdateStats` and simplify the cleanup logic in `TransferDataImpl`.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Bpf test works. Ran heap profiler and observed fewer allocations.

One remaining mystery is a single 384Mb allocation that seems to always arise in the heap profile for `AcceptTcpEvent`. Even commenting out the body of the function does not change this. Originally thought this might be related to the `BPF_HASH(sock_store, uint32_t, struct sock*, 10240);`, but changing its size had no affect on the allocation.

![image](https://github.com/pixie-io/pixie/assets/47846691/015772c5-91dc-4c3b-be39-e9cef8be7c49)