### PR TITLE
Upgrade bcc and libbpf to fix Google COS socket tracer issues

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -130,7 +130,7 @@ REPOSITORY_LOCATIONS = dict(
         sha256 = "d34f9484588a9c25be936c910c86f8b25b04e5b0c802d0630e77cc9a8a272aed",
         strip_prefix = "bcc-e0698be7b797129cb113912e96ad741a551e2291",
         urls = [
-            "https://github.com/ddelnano/bcc/archive/e0698be7b797129cb113912e96ad741a551e2291.tar.gz",
+            "https://github.com/pixie-io/bcc/archive/e0698be7b797129cb113912e96ad741a551e2291.tar.gz",
         ],
     ),
     com_github_iovisor_bpftrace = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -127,10 +127,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/h2o/picohttpparser/archive/1d2b8a184e7ebe6651c30dcede37ba1d89691351.tar.gz"],
     ),
     com_github_iovisor_bcc = dict(
-        sha256 = "38f07777a214582a20a198b535691459d882a1e5da80057ff30f2ee27a53055c",
-        strip_prefix = "bcc-0171a363859b4a96c23543c06ef67517ddc3e789",
+        sha256 = "d34f9484588a9c25be936c910c86f8b25b04e5b0c802d0630e77cc9a8a272aed",
+        strip_prefix = "bcc-e0698be7b797129cb113912e96ad741a551e2291",
         urls = [
-            "https://github.com/pixie-io/bcc/archive/0171a363859b4a96c23543c06ef67517ddc3e789.tar.gz",
+            "https://github.com/ddelnano/bcc/archive/e0698be7b797129cb113912e96ad741a551e2291.tar.gz",
         ],
     ),
     com_github_iovisor_bpftrace = dict(
@@ -146,10 +146,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/jupp0r/prometheus-cpp/archive/81e208c250748657f1d5dab247e82c4429a931af.tar.gz"],
     ),
     com_github_libbpf_libbpf = dict(
-        sha256 = "3d6afde67682c909e341bf194678a8969f17628705af25f900d5f68bd299cb03",
-        strip_prefix = "libbpf-1.0.1",
+        sha256 = "4d503428c7aead070a59630dd0906318a430b3e279a35f51ec601fbdd7d31eb6",
+        strip_prefix = "libbpf-3b0973892891744d20ae79e99c0d1a26a59c4222",
         urls = [
-            "https://github.com/libbpf/libbpf/archive/refs/tags/v1.0.1.tar.gz",
+            "https://github.com/libbpf/libbpf/archive/3b0973892891744d20ae79e99c0d1a26a59c4222.tar.gz",
         ],
     ),
     com_github_libuv_libuv = dict(

--- a/src/stirling/bpf_tools/bcc_symbolizer_bpf_test.cc
+++ b/src/stirling/bpf_tools/bcc_symbolizer_bpf_test.cc
@@ -68,7 +68,8 @@ TEST(BCCSymbolizer, ModuleName) {
   for (const auto& entry : smaps) {
     if (entry.pathname == "[vdso]") {
       const std::string_view symbol = symbolizer.SymbolOrAddrIfUnknown(pid, entry.vmem_start);
-      EXPECT_EQ(symbol, "[m] [vdso] + 0x00000000");
+      const std::string expected = absl::StrCat("[m] [vdso] + 0x", absl::Hex(entry.vmem_start));
+      EXPECT_EQ(symbol, expected);
     }
   }
 }


### PR DESCRIPTION
Summary: Upgrade bcc and libbpf to fix Google COS socket tracer issues

See GitHub issue comments below for more details. This pulls in the following BCC fix (https://github.com/iovisor/bcc/commit/57ca51bdd9c86870a43b9f76e062b3aede226ca4).

Relevant Issues: Closes #1900, part of #1905

Type of change: /kind bug

Test Plan: Skaffold'ed this change to a Ubuntu and Google COS cluster and verified socket tracer works again
- [x] Verified that all kernel build passes
- [x] Verified that all kernel build used a bcc repo reference that matches latest commit
```
ddelnano@noble-dev:~/code/bcc/build (pixie8) $ git diff pixie/pixie8 ddelnano/pixie8
ddelnano@noble-dev:~/code/bcc/build (pixie8) $
```

Changelog Message: Fix issue with socket tracer on recent Google COS instances