### PR TITLE
Update reference to old kernel label since most recent update

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/runner.bzl
+++ b/bazel/test_runners/qemu_with_kernel/runner.bzl
@@ -84,7 +84,7 @@ qemu_with_kernel_test_runner = rule(
     implementation = _test_runner_impl,
     attrs = {
         "kernel_image": attr.label(
-            default = Label("@linux_build_6_1_8_x86_64//file:linux-build.tar.gz"),
+            default = Label("@linux_build_6_1_18_x86_64//file:linux-build.tar.gz"),
             allow_single_file = True,
         ),
         "_busybox": attr.label(


### PR DESCRIPTION
Summary: Update reference to old kernel label since most recent update

The 6.1.8 kernel was updated to the latest patch version in #1995.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Build without specifying `--//bazel/test_runners/qemu_with_kernel:kernel_version` succeeds

