### PR TITLE
Update px cli to make `--cloud_addr` a required argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,8 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/lestrrat-go/jwx v1.2.26
 	github.com/lib/pq v1.10.4
+	github.com/manifoldco/promptui v0.9.0
+	github.com/mattn/go-isatty v0.0.17
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/mikefarah/yq/v4 v4.30.8
 	github.com/nats-io/nats-server/v2 v2.10.4
@@ -75,6 +77,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.8
 	go.etcd.io/etcd/server/v3 v3.5.8
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20230307190834-24139beb5833
 	golang.org/x/mod v0.9.0
 	golang.org/x/net v0.17.0
 	golang.org/x/oauth2 v0.6.0
@@ -118,6 +121,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/cockroachdb/errors v1.8.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
@@ -204,7 +208,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-sqlite3 v1.14.5 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
@@ -267,7 +270,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.15.0 // indirect
-	golang.org/x/exp v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,11 @@ github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNS
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
@@ -642,6 +645,8 @@ github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -2517,6 +2517,13 @@ def pl_go_dependencies():
         version = "v1.0.0",
     )
     go_repository(
+        name = "com_github_manifoldco_promptui",
+        build_directives = ["gazelle:map_kind go_binary pl_go_binary @px//bazel:pl_build_system.bzl", "gazelle:map_kind go_test pl_go_test @px//bazel:pl_build_system.bzl"],
+        importpath = "github.com/manifoldco/promptui",
+        sum = "h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=",
+        version = "v0.9.0",
+    )
+    go_repository(
         name = "com_github_markbates_oncer",
         build_directives = ["gazelle:map_kind go_binary pl_go_binary @px//bazel:pl_build_system.bzl", "gazelle:map_kind go_test pl_go_test @px//bazel:pl_build_system.bzl"],
         importpath = "github.com/markbates/oncer",

--- a/src/pixie_cli/pkg/cmd/BUILD.bazel
+++ b/src/pixie_cli/pkg/cmd/BUILD.bazel
@@ -71,6 +71,8 @@ go_library(
         "@com_github_fatih_color//:color",
         "@com_github_gofrs_uuid//:uuid",
         "@com_github_lestrrat_go_jwx//jwt",
+        "@com_github_manifoldco_promptui//:promptui",
+        "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_segmentio_analytics_go_v3//:analytics-go",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_cobra//:cobra",
@@ -82,6 +84,7 @@ go_library(
         "@io_k8s_client_go//kubernetes",
         "@io_k8s_client_go//rest",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_term//:term",
     ],
 )

--- a/src/pixie_cli/pkg/cmd/deploy.go
+++ b/src/pixie_cli/pkg/cmd/deploy.go
@@ -33,6 +33,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -57,8 +58,6 @@ import (
 )
 
 const (
-	// DefaultCloudAddr is the Community Cloud address.
-	DefaultCloudAddr = "withpixie.ai:443"
 	// DeploySuccess is the successful deploy const.
 	DeploySuccess = "successfulDeploy"
 )
@@ -144,7 +143,7 @@ var DeployCmd = &cobra.Command{
 
 		cloudAddr := viper.GetString("cloud_addr")
 		docsAddr := cloudAddr
-		if cloudAddr != DefaultCloudAddr {
+		if !slices.Contains(AvailableCloudAddrs, cloudAddr) {
 			docsAddr = "px.dev"
 		}
 

--- a/src/pixie_cli/pkg/cmd/root.go
+++ b/src/pixie_cli/pkg/cmd/root.go
@@ -214,7 +214,7 @@ func getCloudAddrIfRequired(cmd *cobra.Command) string {
 	cloudAddr := viper.GetString("cloud_addr")
 	if cloudAddr == "" {
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
-			utils.Errorf("No cloud address provided during run within interactive shell. Please set the cloud address using the `--cloud_addr` flag or `PX_CLOUD_ADDR` environment variable.")
+			utils.Errorf("No cloud address provided during run within non-interactive shell. Please set the cloud address using the `--cloud_addr` flag or `PX_CLOUD_ADDR` environment variable.")
 			os.Exit(1)
 		} else {
 			prompt := promptui.Select{

--- a/src/pixie_cli/pkg/cmd/root.go
+++ b/src/pixie_cli/pkg/cmd/root.go
@@ -214,7 +214,6 @@ func getCloudAddrIfRequired(cmd *cobra.Command) string {
 	cloudAddr := viper.GetString("cloud_addr")
 	if cloudAddr == "" {
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
-
 			utils.Errorf("No cloud address provided during run within interactive shell. Please set the cloud address using the `--cloud_addr` flag or `PX_CLOUD_ADDR` environment variable.")
 			os.Exit(1)
 		} else {

--- a/src/pixie_cli/pkg/cmd/root.go
+++ b/src/pixie_cli/pkg/cmd/root.go
@@ -24,10 +24,13 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/manifoldco/promptui"
+	"github.com/mattn/go-isatty"
 	"github.com/segmentio/analytics-go/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/slices"
 
 	"px.dev/pixie/src/pixie_cli/pkg/auth"
 	"px.dev/pixie/src/pixie_cli/pkg/pxanalytics"
@@ -36,9 +39,18 @@ import (
 	"px.dev/pixie/src/pixie_cli/pkg/utils"
 )
 
+var (
+	AvailableCloudAddrs = []string{
+		"withpixie.ai:443",
+	}
+	// cloud addr is a required argument. Use empty string since Viper requires a default value.
+	defaultCloudAddr = ""
+)
+
 func init() {
 	// Flags that are relevant to all sub-commands.
-	RootCmd.PersistentFlags().StringP("cloud_addr", "a", "withpixie.ai:443", "The address of Pixie Cloud")
+
+	RootCmd.PersistentFlags().StringP("cloud_addr", "a", defaultCloudAddr, "The address of Pixie Cloud")
 	viper.BindPFlag("cloud_addr", RootCmd.PersistentFlags().Lookup("cloud_addr"))
 
 	RootCmd.PersistentFlags().StringP("dev_cloud_namespace", "m", "", "The namespace of Pixie Cloud, if using a cluster local cloud.")
@@ -129,7 +141,8 @@ var RootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		printEnvVars()
 
-		cloudAddr := viper.GetString("cloud_addr")
+		cloudAddr := getCloudAddrIfRequired(cmd)
+
 		if matched, err := regexp.MatchString(".+:[0-9]+$", cloudAddr); !matched && err == nil {
 			viper.Set("cloud_addr", cloudAddr+":443")
 		}
@@ -183,6 +196,43 @@ var RootCmd = &cobra.Command{
 		// Check if any parents of the subcommand requires auth.
 		cmd.VisitParents(checkAuthForCmd)
 	},
+}
+
+// Name a variable to store a slice of commands that don't require cloudAddr
+var cmdsCloudAddrNotReqd = []*cobra.Command{
+	CollectLogsCmd,
+	VersionCmd,
+}
+
+func getCloudAddrIfRequired(cmd *cobra.Command) string {
+	// Commands within allow list should be opted out in addition to Cobra's
+	// default help command
+	if slices.Contains(cmdsCloudAddrNotReqd, cmd) || cmd.Short == "Help about any command" {
+		return defaultCloudAddr
+	}
+
+	cloudAddr := viper.GetString("cloud_addr")
+	if cloudAddr == "" {
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+
+			utils.Errorf("No cloud address provided during run within interactive shell. Please set the cloud address using the `--cloud_addr` flag or `PX_CLOUD_ADDR` environment variable.")
+			os.Exit(1)
+		} else {
+			prompt := promptui.Select{
+				Label: "Select Pixie cloud",
+				Items: AvailableCloudAddrs,
+			}
+			_, selectedCloud, err := prompt.Run()
+			if err != nil {
+				utils.WithError(err).Fatal("Failed to select cloud address")
+				os.Exit(1)
+			}
+
+			cloudAddr = selectedCloud
+			viper.Set("cloud_addr", cloudAddr)
+		}
+	}
+	return cloudAddr
 }
 
 func checkAuthForCmd(c *cobra.Command) {

--- a/src/pixie_cli/pkg/cmd/run.go
+++ b/src/pixie_cli/pkg/cmd/run.go
@@ -39,13 +39,14 @@ import (
 )
 
 func init() {
+	cloudAddr := viper.GetString("cloud_addr")
 	RunCmd.Flags().StringP("output", "o", "", "Output format: one of: json|table|csv")
 	RunCmd.Flags().StringP("file", "f", "", "Script file, specify - for STDIN")
 	RunCmd.Flags().BoolP("list", "l", false, "List available scripts")
 	RunCmd.Flags().BoolP("e2e_encryption", "e", true, "Enable E2E encryption")
 	RunCmd.Flags().BoolP("all-clusters", "d", false, "Run script across all clusters")
 	RunCmd.Flags().StringP("cluster", "c", "", "ID of the cluster to run on. "+
-		"Use 'px get viziers', or visit Admin console: work.withpixie.ai/admin, to find the ID")
+		fmt.Sprintf("Use 'px get viziers', or visit Admin console: work.%s/admin, to find the ID", cloudAddr))
 	RunCmd.Flags().MarkHidden("all-clusters")
 
 	RunCmd.Flags().StringP("bundle", "b", "", "Path/URL to bundle file")

--- a/src/pixie_cli/pkg/cmd/run.go
+++ b/src/pixie_cli/pkg/cmd/run.go
@@ -39,14 +39,13 @@ import (
 )
 
 func init() {
-	cloudAddr := viper.GetString("cloud_addr")
 	RunCmd.Flags().StringP("output", "o", "", "Output format: one of: json|table|csv")
 	RunCmd.Flags().StringP("file", "f", "", "Script file, specify - for STDIN")
 	RunCmd.Flags().BoolP("list", "l", false, "List available scripts")
 	RunCmd.Flags().BoolP("e2e_encryption", "e", true, "Enable E2E encryption")
 	RunCmd.Flags().BoolP("all-clusters", "d", false, "Run script across all clusters")
 	RunCmd.Flags().StringP("cluster", "c", "", "ID of the cluster to run on. "+
-		fmt.Sprintf("Use 'px get viziers', or visit Admin console: work.%s/admin, to find the ID", cloudAddr))
+		"Use 'px get viziers' to find the ID")
 	RunCmd.Flags().MarkHidden("all-clusters")
 
 	RunCmd.Flags().StringP("bundle", "b", "", "Path/URL to bundle file")


### PR DESCRIPTION
Summary: Update px cli to make `--cloud_addr` a required argument

This removes the CC4P dependency on the Pixie cli so that the project is agnostic to any vendor provided Pixie cloud. While this argument is now required, if the cli is run within an interactive shell, the user will be presented with the available Pixie clouds and have the opportunity to select the one they want to use (see Test Plan below).

My plan is to take this a step further for the interactive case and have the cli populate the `~/.pixie/config.json` (or similar) file if the user wants to save their selected cloud. Future invocations of the cli will use what is stored in `~/.pixie`.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Tested the following scenarios
- [x] `px help`, `px --help`, `px deploy --help` (command) and `px script help` (command with sub commands) bypass the new required logic. Note: `px deploy help` would require the argument since it is an invalid command (`deploy` doesn't have a help subcommand)
- [x] Running non interactively exits if `--cloud_addr` has not been provided
```
$ ssh host-with-pixie-cli "/bin/bash -c '~/code/pixie/px deploy help'"
Pixie CLI
No cloud address provided. Please set the cloud address using the `--cloud_addr` flag or `PX_CLOUD_ADDR` environment variable.
```

- [x] Running interactively shows the list of possible clouds
```
$ bazel run src/pixie_cli:px -- deploy
INFO: Analyzed target //src/pixie_cli:px (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src/pixie_cli:px up-to-date:
  bazel-bin/src/pixie_cli/px_/px
INFO: Elapsed time: 0.309s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/src/pixie_cli/px_/px deploy
Pixie CLI
Use the arrow keys to navigate: ↓ ↑ → ←
? Select Pixie cloud:
  ▸ withpixie.ai:443
```
- [x] Running command that requires cloud addr succeeds

Changelog Message: Update `px` cli to make `--cloud_addr` a required argument if not populated by the `PX_CLOUD_ADDR` environment variable

