### PR TITLE
Upgrade cloud-sql-proxy from v1 to v2

### DIFF
--- a/k8s/cloud/prod/db_sidecar.yaml
+++ b/k8s/cloud/prod/db_sidecar.yaml
@@ -9,11 +9,12 @@ spec:
       containers:
       - name: cloudsql-proxy
         # yamllint disable-line rule:line-length
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
-        command: ["/cloud_sql_proxy",
-                  "-instances=pixie-prod:us-west1:pixie-cloud-prod-db-pg13=tcp:5432",
-                  "-ip_address_types=PRIVATE",
-                  "-credential_file=/secrets/cloudsql/db_service_account.json"]
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
+        args:
+          - "--private-ip"
+          - "--auto-iam-authn"
+          - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+          - "pixie-prod:us-west1:pixie-cloud-prod-db-pg13"
         # [START cloudsql_security_context]
         securityContext:
           runAsUser: 2  # non-root user

--- a/k8s/cloud/prod/db_sidecar.yaml
+++ b/k8s/cloud/prod/db_sidecar.yaml
@@ -11,10 +11,10 @@ spec:
         # yamllint disable-line rule:line-length
         image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
         args:
-          - "--private-ip"
-          - "--auto-iam-authn"
-          - "--credentials-file=/secrets/cloudsql/db_service_account.json"
-          - "pixie-prod:us-west1:pixie-cloud-prod-db-pg13"
+        - "--private-ip"
+        - "--auto-iam-authn"
+        - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+        - "pixie-prod:us-west1:pixie-cloud-prod-db-pg13"
         # [START cloudsql_security_context]
         securityContext:
           runAsUser: 2  # non-root user

--- a/k8s/cloud/staging/db_sidecar.yaml
+++ b/k8s/cloud/staging/db_sidecar.yaml
@@ -9,11 +9,12 @@ spec:
       containers:
       - name: cloudsql-proxy
         # yamllint disable-line rule:line-length
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
-        command: ["/cloud_sql_proxy",
-                  "-instances=pixie-prod:us-west1:pixie-cloud-staging-db-pg13=tcp:5432",
-                  "-ip_address_types=PRIVATE",
-                  "-credential_file=/secrets/cloudsql/db_service_account.json"]
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
+        args:
+          - "--private-ip"
+          - "--auto-iam-authn"
+          - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+          - "pixie-prod:us-west1:pixie-cloud-staging-db-pg13"
         # [START cloudsql_security_context]
         securityContext:
           runAsUser: 2  # non-root user

--- a/k8s/cloud/staging/db_sidecar.yaml
+++ b/k8s/cloud/staging/db_sidecar.yaml
@@ -11,10 +11,10 @@ spec:
         # yamllint disable-line rule:line-length
         image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
         args:
-          - "--private-ip"
-          - "--auto-iam-authn"
-          - "--credentials-file=/secrets/cloudsql/db_service_account.json"
-          - "pixie-prod:us-west1:pixie-cloud-staging-db-pg13"
+        - "--private-ip"
+        - "--auto-iam-authn"
+        - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+        - "pixie-prod:us-west1:pixie-cloud-staging-db-pg13"
         # [START cloudsql_security_context]
         securityContext:
           runAsUser: 2  # non-root user

--- a/k8s/cloud/testing/db_sidecar.yaml
+++ b/k8s/cloud/testing/db_sidecar.yaml
@@ -11,10 +11,10 @@ spec:
         # yamllint disable-line rule:line-length
         image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
         args:
-          - "--private-ip"
-          - "--auto-iam-authn"
-          - "--credentials-file=/secrets/cloudsql/db_service_account.json"
-          - "pl-pixies:us-west1:pixie-cloud-testing-db-pg13"
+        - "--private-ip"
+        - "--auto-iam-authn"
+        - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+        - "pl-pixies:us-west1:pixie-cloud-testing-db-pg13"
         # [START cloudsql_security_context]
         securityContext:
           runAsUser: 2  # non-root user

--- a/k8s/cloud/testing/db_sidecar.yaml
+++ b/k8s/cloud/testing/db_sidecar.yaml
@@ -9,11 +9,12 @@ spec:
       containers:
       - name: cloudsql-proxy
         # yamllint disable-line rule:line-length
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
-        command: ["/cloud_sql_proxy",
-                  "-instances=pl-pixies:us-west1:pixie-cloud-testing-db-pg13=tcp:5432",
-                  "-ip_address_types=PRIVATE",
-                  "-credential_file=/secrets/cloudsql/db_service_account.json"]
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
+        args:
+          - "--private-ip"
+          - "--auto-iam-authn"
+          - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+          - "pl-pixies:us-west1:pixie-cloud-testing-db-pg13"
         # [START cloudsql_security_context]
         securityContext:
           runAsUser: 2  # non-root user


### PR DESCRIPTION
Summary: Upgrade cloud-sql-proxy from v1 to v2

Relevant Issues: N/A

Type of change: /kind dependency

Test Plan: Deployed new testing cloud and verified database access works with v2 image

