### PR TITLE
Update release image locations

### DIFF
--- a/scripts/regclient/regbot_releases.yaml
+++ b/scripts/regclient/regbot_releases.yaml
@@ -15,79 +15,79 @@ scripts:
 - name: sync cloud/api_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/api_server_image")
+    releases.mirror("cloud-api_server_image")
 - name: sync cloud/artifact_tracker_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/artifact_tracker_server_image")
+    releases.mirror("cloud-artifact_tracker_server_image")
 - name: sync cloud/auth_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/auth_server_image")
+    releases.mirror("cloud-auth_server_image")
 - name: sync cloud/config_manager_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/config_manager_server_image")
+    releases.mirror("cloud-config_manager_server_image")
 - name: sync cloud/cron_script_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/cron_script_server_image")
+    releases.mirror("cloud-cron_script_server_image")
 - name: sync cloud/indexer_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/indexer_server_image")
+    releases.mirror("cloud-indexer_server_image")
 - name: sync cloud/metrics_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/metrics_server_image")
+    releases.mirror("cloud-metrics_server_image")
 - name: sync cloud/plugin/load_db
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/plugin/load_db")
+    releases.mirror("cloud-plugin/load_db")
 - name: sync cloud/plugin_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/plugin_server_image")
+    releases.mirror("cloud-plugin_server_image")
 - name: sync cloud/profile_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/profile_server_image")
+    releases.mirror("cloud-profile_server_image")
 - name: sync cloud/project_manager_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/project_manager_server_image")
+    releases.mirror("cloud-project_manager_server_image")
 - name: sync cloud/proxy_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/proxy_server_image")
+    releases.mirror("cloud-proxy_server_image")
 - name: sync cloud/scriptmgr_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/scriptmgr_server_image")
+    releases.mirror("cloud-scriptmgr_server_image")
 - name: sync cloud/vzconn_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/vzconn_server_image")
+    releases.mirror("cloud-vzconn_server_image")
 - name: sync cloud/vzmgr_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("cloud/vzmgr_server_image")
+    releases.mirror("cloud-vzmgr_server_image")
 - name: sync operator/bundle
   script: |
     releases = require 'releases'
-    releases.mirror("operator/bundle")
+    releases.mirror("operator-bundle")
 - name: sync operator/bundle_index
   script: |
     releases = require 'releases'
-    releases.mirror("operator/bundle_index")
+    releases.mirror("operator-bundle_index")
 - name: sync operator/operator_image
   script: |
     releases = require 'releases'
-    releases.mirror("operator/operator_image")
+    releases.mirror("operator-operator_image")
 - name: sync operator/vizier_deleter
   script: |
     releases = require 'releases'
-    releases.mirror("operator/vizier_deleter")
+    releases.mirror("operator-vizier_deleter")
 - name: sync px
   script: |
     releases = require 'releases'
@@ -95,28 +95,28 @@ scripts:
 - name: sync vizier/cert_provisioner_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/cert_provisioner_image")
+    releases.mirror("vizier-cert_provisioner_image")
 - name: sync vizier/cloud_connector_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/cloud_connector_server_image")
+    releases.mirror("vizier-cloud_connector_server_image")
 - name: sync vizier/kelvin_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/kelvin_image")
+    releases.mirror("vizier-kelvin_image")
 - name: sync vizier/metadata_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/metadata_server_image")
+    releases.mirror("vizier-metadata_server_image")
 - name: sync vizier/pem_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/pem_image")
+    releases.mirror("vizier-pem_image")
 - name: sync vizier/query_broker_server_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/query_broker_server_image")
+    releases.mirror("vizier-query_broker_server_image")
 - name: sync vizier/vizier_updater_image
   script: |
     releases = require 'releases'
-    releases.mirror("vizier/vizier_updater_image")
+    releases.mirror("vizier-vizier_updater_image")

--- a/scripts/regclient/releases.lua
+++ b/scripts/regclient/releases.lua
@@ -9,7 +9,7 @@ function releases.mirror(path)
   -- loop through tags on each image
   for _, t in ipairs(tags) do
     local major, _, _, ext = utils.parseVersion(t)
-    if major ~= nil and string.sub(ext, 1, 1) ~= "-" then
+    if (major ~= nil and string.sub(ext, 1, 1) ~= "-") or string.sub(t, -4) == '.sig' then
       srcRef:tag(t)
       -- loop through destinations
       for _, destination in ipairs(mirrors.destinationRegistries) do


### PR DESCRIPTION
Summary: The image mirroring wasn't updated in #1593 and as a result the releases weren't getting mirrored. This fixes the same and also ensures that the signatures get copied over.

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Ran a regbot dry run to ensure new images would get copied over.
