### PR TITLE
Exclude DaemonSets (PEMs) from modification by a Vizier's nodeSelector

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,13 @@ output:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  # TODO(ddelnano): Remove once typecheck is upgraded in next golangci-lint upgrade
+  # This error originates from the stdlib due to generics usage
+  exclude-rules:
+  - path: .*slices\/sort.go
+    linters:
+    - typecheck
+    text: "^(undefined: (min|max))"
 
 linters:
   enable:


### PR DESCRIPTION
Summary: Exclude DaemonSets (PEMs) from modification by a Vizier's nodeSelector

This accomplishes part of #1861. The remaining work is to include new additional node selector configuration values that only apply to PEMs -- similar to how `pemMemoryLimit` and `pemMemoryRequest` work. From my investigation so far, it appears that adding the PEM specific selectors will require a different implementation (via the vizier yaml templating on the Pixie cloud side) and so I thought staging this in two changes made sense.

Relevant Issues: #1861

Type of change: /kind bug

Test Plan: Skaffolded a vizier operator and verified that setting a `kubernetes.io/hostname` node selector no longer prevents PEMs from being scheduled on all nodes

Changelog Message: Fixed an issue that caused the `Vizier` CRD to apply node selectors to pods that should be scheduled on all nodes (DaemonSets)