### PR TITLE
Add test to verify that ConsumeMetrics and ConsumeTraces clear response members

### DIFF
--- a/src/carnot/exec/otel_export_sink_node_test.cc
+++ b/src/carnot/exec/otel_export_sink_node_test.cc
@@ -1738,16 +1738,14 @@ TEST_F(OTelExportSinkNodeTest, consume_spans_clears_span_responses) {
   EXPECT_CALL(*trace_mock_, Export(_, _, _))
       .Times(::testing::AtLeast(2))
       .WillOnce(DoAll(SetArgPointee<2>(error_response), Return(grpc::Status::OK)))
-      .WillRepeatedly(Invoke(
-          [&](const auto&, const auto&, auto* response) {
-
-              // It's expected that the response argument provided to Export
-              // has .Clear() called on it. This CALL assertion verifies that the
-              // response object no longer has rejected data points since it should
-              // have been .Clear()'ed at the beginning of the second ConsumeTraces invocation
-            EXPECT_TRUE(response->partial_success().rejected_spans() == 0);
-            return grpc::Status::OK;
-          }));
+      .WillRepeatedly(Invoke([&](const auto&, const auto&, auto* response) {
+        // It's expected that the response argument provided to Export
+        // has .Clear() called on it. This CALL assertion verifies that the
+        // response object no longer has rejected data points since it should
+        // have been .Clear()'ed at the beginning of the second ConsumeTraces invocation
+        EXPECT_EQ(response->partial_success().rejected_spans(), 0);
+        return grpc::Status::OK;
+      }));
 
   planpb::OTelExportSinkOperator otel_sink_op;
 
@@ -1794,16 +1792,14 @@ TEST_F(OTelExportSinkNodeTest, metrics_response_is_cleared) {
   EXPECT_CALL(*metrics_mock_, Export(_, _, _))
       .Times(::testing::AtLeast(2))
       .WillOnce(DoAll(SetArgPointee<2>(error_response), Return(grpc::Status::OK)))
-      .WillRepeatedly(Invoke(
-          [&](const auto&, const auto&, auto* response) {
-
-              // It's expected that the response argument provided to Export
-              // has .Clear() called on it. This CALL assertion verifies that the
-              // response object no longer has rejected data points since it should
-              // have been .Clear()'ed at the beginning of the second ConsumeMetrics invocation
-            EXPECT_TRUE(response->partial_success().rejected_data_points() == 0);
-            return grpc::Status::OK;
-          }));
+      .WillRepeatedly(Invoke([&](const auto&, const auto&, auto* response) {
+        // It's expected that the response argument provided to Export
+        // has .Clear() called on it. This CALL assertion verifies that the
+        // response object no longer has rejected data points since it should
+        // have been .Clear()'ed at the beginning of the second ConsumeMetrics invocation
+        EXPECT_EQ(response->partial_success().rejected_data_points(), 0);
+        return grpc::Status::OK;
+      }));
 
   planpb::OTelExportSinkOperator otel_sink_op;
 


### PR DESCRIPTION
Summary: Add test to verify that ConsumeMetrics and ConsumeTraces clear response members

This adds test coverage for the bug fix in #1910. This is a follow up to the conversation [here](https://github.com/pixie-io/pixie/pull/1910#discussion_r1607339561)

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Verified that unit test fails if #1910 is reverted
```
$ git show HEAD
commit 4ab4a9ce58bd394e4cd8287b44767e870fedd127 (HEAD -> ddelnano/add-tests-for-otel-sink-bug, ddelnano/ddelnano/add-tests-for-otel-sink-bug)
Author: Dom Del Nano <ddelnano@gmail.com>
Date:   Fri Jul 26 12:17:00 2024 +0000

    Revert "Clear trace response instead of metric response in `OTelExportSinkNode::ConsumeSpans` (#1910)"

    This reverts commit 970a54a7b9deb9469c406d73069c1e310a53ea96.

$ bazel test src/carnot/exec:otel_export_sink_node_test --test_output=all

[ ... ]
[ RUN      ] OTelExportSinkNodeTest.consume_spans_clears_span_responses
src/carnot/exec/otel_export_sink_node_test.cc:1748: Failure
Value of: response->partial_success().rejected_spans() == 0
  Actual: false
Expected: true

```