### PR TITLE
Use fpm binary from within dev_image_extras container for cli releases

### DIFF
--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -53,11 +53,7 @@ bazel run -c opt --config=stamp //src/pixie_cli:push_px_image
 
 if [[ ! "$release_tag" == *"-"* ]]; then
   # Create rpm package.
-  podman run -i --rm \
-    -v "${binary_dir}:/src/" \
-    -v "$(pwd):/image" \
-    docker.io/cdrx/fpm-fedora:24 \
-    fpm \
+  fpm \
     -f \
     -p "/image/${pkg_prefix}.rpm" \
     -s dir \
@@ -68,11 +64,7 @@ if [[ ! "$release_tag" == *"-"* ]]; then
     px
 
   # Create deb package.
-  podman run -i --rm \
-    -v "${binary_dir}:/src/" \
-    -v "$(pwd):/image" \
-    docker.io/cdrx/fpm-ubuntu:18.04 \
-    fpm \
+  fpm \
     -f \
     -p "/image/${pkg_prefix}.deb" \
     -s dir \


### PR DESCRIPTION
Summary: Use fpm binary from within dev_image_extras container for cli releases

With #2012 merged, the `dev_image_with_extras` container image now contains `fpm`. This change removes the use of podman to avoid the permission issues seen in recent cli builds. This should allow the production cli release build to succeed.

Relevant Issues: Closes #1993

Type of change: /kind bugfix

Test Plan: Verified that `fpm` exists in most recent image and packaging building commands work (see testing on #2012). Running a production cli release build is needed after this is merged to complete the testing.
```
$ ./scripts/run_docker.sh
sha256:c14b06e5753d4d9c6b2ff8671843043113cdcfa3f3cb36a492a665d71dc42fad
grep: /etc/bazelrc: No such file or directory
Run Parameters:
        Build Buddy:             Disabled
        Shell:                   /bin/bash
+ docker run --rm --hostname px-dev-docker-dev-vm.us-west1-a.c.endless-datum-422018.internal -it -v /dev/shm:/dev/shm -v /home/ddelnano:/home/ddelnano -v /var/run/docker.sock:/var/run/docker.sock -v /home/ddelnano/code/pixie-worktree:/px/src/px.dev/pixie --network=host -v /usr/local/bin/px:/bin/px px_dev_image:202409092344 /bin/bash
ddelnano@px-dev-docker-dev-vm:/px/src/px.dev/pixie (ddelnano/use-fpm-within-dev_image_extras-container) $ fpm --version
1.15.1

```