### PR TITLE
[actions] Disable Perf PR action

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -1,8 +1,6 @@
 ---
 name: perf-eval
 on:
-  issue_comment:
-    types: [created]
   schedule:
   # Run at 23:49 PST (07:49 UTC) every day. Github suggests not running actions on the hour.
   - cron: '49 7 * * *'


### PR DESCRIPTION
Summary: We need to rethink how we trigger perf on PRs.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Disables the perf action, no test necessary.
