### PR TITLE
Update GitHub matrix to use correct 6.1.x kernel

### DIFF
--- a/bazel/test_runners/qemu_with_kernel/runner.bzl
+++ b/bazel/test_runners/qemu_with_kernel/runner.bzl
@@ -84,7 +84,7 @@ qemu_with_kernel_test_runner = rule(
     implementation = _test_runner_impl,
     attrs = {
         "kernel_image": attr.label(
-            default = Label("@linux_build_6_1_18_x86_64//file:linux-build.tar.gz"),
+            default = Label("@linux_build_6_1_106_x86_64//file:linux-build.tar.gz"),
             allow_single_file = True,
         ),
         "_busybox": attr.label(

--- a/ci/github/matrix.sh
+++ b/ci/github/matrix.sh
@@ -39,7 +39,7 @@ all_kernel_versions=(
 )
 default_kernel_versions=(
   "4.14.254"
-  "6.1.18"
+  "6.1.106"
 )
 kernel_versions=( "${default_kernel_versions[@]}" )
 


### PR DESCRIPTION
Summary: Update GitHub matrix to use correct 6.1.x kernel

Builds after #1995 would fail since GitHub would attempt to run the 6.1.8 kernel build, which bazel no longer understands. This also updates the qemu test runner kernel that was incorrectly updated in #1999. I thought I had exercised that default value with my testing, but it didn't trigger that default value.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: GitHub build on #2002 which pulls in the matrix change is no longer failing

