### PR TITLE
Move all terms and privacy links to tos-privacy configurables module

### DIFF
--- a/src/ui/src/components/auth/auth-box.tsx
+++ b/src/ui/src/components/auth/auth-box.tsx
@@ -25,6 +25,7 @@ import { createStyles, makeStyles } from '@mui/styles';
 
 import pixieAnalytics from 'app/utils/analytics';
 import { WithChildren } from 'app/utils/react-boilerplate';
+import { privacyUri, termsUri } from 'configurable/tos-privacy';
 
 import { PixienautBox } from './pixienaut-box';
 
@@ -113,9 +114,9 @@ export const AuthBox: React.FC<WithChildren<AuthBoxProps>> = React.memo((props) 
           <>
             <Typography variant='subtitle2' className={classes.disclaimer}>
               By signing up, you&apos;re agreeing to&nbsp;
-              <a href='https://pixielabs.ai/terms/'>Terms of Service</a>
+              <a href={termsUri}>Terms of Service</a>
               &nbsp;and&nbsp;
-              <a href='https://pixielabs.ai/privacy'>Privacy Policy</a>
+              <a href={privacyUri}>Privacy Policy</a>
               .
             </Typography>
           </>

--- a/src/ui/src/configurables/base/signup.ts
+++ b/src/ui/src/configurables/base/signup.ts
@@ -16,5 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Need to encapsulate so that newline is properly escaped.
 export const signupMessage = `Pixie Community is Free Forever.
 No Credit Card Needed.`;

--- a/src/ui/src/configurables/base/tos-privacy.tsx
+++ b/src/ui/src/configurables/base/tos-privacy.tsx
@@ -17,15 +17,15 @@
  */
 
 import * as React from 'react';
-export const termsUri = 'https://pixielabs.ai/terms';
-export const privacyUri = 'https://pixielabs.ai/privacy';
+export const termsUri = 'https://www.linuxfoundation.org/terms';
+export const privacyUri = 'https://www.linuxfoundation.org/privacy';
 
 export const TermsAndPrivacy = React.memo<{ classes: Record<'text', string> }>(({ classes }) => {
   return (<>
-    <a href='https://www.linuxfoundation.org/terms' className={classes.text}>
+    <a href={termsUri} className={classes.text}>
       Terms & Conditions
     </a>
-    <a href='https://www.linuxfoundation.org/privacy' className={classes.text}>
+    <a href={privacyUri} className={classes.text}>
       Privacy Policy
     </a>
   </>);

--- a/src/ui/src/configurables/base/tos-privacy.tsx
+++ b/src/ui/src/configurables/base/tos-privacy.tsx
@@ -17,6 +17,8 @@
  */
 
 import * as React from 'react';
+export const termsUri = 'https://pixielabs.ai/terms';
+export const privacyUri = 'https://pixielabs.ai/privacy';
 
 export const TermsAndPrivacy = React.memo<{ classes: Record<'text', string> }>(({ classes }) => {
   return (<>

--- a/src/ui/src/pages/auth/signup.tsx
+++ b/src/ui/src/pages/auth/signup.tsx
@@ -64,7 +64,6 @@ export const SignupPage = React.memo(() => {
           <AuthBox
             toggleURL={`/auth/login${window.location.search}`}
             title='Get Started'
-            // Need to encapsulate so that newline is properly escaped.
             body={signupMessage}
             buttonCaption='Already have an account?'
             buttonText='Login'


### PR DESCRIPTION
Summary: Move all terms and privacy links to tos-privacy configurables module

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Verified that the links on `/auth/signup` are correct with ui local dev workflow
