### PR TITLE
chore: Bump scorecard action

### DIFF
--- a/.github/workflows/oss_scorecard.yaml
+++ b/.github/workflows/oss_scorecard.yaml
@@ -20,7 +20,7 @@ jobs:
       actions: read
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
-    - uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86  # v2.1.2
+    - uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534  # v2.3.3
       with:
         publish_results: true
         results_file: results.sarif


### PR DESCRIPTION
Summary: This upgrades pulls in a fix for github.com/ossf/scorecard-action/issues/998 which was causing the action to fail.

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Scorecard runs should succeed again after this.
