### PR TITLE
Unify curl image usage to use curl 7.87.0 multiarch image

### DIFF
--- a/bazel/container_images.bzl
+++ b/bazel/container_images.bzl
@@ -159,11 +159,12 @@ def stirling_test_images():
     )
 
     # Curl container, for OpenSSL tracing tests.
-    # curlimages/curl:7.74.0
+    # curlimages/curl:7.87.0
+    # multiarch sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
     _container_image(
         name = "curl_base_image",
-        repository = "curlimages/curl",
-        digest = "sha256:5594e102d5da87f8a3a6b16e5e9b0e40292b5404c12f9b6962fd6b056d2a4f82",
+        repository = "pixie-oss-pixie-dev-public-curl",
+        digest = "sha256:4311823d3576c0b7330beccbe09896ff0378c9c1c6f6974ff9064af803fed766",
     )
 
     # Ruby container, for OpenSSL tracing tests.

--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -28,7 +28,7 @@ spec:
 
       initContainers:
       - name: wait-sock-shop
-        image: ghcr.io/pixie-io/px-sock-shop-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do
             echo "waiting for ${SOCK_SHOP_HEALTH_ADDR}";

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -157,7 +157,7 @@ spec:
       - name: admin-create-if-not-exists
         imagePullPolicy: IfNotPresent
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           URL="${ADMIN_URL}/admin/health/ready";
           until [ $(curl -k -m 0.5 -s -o /dev/null -w "%{http_code}" ${URL}) -eq 200 ]; do

--- a/k8s/devinfra/buildbuddy-executor/values.yaml
+++ b/k8s/devinfra/buildbuddy-executor/values.yaml
@@ -18,7 +18,7 @@ config:
 extraInitContainers:
 - name: download-executor
   # yamllint disable-line rule:line-length
-  image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+  image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
   # yamllint disable rule:line-length
   command: ['sh', '-c', 'set -e;
     curl -fsSL https://github.com/buildbuddy-io/buildbuddy/releases/download/v2.12.42/executor-enterprise-linux-amd64 > /bb-executor/executor;

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/patch_sentry.yaml
+++ b/k8s/vizier/base/patch_sentry.yaml
@@ -9,7 +9,7 @@ spec:
       initContainers:
       - name: cc-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/readyz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
       - name: mds-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -57,7 +57,7 @@ spec:
           value: "http"
       - name: etcd-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           ETCD_PATH="${PL_MD_ETCD_SERVER}";

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       initContainers:
       - name: wait-for-publisher
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://jetstream-publisher.${NS}.svc.cluster.local:8080/metrics";

--- a/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
       - name: server-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: server-wait
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://${SERVICE_NAME}:${SERVICE_PORT}/";


### PR DESCRIPTION
Summary: Unify curl image usage to use curl 7.87.0 multiarch image

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Verified the following:
- [x] Successful trace bpf test runs validate noop for test usage
- [x] Verified that the upstream curlimages/curl:7.87.0 is the source of our ghcr.io image
```
$ docker images
REPOSITORY                                                                       TAG       IMAGE ID       CREATED         SIZE
bazel/image                                                                      image     3148ec916ea7   17 months ago   15MB
curlimages/curl                                                                  7.87.0    3148ec916ea7   17 months ago   15MB
gcr.io/pixie-oss/pixie-dev-public/curl                                           <none>    3148ec916ea7   17 months ago   15MB
ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl                                 <none>    3148ec916ea7   17 months ago   15MB
```

