### PR TITLE
Update px-finagle demo to use ghcr.io mirrored images

### DIFF
--- a/demos/finagle/finagle.yaml
+++ b/demos/finagle/finagle.yaml
@@ -53,7 +53,7 @@ spec:
       containers:
       - args:
         - client/run
-        image: gcr.io/pixie-prod/demos/finagle/hello:1.0@sha256:85006a2eae6e86019d85e1e12915d9d21e4af85b80a24674dc2b7a2ef4e7dbff
+        image: ghcr.io/pixie-io/px-finagle-hello:1.0@sha256:85006a2eae6e86019d85e1e12915d9d21e4af85b80a24674dc2b7a2ef4e7dbff
         name: finagle-client
         resources: {}
       restartPolicy: Always
@@ -86,7 +86,7 @@ spec:
         io.kompose.service: finagle-server
     spec:
       containers:
-      - image: gcr.io/pixie-prod/demos/finagle/hello:1.0@sha256:85006a2eae6e86019d85e1e12915d9d21e4af85b80a24674dc2b7a2ef4e7dbff
+      - image: ghcr.io/pixie-io/px-finagle-hello:1.0@sha256:85006a2eae6e86019d85e1e12915d9d21e4af85b80a24674dc2b7a2ef4e7dbff
         name: finagle-server
         ports:
         - containerPort: 9992


### PR DESCRIPTION
Summary: Update px-finagle demo to use ghcr.io mirrored images

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Deployed the demo by building and serving the px-finagle tar.gz locally

```
$ bazel build //demos:px-finagle
$ cp bazel-bin/demos/px-finagle.tar.gz demos/ && cd demos && python -m http.server
$ px demo deploy  --artifacts http://localhost:8000 px-finagle
```
![screen02](https://github.com/pixie-io/pixie/assets/5855593/cb36f2fd-e33b-4920-9b9d-e5cc3459cdfb)



Changelog Message: Moved hosting of px-finagle demo container images from gcr.io to ghcr.io