### PR TITLE
Reorder kustomization patches to keep consistent ordering between envs

### DIFF
--- a/k8s/cloud/prod/kustomization.yaml
+++ b/k8s/cloud/prod/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../overlays/exposed_services_gclb
 - ../overlays/plugin_job
 patches:
+- path: auth_deployment.yaml
 - path: db_sidecar.yaml
   target:
     kind: Deployment
@@ -50,7 +51,6 @@ patches:
 - path: script_bundles_config.yaml
 - path: scriptmgr_config.yaml
 - path: proxy_envoy.yaml
-- path: auth_deployment.yaml
 labels:
 - includeSelectors: true
   pairs:

--- a/k8s/cloud/testing/kustomization.yaml
+++ b/k8s/cloud/testing/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../overlays/exposed_services_gclb
 - ../overlays/plugin_job
 patches:
+- path: auth_deployment.yaml
 - path: db_sidecar.yaml
   target:
     kind: Deployment
@@ -42,4 +43,3 @@ patches:
 - path: cloud_ingress_ip.yaml
 - path: script_bundles_config.yaml
 - path: proxy_envoy.yaml
-- path: auth_deployment.yaml


### PR DESCRIPTION
Summary: Reorder kustomization patches to keep consistent ordering between envs

This reordering was introduced in https://github.com/pixie-io/pixie/pull/1938. Note how the testing performed on that PR required looking at how the yaml was reordered for a few cases. This change fixes that reordering.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Verified with `kustomize build k8s/cloud/prod` and `kustomize build k8s/cloud/testing` that the yaml before #1938 and after this fix match exactly

