### PR TITLE
Add node selectors fields in helm chart to control scheduling of OLM and operator pods

### DIFF
--- a/k8s/operator/helm/templates/00_olm.yaml
+++ b/k8s/operator/helm/templates/00_olm.yaml
@@ -92,8 +92,10 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
+      {{- $selectorDefaults := dict "kubernetes.io/os" "linux" }}
+      {{- $nodeSelectors := merge $selectorDefaults .Values.olmNodeSelector }}
       nodeSelector:
-        kubernetes.io/os: linux
+      {{- $nodeSelectors | toYaml | nindent 8 }}
       tolerations:
       - key: "kubernetes.io/arch"
         operator: "Equal"
@@ -165,8 +167,10 @@ spec:
             requests:
               cpu: 10m
               memory: 80Mi
+      {{- $selectorDefaults := dict "kubernetes.io/os" "linux" }}
+      {{- $nodeSelectors := merge $selectorDefaults .Values.olmNodeSelector }}
       nodeSelector:
-        kubernetes.io/os: linux
+      {{- $nodeSelectors | toYaml | nindent 8 }}
       tolerations:
       - key: "kubernetes.io/arch"
         operator: "Equal"

--- a/k8s/operator/helm/templates/02_catalog.yaml
+++ b/k8s/operator/helm/templates/02_catalog.yaml
@@ -18,6 +18,9 @@ spec:
     registryPoll:
       interval: 10m
   grpcPodConfig:
+    {{- if .Values.olmCatalogSource.nodeSelector }}
+    nodeSelector: {{ .Values.olmCatalogSource.nodeSelector | toYaml | nindent 6 }}
+    {{- end }}
     tolerations:
     - key: "kubernetes.io/arch"
       operator: "Equal"

--- a/k8s/operator/helm/templates/03_subscription.yaml
+++ b/k8s/operator/helm/templates/03_subscription.yaml
@@ -9,3 +9,7 @@ spec:
   source: pixie-operator-index
   sourceNamespace: {{ .Values.olmOperatorNamespace }}
   installPlanApproval: Automatic
+  {{- if .Values.olmCatalogSource.nodeSelector }}
+  config:
+    nodeSelector: {{ .Values.olmCatalogSource.nodeSelector | toYaml | nindent 6 }}
+  {{- end }}

--- a/k8s/operator/helm/values.yaml
+++ b/k8s/operator/helm/values.yaml
@@ -8,6 +8,7 @@ deployOLM: ""
 # The namespace that olm should run in. If olm has already been deployed
 # to the cluster, this should be the namespace that olm is already running in.
 olmNamespace: "olm"
+olmNodeSelector: {}
 # The namespace which olm operators should run in. If olm has already
 # been deployed to the cluster, this should be the namespace that the olm operators
 # are running in.
@@ -21,6 +22,8 @@ olmCatalogSource:
   annotations: {}
   # Optional custom labels to add to deployed pods managed by CatalogSource object.
   labels: {}
+  # Node selectors to apply for pods managed by CatalogSource object
+  nodeSelector: {}
 ## Vizier configuration
 # The name of the Vizier instance deployed to the cluster.
 name: "pixie"


### PR DESCRIPTION
Summary: Add node selectors fields in helm chart to control scheduling of OLM and operator pods

Previously a helm chart user could only specify the node selectors for the vizier components. This PR allows for applying node selectors to OLM and the operator. This was feedback from @ashutoshrathore after the functionality from #1887 was released.

Relevant Issues: #1861

Type of change: /kind feature

Test Plan: Tested the following scenarios
- [x] Used `helm template` to verify that the manifests are the same if node selectors are not defined
```
$ helm template pixie-operator k8s/operator/helm/ -f k8s/operator/helm/values.yaml --debug  > new.yaml
install.go:200: [debug] Original chart version: ""
install.go:217: [debug] CHART PATH: /home/ddelnano/code/pixie-worktree/k8s/operator/helm

# Switch branches to capture templated output from existing helm chart
$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
$ helm template pixie-operator k8s/operator/helm/ -f k8s/operator/helm/values.yaml --debug  > old.yaml
install.go:200: [debug] Original chart version: ""
install.go:217: [debug] CHART PATH: /home/ddelnano/code/pixie-worktree/k8s/operator/helm

$ diff old.yaml new.yaml
$
```
- [x] Deployed a local version of the helm chart to a cluster and verified that the node selector values are set properly for pods in the `olm` and `px-operator` namespace
- [x] Verified that pods failed to schedule if the pinned host was terminated
```
$ kubectl -n olm get pods
NAME                                READY   STATUS    RESTARTS   AGE
catalog-operator-77554fbc46-zjq8m   0/1     Pending   0          2m13s
olm-operator-76dc499446-d8qvh       0/1     Pending   0          2m11s
$ kubectl -n px-operator get pods
NAME                               READY   STATUS    RESTARTS   AGE
vizier-operator-5ff9749c94-98q87   0/1     Pending   0          2m17s
```

Changelog Message: Add support for specifying node selector in the helm chart for OLM and operator pods