### PR TITLE
Add x86_64 sysroot profile to cloud and operator skaffold configs

### DIFF
--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -153,3 +153,9 @@ profiles:
     path: /manifests/kustomize/paths
     value:
     - k8s/cloud/public/base
+- name: x86_64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=x86_64_sysroot

--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -1,9 +1,9 @@
 ---
 .common_bazel_args: &common_bazel_args
-  - --compilation_mode=opt
-  - --config=stamp
-  - --action_env=GOOGLE_APPLICATION_CREDENTIALS
-  - --config=x86_64_sysroot
+- --compilation_mode=opt
+- --config=stamp
+- --action_env=GOOGLE_APPLICATION_CREDENTIALS
+- --config=x86_64_sysroot
 apiVersion: skaffold/v4beta1
 kind: Config
 build:

--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -1,4 +1,9 @@
 ---
+.common_bazel_args: &common_bazel_args
+  - --compilation_mode=opt
+  - --config=stamp
+  - --action_env=GOOGLE_APPLICATION_CREDENTIALS
+  - --config=x86_64_sysroot
 apiVersion: skaffold/v4beta1
 kind: Config
 build:
@@ -112,9 +117,7 @@ profiles:
   - op: add
     path: /build/artifacts/context=./bazel/args
     value:
-    - --compilation_mode=opt
-    - --config=stamp
-    - --action_env=GOOGLE_APPLICATION_CREDENTIALS
+      *common_bazel_args
   - op: replace
     path: /manifests/kustomize/paths
     value:
@@ -126,9 +129,7 @@ profiles:
   - op: add
     path: /build/artifacts/context=./bazel/args
     value:
-    - --compilation_mode=opt
-    - --config=stamp
-    - --action_env=GOOGLE_APPLICATION_CREDENTIALS
+      *common_bazel_args
   - op: replace
     path: /manifests/kustomize/paths
     value:
@@ -140,9 +141,7 @@ profiles:
   - op: add
     path: /build/artifacts/context=./bazel/args
     value:
-    - --compilation_mode=opt
-    - --config=stamp
-    - --action_env=GOOGLE_APPLICATION_CREDENTIALS
+      *common_bazel_args
   - op: replace
     path: /manifests/kustomize/paths
     value:
@@ -153,9 +152,3 @@ profiles:
     path: /manifests/kustomize/paths
     value:
     - k8s/cloud/public/base
-- name: x86_64_sysroot
-  patches:
-  - op: add
-    path: /build/artifacts/context=./bazel/args
-    value:
-    - --config=x86_64_sysroot

--- a/skaffold/skaffold_operator.yaml
+++ b/skaffold/skaffold_operator.yaml
@@ -22,3 +22,9 @@ profiles:
     path: /build/local
     value:
       push: false
+- name: x86_64_sysroot
+  patches:
+  - op: add
+    path: /build/artifacts/context=./bazel/args
+    value:
+    - --config=x86_64_sysroot


### PR DESCRIPTION
Summary: Add x86_64 sysroot profile to cloud and operator skaffold configs

Deploying builds from a noble (Ubuntu 24.04) environment requires using the x86_64 sysroot at all times. Add this to the config to make this addition easy to opt into.

Relevant Issues: N/A

Type of change: /kind compatibility

Test Plan: Deployed a new cloud and got it successfully running with `skaffold run -p ${env},x86_64_sysroot -f skaffold/skaffold_cloud.yaml`
