### PR TITLE
Allow configuring all ConnTrackers' debug trace level at runtime

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -694,6 +694,12 @@ void SocketTraceConnector::UpdateTrackerTraceLevel(ConnTracker* tracker) {
   if (pids_to_trace_disable_.contains(tracker->conn_id().upid.pid)) {
     tracker->SetDebugTrace(0);
   }
+  // Debugging Server side tracing is difficult when the server side services requests pre fork
+  // (certain web servers, postgres, etc). This provides a means for enabling CONN_TRACE for
+  // all processes since these situations are impossible to debug via --stirling_conn_trace_pid.
+  if (debug_level_ >= 2) {
+    tracker->SetDebugTrace(2);
+  }
 }
 
 // Verifies that our openssl tracing does not encounter conditions that invalidate our


### PR DESCRIPTION
Summary: Allow configuring all ConnTrackers' debug trace level at runtime

When debugging tracing issues with servers that handle requests pre-fork, it's not practical to use `--stirling_conn_trace_pid` (each request is served by a new PID). This change allows enabling debug tracing for all conn trackers to facilitate easier debugging.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: Skaffolded this change and verified that the following `stirling_ctrl` command enables `CONN_TRACE` globally.
```
$ ./stirling_ctrl ${pid_of_pem} 1 2
```

Changelog Message: Provide mechanism for debugging a PEM's connection tracking more easily at runtime
