### PR TITLE
Add gke PodMonitoring compatible labels for prometheus scrape-able services

### DIFF
--- a/k8s/cloud/base/indexer_deployment.yaml
+++ b/k8s/cloud/base/indexer_deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         name: indexer-server
         monitoring.gke.io/scrape: 'true'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '51801'
+        prometheus.io/scheme: 'http'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '51801'

--- a/k8s/cloud/base/metrics_deployment.yaml
+++ b/k8s/cloud/base/metrics_deployment.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         name: metrics-server
         monitoring.gke.io/scrape: 'true'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '50801'
+        prometheus.io/scheme: 'http'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '50801'

--- a/k8s/cloud/base/vzconn_deployment.yaml
+++ b/k8s/cloud/base/vzconn_deployment.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         name: vzconn-server
         monitoring.gke.io/scrape: 'true'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '51601'
+        prometheus.io/scheme: 'http'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '51601'

--- a/k8s/cloud/base/vzmgr_deployment.yaml
+++ b/k8s/cloud/base/vzmgr_deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         name: vzmgr-server
         monitoring.gke.io/scrape: 'true'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '51801'
+        prometheus.io/scheme: 'http'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '51801'


### PR DESCRIPTION
Summary: Add gke PodMonitoring compatible labels for prometheus scrape-able services

GKE's managed prometheus works by creating [PodMonitoring](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.10.0/doc/api.md#podmonitoring) resources that identify what targets to scrape. This resource only supports matching by labels and does not work with the existing annotations present in the Pixie cloud manifests. This PR adds PodMonitoring compatible labels that match the existing annotations

Relevant Issues: N/A

Type of change: /kind compatibility

Test Plan: Skaffold'ed to a cluster and verified the following:
- [x] Annotations and labels are set on the modified Deployments
- [x] GKE PodMonitoring resource correctly identifies backends now
