### PR TITLE
Refactor vendor specific signup message to configurables

### DIFF
--- a/src/ui/src/configurables/base/signup.ts
+++ b/src/ui/src/configurables/base/signup.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const signupMessage = `Pixie Community is Free Forever.
+No Credit Card Needed.`;

--- a/src/ui/src/pages/auth/signup.tsx
+++ b/src/ui/src/pages/auth/signup.tsx
@@ -24,6 +24,7 @@ import { createStyles, makeStyles } from '@mui/styles';
 
 import { AuthBox, SignupMarcom } from 'app/components';
 import pixieAnalytics from 'app/utils/analytics';
+import { signupMessage } from 'configurable/signup';
 
 import { BasePage } from './base';
 import { GetOAuthProvider } from './utils';
@@ -64,8 +65,7 @@ export const SignupPage = React.memo(() => {
             toggleURL={`/auth/login${window.location.search}`}
             title='Get Started'
             // Need to encapsulate so that newline is properly escaped.
-            body={`Pixie Community is Free Forever.
-          No Credit Card Needed.`}
+            body={signupMessage}
             buttonCaption='Already have an account?'
             buttonText='Login'
             showTOSDisclaimer


### PR DESCRIPTION
Summary: Refactor vendor specific signup message to configurables

Relevant Issues: N/A

Type of change: /kind clenaup

Test Plan:  Verified `/auth/signup`'s text is displayed as it was before

