### PR TITLE
Skip k8s resources that have an empty name during resource deletion

### DIFF
--- a/src/utils/shared/k8s/delete.go
+++ b/src/utils/shared/k8s/delete.go
@@ -185,6 +185,13 @@ func (o *ObjectDeleter) runDelete(r *resource.Result) (int, error) {
 		if err != nil {
 			return err
 		}
+		// In newer versions of k8s, the resource name can be empty. This causes
+		// the delete to fail since it can't watch for the resource. See
+		// https://github.com/pixie-io/pixie/issues/2029 for more details.
+		if info.Name == "" {
+			log.Debugf("Skipping resource with empty name: %+v\n", info)
+			return nil
+		}
 		deletedInfos = append(deletedInfos, info)
 		found++
 


### PR DESCRIPTION
Summary: Skip k8s resources that have an empty name during resource deletion

Newer versions of k8s break our `px delete` cli logic (see details on #2029). I tracked this down to the the [condition function](https://github.com/kubernetes/kubectl/blob/0315be426ca25e6554f1c9089534b62ce12254d4/pkg/cmd/wait/delete.go#L41-L43) in our ObjectDeleter. I believe the newer versions of k8s added resources that match our visitor, but don't have a resource name. From my testing, it seemed related to the `ValidatingAdmissionPolicies` or `ValidatingAdmissionPolicyBindings` resources.

Relevant Issues: Closes #2029

Type of change: /kind bugfix

Test Plan: Deployed a vizier and verified that a subsequent `px delete` deleted the following
* `pl` namespace
* `px-operator` namespace
* Cluster scoped resources: `pl-cloud-connector-role`, `pl-vizier-metadata` and `pl-node-view` cluster roles

Changelog Message: Fixed an issue that caused `px delete` to fail on newer k8s clusters (1.30 and later)
