### PR TITLE
Fix busybox path in plugin job with switch to `x86_64_sysroot` skaffold profile

### DIFF
--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: updater
         image: cloud-plugin-load_db:latest
-        command: ["/busybox/sh", "-c"]
+        command: ["/bin/busybox", "sh", "-c"]
         args:
         - |
             trap "touch /tmp/pod/terminated" EXIT


### PR DESCRIPTION
Summary: Fix busybox path in plugin job with switch to `x86_64_sysroot` skaffold profile

#1941 switched the cloud skaffold build to use the x86_64_sysroot profile. After that was introduced, the plugin load job no longer runs due to a missing `/busybox` path. This change updates the kubernetes manifests to work with the correct path.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Verified the following:
- [x] Verified there is no more usage of `/busybox` in other k8s manifests
- [x] `src/cloud/plugin/load_db:plugin_db_updater_image` doesn't contain `/busybox` when sysroot config is used (current skaffold behavior)
```
$ bazel run --config=x86_64_sysroot --config=stamp -c opt src/cloud/plugin/load_db:plugin_db_updater_image
INFO: Analyzed target //src/cloud/plugin/load_db:plugin_db_updater_image (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src/cloud/plugin/load_db:plugin_db_updater_image up-to-date:
  bazel-bin/src/cloud/plugin/load_db/plugin_db_updater_image-layer.tar
INFO: Elapsed time: 0.396s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/src/cloud/plugin/load_db/plugin_db_updater_image.executable
Loaded image ID: sha256:f06831dfaf1f3896d629b2919ebc004312221a616f34f164f47c92472330aced
Tagging f06831dfaf1f3896d629b2919ebc004312221a616f34f164f47c92472330aced as bazel/src/cloud/plugin/load_db:plugin_db_updater_image

$ sudo docker run --entrypoint sh -it bazel/src/cloud/plugin/load_db:plugin_db_updater_image
# ls -alh /busybox
ls: cannot access '/busybox': No such file or directory
```
- [x] `src/cloud/plugin/load_db:plugin_db_updater_image` does contain `/busybox` without sysroot config (previous behavior in skaffold)
```
$ bazel run src/cloud/plugin/load_db:plugin_db_updater_image

$ sudo docker run --entrypoint sh -it bazel/src/cloud/plugin/load_db:plugin_db_updater_image
/app/src/cloud/plugin/load_db/load_db.runfiles/px # ls -alh /busybox
[ ... ]

total 1M
drwxr-xr-x    2 root     root       12.0K Feb 27  2023 .
drwxr-xr-x    1 root     root        4.0K Jun 21 17:34 ..
lrwxrwxrwx    1 root     root           7 Feb 27  2023 [ -> busybox
lrwxrwxrwx    1 root     root           7 Feb 27  2023 [[ -> busybox
lrwxrwxrwx    1 root     root           7 Feb 27  2023 acpid -> busybox
```
- [x] New cloud deploy is successful