### PR TITLE
Provide mechanism for config based kube dns service

### DIFF
--- a/k8s/cloud/base/domain_config.yaml
+++ b/k8s/cloud/base/domain_config.yaml
@@ -4,5 +4,6 @@ kind: ConfigMap
 metadata:
   name: pl-domain-config
 data:
+  PL_KUBE_DNS_SERVICE: kube-dns.kube-system.svc.cluster.local
   PL_DOMAIN_NAME: dev.withpixie.dev
   PASSTHROUGH_PROXY_PORT: "4444"

--- a/src/cloud/proxy/entrypoint.sh
+++ b/src/cloud/proxy/entrypoint.sh
@@ -23,4 +23,8 @@ else
    exit 1
 fi
 
+if [ -n "$PL_KUBE_DNS_SERVICE" ]; then
+    sed -i -e "s/[@]PL_KUBE_DNS_SERVICE[@]/$PL_KUBE_DNS_SERVICE/" /usr/local/openresty/nginx/conf/nginx.conf
+fi    
+
 /usr/bin/openresty -g "daemon off;"

--- a/src/cloud/proxy/nginx.conf
+++ b/src/cloud/proxy/nginx.conf
@@ -40,7 +40,7 @@ http {
 
     log_format upstreamlog '[$time_local] $remote_addr - $remote_user - $server_name to: $upstream_addr: $request upstream_response_time $upstream_response_time msec $msec request_time $request_time';
 
-    resolver kube-dns.kube-system.svc.cluster.local valid=5s;
+    resolver @PL_KUBE_DNS_SERVICE@ valid=5s;
 
     # Tune nginx keepalives to work with the GCP HTTP(S) Load Balancer:
     keepalive_timeout 650;


### PR DESCRIPTION
Currently the nginx.conf expects the a kubernetes dns service named kube-dns.kube-system.svc.cluster.local to be existing in the cluster. If this dns service does not exist the cloud-proxy pod gets terminated on startup. This issue has been addressed in this PR. Here, we are moving the kubeernetes dns service name to a config and updating the nginx conf with this name at startup. This will prevent the container failing to be up on clusters that do not have a standard naming convention for the dns service.