### PR TITLE
Upgrade OTel proto to v1.3.1.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -177,9 +177,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/nlohmann/json/releases/download/v3.7.3/include.zip"],
     ),
     com_github_opentelemetry_proto = dict(
-        urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v0.10.0.tar.gz"],
-        strip_prefix = "opentelemetry-proto-0.10.0",
-        sha256 = "f1004a49f40d7acb43e86b1fd95f73e80c778acb163e309bba86f0cbd7fa8a71",
+        urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.3.1.tar.gz"],
+        strip_prefix = "opentelemetry-proto-1.3.1",
+        sha256 = "bed250ceec8e4a83aa5604d7d5595a61945059dc662edd058a9da082283f7a00",
     ),
     com_github_packetzero_dnsparser = dict(
         sha256 = "bdf6c7f56f33725c1c32e672a4779576fb639dd2df565115778eb6be48296431",

--- a/src/carnot/exec/otel_export_sink_node.cc
+++ b/src/carnot/exec/otel_export_sink_node.cc
@@ -233,9 +233,9 @@ Status OTelExportSinkNode::ConsumeMetrics(ExecState* exec_state, const RowBatch&
     // TODO(philkuz) optimize by pooling metrics by resource within a batch.
     // TODO(philkuz) optimize by pooling data per metric per resource.
 
-    auto library_metrics = resource_metrics.add_instrumentation_library_metrics();
+    auto scope_metrics = resource_metrics.add_scope_metrics();
     for (const auto& metric_pb : plan_node_->metrics()) {
-      auto metric = library_metrics->add_metrics();
+      auto metric = scope_metrics->add_metrics();
       metric->set_name(metric_pb.name());
       metric->set_description(metric_pb.description());
       metric->set_unit(metric_pb.unit());
@@ -349,9 +349,9 @@ Status OTelExportSinkNode::ConsumeSpans(ExecState* exec_state, const RowBatch& r
     auto resource = resource_spans.mutable_resource();
     AddAttributes(resource->mutable_attributes(), plan_node_->resource_attributes_normal_encoding(),
                   rb, row_idx);
-    auto library_spans = resource_spans.add_instrumentation_library_spans();
+    auto scope_spans = resource_spans.add_scope_spans();
     for (const auto& span_pb : plan_node_->spans()) {
-      auto span = library_spans->add_spans();
+      auto span = scope_spans->add_spans();
       if (span_pb.has_name_string()) {
         span->set_name(span_pb.name_string());
       } else {

--- a/src/carnot/exec/otel_export_sink_node_test.cc
+++ b/src/carnot/exec/otel_export_sink_node_test.cc
@@ -200,7 +200,7 @@ metrics {
   tester.ConsumeNext(rb1, 1, 0);
   EXPECT_EQ(non_utf_8_bytes, actual_protos[0]
                                  .resource_metrics(0)
-                                 .instrumentation_library_metrics(0)
+                                 .scope_metrics(0)
                                  .metrics(0)
                                  .gauge()
                                  .data_points(0)
@@ -300,7 +300,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       summary {
@@ -329,7 +329,7 @@ resource_metrics {
 }
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       summary {
@@ -398,7 +398,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -425,7 +425,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -460,7 +460,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -474,7 +474,7 @@ resource_metrics {
 }
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -503,7 +503,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -517,7 +517,7 @@ resource_metrics {
 }
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -547,7 +547,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       description: "tracks the response latency of http requests"
@@ -581,7 +581,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -596,7 +596,7 @@ resource_metrics {
                                R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -632,7 +632,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       summary {
@@ -670,7 +670,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "metric1"
       gauge {
@@ -740,7 +740,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -767,7 +767,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -794,7 +794,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -821,7 +821,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -881,7 +881,7 @@ eos: true)pb"},
                               {R"pb(
 resource_metrics {
   resource {}
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -950,7 +950,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -977,7 +977,7 @@ resource_metrics {
       }
     }
   }
-  instrumentation_library_metrics {
+  scope_metrics {
     metrics {
       name: "http.resp.latency"
       gauge {
@@ -1092,7 +1092,7 @@ resource_spans {
       }
     }
   }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1135,7 +1135,7 @@ eos: true)pb"},
                               {R"pb(
 resource_spans {
   resource { }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1173,7 +1173,7 @@ eos: true)pb"},
                               {R"pb(
 resource_spans {
   resource {}
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span1"
       start_time_unix_nano: 10
@@ -1188,7 +1188,7 @@ resource_spans {
 }
 resource_spans {
   resource {}
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span2"
       start_time_unix_nano: 20
@@ -1257,7 +1257,7 @@ resource_spans {
       }
     }
   }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1284,7 +1284,7 @@ resource_spans {
       }
     }
   }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1311,7 +1311,7 @@ resource_spans {
       }
     }
   }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1338,7 +1338,7 @@ resource_spans {
       }
     }
   }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1365,7 +1365,7 @@ resource_spans {
       }
     }
   }
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 20
@@ -1432,7 +1432,7 @@ eos: true)pb"},
                               {R"pb(
 resource_spans {
   resource {}
-  instrumentation_library_spans {
+  scope_spans {
     spans {
       name: "span"
       start_time_unix_nano: 10
@@ -1530,7 +1530,7 @@ TEST_P(SpanIDTests, generate_ids) {
   tester.ConsumeNext(*rb.get(), 1, 0);
 
   for (const auto& [s_idx, span] : Enumerate(actual_proto.resource_spans())) {
-    for (const auto& ilm : span.instrumentation_library_spans()) {
+    for (const auto& ilm : span.scope_spans()) {
       for (const auto& span : ilm.spans()) {
         SCOPED_TRACE(absl::Substitute("span $0", s_idx));
         {


### PR DESCRIPTION
Summary: We upgrade the OTel proto version from `v0.10.0` to `v1.3.1`.

Type of change: /kind feature

Test Plan: Existing tests, sakffold'd standalone pem and ran export scripts saw data in flowing via OTel.
