### PR TITLE
Fix self hosted cloud image pull error for plugin db updater Job

### DIFF
--- a/k8s/cloud/public/kustomization.yaml
+++ b/k8s/cloud/public/kustomization.yaml
@@ -46,6 +46,6 @@ images:
 - name: cloud-vzmgr_server_image
   newName: gcr.io/pixie-oss/pixie-prod/cloud-vzmgr_server_image
   newTag: latest
-- name: cloud-plugin/load_db
-  newName: gcr.io/pixie-oss/pixie-prod/cloud-plugin/load_db
+- name: cloud-plugin-load_db
+  newName: gcr.io/pixie-oss/pixie-prod/cloud-plugin-load_db
   newTag: latest


### PR DESCRIPTION
Summary: Fix self hosted cloud image pull error for plugin db updater Job

During the 0.1.8 cloud prerelease testing, I noticed that the plugin db updater Job hits an image pull error. This was something that was also reported in the Community slack for the latest release (0.1.7).

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: The Job is successfully created without any additional manifest edits

Changelog Message: Fixed an issue where the self-hosted cloud install hit an image pull error for the plugin db updater Job
