### PR TITLE
Fix production cli release build by using seccomp profile recommended by podman maintainers

### DIFF
--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -53,7 +53,11 @@ bazel run -c opt --config=stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
   # Create rpm package.
+
+  # podman package depends on golang-github-containers-common, which
+  # provides the following seccomp profile.
   podman run -i --rm \
+    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-fedora:24 \
@@ -69,6 +73,7 @@ if [[ ! "$release_tag" == *"-"* ]]; then
 
   # Create deb package.
   podman run -i --rm \
+    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-ubuntu:18.04 \


### PR DESCRIPTION
Summary: Fix production cli release build by using seccomp profile recommended by podman maintainers

The cli pre-release builds do not trigger our RPM and deb packaging. This packaging step is accomplished by running podman containers and failed during our most recent production cli release (error below):

```
+ podman run -i --rm -v /tmp/tmp.xkTyDurlVW:/src/ -v /__w/pixie/pixie:/image docker.io/cdrx/fpm-fedora:24 fpm -f -p /image/pixie-px-0.8.3.x86_64.rpm -s dir -t rpm -n pixie-px -v 0.8.3 --prefix /usr/local/bin px
time="2024-09-05T22:47:26Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
cannot clone: Operation not permitted
Error: cannot re-exec process
```

This is an attempt to remediate the issue by following what was recommended by podman's maintainers in a [past issue](https://github.com/containers/podman/issues/10802#issuecomment-869925846).

Relevant Issues: #1993

Type of change: /kind bugfix

Test Plan: Requires building a production release cli since this logic is skipped otherwise
- [x] Verified this seccomp profile is a dependency of the podman Ubuntu package and installed in our dev image that the CI job uses.
```
ddelnano@dev-vm:~/code/pixie-worktree (ddelnano/address-unable-to-clone-error) $ ./scripts/run_docker.sh  pwd && ls -alh /usr/share/containers/seccomp.json
sha256:e8d76daa1fe01efdff68cacf982f00a94a674b1d450f8eab11b98f5bd6a5c397
grep: /etc/bazelrc: No such file or directory
Run Parameters:
        Build Buddy:             Disabled
        Shell:                   /bin/bash
+ docker run --rm --hostname px-dev-docker-dev-vm.us-west1-a.c.endless-datum-422018.internal -it -v /dev/shm:/dev/shm -v /home/ddelnano:/home/ddelnano -v /var/run/docker.sock:/var/run/docker.sock -v /home/ddelnano/code/pixie-worktree:/px/src/px.dev/pixie --network=host -v /usr/local/bin/px:/bin/px px_dev_image:202405102250 /bin/bash -c pwd
/px/src/px.dev/pixie
-rw-r--r-- 1 root root 17K Feb  1  2024 /usr/share/containers/seccomp.json

ddelnano@px-dev-docker-dev-vm:/px/src/px.dev/pixie (ddelnano/address-unable-to-clone-error) $ dpkg -S /usr/share/containers/seccomp.json
golang-github-containers-common: /usr/share/containers/seccomp.json
ddelnano@px-dev-docker-dev-vm:/px/src/px.dev/pixie (ddelnano/address-unable-to-clone-error) $ apt-cache rdepends golang-github-containers-common | grep podman
  podman


```