### PR TITLE
Remove dry_run inputs responsible for regbot dry runs to always execute

### DIFF
--- a/.github/workflows/mirror_demos.yaml
+++ b/.github/workflows/mirror_demos.yaml
@@ -2,12 +2,6 @@
 name: mirror-demos
 on:
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Run the sync in dry-run mode'
-        required: false
-        default: false
-        type: boolean
 permissions:
   contents: read
 jobs:
@@ -42,4 +36,4 @@ jobs:
       shell: bash
       run: |
         cd scripts/regclient
-        regbot once ${{ github.event.inputs.dry_run && '--dry-run' || '' }} --config regbot_demos.yaml
+        regbot once --config regbot_demos.yaml

--- a/.github/workflows/mirror_deps.yaml
+++ b/.github/workflows/mirror_deps.yaml
@@ -2,12 +2,6 @@
 name: mirror-deps
 on:
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Run the sync in dry-run mode'
-        required: false
-        default: false
-        type: boolean
 permissions:
   contents: read
 jobs:
@@ -42,4 +36,4 @@ jobs:
       shell: bash
       run: |
         cd scripts/regclient
-        regbot once ${{ github.event.inputs.dry_run && '--dry-run' || '' }} --config regbot_deps.yaml
+        regbot once --config regbot_deps.yaml


### PR DESCRIPTION
Summary: Remove dry_run inputs responsible for regbot dry runs to always execute

I attempted to fix the bug where `--dry-run` is always passed to the `regbot` cli in the mirror workflows in #1921. That attempt unfortunatley did not work, so let's remove the input and the cli argument templating entirely. Running `regbot --dry-run` locally is an easy enough mechanism for testing the workflow logic.

Relevant Issues: Precursor to fixing px-sock-shop (https://github.com/pixie-io/pixie/issues/1905)

Type of change: /kind bug

Test Plan: Expecting that the next run off main after this change will result in mirrored demo container images
