### PR TITLE
chore: Disable yamllint multiline indentation

### DIFF
--- a/.github/actions/comment_command/action.yaml
+++ b/.github/actions/comment_command/action.yaml
@@ -20,7 +20,6 @@ runs:
     env:
       BODY: ${{ github.event.comment.body }}
       COMMAND_NAME: ${{ inputs.command-name }}
-    # yamllint disable rule:indentation
     run: |
       if [[ "${BODY}" =~ "/${COMMAND_NAME}"* ]]; then
         exit 0
@@ -28,14 +27,12 @@ runs:
         echo "${BODY} is not a /${COMMAND_NAME} command" >&2
         exit 1
       fi
-    # yamllint enable rule:indentation
   - name: Check permissions
     shell: bash
     env:
       PR_AUTHOR_ASSOC: ${{ github.event.issue.author_association }}
       COMMENT_AUTHOR_ASSOC: ${{ github.event.comment.author_association }}
       ADMIN_ONLY: ${{ inputs.admin-only }}
-    # yamllint disable rule:indentation
     run: |
       if [[ -z "${PR_AUTHOR_ASSOC}" ]] || [[ -z "${COMMENT_AUTHOR_ASSOC}" ]]; then
         echo "failed to get permission levels of users involved" >&2
@@ -59,7 +56,6 @@ runs:
       fi
       echo "members can only run this command on other members prs: permission denied" >&2
       exit 2
-    # yamllint enable rule:indentation
   - name: Parse command
     id: parse
     shell: bash

--- a/.github/actions/env_protected_pr/action.yaml
+++ b/.github/actions/env_protected_pr/action.yaml
@@ -15,7 +15,6 @@ runs:
   using: "composite"
   steps:
   - name: Not pull_request_target
-    # yamllint disable rule:indentation
     if: github.event_name != 'pull_request_target'
     shell: bash
     run: |
@@ -29,21 +28,18 @@ runs:
         github.event.pull_request.author_association == 'OWNER' ||
         github.event.pull_request.author_association == 'MEMBER'
       )
-    # yamllint enable rule:indentation
     shell: bash
     run: |
       echo "" > env_name
       echo "${{ github.event.pull_request.head.sha }}" >> ref
       echo "${{ github.event.pull_request.head.sha }}" >> sha
   - name: Require external environment authorization.
-    # yamllint disable rule:indentation
     if: >-
       github.event_name == 'pull_request_target' &&
       !(
         github.event.pull_request.author_association == 'OWNER' ||
         github.event.pull_request.author_association == 'MEMBER'
       )
-    # yamllint enable rule:indentation
     shell: bash
     run: |
       echo "pr-actions-approval" > env_name

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -55,14 +55,12 @@ jobs:
       run: ./ci/save_diff_info.sh
     - name: Run Clang Tidy
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         diff_file="diff_origin_main_cc"
         if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "schedule" ]]; then
           diff_file="diff_head_cc"
         fi
         ./ci/run_clang_tidy.sh -f "${diff_file}"
-      # yamllint enable rule:indentation
   code-coverage:
     if: github.event_name == 'push'
     needs: [authorize, env-protect-setup, get-dev-image]
@@ -151,23 +149,19 @@ jobs:
       run: rm -rf "$(bazel info ${{ matrix.args }} bazel-testlogs --noshow_progress 2>/dev/null)"
     - name: Build ${{ matrix.name }}
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         ./scripts/bazel_ignore_codes.sh build \
           ${{ matrix.args }} \
           --target_pattern_file=target_files/${{ matrix.buildables }} \
           2> >(tee bazel_stderr)
-      # yamllint enable rule:indentation
     - name: Test ${{ matrix.name }}
       if: ${{ matrix.tests }}
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         # Github actions container runner creates a docker network without IPv6 support. We enable it manually.
         sysctl -w net.ipv6.conf.lo.disable_ipv6=0
         ./scripts/bazel_ignore_codes.sh test ${{ matrix.args }} --target_pattern_file=target_files/${{ matrix.tests }} \
           2> >(tee bazel_stderr)
-      # yamllint enable rule:indentation
     - name: Parse junit reports
       uses: dorny/test-reporter@afe6793191b75b608954023a46831a3fe10048d4  # v1.7.0
       if: always()
@@ -196,13 +190,11 @@ jobs:
         needs.generate-matrix.result == 'success' && needs.clang-tidy.result == 'success'
         && needs.build-and-test.result == 'skipped'
       run: echo "Build and Test skipped no matrix configs generated ✓"
-    # yamllint disable rule:indentation
     - if: >
         !(needs.build-and-test.result == 'success' && needs.clang-tidy.result == 'success') &&
         !(needs.generate-matrix.result == 'success' &&
           needs.clang-tidy.result == 'success' &&
           needs.build-and-test.result == 'skipped')
-    # yamllint enable rule:indentation
       run: |
         echo "Build and Test failed"
         exit 1

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -171,7 +171,6 @@ jobs:
         REF: ${{ github.event.ref }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         export TAG_NAME="${REF#*/tags/}"
         # actions/checkout doesn't get the tag annotation properly.
@@ -185,7 +184,6 @@ jobs:
           --title "CLI ${TAG_NAME#release/cli/}" \
           --notes $'Pixie CLI Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" linux-artifacts/* macos-artifacts/*
-      # yamllint enable rule:indentation
   update-gh-artifacts-manifest:
     runs-on: ubuntu-latest-8-cores
     needs: [get-dev-image, create-github-release]

--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -79,7 +79,6 @@ jobs:
         OWNER: pixie-io
         REPO: pixie
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         export TAG_NAME="${REF#*/tags/}"
         # actions/checkout doesn't get the tag annotation properly.
@@ -88,4 +87,3 @@ jobs:
         gh release create "${TAG_NAME}" --title "Cloud ${TAG_NAME#release/cloud/}" \
           --notes $'Pixie Cloud Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" cloud-artifacts/*
-      # yamllint enable rule:indentation

--- a/.github/workflows/mirror_demos.yaml
+++ b/.github/workflows/mirror_demos.yaml
@@ -40,8 +40,6 @@ jobs:
       run: go install github.com/regclient/regclient/cmd/regbot@v0.4.8
     - name: sync images
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         cd scripts/regclient
         regbot once ${{ github.event.inputs.dry_run && ' --dry-run' }} --config regbot_demos.yaml
-      # yamllint enable rule:indentation

--- a/.github/workflows/mirror_deps.yaml
+++ b/.github/workflows/mirror_deps.yaml
@@ -40,8 +40,6 @@ jobs:
       run: go install github.com/regclient/regclient/cmd/regbot@v0.4.8
     - name: sync images
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         cd scripts/regclient
         regbot once ${{ github.event.inputs.dry_run && ' --dry-run' }} --config regbot_deps.yaml
-      # yamllint enable rule:indentation

--- a/.github/workflows/mirror_releases.yaml
+++ b/.github/workflows/mirror_releases.yaml
@@ -35,8 +35,6 @@ jobs:
       run: go install github.com/regclient/regclient/cmd/regbot@v0.4.8
     - name: sync images
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         cd scripts/regclient
         regbot once --config regbot_releases.yaml
-      # yamllint enable rule:indentation

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -95,7 +95,6 @@ jobs:
         REF: ${{ github.event.ref }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         export TAG_NAME="${REF#*/tags/}"
         # actions/checkout doesn't get the tag annotation properly.
@@ -136,14 +135,12 @@ jobs:
         TAG_NAME: ${{ github.event.release.tag_name }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
-      # yamllint disable rule:indentation
       run: |
         cp index-artifacts/index.yaml helm_charts/operator/index.yaml
         git add helm_charts/operator/index.yaml
         export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
         git commit -s -m "Release Helm chart ${VERSION}"
         git push origin "gh-pages"
-      # yamllint enable rule:indentation
   update-gh-artifacts-manifest:
     runs-on: ubuntu-latest-8-cores
     needs: [get-dev-image, create-github-release]

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -72,7 +72,6 @@ jobs:
         echo "tags=${tags}" >> $GITHUB_OUTPUT
     - name: Add default tags
       id: default-tags
-      # yamllint disable rule:indentation
       run: |
         default_tags="PR#${{ github.event.issue.number }}"
         tags="${{ steps.parse.outputs.tags }}"
@@ -81,7 +80,6 @@ jobs:
         fi
         tags="${tags}${default_tags}"
         echo "tags=${tags}" >> $GITHUB_OUTPUT
-      # yamllint enable rule:indentation
   pr-perf-eval:
     name: PR Performance Evaluation
     needs: pr-perf-setup
@@ -100,7 +98,6 @@ jobs:
     steps:
     - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975  # v6.4.0
       with:
-        # yamllint disable rule:indentation
         script: |
           const experiments = JSON.parse('${{ needs.pr-perf-eval.outputs.experiments }}');
           let comment = `Perf eval finished:
@@ -116,5 +113,3 @@ jobs:
             repo: context.repo.repo,
             body: comment,
           })
-
-        # yamllint enable rule:indentation

--- a/.github/workflows/perf_common.yaml
+++ b/.github/workflows/perf_common.yaml
@@ -93,7 +93,6 @@ jobs:
       env:
         PX_API_KEY: ${{ secrets.PERF_PX_API_KEY }}
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
-      # yamllint disable rule:indentation
       run: |
         echo "$GOOGLE_APPLICATION_CREDENTIALS"
         bazel run //src/e2e_test/perf_tool -- run --commit_sha "${{ steps.get-commit-sha.outputs.commit-sha }}" \
@@ -104,7 +103,6 @@ jobs:
           --tags "${{ inputs.tags }}" \
           --suite "${{ matrix.suite }}" \
           --experiment_name "${{ matrix.experiment_name }}" > run_output
-      # yamllint enable rule:indentation
     - name: deactivate gcloud service account
       run: gcloud auth revoke
     # Github actions doesn't have native support for gathering outputs from matrix runs.

--- a/.github/workflows/pr_genfiles.yml
+++ b/.github/workflows/pr_genfiles.yml
@@ -68,7 +68,6 @@ jobs:
       run: make go-setup
     - name: Fail if any files changed
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         if [[ $(git status --porcelain=v1 | wc -l) -ne 0 ]]; then
           echo "Please update generated files by running the appropriate script."
@@ -76,4 +75,3 @@ jobs:
           git diff --name-only
           exit 1
         fi
-      # yamllint enable rule:indentation

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -39,7 +39,6 @@ jobs:
       run: arc lint --apply-patches --trace
     - name: Fail if any files changed
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         if [[ $(git status --porcelain=v1 | wc -l) -ne 0 ]]; then
           echo "Please apply the autofix patches suggested by arc lint."
@@ -47,4 +46,3 @@ jobs:
           git diff --name-only
           exit 1
         fi
-      # yamllint enable rule:indentation

--- a/.github/workflows/release_update_docs_px_dev.yaml
+++ b/.github/workflows/release_update_docs_px_dev.yaml
@@ -77,7 +77,6 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
-      # yamllint disable rule:indentation
       run: |
         if [[ $(git status --porcelain=v1 | wc -l) -eq 0 ]]; then
           echo "No updates to the documentation detected, exiting."

--- a/.github/workflows/release_update_readme.yaml
+++ b/.github/workflows/release_update_readme.yaml
@@ -51,7 +51,6 @@ jobs:
         TAG_NAME: ${{ github.event.release.tag_name }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
-      # yamllint disable rule:indentation
       run: |
         export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
         export BRANCH="${VERSION}-update-readme"
@@ -62,4 +61,3 @@ jobs:
         gh pr create --repo pixie-io/pixie \
           --head "pixie-io-buildbot:${BRANCH}" \
           --body "$(cat pr_body)" --title "$(cat pr_title)"
-      # yamllint enable rule:indentation

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -49,13 +49,11 @@ jobs:
         mkdir -p sarif/${{ matrix.artifact }}
         ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
-    # yamllint disable rule:indentation
     - run: |
         for f in "sarif/${{ matrix.artifact }}/"*; do
           jq '.runs[].tool.driver.name = "trivy-images"' < "$f" > tmp
           mv tmp "$f"
         done
-    # yamllint enable rule:indentation
     - uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b  # v2.2.9
       with:
         sarif_file: sarif/${{ matrix.artifact }}

--- a/.github/workflows/update_script_bundle.yaml
+++ b/.github/workflows/update_script_bundle.yaml
@@ -15,7 +15,6 @@ jobs:
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - name: Install Pixie CLI
-      # yamllint disable rule:indentation
       run: |
         jq_script=(
           '.[] | '
@@ -29,7 +28,6 @@ jobs:
         download_link=$(curl -fssL "https://artifacts.px.dev/artifacts/manifest.json" | jq "${jq_script[*]}" -r )
         curl -fssL "${download_link}" -o px
         chmod +x px
-      # yamllint enable rule:indentation
     - name: Build bundle
       shell: bash
       run: |
@@ -72,7 +70,6 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
-      # yamllint disable rule:indentation
       run: |
         mkdir -p pxl_scripts
         cp bundle/bundle-oss.json pxl_scripts/bundle.json
@@ -84,4 +81,3 @@ jobs:
         fi
         git commit -s -m "Update PxL script bundle"
         git push origin "gh-pages"
-      # yamllint enable rule:indentation

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -102,7 +102,6 @@ jobs:
         REF: ${{ github.event.ref }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
       shell: bash
-      # yamllint disable rule:indentation
       run: |
         export TAG_NAME="${REF#*/tags/}"
         # actions/checkout doesn't get the tag annotation properly.
@@ -116,7 +115,6 @@ jobs:
           --title "Vizier ${TAG_NAME#release/vizier/}" \
           --notes $'Pixie Vizier Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" vizier-artifacts/*
-      # yamllint enable rule:indentation
   create-helm-chart:
     if: ${{ !contains(github.event.ref, '-') }}
     name: Create Helm chart on Github
@@ -144,14 +142,12 @@ jobs:
         TAG_NAME: ${{ github.event.release.tag_name }}
         GH_TOKEN: ${{ secrets.BUILDBOT_GH_API_TOKEN }}
         GIT_SSH_COMMAND: "ssh -i /tmp/ssh.key"
-      # yamllint disable rule:indentation
       run: |
         cp index-artifacts/index.yaml helm_charts/vizier/index.yaml
         git add helm_charts/vizier/index.yaml
         export VERSION="$(echo "${TAG_NAME}" | cut -d'/' -f3)"
         git commit -s -m "Release Helm chart Vizier ${VERSION}"
         git push origin "gh-pages"
-      # yamllint enable rule:indentation
   update-gh-artifacts-manifest:
     runs-on: ubuntu-latest-8-cores
     needs: [get-dev-image, create-github-release]

--- a/.yamllint
+++ b/.yamllint
@@ -5,7 +5,6 @@ rules:
   indentation:
     spaces: 2
     indent-sequences: false
-    check-multi-line-strings: true
   line-length:
     max: 120
   truthy:

--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -29,13 +29,11 @@ spec:
       initContainers:
       - name: wait-sock-shop
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do
             echo "waiting for ${SOCK_SHOP_HEALTH_ADDR}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation
         env:
         - name: SOCK_SHOP_HEALTH_ADDR
           value: "http://orders.px-sock-shop.svc.cluster.local/health"

--- a/k8s/cloud/base/ory_auth/hydra/hydra_config.yaml
+++ b/k8s/cloud/base/ory_auth/hydra/hydra_config.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hydra-config
-# yamllint disable rule:indentation
 data:
   hydra.yml: |+
     # All URLS must be set in the environment variables instead of config.

--- a/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
@@ -154,7 +154,6 @@ spec:
       - name: client-create-or-update
         imagePullPolicy: IfNotPresent
         image: oryd/hydra:v1.9.2-alpine@sha256:faa6ca02e77e0a08f66bfa7470a5e06d80e6e68c9c35410c65a4ea7b501aea61
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://localhost:4445/health/ready";
           until [
@@ -183,7 +182,6 @@ spec:
             --skip-tls-verify;
           sleep infinity;
         ']
-        # yamllint enable rule:indentation
         envFrom:
         - configMapRef:
             name: pl-domain-config

--- a/k8s/cloud/base/ory_auth/kratos/kratos_config.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_config.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: kratos-config
 data:
-  # yamllint disable rule:indentation
   kratos.yml: |
     # All URLS must be set in the environment variables instead of config.
     selfservice:

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -158,7 +158,6 @@ spec:
         imagePullPolicy: IfNotPresent
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="${ADMIN_URL}/admin/health/ready";
           until [ $(curl -k -m 0.5 -s -o /dev/null -w "%{http_code}" ${URL}) -eq 200 ]; do

--- a/k8s/cloud/base/proxy_envoy.yaml
+++ b/k8s/cloud/base/proxy_envoy.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: proxy-envoy-config
 data:
-  # yamllint disable rule:indentation
   envoy.yaml: >
     static_resources:
       listeners:
@@ -76,4 +75,3 @@ data:
                   filename: "/service-certs/client.crt"
                 private_key:
                   filename: "/service-certs/client.key"
-  # yamllint enable rule:indentation

--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -16,13 +16,11 @@ spec:
       initContainers:
       - name: postgres-wait
         image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
-        # yamllint disable rule:indentation
         command: ['sh', '-c',
-          'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do
-            echo "waiting for postgres";
-            sleep 2;
-          done;']
-        # yamllint enable rule:indentation
+                  'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do
+                  echo "waiting for postgres";
+                  sleep 2;
+                  done;']
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/dev/proxy_envoy.yaml
+++ b/k8s/cloud/dev/proxy_envoy.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: proxy-envoy-config
 data:
-  # yamllint disable rule:indentation
   # This envoy.yaml is almost an exact copy of cloud/base/proxy_envoy.yaml, minus
   # the alpn_protocols in common_tls_context. This is because GCP health check only
   # supports alpn h2, making the alpn field is required in our prod cloud instances.
@@ -82,4 +81,3 @@ data:
                   filename: "/service-certs/client.crt"
                 private_key:
                   filename: "/service-certs/client.key"
-  # yamllint enable rule:indentation

--- a/k8s/cloud/prod/proxy_envoy.yaml
+++ b/k8s/cloud/prod/proxy_envoy.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: proxy-envoy-config
 data:
-  # yamllint disable rule:indentation
   # This is almost an exact copy of base/proxy_envoy.yaml, except with a different CORS suffix. This
   # is because kustomize can't do patches within the embedded YAML.
   envoy.yaml: >
@@ -78,4 +77,3 @@ data:
                   filename: "/service-certs/client.crt"
                 private_key:
                   filename: "/service-certs/client.key"
-  # yamllint enable rule:indentation

--- a/k8s/cloud/public/base/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/base/plugin_db_updater_job.yaml
@@ -16,13 +16,11 @@ spec:
       initContainers:
       - name: postgres-wait
         image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
-        # yamllint disable rule:indentation
         command: ['sh', '-c',
-          'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do
-            echo "waiting for postgres";
-            sleep 2;
-          done;']
-        # yamllint enable rule:indentation
+                  'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do
+                  echo "waiting for postgres";
+                  sleep 2;
+                  done;']
         envFrom:
         - configMapRef:
             name: pl-db-config

--- a/k8s/cloud/public/base/proxy_envoy.yaml
+++ b/k8s/cloud/public/base/proxy_envoy.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: proxy-envoy-config
 data:
-  # yamllint disable rule:indentation
   # This envoy.yaml is almost an exact copy of cloud/base/proxy_envoy.yaml, minus
   # the alpn_protocols in common_tls_context. This is because GCP health check only
   # supports alpn h2, making the alpn field is required in our prod cloud instances.
@@ -82,4 +81,3 @@ data:
                   filename: "/service-certs/client.crt"
                 private_key:
                   filename: "/service-certs/client.key"
-  # yamllint enable rule:indentation

--- a/k8s/cloud/staging/proxy_envoy.yaml
+++ b/k8s/cloud/staging/proxy_envoy.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: proxy-envoy-config
 data:
-  # yamllint disable rule:indentation
   # This is almost an exact copy of base/proxy_envoy.yaml, except with a different CORS suffix. This
   # is because kustomize can't do patches within the embedded YAML.
   envoy.yaml: >
@@ -78,4 +77,3 @@ data:
                   filename: "/service-certs/client.crt"
                 private_key:
                   filename: "/service-certs/client.key"
-  # yamllint enable rule:indentation

--- a/k8s/cloud/testing/proxy_envoy.yaml
+++ b/k8s/cloud/testing/proxy_envoy.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: proxy-envoy-config
 data:
-  # yamllint disable rule:indentation
   # This is almost an exact copy of base/proxy_envoy.yaml, except with a different CORS suffix. This
   # is because kustomize can't do patches within the embedded YAML.
   envoy.yaml: >
@@ -78,4 +77,3 @@ data:
                   filename: "/service-certs/client.crt"
                 private_key:
                   filename: "/service-certs/client.key"
-  # yamllint enable rule:indentation

--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -22,7 +22,6 @@ kind: ConfigMap
 metadata:
   name: nats-config
 data:
-  # yamllint disable rule:indentation
   nats.conf: |
     pid_file: "/var/run/nats/nats.pid"
     http: 8222
@@ -60,7 +59,6 @@ data:
       advertise: $CLUSTER_ADVERTISE
       connect_retries: 30
     }
-  # yamllint enable rule:indentation
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/cloud_deps/dev/nats/config_patch.yaml
+++ b/k8s/cloud_deps/dev/nats/config_patch.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: nats-config
 data:
-  # yamllint disable rule:indentation
   nats.conf: |
     pid_file: "/var/run/nats/nats.pid"
     http: 8222
@@ -40,4 +39,3 @@ data:
       advertise: $CLUSTER_ADVERTISE
       connect_retries: 30
     }
-  # yamllint enable rule:indentation

--- a/k8s/cloud_deps/public/nats/config_patch.yaml
+++ b/k8s/cloud_deps/public/nats/config_patch.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: nats-config
 data:
-  # yamllint disable rule:indentation
   nats.conf: |
     pid_file: "/var/run/nats/nats.pid"
     http: 8222
@@ -40,4 +39,3 @@ data:
       advertise: $CLUSTER_ADVERTISE
       connect_retries: 30
     }
-  # yamllint enable rule:indentation

--- a/k8s/devinfra/action-runners/runners/shared/docker_config.yaml
+++ b/k8s/devinfra/action-runners/runners/shared/docker_config.yaml
@@ -4,10 +4,8 @@ kind: ConfigMap
 metadata:
   name: dockerd-config
 data:
-  # yamllint disable rule:indentation
   daemon.json: |
     {
       "ipv6": true,
       "fixed-cidr-v6": "2001:db8:1::/64"
     }
-  # yamllint enable rule:indentation

--- a/k8s/devinfra/buildbuddy-executor/values.yaml
+++ b/k8s/devinfra/buildbuddy-executor/values.yaml
@@ -19,11 +19,11 @@ extraInitContainers:
 - name: download-executor
   # yamllint disable-line rule:line-length
   image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-  # yamllint disable rule:indentation rule:line-length
+  # yamllint disable rule:line-length
   command: ['sh', '-c', 'set -e;
     curl -fsSL https://github.com/buildbuddy-io/buildbuddy/releases/download/v2.12.42/executor-enterprise-linux-amd64 > /bb-executor/executor;
     chmod +x /bb-executor/executor']
-  # yamllint enable rule:indentation rule:line-length
+  # yamllint enable rule:line-length
   volumeMounts:
   - name: bb-executor
     mountPath: /bb-executor
@@ -81,11 +81,9 @@ extraContainers:
   volumeMounts:
   - name: tmp
     mountPath: /tmp
-  # yamllint disable rule:indentation
   command: ['/bin/bash', '-c', 'set -xe;
     while true; do
       find /tmp -maxdepth 1 \( -type d -mmin +360 -not -path "/tmp" \) -exec rm -rf {} \; ;
       sleep 60;
     done;'
   ]
-  # yamllint enable rule:indentation

--- a/k8s/grafana_demo/grafana-dashboardSources.yaml
+++ b/k8s/grafana_demo/grafana-dashboardSources.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboards
 data:
-  # yamllint disable rule:indentation
   dashboards.yaml: |-
     apiVersion: 1
     providers:
@@ -15,4 +14,3 @@ data:
       orgId: 1
       type: "file"
       allowUiUpdates: false
-  # yamllint enable rule:indentation

--- a/k8s/grafana_demo/grafana-datasources.yaml
+++ b/k8s/grafana_demo/grafana-datasources.yaml
@@ -4,7 +4,6 @@ kind: ConfigMap
 metadata:
   name: grafana-datasources
 data:
-  # yamllint disable rule:indentation
   pixie.yaml: |-
     apiVersion: 1
     datasources:
@@ -17,4 +16,3 @@ data:
       version: 1
       secureJsonData:
         apiKey: $PIXIE_API_KEY
-  # yamllint enable rule:indentation

--- a/k8s/grafana_demo/grafana-deployment.yaml
+++ b/k8s/grafana_demo/grafana-deployment.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /bin/sh
         - -c
-        # yamllint disable rule:indentation
         - |
             GRAFANA_PATH=/var/lib/grafana
             PLUGIN_PATH=$GRAFANA_PATH/plugins
@@ -46,7 +45,6 @@ spec:
               rm $PLUGIN_PATH/$PLUGIN_ZIP
               echo "Unzipped plugin into $PLUGIN_PATH/$PLUGIN"
             fi
-        # yamllint enable rule:indentation
       - name: init-grafana-dashboards
         image: alpine/git
         volumeMounts:
@@ -56,7 +54,6 @@ spec:
         command:
         - /bin/sh
         - -c
-        # yamllint disable rule:indentation
         - |
             GRAFANA_PATH=/var/lib/grafana
             GRAFANA_DASHBOARDS_PATH=$GRAFANA_PATH/grafana-dashboard-definitions/pixie
@@ -82,7 +79,6 @@ spec:
               echo 'Replaced ${PLUGIN_UID_TEMPLATE_STRING} with ${PLUGIN_UID}
               in all dashboard files in $GRAFANA_DASHBOARDS_PATH.'
             fi
-        # yamllint enable rule:indentation
       containers:
       - name: grafana
         image: grafana/grafana:7.5.16@sha256:9b7b1d9a1deadbe6fed74416d58db47f8af31b5cee214cfb659f89e6dda3f716

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -35,7 +35,6 @@ spec:
       - name: qb-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -43,7 +42,6 @@ spec:
             sleep 2;
           done;
         ']
-        # yamllint enable rule:indentation
         env:
           # The name of the service that Kelvin must connect with before becoming available.
         - name: SERVICE_NAME

--- a/k8s/vizier/base/patch_sentry.yaml
+++ b/k8s/vizier/base/patch_sentry.yaml
@@ -10,7 +10,6 @@ spec:
       - name: cc-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/readyz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -18,7 +17,6 @@ spec:
             sleep 2;
           done;
         ']
-        # yamllint enable rule:indentation
         env:
           # The name of the service that Kelvin must connect with before becoming available.
         - name: SERVICE_NAME

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -39,7 +39,6 @@ spec:
       - name: mds-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -47,7 +46,6 @@ spec:
             sleep 2;
           done;
         ']
-        # yamllint enable rule:indentation
         env:
           # The name of the service that the QB must connect with before becoming available.
         - name: SERVICE_NAME

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -37,14 +37,12 @@ spec:
       - name: nats-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation
         env:
         - name: SERVICE_NAME
           value: "pl-nats-mgmt"

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -40,14 +40,12 @@ spec:
       - name: nats-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation
         env:
         - name: SERVICE_NAME
           value: "pl-nats-mgmt"
@@ -60,7 +58,7 @@ spec:
       - name: etcd-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation rule:line-length
+        # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           ETCD_PATH="${PL_MD_ETCD_SERVER}";
           URL="${ETCD_PATH}${HEALTH_PATH}";
@@ -68,7 +66,7 @@ spec:
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation rule:line-length
+        # yamllint enable rule:line-length
         env:
         - name: HEALTH_PATH
           value: "/health"

--- a/k8s/vizier/heap_profile/kustomization.yaml
+++ b/k8s/vizier/heap_profile/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
 - ../base
 - ../pem
 patches:
-# yamllint disable rule:indentation
 - patch: |-
     - op: add
       path: "/spec/template/spec/containers/0/env/-"
@@ -40,7 +39,6 @@ patches:
         hostPath:
           path: /profiles
           type: DirectoryOrCreate
-# yamllint enable rule:indentation
   target:
     kind: DaemonSet
     namespace: pl

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -46,7 +46,6 @@ spec:
       - name: qb-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -55,7 +54,6 @@ spec:
           done;
           '
         ]
-        # yamllint enable rule:indentation
         env:
         - name: SERVICE_NAME
           value: "vizier-query-broker-svc"

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -43,14 +43,12 @@ spec:
       - name: nats-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation
         env:
         - name: SERVICE_NAME
           value: "pl-nats-mgmt"

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -16,7 +16,6 @@ spec:
       - name: qb-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -24,7 +23,6 @@ spec:
             sleep 2;
           done;
         ']
-        # yamllint enable rule:indentation
         env:
         - name: SERVICE_NAME
           value: "vizier-query-broker-svc"

--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -22,7 +22,6 @@ kind: ConfigMap
 metadata:
   name: nats-config
 data:
-  # yamllint disable rule:indentation
   nats.conf: |
     pid_file: "/var/run/nats/nats.pid"
     http: 8222
@@ -34,7 +33,6 @@ data:
       timeout: 3
       verify: true
     }
-  # yamllint enable rule:indentation
 ---
 apiVersion: v1
 kind: Service

--- a/scripts/regclient/regbot_demos.yaml
+++ b/scripts/regclient/regbot_demos.yaml
@@ -10,10 +10,8 @@ defaults:
   timeout: 10m
 scripts:
 - name: sync demo images
-  # yamllint disable rule:indentation
   script: |
     local deps = require 'deps'
     for ns, images in pairs(deps.demoImages) do
       deps.mirrorImgs(images, ns)
     end
-  # yamllint enable rule:indentation

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -21,14 +21,14 @@ spec:
       - name: wait-for-publisher
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation rule:line-length
+        # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://jetstream-publisher.${NS}.svc.cluster.local:8080/metrics";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" ${URL}) -eq 200 ]; do
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation rule:line-length
+        # yamllint enable rule:line-length
         env:
         - name: NS
           valueFrom:

--- a/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
@@ -30,14 +30,14 @@ spec:
       - name: server-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation rule:line-length
+        # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data {} ${URL}) -eq 200 ]; do
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation rule:line-length
+        # yamllint enable rule:line-length
         env:
         - name: SERVICE_NAME
           value: "server"
@@ -50,12 +50,12 @@ spec:
       containers:
       - name: app
         image: gcr.io/pixie-oss/pixie-dev/src/e2e_test/protocol_loadtest/http/wrk:latest
-        # yamllint disable rule:indentation rule:line-length
+        # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           while true; do
             wrk -t${NUM_THREADS} -c${NUM_CONNECTIONS} -d${DURATION} -s/config/wrk.lua http://${SERVICE_NAME}:${SERVICE_PORT};
           done;']
-        # yamllint enable rule:indentation rule:line-length
+        # yamllint enable rule:line-length
         env:
         - name: SERVICE_NAME
           value: "server"

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -18,14 +18,14 @@ spec:
       - name: server-wait
         # yamllint disable-line rule:line-length
         image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
-        # yamllint disable rule:indentation rule:line-length
+        # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://${SERVICE_NAME}:${SERVICE_PORT}/";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data {} ${URL}) -eq 200 ]; do
             echo "waiting for ${URL}";
             sleep 2;
           done;']
-        # yamllint enable rule:indentation rule:line-length
+        # yamllint enable rule:line-length
         env:
         - name: SERVICE_NAME
           value: "server.px-protocol-loadtest.svc.cluster.local"


### PR DESCRIPTION
Summary: This rule causes more noise than we'd like and it ends up being disabled all over the place. So instead just remove it at the top level.

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Lint runs should continue to pass.
