### PR TITLE
Use maintained gon fork to address Apple signing deprecation

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -92,7 +92,7 @@ jobs:
     - name: Sign CLI release
       env:
         REF: ${{ github.event.ref }}
-        AC_PASSWD: ${{ secrets.APPLE_ID_PASSWORD }}
+        AC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
         CERT_BASE64: ${{ secrets.APPLE_SIGN_CERT_B64 }}
         CERT_PASSWORD: ${{ secrets.APPLE_SIGN_CERT_PASSWORD }}

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -135,6 +135,9 @@ jobs:
       uses: ./.github/actions/gcloud_creds
       with:
         SERVICE_ACCOUNT_KEY: ${{ secrets.GH_RELEASE_SA_PEM_B64 }}
+    - name: Add pwd to git safe dir
+      run: |
+        git config --global --add safe.directory `pwd`
     - name: Upload signed CLI
       env:
         REF: ${{ github.event.ref }}

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -88,7 +88,7 @@ jobs:
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
     - name: Install gon
-      run: brew install mitchellh/gon/gon
+      run: brew install Bearer/tap/gon
     - name: Sign CLI release
       env:
         REF: ${{ github.event.ref }}

--- a/ci/cli_upload_signed.sh
+++ b/ci/cli_upload_signed.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -ex
 
 # Copyright 2018- The Pixie Authors.
 #
@@ -17,8 +17,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repo_path=$(bazel info workspace)
-
-set -ex
 
 # shellcheck source=ci/artifact_utils.sh
 . "${repo_path}/ci/artifact_utils.sh"

--- a/ci/cli_upload_signed.sh
+++ b/ci/cli_upload_signed.sh
@@ -18,10 +18,10 @@
 
 repo_path=$(bazel info workspace)
 
+set -ex
+
 # shellcheck source=ci/artifact_utils.sh
 . "${repo_path}/ci/artifact_utils.sh"
-
-set -ex
 
 printenv
 

--- a/ci/gon.hcl
+++ b/ci/gon.hcl
@@ -9,6 +9,8 @@ bundle_id = "ai.pixielabs.px"
 apple_id {
   username = "zasgar@gmail.com"
   password = "@env:AC_PASSWD"
+  # Unfortunately gon's HCL doesn't allow declaring variables so this literal is specified twice
+  provider = "SZCNTABEXY"
 }
 
 sign {

--- a/ci/gon.hcl
+++ b/ci/gon.hcl
@@ -2,19 +2,16 @@
 // using Gon.
 
 source = ["./cli_darwin_amd64", "./cli_darwin_arm64", "cli_darwin_universal"]
-bundle_id = "ai.pixielabs.px"
+bundle_id = "ai.getcosmic.px"
 
-// TODO(zasgar): Update this to the orders@pixielabs.ai account. It has access to the certs,
-// but does not have access to application passwords.
 apple_id {
-  username = "zasgar@gmail.com"
+  username = "apple-dev@getcosmic.ai"
   password = "@env:AC_PASSWD"
-  # Unfortunately gon's HCL doesn't allow declaring variables so this literal is specified twice
-  provider = "SZCNTABEXY"
+  provider = "769M9XJDG6"
 }
 
 sign {
-  application_identity = "Developer ID Application: Pixie Labs Inc. (SZCNTABEXY)"
+  application_identity = "Developer ID Application: Cosmic Observe, Inc."
 }
 
 zip {

--- a/ci/gon.hcl
+++ b/ci/gon.hcl
@@ -6,7 +6,7 @@ bundle_id = "ai.getcosmic.px"
 
 apple_id {
   username = "apple-dev@getcosmic.ai"
-  password = "@env:AC_PASSWD"
+  # Password is provided via AC_PASSWORD env var
   provider = "769M9XJDG6"
 }
 


### PR DESCRIPTION
Summary: Use maintained gon fork to address Apple signing deprecation

This is a continuation of #1994. Rather than using the macos tools directly, we can continue using gon by switching to the maintained fork ([github.com/Bearer/gon](https://github.com/Bearer/gon))

Relevant Issues: Closes https://github.com/pixie-io/pixie/issues/1993

Type of change: /kind bugfix

Test Plan: cli-release GitHub workflow [succeeds](https://github.com/pixie-io/pixie/actions/runs/10724342153/job/29740236170) when built from this branch

Changelog Message: Fix macos signing for px cli releases