### PR TITLE
Another attempt to remediate user namespace issues with ubuntu24 runners

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -59,6 +59,7 @@ jobs:
         export TAG_NAME="${REF#*/tags/}"
         mkdir -p "artifacts/"
         export ARTIFACTS_DIR="$(realpath artifacts/)"
+        sysctl -w kernel.unprivileged_userns_clone=1
         ./ci/save_version_info.sh
         ./ci/cli_build_release.sh
     - name: Upload Github Artifacts

--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -53,11 +53,7 @@ bazel run -c opt --config=stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
   # Create rpm package.
-
-  # podman package depends on golang-github-containers-common, which
-  # provides the following seccomp profile.
   podman run -i --rm \
-    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-fedora:24 \
@@ -73,7 +69,6 @@ if [[ ! "$release_tag" == *"-"* ]]; then
 
   # Create deb package.
   podman run -i --rm \
-    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-ubuntu:18.04 \


### PR DESCRIPTION
Summary: Another attempt to remediate user namespace issues with ubuntu 24.04 runners

This reverts the failed previous attempt and re-enables user namespaces on ubuntu 24.04. This is a well known behavior change between Ubuntu 22.04 and 24.04 (https://github.com/actions/runner-images/issues/10443#issuecomment-2296608244). Since podman is running rootless, I think it's possible that the user namespace creation (clone syscall) is failing.

Relevant Issues: #1993

Type of change: /kind bugfix

Test Plan: Run another production release build after merging this
- Verified that this sysctl cli invocation is similar to our [existing example](https://github.com/pixie-io/pixie/blob/aa1f72a69f0a072d97accd721081f89cb8108fd1/.github/workflows/build_and_test.yaml#L87)

