### PR TITLE
Upgrade remaining references to cloud-sql-proxy v1 to v2

### DIFF
--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -57,7 +57,8 @@ spec:
         - name: PL_PLUGIN_REPO
           value: "pixie-io/pixie-plugin"
       # yamllint disable-line rule:line-length
-      - image: b.gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
+      # The alpine based image contains a shell and is needed for this command to work.
+      - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3-alpine@sha256:4885fd3e6362ba22abff1804a7f5e75cec5fafbeb4e41be8b0059ecad94a16f1
         name: cloudsql-proxy
         command: ["/bin/sh", "-c"]
         envFrom:
@@ -65,10 +66,11 @@ spec:
             name: pl-db-config
         args:
         - |
-            /cloud_sql_proxy \
-            -instances=${PL_POSTGRES_INSTANCE}=tcp:${PL_POSTGRES_PORT} \
-            -ip_address_types=PRIVATE \
-            -credential_file=/secrets/cloudsql/db_service_account.json & CHILD_PID=$!
+            /cloud-sql-proxy \
+            --private-ip \
+            --auto-iam-authn \
+            --credentials-file=/secrets/cloudsql/db_service_account.json \
+            ${PL_POSTGRES_INSTANCE} & CHILD_PID=$!
             (while true; do if [[ -f "/tmp/pod/terminated" ]]; then kill $CHILD_PID;
             echo "Killed $CHILD_PID because the main container terminated."; fi; sleep 1; done) &
             wait $CHILD_PID

--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -56,8 +56,8 @@ spec:
               key: PL_PLUGIN_SERVICE
         - name: PL_PLUGIN_REPO
           value: "pixie-io/pixie-plugin"
-      # yamllint disable-line rule:line-length
       # The alpine based image contains a shell and is needed for this command to work.
+      # yamllint disable-line rule:line-length
       - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3-alpine@sha256:4885fd3e6362ba22abff1804a7f5e75cec5fafbeb4e41be8b0059ecad94a16f1
         name: cloudsql-proxy
         command: ["/bin/sh", "-c"]

--- a/k8s/clusters/prod/db_reader.yaml
+++ b/k8s/clusters/prod/db_reader.yaml
@@ -23,13 +23,13 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         tty: true
-      - command:
-        - /cloud_sql_proxy
-        - -instances=pixie-prod:us-west1:pixie-cloud-prod-db-pg13=tcp:5432
-        - -ip_address_types=PRIVATE
-        - -credential_file=/secrets/cloudsql/db_service_account.json
         # yamllint disable-line rule:line-length
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
+      - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
+        args:
+        - "--private-ip"
+        - "--auto-iam-authn"
+        - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+        - "pixie-prod:us-west1:pixie-cloud-prod-db-pg13"
         imagePullPolicy: IfNotPresent
         name: cloudsql-proxy
         resources: {}

--- a/k8s/clusters/staging/db_reader.yaml
+++ b/k8s/clusters/staging/db_reader.yaml
@@ -23,6 +23,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         tty: true
+      # yamllint disable-line rule:line-length
       - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
         args:
         - "--private-ip"

--- a/k8s/clusters/staging/db_reader.yaml
+++ b/k8s/clusters/staging/db_reader.yaml
@@ -23,13 +23,12 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         tty: true
-      - command:
-        - /cloud_sql_proxy
-        - -instances=pixie-prod:us-west1:pixie-cloud-staging-db-pg13=tcp:5432
-        - -ip_address_types=PRIVATE
-        - -credential_file=/secrets/cloudsql/db_service_account.json
-        # yamllint disable-line rule:line-length
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
+      - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
+        args:
+        - "--private-ip"
+        - "--auto-iam-authn"
+        - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+        - "pixie-prod:us-west1:pixie-cloud-staging-db-pg13"
         imagePullPolicy: IfNotPresent
         name: cloudsql-proxy
         resources: {}

--- a/k8s/clusters/testing/db_reader.yaml
+++ b/k8s/clusters/testing/db_reader.yaml
@@ -23,13 +23,12 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         tty: true
-      - command:
-        - /cloud_sql_proxy
-        - -instances=pl-pixies:us-west1:pixie-cloud-testing-db-pg13=tcp:5432
-        - -ip_address_types=PRIVATE
-        - -credential_file=/secrets/cloudsql/db_service_account.json
-        # yamllint disable-line rule:line-length
-        image: gcr.io/cloudsql-docker/gce-proxy:1.14@sha256:96689ad665bffc521fc9ac3cbcaa90f7d543a3fc6f1c84f81e4148a22ffa66e0
+      - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
+        args:
+        - "--private-ip"
+        - "--auto-iam-authn"
+        - "--credentials-file=/secrets/cloudsql/db_service_account.json"
+        - "pl-pixies:us-west1:pixie-cloud-testing-db-pg13"
         imagePullPolicy: IfNotPresent
         name: cloudsql-proxy
         resources: {}

--- a/k8s/clusters/testing/db_reader.yaml
+++ b/k8s/clusters/testing/db_reader.yaml
@@ -23,6 +23,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         tty: true
+      # yamllint disable-line rule:line-length
       - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.3@sha256:698174c37a5d4da797123a20bd5dc2b70fcaeae63c4cd634bdc9a70ce3282cbf
         args:
         - "--private-ip"


### PR DESCRIPTION
Summary: Upgrade remaining references to cloud-sql-proxy v1 to v2

This is a continuation of #1942.

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Verified the following
- [x] All gce-proxy image references are gone
```
$ git grep gce-proxy
$
```
- [x] Verified that plugins are properly populated in a testing cloud
