### PR TITLE
Fix dry run logic

### DIFF
--- a/.github/workflows/mirror_demos.yaml
+++ b/.github/workflows/mirror_demos.yaml
@@ -42,4 +42,4 @@ jobs:
       shell: bash
       run: |
         cd scripts/regclient
-        regbot once ${{ github.event.inputs.dry_run && ' --dry-run' }} --config regbot_demos.yaml
+        regbot once ${{ github.event.inputs.dry_run && '--dry-run' || '' }} --config regbot_demos.yaml

--- a/.github/workflows/mirror_deps.yaml
+++ b/.github/workflows/mirror_deps.yaml
@@ -42,4 +42,4 @@ jobs:
       shell: bash
       run: |
         cd scripts/regclient
-        regbot once ${{ github.event.inputs.dry_run && ' --dry-run' }} --config regbot_deps.yaml
+        regbot once ${{ github.event.inputs.dry_run && '--dry-run' || '' }} --config regbot_deps.yaml


### PR DESCRIPTION
Summary: Fix use of GitHub expression to fix image mirroring dry run logic

The version of the workflow on main always runs with `--dry-run` provided regardless of the input value. I thought that the 'else' case of a ternary could be omitted, but that was incorrect. The latest implementation aligns with the example in the [GitHub docs](https://docs.github.com/en/actions/learn-github-actions/expressions#example).

Relevant Issues: Precursor to fixing px-sock-shop (https://github.com/pixie-io/pixie/issues/1905)

Type of change: /kind bug

Test Plan: Updated based on the docs. Needs to be validated with a workflow run against a branch in the pixie-io org