### PR TITLE
Provide mechanism for cloud proxy to opt out of listening on ipv6 address

### DIFF
--- a/src/cloud/proxy/entrypoint.sh
+++ b/src/cloud/proxy/entrypoint.sh
@@ -23,4 +23,8 @@ else
    exit 1
 fi
 
+if [ -n "$PL_IPV6_DISABLE" ]; then
+    sed -i -e "/IPV6_DISABLE_MARKER/d" /usr/local/openresty/nginx/conf/nginx.conf
+fi
+
 /usr/bin/openresty -g "daemon off;"

--- a/src/cloud/proxy/nginx.conf
+++ b/src/cloud/proxy/nginx.conf
@@ -75,7 +75,7 @@ http {
 
     # This is the default fallback server if none of the subdomains match.
     server {
-        listen [::]:56000 default_server;
+        listen [::]:56000 default_server; # IPV6_DISABLE_MARKER
         listen 56000;
         server_name _;
 
@@ -96,7 +96,7 @@ http {
     # This is the server that we use for all the locations that don't have a subdomain.
     # This just serves the minimal pages necessary to authenticate and get into a subdomain specfic site.
     server {
-        listen [::]:56000 ssl http2;
+        listen [::]:56000 ssl http2; # IPV6_DISABLE_MARKER
         listen 56000 ssl http2;
         server_name @PL_DOMAIN_NAME@ *.cluster.local;
 
@@ -121,7 +121,7 @@ http {
 
     # This is the server for the work subdomain.
     server {
-        listen [::]:56000 ssl http2;
+        listen [::]:56000 ssl http2; # IPV6_DISABLE_MARKER
         listen 56000 ssl http2;
         server_name work.@PL_DOMAIN_NAME@;
 
@@ -214,7 +214,7 @@ http {
 
     # This is the proxy server for segment.
     server {
-        listen [::]:56000 ssl http2;
+        listen [::]:56000 ssl http2; # IPV6_DISABLE_MARKER
         listen 56000 ssl http2;
         server_name segment.@PL_DOMAIN_NAME@;
 
@@ -262,7 +262,7 @@ http {
 
     # This is the redirect to the netlify hosted site for docs.
     server {
-        listen [::]:56000 ssl http2;
+        listen [::]:56000 ssl http2; # IPV6_DISABLE_MARKER
         listen 56000 ssl http2;
         server_name docs.@PL_DOMAIN_NAME@;
 


### PR DESCRIPTION
Summary: Provide mechanism for cloud proxy to opt out of listening on ipv6 address

This was a request from a community member in slack. They have a cluster that has ipv6 disabled and their cloud proxy service is unable to start.

Relevant Issues: Closes #2013

Type of change: /kind feature

Test Plan: Deployed to a cloud cluster and verified that setting `PL_IPV6_DISABLED ` templates the nginx file correctly

Changelog Message: Provide mechanism for opting the cloud proxy service out of listening on an ipv6 address