### PR TITLE
Fix path to cli artifacts and output file now that container volume mounts are removed

### DIFF
--- a/ci/cli_build_release.sh
+++ b/ci/cli_build_release.sh
@@ -55,24 +55,24 @@ if [[ ! "$release_tag" == *"-"* ]]; then
   # Create rpm package.
   fpm \
     -f \
-    -p "/image/${pkg_prefix}.rpm" \
+    -p "${pkg_prefix}.rpm" \
     -s dir \
     -t rpm \
     -n pixie-px \
     -v "${release_tag}" \
     --prefix /usr/local/bin \
-    px
+    "${binary_dir}/px"
 
   # Create deb package.
   fpm \
     -f \
-    -p "/image/${pkg_prefix}.deb" \
+    -p "${pkg_prefix}.deb" \
     -s dir \
     -t deb \
     -n pixie-px \
     -v "${release_tag}" \
     --prefix /usr/local/bin \
-    px
+    "${binary_dir}/px"
 
    # TODO(james): Add push to docker hub/quay.io.
 fi


### PR DESCRIPTION
Summary: Fix path to cli artifacts and output file now that container volume mounts are removed

In #2015, I forgot to account for [the](https://github.com/pixie-io/pixie/commit/4528883d85f3f372f9b298346d74b36aba87febd#diff-ff4ee1801a9dce2de46b26ff5fd877e777db222b39dcc48a086ba5fb6f10a887L57) volume [mounts](https://github.com/pixie-io/pixie/commit/4528883d85f3f372f9b298346d74b36aba87febd#diff-ff4ee1801a9dce2de46b26ff5fd877e777db222b39dcc48a086ba5fb6f10a887L58) used to place the `px` build artifacts in the container's working directory. This restores the filepath access that the containerized version had.

Relevant Issues: #1993

Type of change: /kind bugfix

Test Plan: Reviewed the previous podman command more closely. Still needs to be validated with a successful production cli release.