### PR TITLE
Update self-hosted vizier version in artifact tracker configuration

### DIFF
--- a/k8s/cloud/public/base/artifact_tracker_versions.yaml
+++ b/k8s/cloud/public/base/artifact_tracker_versions.yaml
@@ -10,7 +10,7 @@ spec:
       - name: artifact-tracker-server
         env:
         - name: PL_VIZIER_VERSION
-          value: "0.12.12"
+          value: "0.14.9"
         - name: PL_CLI_VERSION
           value: "0.7.17"
         - name: PL_OPERATOR_VERSION


### PR DESCRIPTION
Summary: Update self-hosted vizier version in artifact tracker configuration

Relevant Issues: #1907

Type of change: /kind dependency

Test Plan: Performed the same change on an existing artifact tracker deployment and verified subsequent `px deploy`s use new version

Changelog Message: Updated the vizier version bundled within self-hosted cloud to 0.14.9