### PR TITLE
Use privileged container for running cli build release steps

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -19,6 +19,9 @@ jobs:
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+      # --privileged is needed in order for podman to work. Otherwise it fails
+      # to create a new namespace when the clone syscall happens.
+      options: --privileged
     env:
       ARTIFACT_UPLOAD_LOG: "artifact_uploads.json"
     steps:

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -59,7 +59,6 @@ jobs:
         export TAG_NAME="${REF#*/tags/}"
         mkdir -p "artifacts/"
         export ARTIFACTS_DIR="$(realpath artifacts/)"
-        sysctl -w kernel.unprivileged_userns_clone=1
         ./ci/save_version_info.sh
         ./ci/cli_build_release.sh
     - name: Upload Github Artifacts

--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -53,7 +53,11 @@ bazel run -c opt --config=stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
   # Create rpm package.
+
+  # podman package depends on golang-github-containers-common, which
+  # provides the following seccomp profile.
   podman run -i --rm \
+    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-fedora:24 \
@@ -69,6 +73,7 @@ if [[ ! "$release_tag" == *"-"* ]]; then
 
   # Create deb package.
   podman run -i --rm \
+    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-ubuntu:18.04 \

--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -53,11 +53,7 @@ bazel run -c opt --config=stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
   # Create rpm package.
-
-  # podman package depends on golang-github-containers-common, which
-  # provides the following seccomp profile.
   podman run -i --rm \
-    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-fedora:24 \
@@ -73,7 +69,6 @@ if [[ ! "$release_tag" == *"-"* ]]; then
 
   # Create deb package.
   podman run -i --rm \
-    --security-opt seccomp=/usr/share/containers/seccomp.json \
     -v "${binary_dir}:/src/" \
     -v "$(pwd):/image" \
     docker.io/cdrx/fpm-ubuntu:18.04 \


### PR DESCRIPTION
Summary: Use privileged container for running cli build release steps

This reverts my second attempt at fixing the issue with our recent cli builds and tries to address the issue by running the GitHub action's container privileged. This is to address the following error seen in recent cli release builds:

```
+ podman run -i --rm -v /tmp/tmp.xkTyDurlVW:/src/ -v /__w/pixie/pixie:/image docker.io/cdrx/fpm-fedora:24 fpm -f -p /image/pixie-px-0.8.3.x86_64.rpm -s dir -t rpm -n pixie-px -v 0.8.3 --prefix /usr/local/bin px
time="2024-09-05T22:47:26Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
cannot clone: Operation not permitted
Error: cannot re-exec process
```

Relevant Issues: #1993

Type of change: /kind bugfix

Test Plan: Reproduced the `clone: Operation not permitted` issue on my dev VM. Verified that adding `--privileged` no longer sees the issue
```
# Note: running podman without sudo runs into an issue before the clone issue happens.
# This may not be the most representative test but hopefully it reproduces the issue closely enough

$ ./scripts/run_docker.sh
sha256:e8d76daa1fe01efdff68cacf982f00a94a674b1d450f8eab11b98f5bd6a5c397
grep: /etc/bazelrc: No such file or directory
Run Parameters:
        Build Buddy:             Disabled
        Shell:                   /bin/bash
+ docker run --rm --hostname px-dev-docker-dev-vm.us-west1-a.c.endless-datum-422018.internal -it -v /dev/shm:/dev/shm -v /home/ddelnano:/home/ddelnano -v /var/run/docker.sock:/var/run/docker.sock -v /home/ddelnano/code/pixie-worktree:/px/src/px.dev/pixie --network=host -v /usr/local/bin/px:/bin/px px_dev_image:202405102250 /bin/bash

$ sudo podman info
sudo: unable to resolve host px-dev-docker-dev-vm.us-west1-a.c.endless-datum-422018.internal: Name or service not known
WARN[0000] "/" is not a shared mount, this could cause issues or missing mounts with rootless containers
cannot clone: Operation not permitted
Error: cannot re-exec process

# Run same ./scripts/run_docker.sh but with --privileged added

$ docker run --rm --hostname px-dev-docker-dev-vm.us-west1-a.c.endless-datum-422018.internal -it -v /dev/shm:/dev/shm -v /home/ddelnano:/home/ddelnano -v /var/run/docker.sock:/var/run/docker.sock -v /home/ddelnano/code/pixie-worktree:/px/src/px.dev/pixie --network=host -v /usr/local/bin/px:/bin/px --privileged px_dev_image:202405102250 /bin/bash

# podman info succeeds
$ sudo podman info
sudo: unable to resolve host px-dev-docker-dev-vm.us-west1-a.c.endless-datum-422018.internal: Name or service not known
host:
  arch: amd64
```
