### PR TITLE
Use kustomize edit fix to remove deprecated constructs (patchesJson6902 and other fixes)

### DIFF
--- a/k8s/cloud/dev/kustomization.yaml
+++ b/k8s/cloud/dev/kustomization.yaml
@@ -1,35 +1,37 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
 namespace: plc-dev
 replicas:
-- name: api-server
-  count: 1
-- name: auth-server
-  count: 1
-- name: profile-server
-  count: 1
-- name: cloud-proxy
-  count: 1
-- name: project-manager-server
-  count: 1
-- name: vzmgr-server
-  count: 1
-- name: scriptmgr-server
-  count: 1
+- count: 1
+  name: api-server
+- count: 1
+  name: auth-server
+- count: 1
+  name: profile-server
+- count: 1
+  name: cloud-proxy
+- count: 1
+  name: project-manager-server
+- count: 1
+  name: vzmgr-server
+- count: 1
+  name: scriptmgr-server
 resources:
 - ../base
 - ../overlays/exposed_services_ilb
 - plugin_db_updater_job.yaml
-patchesStrategicMerge:
 # bq_config is useful for testing, but we don't want dev clusters to typically send data to bq.
 # - bq_config.yaml
-- auth_deployment_patch.yaml
-- db_config.yaml
-- indexer_config.yaml
-- ory_service_config.yaml
-- script_bundles_config.yaml
-- proxy_envoy.yaml
-- service_config.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+patches:
+- path: auth_deployment_patch.yaml
+- path: db_config.yaml
+- path: indexer_config.yaml
+- path: ory_service_config.yaml
+- path: script_bundles_config.yaml
+- path: proxy_envoy.yaml
+- path: service_config.yaml

--- a/k8s/cloud/dev/kustomization.yaml
+++ b/k8s/cloud/dev/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc-dev
 replicas:
-- count: 1
-  name: api-server
-- count: 1
-  name: auth-server
-- count: 1
-  name: profile-server
-- count: 1
-  name: cloud-proxy
-- count: 1
-  name: project-manager-server
-- count: 1
-  name: vzmgr-server
-- count: 1
-  name: scriptmgr-server
+- name: api-server
+  count: 1
+- name: auth-server
+  count: 1
+- name: profile-server
+  count: 1
+- name: cloud-proxy
+  count: 1
+- name: project-manager-server
+  count: 1
+- name: vzmgr-server
+  count: 1
+- name: scriptmgr-server
+  count: 1
 resources:
 - ../base
 - ../overlays/exposed_services_ilb

--- a/k8s/cloud/dev/kustomization.yaml
+++ b/k8s/cloud/dev/kustomization.yaml
@@ -21,8 +21,6 @@ resources:
 - ../base
 - ../overlays/exposed_services_ilb
 - plugin_db_updater_job.yaml
-# bq_config is useful for testing, but we don't want dev clusters to typically send data to bq.
-# - bq_config.yaml
 labels:
 - includeSelectors: true
   pairs:
@@ -35,3 +33,5 @@ patches:
 - path: script_bundles_config.yaml
 - path: proxy_envoy.yaml
 - path: service_config.yaml
+# bq_config is useful for testing, but we don't want dev clusters to typically send data to bq.
+# - path: bq_config.yaml

--- a/k8s/cloud/prod/kustomization.yaml
+++ b/k8s/cloud/prod/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc
 replicas:
-- count: 3
-  name: api-server
-- count: 3
-  name: auth-server
-- count: 3
-  name: profile-server
-- count: 5
-  name: cloud-proxy
-- count: 3
-  name: project-manager-server
-- count: 1
-  name: vzmgr-server
-- count: 3
-  name: scriptmgr-server
+- name: api-server
+  count: 3
+- name: auth-server
+  count: 3
+- name: profile-server
+  count: 3
+- name: cloud-proxy
+  count: 5
+- name: project-manager-server
+  count: 3
+- name: vzmgr-server
+  count: 1
+- name: scriptmgr-server
+  count: 3
 resources:
 - frontend_config.yaml
 - cloud_ingress_managed_cert.yaml

--- a/k8s/cloud/prod/kustomization.yaml
+++ b/k8s/cloud/prod/kustomization.yaml
@@ -1,24 +1,22 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
 namespace: plc
 replicas:
-- name: api-server
-  count: 3
-- name: auth-server
-  count: 3
-- name: profile-server
-  count: 3
-- name: cloud-proxy
-  count: 5
-- name: project-manager-server
-  count: 3
-- name: vzmgr-server
-  count: 1
-- name: scriptmgr-server
-  count: 3
+- count: 3
+  name: api-server
+- count: 3
+  name: auth-server
+- count: 3
+  name: profile-server
+- count: 5
+  name: cloud-proxy
+- count: 3
+  name: project-manager-server
+- count: 1
+  name: vzmgr-server
+- count: 3
+  name: scriptmgr-server
 resources:
 - frontend_config.yaml
 - cloud_ingress_managed_cert.yaml
@@ -28,20 +26,6 @@ resources:
 - ../base
 - ../overlays/exposed_services_gclb
 - ../overlays/plugin_job
-patchesStrategicMerge:
-- support_access_config.yaml
-- analytics_config.yaml
-- bq_config.yaml
-- api_deployment.yaml
-- contact_config.yaml
-- db_config.yaml
-- service_config.yaml
-- domain_config.yaml
-- cloud_ingress_ip.yaml
-- script_bundles_config.yaml
-- scriptmgr_config.yaml
-- proxy_envoy.yaml
-- auth_deployment.yaml
 patches:
 - path: db_sidecar.yaml
   target:
@@ -54,3 +38,20 @@ patches:
   target:
     kind: Job
     labelSelector: jobgroup=plugin-db-updater
+- path: support_access_config.yaml
+- path: analytics_config.yaml
+- path: bq_config.yaml
+- path: api_deployment.yaml
+- path: contact_config.yaml
+- path: db_config.yaml
+- path: service_config.yaml
+- path: domain_config.yaml
+- path: cloud_ingress_ip.yaml
+- path: script_bundles_config.yaml
+- path: scriptmgr_config.yaml
+- path: proxy_envoy.yaml
+- path: auth_deployment.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud

--- a/k8s/cloud/public/base/kustomization.yaml
+++ b/k8s/cloud/public/base/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc
 replicas:
-- count: 1
-  name: api-server
-- count: 1
-  name: auth-server
-- count: 1
-  name: profile-server
-- count: 1
-  name: cloud-proxy
-- count: 1
-  name: project-manager-server
-- count: 1
-  name: vzmgr-server
-- count: 1
-  name: scriptmgr-server
+- name: api-server
+  count: 1
+- name: auth-server
+  count: 1
+- name: profile-server
+  count: 1
+- name: cloud-proxy
+  count: 1
+- name: project-manager-server
+  count: 1
+- name: vzmgr-server
+  count: 1
+- name: scriptmgr-server
+  count: 1
 resources:
 - ../../base
 - ../../base/ory_auth

--- a/k8s/cloud/public/base/kustomization.yaml
+++ b/k8s/cloud/public/base/kustomization.yaml
@@ -1,31 +1,33 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
 namespace: plc
 replicas:
-- name: api-server
-  count: 1
-- name: auth-server
-  count: 1
-- name: profile-server
-  count: 1
-- name: cloud-proxy
-  count: 1
-- name: project-manager-server
-  count: 1
-- name: vzmgr-server
-  count: 1
-- name: scriptmgr-server
-  count: 1
+- count: 1
+  name: api-server
+- count: 1
+  name: auth-server
+- count: 1
+  name: profile-server
+- count: 1
+  name: cloud-proxy
+- count: 1
+  name: project-manager-server
+- count: 1
+  name: vzmgr-server
+- count: 1
+  name: scriptmgr-server
 resources:
 - ../../base
 - ../../base/ory_auth
 - ../../overlays/exposed_services_ilb
 - plugin_db_updater_job.yaml
-patchesStrategicMerge:
-- artifact_tracker_versions.yaml
-- domain_config.yaml
-- script_bundles_config.yaml
-- proxy_envoy.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+patches:
+- path: artifact_tracker_versions.yaml
+- path: domain_config.yaml
+- path: script_bundles_config.yaml
+- path: proxy_envoy.yaml

--- a/k8s/cloud/staging/kustomization.yaml
+++ b/k8s/cloud/staging/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc-staging
 replicas:
-- name: api-server
-  count: 3
-- name: auth-server
-  count: 3
-- name: profile-server
-  count: 3
-- name: cloud-proxy
-  count: 3
-- name: project-manager-server
-  count: 3
-- name: vzmgr-server
-  count: 1
-- name: scriptmgr-server
-  count: 3
+- count: 3
+  name: api-server
+- count: 3
+  name: auth-server
+- count: 3
+  name: profile-server
+- count: 3
+  name: cloud-proxy
+- count: 3
+  name: project-manager-server
+- count: 1
+  name: vzmgr-server
+- count: 3
+  name: scriptmgr-server
 resources:
 - frontend_config.yaml
 - cloud_ingress_managed_cert.yaml
@@ -26,18 +26,6 @@ resources:
 - ../base
 - ../overlays/exposed_services_gclb
 - ../overlays/plugin_job
-patchesStrategicMerge:
-- support_access_config.yaml
-- analytics_config.yaml
-- bq_config.yaml
-- contact_config.yaml
-- db_config.yaml
-- indexer_config.yaml
-- service_config.yaml
-- domain_config.yaml
-- cloud_ingress_ip.yaml
-- script_bundles_config.yaml
-- proxy_envoy.yaml
 patches:
 - path: db_sidecar.yaml
   target:
@@ -47,3 +35,14 @@ patches:
   target:
     kind: Job
     labelSelector: jobgroup=plugin-db-updater
+- path: support_access_config.yaml
+- path: analytics_config.yaml
+- path: bq_config.yaml
+- path: contact_config.yaml
+- path: db_config.yaml
+- path: indexer_config.yaml
+- path: service_config.yaml
+- path: domain_config.yaml
+- path: cloud_ingress_ip.yaml
+- path: script_bundles_config.yaml
+- path: proxy_envoy.yaml

--- a/k8s/cloud/staging/kustomization.yaml
+++ b/k8s/cloud/staging/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc-staging
 replicas:
-- count: 3
-  name: api-server
-- count: 3
-  name: auth-server
-- count: 3
-  name: profile-server
-- count: 3
-  name: cloud-proxy
-- count: 3
-  name: project-manager-server
-- count: 1
-  name: vzmgr-server
-- count: 3
-  name: scriptmgr-server
+- name: api-server
+  count: 3
+- name: auth-server
+  count: 3
+- name: profile-server
+  count: 3
+- name: cloud-proxy
+  count: 3
+- name: project-manager-server
+  count: 3
+- name: vzmgr-server
+  count: 1
+- name: scriptmgr-server
+  count: 3
 resources:
 - frontend_config.yaml
 - cloud_ingress_managed_cert.yaml

--- a/k8s/cloud/testing/kustomization.yaml
+++ b/k8s/cloud/testing/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc-testing
 replicas:
-- name: api-server
-  count: 3
-- name: auth-server
-  count: 3
-- name: profile-server
-  count: 3
-- name: cloud-proxy
-  count: 3
-- name: project-manager-server
-  count: 3
-- name: vzmgr-server
-  count: 1
-- name: scriptmgr-server
-  count: 3
+- count: 3
+  name: api-server
+- count: 3
+  name: auth-server
+- count: 3
+  name: profile-server
+- count: 3
+  name: cloud-proxy
+- count: 3
+  name: project-manager-server
+- count: 1
+  name: vzmgr-server
+- count: 3
+  name: scriptmgr-server
 resources:
 - frontend_config.yaml
 - cloud_ingress_managed_cert.yaml
@@ -26,21 +26,20 @@ resources:
 - ../base
 - ../overlays/exposed_services_gclb
 - ../overlays/plugin_job
-patchesStrategicMerge:
-- bq_config.yaml
-- support_access_config.yaml
-- analytics_config.yaml
-- contact_config.yaml
-- db_config.yaml
-- indexer_config.yaml
-- service_config.yaml
-- domain_config.yaml
-- cloud_ingress_ip.yaml
-- script_bundles_config.yaml
-- proxy_envoy.yaml
-- auth_deployment.yaml
 patches:
 - path: db_sidecar.yaml
   target:
     kind: Deployment
     labelSelector: db=pgsql
+- path: bq_config.yaml
+- path: support_access_config.yaml
+- path: analytics_config.yaml
+- path: contact_config.yaml
+- path: db_config.yaml
+- path: indexer_config.yaml
+- path: service_config.yaml
+- path: domain_config.yaml
+- path: cloud_ingress_ip.yaml
+- path: script_bundles_config.yaml
+- path: proxy_envoy.yaml
+- path: auth_deployment.yaml

--- a/k8s/cloud/testing/kustomization.yaml
+++ b/k8s/cloud/testing/kustomization.yaml
@@ -3,20 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: plc-testing
 replicas:
-- count: 3
-  name: api-server
-- count: 3
-  name: auth-server
-- count: 3
-  name: profile-server
-- count: 3
-  name: cloud-proxy
-- count: 3
-  name: project-manager-server
-- count: 1
-  name: vzmgr-server
-- count: 3
-  name: scriptmgr-server
+- name: api-server
+  count: 3
+- name: auth-server
+  count: 3
+- name: profile-server
+  count: 3
+- name: cloud-proxy
+  count: 3
+- name: project-manager-server
+  count: 3
+- name: vzmgr-server
+  count: 1
+- name: scriptmgr-server
+  count: 3
 resources:
 - frontend_config.yaml
 - cloud_ingress_managed_cert.yaml

--- a/k8s/cloud_deps/dev/nats/kustomization.yaml
+++ b/k8s/cloud_deps/dev/nats/kustomization.yaml
@@ -1,15 +1,17 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
-  component: cloud-deps
 namespace: plc-dev
 resources:
 - clusterroles
 - ../../base/nats
-patchesStrategicMerge:
-- config_patch.yaml
-- jetstream_config_patch.yaml
-- replica_patch.yaml
-- storage_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+    component: cloud-deps
+patches:
+- path: config_patch.yaml
+- path: jetstream_config_patch.yaml
+- path: replica_patch.yaml
+- path: storage_patch.yaml

--- a/k8s/cloud_deps/prod/nats/kustomization.yaml
+++ b/k8s/cloud_deps/prod/nats/kustomization.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
-  component: cloud-deps
 namespace: plc
 resources:
 - clusterroles
 - ../../base/nats
-patchesStrategicMerge:
-- storage_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+    component: cloud-deps
+patches:
+- path: storage_patch.yaml

--- a/k8s/cloud_deps/public/nats/kustomization.yaml
+++ b/k8s/cloud_deps/public/nats/kustomization.yaml
@@ -1,15 +1,17 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
-  component: cloud-deps
 namespace: plc
 resources:
 - clusterroles
 - ../../base/nats
-patchesStrategicMerge:
-- config_patch.yaml
-- jetstream_config_patch.yaml
-- replica_patch.yaml
-- storage_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+    component: cloud-deps
+patches:
+- path: config_patch.yaml
+- path: jetstream_config_patch.yaml
+- path: replica_patch.yaml
+- path: storage_patch.yaml

--- a/k8s/cloud_deps/staging/nats/kustomization.yaml
+++ b/k8s/cloud_deps/staging/nats/kustomization.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
-  component: cloud-deps
 namespace: plc-staging
 resources:
 - clusterroles
 - ../../base/nats
-patchesStrategicMerge:
-- storage_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+    component: cloud-deps
+patches:
+- path: storage_patch.yaml

--- a/k8s/cloud_deps/testing/nats/kustomization.yaml
+++ b/k8s/cloud_deps/testing/nats/kustomization.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: pl-cloud
-  component: cloud-deps
 namespace: plc-testing
 resources:
 - clusterroles
 - ../../base/nats
-patchesStrategicMerge:
-- storage_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: pl-cloud
+    component: cloud-deps
+patches:
+- path: storage_patch.yaml

--- a/k8s/vizier/sanitizer/kustomization.yaml
+++ b/k8s/vizier/sanitizer/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../dev
-patchesStrategicMerge:
-- pem_deployment.yaml
-- kelvin_deployment.yaml
+patches:
+- path: pem_deployment.yaml
+- path: kelvin_deployment.yaml


### PR DESCRIPTION
Summary: Use kustomize edit fix to remove deprecated constructs (patchesJson6902 and other fixes)

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Modified these files with `kustomize edit fix` and verified the following:
- [x] yaml is equivalent before and after except for a minor reordering of containers in a single prod and staging deployment
<details><summary> output </summary>

```
# Generate list from commits
(ddelnano/update-deprecated-patches-strategic-merge) $ git diff HEAD~1 --name-only > files

# Generate yaml from new and old versions
(ddelnano/update-deprecated-patches-strategic-merge) $ cat files  | xargs -I{} dirname {} | sort -u | xargs -I{} bash -c "kustomize build {} > {}/new"
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.

(master) $ cat files | xargs -I{} bash -c "sha256sum {}/new; sha256 {}/old"
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.


# Diff files and see that only differences are due to a container reordering in prod and staging
$ cat dirs | xargs -I{} bash -c "echo 'Testing {}'; diff {}/new {}/old"
Testing k8s/cloud/dev
Testing k8s/cloud/prod
835a836,849
>       - command:
>         - /cloud_sql_proxy
>         - -instances=pixie-prod:us-west1:pixie-cloud-prod-db-pg13=tcp:5432
>         - -ip_address_types=PRIVATE
>         - -credential_file=/secrets/cloudsql/db_service_account.json
>         image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
>         name: cloudsql-proxy
>         securityContext:
>           allowPrivilegeEscalation: false
>           runAsUser: 2
>         volumeMounts:
>         - mountPath: /secrets/cloudsql
>           name: pl-db-secrets
>           readOnly: true
943,956d956
<       - command:
<         - /cloud_sql_proxy
<         - -instances=pixie-prod:us-west1:pixie-cloud-prod-db-pg13=tcp:5432
<         - -ip_address_types=PRIVATE
<         - -credential_file=/secrets/cloudsql/db_service_account.json
<         image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
<         name: cloudsql-proxy
<         securityContext:
<           allowPrivilegeEscalation: false
<           runAsUser: 2
<         volumeMounts:
<         - mountPath: /secrets/cloudsql
<           name: pl-db-secrets
<           readOnly: true
Testing k8s/cloud/public/base
Testing k8s/cloud/staging
Testing k8s/cloud/testing
829a830,843
>       - command:
>         - /cloud_sql_proxy
>         - -instances=pl-pixies:us-west1:pixie-cloud-testing-db-pg13=tcp:5432
>         - -ip_address_types=PRIVATE
>         - -credential_file=/secrets/cloudsql/db_service_account.json
>         image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
>         name: cloudsql-proxy
>         securityContext:
>           allowPrivilegeEscalation: false
>           runAsUser: 2
>         volumeMounts:
>         - mountPath: /secrets/cloudsql
>           name: pl-db-secrets
>           readOnly: true
937,950d950
<       - command:
<         - /cloud_sql_proxy
<         - -instances=pl-pixies:us-west1:pixie-cloud-testing-db-pg13=tcp:5432
<         - -ip_address_types=PRIVATE
<         - -credential_file=/secrets/cloudsql/db_service_account.json
<         image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
<         name: cloudsql-proxy
<         securityContext:
<           allowPrivilegeEscalation: false
<           runAsUser: 2
<         volumeMounts:
<         - mountPath: /secrets/cloudsql
<           name: pl-db-secrets
<           readOnly: true
Testing k8s/cloud_deps/dev/nats
Testing k8s/cloud_deps/prod/nats
Testing k8s/cloud_deps/public/nats
Testing k8s/cloud_deps/staging/nats
Testing k8s/cloud_deps/testing/nats
Testing k8s/vizier/sanitizer

```

</details>