### PR TITLE
Clear trace response instead of metric response in `OTelExportSinkNode::ConsumeSpans`

### DIFF
--- a/src/carnot/exec/otel_export_sink_node.cc
+++ b/src/carnot/exec/otel_export_sink_node.cc
@@ -340,7 +340,7 @@ Status OTelExportSinkNode::ConsumeSpans(ExecState* exec_state, const RowBatch& r
   }
   context.set_compression_algorithm(GRPC_COMPRESS_GZIP);
 
-  metrics_response_.Clear();
+  trace_response_.Clear();
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request;
 
   for (int64_t row_idx = 0; row_idx < rb.ColumnAt(0)->length(); ++row_idx) {

--- a/src/carnot/planner/objects/otel.cc
+++ b/src/carnot/planner/objects/otel.cc
@@ -338,7 +338,6 @@ Status OTelModule::Init(CompilerState* compiler_state, IR* ir) {
 
   AddMethod(kEndpointOpID, endpoint_fn);
   PX_RETURN_IF_ERROR(endpoint_fn->SetDocString(kEndpointOpDocstring));
-  return Status::OK();
 
   return Status::OK();
 }


### PR DESCRIPTION
Summary: Addresses a couple of small-ish bugs
- `ConsumeSpans` is mistakenly clearing the `metrics_response_` (which is used in `ConsumeMetrics`) instead of the `trace_response_`.
- There is a duplicate return statement in `OTelModule::Init`.

Type of change: /kind bug

Test Plan: CI, skaffold-ed standalone pem and ran OTel export scripts