### PR TITLE
Replace hand crafted query interpolation with sqlx parameter binding

### DIFF
--- a/src/cloud/vzmgr/controllers/server.go
+++ b/src/cloud/vzmgr/controllers/server.go
@@ -347,10 +347,9 @@ func (s *Server) GetVizierInfos(ctx context.Context, req *vzmgrpb.GetVizierInfos
               i.control_plane_pod_statuses, i.unhealthy_data_plane_pod_statuses,
 							i.num_nodes, i.num_instrumented_nodes, i.status_message, i.prev_status, i.prev_status_time
               FROM vizier_cluster_info as i, vizier_cluster as c
-              WHERE i.vizier_cluster_id=c.id AND i.vizier_cluster_id IN (?) AND c.org_id='%s'`
-	strQuery = fmt.Sprintf(strQuery, orgIDstr)
+              WHERE i.vizier_cluster_id=c.id AND i.vizier_cluster_id IN (?) AND c.org_id=?`
 
-	query, args, err := sqlx.In(strQuery, ids)
+	query, args, err := sqlx.In(strQuery, ids, orgIDstr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Summary: Replace hand crafted query interpolation with sqlx parameter binding

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Verified the following after skaffold'ing this change
- [x] Verified that the "Data Retention Scripts" page loads
- [x] Verified that `/admin/clusters` page loads to test the 
