### PR TITLE
Add `--stirling_uprobe_opt_out` cli flag to allow opting binaries from uprobe attachment

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -67,6 +67,8 @@ using ::px::system::KernelVersion;
 using ::px::system::KernelVersionOrder;
 using ::px::system::ProcPidRootPath;
 
+constexpr std::string_view kUprobeSkippedMessage = "binary filename '$0' contained in uprobe opt out list, skipping.";
+
 UProbeManager::UProbeManager(bpf_tools::BCCWrapper* bcc) : bcc_(bcc) {
   proc_parser_ = std::make_unique<system::ProcParser>();
   uprobe_opt_out_ = absl::StrSplit(FLAGS_stirling_uprobe_opt_out, ",", absl::SkipWhitespace());
@@ -484,7 +486,7 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid,
   if (std::find(uprobe_opt_out_.begin(), uprobe_opt_out_.end(), node_application_filepath) !=
       uprobe_opt_out_.end()) {
       VLOG(1) << absl::Substitute(
-          "binary filename '$0' contained in uprobe opt out list, skipping.", node_application_filepath);
+          kUprobeSkippedMessage, node_application_filepath);
     return 0;
   }
   const auto host_proc_exe = ProcPidRootPath(pid, proc_exe);
@@ -582,7 +584,7 @@ std::map<std::string, std::vector<int32_t>> ConvertPIDsListToMap(
     if (std::find(binary_filter.begin(), binary_filter.end(), host_exe_path.filename()) !=
         binary_filter.end()) {
       VLOG(1) << absl::Substitute(
-          "binary filename '$0' contained in uprobe opt out list, skipping.", host_exe_path.string());
+          kUprobeSkippedMessage, host_exe_path.string());
       continue;
     }
     pids[host_exe_path.string()].push_back(upid.pid());
@@ -633,7 +635,7 @@ int UProbeManager::DeployOpenSSLUProbes(const absl::flat_hash_set<md::UPID>& pid
     if (std::find(uprobe_opt_out_.begin(), uprobe_opt_out_.end(), exe_path.filename()) !=
         uprobe_opt_out_.end()) {
       VLOG(1) << absl::Substitute(
-          "binary filename '$0' contained in uprobe opt out list, skipping.", exe_path.string());
+          kUprobeSkippedMessage, exe_path.string());
       continue;
     }
 

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -67,7 +67,8 @@ using ::px::system::KernelVersion;
 using ::px::system::KernelVersionOrder;
 using ::px::system::ProcPidRootPath;
 
-constexpr std::string_view kUprobeSkippedMessage = "binary filename '$0' contained in uprobe opt out list, skipping.";
+constexpr std::string_view kUprobeSkippedMessage =
+    "binary filename '$0' contained in uprobe opt out list, skipping.";
 
 UProbeManager::UProbeManager(bpf_tools::BCCWrapper* bcc) : bcc_(bcc) {
   proc_parser_ = std::make_unique<system::ProcParser>();
@@ -485,8 +486,7 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid,
   const std::string node_application_filepath = GetNodeApplicationFilename(exe_cmdline);
   if (std::find(uprobe_opt_out_.begin(), uprobe_opt_out_.end(), node_application_filepath) !=
       uprobe_opt_out_.end()) {
-      VLOG(1) << absl::Substitute(
-          kUprobeSkippedMessage, node_application_filepath);
+    VLOG(1) << absl::Substitute(kUprobeSkippedMessage, node_application_filepath);
     return 0;
   }
   const auto host_proc_exe = ProcPidRootPath(pid, proc_exe);
@@ -583,8 +583,7 @@ std::map<std::string, std::vector<int32_t>> ConvertPIDsListToMap(
     // Add filter here if the executable should be omitted
     if (std::find(binary_filter.begin(), binary_filter.end(), host_exe_path.filename()) !=
         binary_filter.end()) {
-      VLOG(1) << absl::Substitute(
-          kUprobeSkippedMessage, host_exe_path.string());
+      VLOG(1) << absl::Substitute(kUprobeSkippedMessage, host_exe_path.string());
       continue;
     }
     pids[host_exe_path.string()].push_back(upid.pid());
@@ -634,8 +633,7 @@ int UProbeManager::DeployOpenSSLUProbes(const absl::flat_hash_set<md::UPID>& pid
 
     if (std::find(uprobe_opt_out_.begin(), uprobe_opt_out_.end(), exe_path.filename()) !=
         uprobe_opt_out_.end()) {
-      VLOG(1) << absl::Substitute(
-          kUprobeSkippedMessage, exe_path.string());
+      VLOG(1) << absl::Substitute(kUprobeSkippedMessage, exe_path.string());
       continue;
     }
 

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -484,9 +484,10 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid,
   }
 
   const std::string exe_cmdline = proc_parser_->GetPIDCmdline(pid);
-  const std::string node_application_filepath = GetNodeApplicationFilename(exe_cmdline);
-  if (uprobe_opt_out_.contains(node_application_filepath)) {
-    VLOG(1) << absl::Substitute(kUprobeSkippedMessage, node_application_filepath);
+  const auto node_application_filepath = GetNodeApplicationFilename(exe_cmdline);
+  if (node_application_filepath.has_value() &&
+      uprobe_opt_out_.contains(node_application_filepath.value())) {
+    VLOG(1) << absl::Substitute(kUprobeSkippedMessage, node_application_filepath.value());
     return 0;
   }
   const auto host_proc_exe = ProcPidRootPath(pid, proc_exe);

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -52,6 +52,11 @@ DEFINE_double(stirling_rescan_exp_backoff_factor, 2.0,
               "Exponential backoff factor used in decided how often to rescan binaries for "
               "dynamically loaded libraries");
 
+DEFINE_string(
+    stirling_uprobe_opt_out, "",
+    "Comma separated list of binary filenames that should be excluded from uprobe attachment."
+    "For a binary at path /path/to/binary, the filename would be binary");
+
 namespace px {
 namespace stirling {
 
@@ -64,6 +69,7 @@ using ::px::system::ProcPidRootPath;
 
 UProbeManager::UProbeManager(bpf_tools::BCCWrapper* bcc) : bcc_(bcc) {
   proc_parser_ = std::make_unique<system::ProcParser>();
+  uprobe_opt_out_ = absl::StrSplit(FLAGS_stirling_uprobe_opt_out, ",", absl::SkipWhitespace());
 }
 
 void UProbeManager::Init(bool disable_go_tls_tracing, bool enable_http2_tracing,
@@ -447,8 +453,8 @@ StatusOr<std::array<UProbeTmpl, 6>> UProbeManager::GetNodeOpensslUProbeTmpls(con
   return iter->second;
 }
 
-StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnStaticBinary(const uint32_t pid) {
-  PX_ASSIGN_OR_RETURN(const std::filesystem::path proc_exe, proc_parser_->GetExePath(pid));
+StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnStaticBinary(
+    const uint32_t pid, const std::filesystem::path& proc_exe) {
   const auto host_proc_exe = ProcPidRootPath(pid, proc_exe);
 
   PX_ASSIGN_OR_RETURN(auto elf_reader, ElfReader::Create(host_proc_exe));
@@ -467,13 +473,20 @@ StatusOr<int> UProbeManager::AttachOpenSSLUProbesOnStaticBinary(const uint32_t p
   return kOpenSSLUProbes.size();
 }
 
-StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid) {
-  PX_ASSIGN_OR_RETURN(const std::filesystem::path proc_exe, proc_parser_->GetExePath(pid));
-
+StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid,
+                                                        const std::filesystem::path& proc_exe) {
   if (DetectApplication(proc_exe) != Application::kNode) {
     return 0;
   }
 
+  const std::string exe_cmdline = proc_parser_->GetPIDCmdline(pid);
+  const std::string node_application_filepath = GetNodeApplicationFilename(exe_cmdline);
+  if (std::find(uprobe_opt_out_.begin(), uprobe_opt_out_.end(), node_application_filepath) !=
+      uprobe_opt_out_.end()) {
+      VLOG(1) << absl::Substitute(
+          "binary filename '$0' contained in uprobe opt out list, skipping.", node_application_filepath);
+    return 0;
+  }
   const auto host_proc_exe = ProcPidRootPath(pid, proc_exe);
 
   const auto [_, inserted] = nodejs_binaries_.insert(host_proc_exe.string());
@@ -551,7 +564,7 @@ namespace {
 
 // Convert PID list from list of UPIDs to a map with key=binary name, value=PIDs
 std::map<std::string, std::vector<int32_t>> ConvertPIDsListToMap(
-    const absl::flat_hash_set<md::UPID>& upids) {
+    const absl::flat_hash_set<md::UPID>& upids, const std::vector<std::string>& binary_filter) {
   const system::ProcParser proc_parser;
 
   // Convert to a map of binaries, with the upids that are instances of that binary.
@@ -563,6 +576,13 @@ std::map<std::string, std::vector<int32_t>> ConvertPIDsListToMap(
     const auto host_exe_path = ProcPidRootPath(upid.pid(), exe_path);
 
     if (!fs::Exists(host_exe_path)) {
+      continue;
+    }
+    // Add filter here if the executable should be omitted
+    if (std::find(binary_filter.begin(), binary_filter.end(), host_exe_path.filename()) !=
+        binary_filter.end()) {
+      VLOG(1) << absl::Substitute(
+          "binary filename '$0' contained in uprobe opt out list, skipping.", host_exe_path.string());
       continue;
     }
     pids[host_exe_path.string()].push_back(upid.pid());
@@ -608,6 +628,15 @@ int UProbeManager::DeployOpenSSLUProbes(const absl::flat_hash_set<md::UPID>& pid
       continue;
     }
 
+    PX_ASSIGN_OR(const auto exe_path, proc_parser_->GetExePath(pid.pid()), continue);
+
+    if (std::find(uprobe_opt_out_.begin(), uprobe_opt_out_.end(), exe_path.filename()) !=
+        uprobe_opt_out_.end()) {
+      VLOG(1) << absl::Substitute(
+          "binary filename '$0' contained in uprobe opt out list, skipping.", exe_path.string());
+      continue;
+    }
+
     auto count_or = AttachOpenSSLUProbesOnDynamicLib(pid.pid());
     if (count_or.ok()) {
       uprobe_count += count_or.ValueOrDie();
@@ -622,7 +651,7 @@ int UProbeManager::DeployOpenSSLUProbes(const absl::flat_hash_set<md::UPID>& pid
           count_or.ToString());
     }
 
-    count_or = AttachNodeJsOpenSSLUprobes(pid.pid());
+    count_or = AttachNodeJsOpenSSLUprobes(pid.pid(), exe_path);
     if (count_or.ok()) {
       uprobe_count += count_or.ValueOrDie();
       VLOG(1) << absl::Substitute(
@@ -640,7 +669,7 @@ int UProbeManager::DeployOpenSSLUProbes(const absl::flat_hash_set<md::UPID>& pid
 
     // Attach uprobes to statically linked applications only if no other probes have been attached.
     if (FLAGS_stirling_trace_static_tls_binaries && count_or.ok() && count_or.ValueOrDie() == 0) {
-      count_or = AttachOpenSSLUProbesOnStaticBinary(pid.pid());
+      count_or = AttachOpenSSLUProbesOnStaticBinary(pid.pid(), exe_path);
 
       if (count_or.ok() && count_or.ValueOrDie() > 0) {
         uprobe_count += count_or.ValueOrDie();
@@ -816,7 +845,7 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
 
   static int32_t kPID = getpid();
 
-  for (const auto& [binary, pid_vec] : ConvertPIDsListToMap(pids)) {
+  for (const auto& [binary, pid_vec] : ConvertPIDsListToMap(pids, uprobe_opt_out_)) {
     // Don't bother rescanning binaries that have been scanned before to avoid unnecessary work.
     if (!scanned_binaries_.insert(binary).second) {
       continue;

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -629,7 +629,7 @@ class UProbeManager {
   //               Without clean-up, these could consume more-and-more memory.
   absl::flat_hash_set<std::string> openssl_probed_binaries_;
   absl::flat_hash_set<std::string> scanned_binaries_;
-  std::vector<std::string> uprobe_opt_out_;
+  absl::flat_hash_set<std::string> uprobe_opt_out_;
   absl::flat_hash_set<std::string> go_probed_binaries_;
   absl::flat_hash_set<std::string> go_http2_probed_binaries_;
   absl::flat_hash_set<std::string> go_tls_probed_binaries_;

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -538,7 +538,7 @@ class UProbeManager {
    * @return The number of uprobes deployed. It is not an error if the binary
    * does not use OpenSSL; instead the return value will be zero.
    */
-  StatusOr<int> AttachNodeJsOpenSSLUprobes(uint32_t pid);
+  StatusOr<int> AttachNodeJsOpenSSLUprobes(uint32_t pid, const std::filesystem::path& binary_path);
 
   /**
    * Attaches the required probes for TLS tracing to the specified PID if the binary is
@@ -551,7 +551,8 @@ class UProbeManager {
    * @return The number of uprobes deployed. It is not an error if the binary
    *         does not contain the necessary symbols to probe; instead the return value will be zero.
    */
-  StatusOr<int> AttachOpenSSLUProbesOnStaticBinary(uint32_t pid);
+  StatusOr<int> AttachOpenSSLUProbesOnStaticBinary(uint32_t pid,
+                                                   const std::filesystem::path& binary_path);
 
   /**
    * Calls BCCWrapper.AttachUProbe() with a probe template and log any errors to the probe status
@@ -628,6 +629,7 @@ class UProbeManager {
   //               Without clean-up, these could consume more-and-more memory.
   absl::flat_hash_set<std::string> openssl_probed_binaries_;
   absl::flat_hash_set<std::string> scanned_binaries_;
+  std::vector<std::string> uprobe_opt_out_;
   absl::flat_hash_set<std::string> go_probed_binaries_;
   absl::flat_hash_set<std::string> go_http2_probed_binaries_;
   absl::flat_hash_set<std::string> go_tls_probed_binaries_;

--- a/src/stirling/utils/detect_application.cc
+++ b/src/stirling/utils/detect_application.cc
@@ -49,7 +49,13 @@ Application DetectApplication(const std::filesystem::path& exe) {
   return Application::kUnknown;
 }
 
-std::string GetNodeApplicationFilename(std::string_view cmdline) {
+// This method returns the main nodejs application file from a command line. See the following
+// examples below:
+//
+// "node /usr/bin/test.js" -> "test.js"
+// "node --node-memory-debug /usr/bin/test.js" -> "test.js"
+// "node /usr/bin/test" -> std::nullopt
+std::optional<std::string> GetNodeApplicationFilename(std::string_view cmdline) {
   std::vector<std::string> cmdline_parts = absl::StrSplit(cmdline, ' ');
   for (const auto& part : cmdline_parts) {
     if (absl::EndsWith(part, ".js")) {
@@ -57,7 +63,7 @@ std::string GetNodeApplicationFilename(std::string_view cmdline) {
       return path.filename();
     }
   }
-  return "";
+  return {};
 }
 
 bool operator<(const SemVer& lhs, const SemVer& rhs) {

--- a/src/stirling/utils/detect_application.cc
+++ b/src/stirling/utils/detect_application.cc
@@ -49,6 +49,17 @@ Application DetectApplication(const std::filesystem::path& exe) {
   return Application::kUnknown;
 }
 
+std::string GetNodeApplicationFilename(std::string_view cmdline) {
+  std::vector<std::string> cmdline_parts = absl::StrSplit(cmdline, ' ');
+  for (const auto& part : cmdline_parts) {
+    if (absl::EndsWith(part, ".js")) {
+      std::filesystem::path path(part);
+      return path.filename();
+    }
+  }
+  return "";
+}
+
 bool operator<(const SemVer& lhs, const SemVer& rhs) {
   std::vector<int> lhs_vec = {lhs.major, lhs.minor, lhs.patch};
   std::vector<int> rhs_vec = {rhs.major, rhs.minor, rhs.patch};

--- a/src/stirling/utils/detect_application.h
+++ b/src/stirling/utils/detect_application.h
@@ -36,6 +36,9 @@ enum class Application {
 // Returns the application of the input executable.
 Application DetectApplication(const std::filesystem::path& exe);
 
+// Returns the filename of a node application from the command line.
+std::string GetNodeApplicationFilename(std::string_view cmdline);
+
 // Describes a semantic versioning number.
 struct SemVer {
   int major = 0;

--- a/src/stirling/utils/detect_application.h
+++ b/src/stirling/utils/detect_application.h
@@ -37,7 +37,7 @@ enum class Application {
 Application DetectApplication(const std::filesystem::path& exe);
 
 // Returns the filename of a node application from the command line.
-std::string GetNodeApplicationFilename(std::string_view cmdline);
+std::optional<std::string> GetNodeApplicationFilename(std::string_view cmdline);
 
 // Describes a semantic versioning number.
 struct SemVer {

--- a/src/stirling/utils/detect_application_test.cc
+++ b/src/stirling/utils/detect_application_test.cc
@@ -37,7 +37,7 @@ TEST(DetectApplicationTest, ResultsAreAsExpected) {
 TEST(GetNodeApplicatFilenameTest, ResultsAreAsExpected) {
   EXPECT_EQ(GetNodeApplicationFilename("node /usr/bin/test.js"), "test.js");
   EXPECT_EQ(GetNodeApplicationFilename("node --node-memory-debug /usr/bin/test.js"), "test.js");
-  EXPECT_EQ(GetNodeApplicationFilename("node /usr/bin/test"), "");
+  EXPECT_FALSE(GetNodeApplicationFilename("node /usr/bin/test").has_value());
 }
 
 TEST(GetSemVerTest, AsExpected) {

--- a/src/stirling/utils/detect_application_test.cc
+++ b/src/stirling/utils/detect_application_test.cc
@@ -34,6 +34,12 @@ TEST(DetectApplicationTest, ResultsAreAsExpected) {
   EXPECT_EQ(Application::kNode, DetectApplication("/usr/bin/nodejs"));
 }
 
+TEST(GetNodeApplicatFilenameTest, ResultsAreAsExpected) {
+  EXPECT_EQ(GetNodeApplicationFilename("node /usr/bin/test.js"), "test.js");
+  EXPECT_EQ(GetNodeApplicationFilename("node --node-memory-debug /usr/bin/test.js"), "test.js");
+  EXPECT_EQ(GetNodeApplicationFilename("node /usr/bin/test"), "");
+}
+
 TEST(GetSemVerTest, AsExpected) {
   ASSERT_OK_AND_ASSIGN(SemVer sem_ver, GetSemVer("v1.12.13-test", true));
   EXPECT_EQ(sem_ver.major, 1);


### PR DESCRIPTION
Summary: Add `--stirling_uprobe_opt_out` cli flag to allow opting binaries from uprobe attachment

See https://github.com/pixie-io/pixie/issues/1970 for the motivation of this change.

Relevant Issues: https://github.com/pixie-io/pixie/issues/1970

Type of change: /kind feature

Test Plan: Verified the following scenarios
- [x]  BPF tests pass on all kernels -- see [this build-and-test run](https://github.com/pixie-io/pixie/actions/runs/10063985263) for the results.
- [x] Dynamically linked OpenSSL application is skipped from uprobe attachment
```
# Run //src/stirling/source_connectors/socket_tracer/testing/containers:nginx_alpine_openssl_3_0_8_image
# Run stirling_wrapper with --stirling_uprobe_opt_out=nginx,non_matching --vmodule=uprobe_manager=1

[ .. ]
I20240723 17:40:54.208112 739524 uprobe_manager.cc:584] binary filename '/proc/738767/root/usr/sbin/nginx' contained in uprobe opt out list, skipping.
I20240723 17:40:54.209451 739524 uprobe_manager.cc:584] binary filename '/proc/738731/root/usr/sbin/nginx' contained in uprobe opt out list, skipping.

```
- [x] Statically linked BoringSSL application is skipped from uprobe attachment
```
# Run //src/stirling/source_connectors/socket_tracer/testing/containers/bssl:bssl_image
# Run stirling_wrapper with --stirling_uprobe_opt_out=bssl,non_matching --vmodule=uprobe_manager=1

[ .. ]
I20240723 17:51:14.265595 742187 uprobe_manager.cc:584] binary filename '/proc/741971/root/app/bssl.runfiles/boringssl/bssl' contained in uprobe opt out list, skipping.
```
- [x] Nodejs application is skipped from uprobe attachment
```
# Run //src/stirling/source_connectors/socket_tracer/testing/containers:node_14_18_1_alpine_image
# Run stirling_wrapper with --stirling_uprobe_opt_out=https_server.js,non_matching --vmodule=uprobe_manager=1

[ .. ]
I20240723 16:50:01.197883 725584 uprobe_manager.cc:486] binary filename 'https_server.js' contained in uprobe opt out list, skipping.
```
- [x] Go application attachment is skipped with `--stirling_uprobe_opt_out=https_server.js,non_matching`
```
# Run //src/stirling/testing/demo_apps/go_https/server:golang_1_21_https_server
# Run stirling_wrapper with --stirling_uprobe_opt_out=golang_1_21_server_binary,non_matching --vmodule=uprobe_manager=1

[ .. ]
I20240723 17:29:54.166582 736461 uprobe_manager.cc:635] binary filename '/golang_1_21_server_binary' contained in uprobe opt out list, skipping.
```

Changelog Message: Add mechanism for opting out specific binaries from uprobe attachment