### PR TITLE
update nGram tokenizer to support elasticsearch v8

### DIFF
--- a/src/cloud/indexer/md/mapping.o.go
+++ b/src/cloud/indexer/md/mapping.o.go
@@ -106,7 +106,7 @@ const IndexMapping = `
         },
         "tokenizer": {
           "ngram_tokenizer": {
-            "type": "nGram",
+            "type": "ngram",
             "min_gram": "1",
             "max_gram": "10",
             "token_chars": [


### PR DESCRIPTION
I'm using ElascSearch v8 and I have the following error in indexer-server
`time="2024-06-05T22:35:29Z" level=fatal msg="Could not initialize elastic mapping" error="elastic: Error 400 (Bad Request): The [nGram] tokenizer name was deprecated in 7.6. Please use the tokenizer name to [ngram] for indices created in versions 8 or higher instead. [type=illegal_argument_exception]"`
