### PR TITLE
Update `ElfReaderTest`'s nm usage to be hermetic

### DIFF
--- a/bazel/cc_toolchains/clang/toolchain_files.BUILD
+++ b/bazel/cc_toolchains/clang/toolchain_files.BUILD
@@ -60,6 +60,12 @@ filegroup(
 )
 
 filegroup(
+    name = "toolchain_nm_files",
+    srcs = [":nm"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "toolchain_strip_files",
     srcs = [":strip"],
     visibility = ["//visibility:public"],
@@ -110,6 +116,7 @@ filegroup(
         "as",
         "cov",
         "objcopy",
+        "nm",
         "strip",
         "dwp",
     ]
@@ -124,6 +131,7 @@ filegroup(
         ":toolchain_dwp_files",
         ":toolchain_linker_files",
         ":toolchain_objcopy_files",
+        ":toolchain_nm_files",
         ":toolchain_strip_files",
     ],
     visibility = ["//visibility:public"],

--- a/src/stirling/obj_tools/BUILD.bazel
+++ b/src/stirling/obj_tools/BUILD.bazel
@@ -53,7 +53,7 @@ pl_cc_test(
         "//src/stirling/obj_tools/testdata/cc:test_exe_debug_target",
         "//src/stirling/obj_tools/testdata/cc:test_exe_debuglink_target",
         "//src/stirling/obj_tools/testdata/go:test_go_1_19_binary",
-        "//src/stirling/obj_tools/testdata/go:test_go_1_19_nm_output"
+        "//src/stirling/obj_tools/testdata/go:test_go_1_19_nm_output",
     ],
     deps = [
         ":cc_library",

--- a/src/stirling/obj_tools/BUILD.bazel
+++ b/src/stirling/obj_tools/BUILD.bazel
@@ -53,6 +53,7 @@ pl_cc_test(
         "//src/stirling/obj_tools/testdata/cc:test_exe_debug_target",
         "//src/stirling/obj_tools/testdata/cc:test_exe_debuglink_target",
         "//src/stirling/obj_tools/testdata/go:test_go_1_19_binary",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_19_nm_output"
     ],
     deps = [
         ":cc_library",

--- a/src/stirling/obj_tools/elf_reader_test.cc
+++ b/src/stirling/obj_tools/elf_reader_test.cc
@@ -89,7 +89,8 @@ StatusOr<Section> ObjdumpSectionNameToAddr(const std::string& path,
   return section;
 }
 
-StatusOr<int64_t> NmSymbolNameToAddr(const std::string& nm_output_path, const std::string& symbol_name) {
+StatusOr<int64_t> NmSymbolNameToAddr(const std::string& nm_output_path,
+                                     const std::string& symbol_name) {
   // Extract the address from nm as the gold standard.
   int64_t symbol_addr = -1;
   PX_ASSIGN_OR_RETURN(auto nm_out, px::ReadFileToString(nm_output_path));
@@ -310,7 +311,8 @@ TEST(ElfReaderTest, GolangAppRuntimeBuildVersion) {
                        elf_reader->SearchTheOnlySymbol("runtime.buildVersion"));
 // Coverage build might alter the resultant binary.
 #ifndef PL_COVERAGE
-  ASSERT_OK_AND_ASSIGN(auto expected_addr, NmSymbolNameToAddr(kGoBinNmOutput, "runtime.buildVersion"));
+  ASSERT_OK_AND_ASSIGN(auto expected_addr,
+                       NmSymbolNameToAddr(kGoBinNmOutput, "runtime.buildVersion"));
   EXPECT_EQ(symbol.address, expected_addr);
 #endif
   EXPECT_EQ(symbol.size, 16) << "Symbol table entry size should be 16";

--- a/src/stirling/obj_tools/testdata/cc/BUILD.bazel
+++ b/src/stirling/obj_tools/testdata/cc/BUILD.bazel
@@ -53,8 +53,8 @@ cc_library(
     name = "test_exe_fixture",
     hdrs = ["test_exe_fixture.h"],
     data = [
-      ":test_exe",
-      ":test_exe_nm_output",
+        ":test_exe",
+        ":test_exe_nm_output",
     ],
     deps = ["//src/common/exec:cc_library"],
 )

--- a/src/stirling/obj_tools/testdata/cc/BUILD.bazel
+++ b/src/stirling/obj_tools/testdata/cc/BUILD.bazel
@@ -41,10 +41,21 @@ cc_clang_binary(
     ],
 )
 
+genrule(
+    name = "test_exe_nm_output_target",
+    srcs = [":test_exe"],
+    outs = ["test_exe_nm_output"],
+    cmd = "$(NM) $(location :test_exe) > $(location test_exe_nm_output)",
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
+)
+
 cc_library(
     name = "test_exe_fixture",
     hdrs = ["test_exe_fixture.h"],
-    data = [":test_exe"],
+    data = [
+      ":test_exe",
+      ":test_exe_nm_output",
+    ],
     deps = ["//src/common/exec:cc_library"],
 )
 

--- a/src/stirling/obj_tools/testdata/cc/test_exe_fixture.h
+++ b/src/stirling/obj_tools/testdata/cc/test_exe_fixture.h
@@ -31,7 +31,8 @@ namespace obj_tools {
 class TestExeFixture {
  public:
   static constexpr char kTestExePath[] = "src/stirling/obj_tools/testdata/cc/test_exe_/test_exe";
-  static constexpr char kTestExeNmOutputPath[] = "src/stirling/obj_tools/testdata/cc/test_exe_nm_output";
+  static constexpr char kTestExeNmOutputPath[] =
+      "src/stirling/obj_tools/testdata/cc/test_exe_nm_output";
 
   const std::filesystem::path& Path() const { return test_exe_path_; }
   const std::filesystem::path& NmOutputPath() const { return test_exe_nm_output_path_; }
@@ -43,7 +44,8 @@ class TestExeFixture {
 
  private:
   const std::filesystem::path test_exe_path_ = testing::BazelRunfilePath(kTestExePath);
-  const std::filesystem::path test_exe_nm_output_path_ = testing::BazelRunfilePath(kTestExeNmOutputPath);
+  const std::filesystem::path test_exe_nm_output_path_ =
+      testing::BazelRunfilePath(kTestExeNmOutputPath);
 };
 
 }  // namespace obj_tools

--- a/src/stirling/obj_tools/testdata/cc/test_exe_fixture.h
+++ b/src/stirling/obj_tools/testdata/cc/test_exe_fixture.h
@@ -31,8 +31,10 @@ namespace obj_tools {
 class TestExeFixture {
  public:
   static constexpr char kTestExePath[] = "src/stirling/obj_tools/testdata/cc/test_exe_/test_exe";
+  static constexpr char kTestExeNmOutputPath[] = "src/stirling/obj_tools/testdata/cc/test_exe_nm_output";
 
   const std::filesystem::path& Path() const { return test_exe_path_; }
+  const std::filesystem::path& NmOutputPath() const { return test_exe_nm_output_path_; }
 
   Status Run() const {
     auto stdout_or = Exec(test_exe_path_);
@@ -41,6 +43,7 @@ class TestExeFixture {
 
  private:
   const std::filesystem::path test_exe_path_ = testing::BazelRunfilePath(kTestExePath);
+  const std::filesystem::path test_exe_nm_output_path_ = testing::BazelRunfilePath(kTestExeNmOutputPath);
 };
 
 }  // namespace obj_tools

--- a/src/stirling/obj_tools/testdata/go/BUILD.bazel
+++ b/src/stirling/obj_tools/testdata/go/BUILD.bazel
@@ -47,6 +47,14 @@ pl_go_binary(
     for sdk_version in pl_supported_go_sdk_versions
 ]
 
+genrule(
+    name = "test_go_1_19_nm_output_target",
+    srcs = [":test_go_1_19_binary"],
+    outs = ["test_go_1_19_nm_output"],
+    cmd = "$(NM) $(location :test_go_1_19_binary) > $(location test_go_1_19_nm_output)",
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
+)
+
 filegroup(
     name = "test_binaries",
     testonly = True,


### PR DESCRIPTION
Summary: Update `ElfReaderTest`'s nm usage to be hermetic

This was feedback from #1976. See [this comment](https://github.com/pixie-io/pixie/pull/1976#discussion_r1707595841) for the previous discussion.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Elf reader tests pass with updates

