### PR TITLE
Fix bug with resolving relative symlinks during linux header detection

### DIFF
--- a/src/stirling/utils/linux_headers.cc
+++ b/src/stirling/utils/linux_headers.cc
@@ -231,15 +231,16 @@ StatusOr<std::filesystem::path> ResolvePossibleSymlinkToHostPath(const std::file
 
   // Relative paths containing "../" can result in an invalid host mount path when using
   // ToHostPath. Therefore, we need to treat the absolute and relative cases differently.
-  std::filesystem::path resolved_host_path = p.parent_path();
+  std::filesystem::path resolved_host_path;
   if (resolved.is_absolute()) {
     resolved_host_path = system::Config::GetInstance().ToHostPath(resolved);
-    LOG(INFO) << absl::Substitute(
+    VLOG(1) << absl::Substitute(
         "Symlink target is an absolute path. Converting that to host path: $0 -> $1.",
         resolved.string(), resolved_host_path.string());
   } else {
+    resolved_host_path = p.parent_path();
     resolved_host_path /= resolved.string();
-    LOG(INFO) << absl::Substitute(
+    VLOG(1) << absl::Substitute(
         "Symlink target is a relative path. Concatenating it to parent directory: $0",
         resolved_host_path.string());
   }


### PR DESCRIPTION
Summary: Fix bug with resolving relative symlinks during linux header detection

Please see linked issue for details

Relevant Issues: Closes #2037

Type of change: /kind bugfix

Test Plan: Verified the following
- [x] Confirmed with user that reported the issue that this works for openSUSE's MicroOS linux headers
- [x] Verified on Ubuntu that using an absolute symlink works (upstream package, no modification)
```
ddelnano@dev-vm:/lib/modules/6.8.0-1015-gcp$ ls -l build
lrwxrwxrwx 1 root root 37 Sep  2 14:42 build -> /usr/src/linux-headers-6.8.0-1015-gcp

# Verify custom built stirling_wrapper identifies absolute headers
$ sudo docker run -v /:/host -v /sys:/sys -v /var/lib/docker:/var/lib/docker --pid=host --cgroupns host --env "PL_HOST_PATH=/host"  bazel/src/stirling/binaries:stirling_wrapper_image

I20241011 21:32:38.893605 395713 linux_headers.cc:257] Looking for host Linux headers at /host/lib/modules/6.8.0-1015-gcp/build.
I20241011 21:32:38.893646 395713 linux_headers.cc:237] Symlink target is an absolute path. Converting that to host path: /usr/src/linux-headers-6.8.0-1015-gcp -> /host/usr/src/linux-headers-6.8.0-1015-gcp.
I20241011 21:32:38.893750 395713 linux_headers.cc:261] Linked host headers at /host/usr/src/linux-headers-6.8.0-1015-gcp to symlink in pem namespace at /lib/modules/6.8.0-1015-gcp/build.
I20241011 21:32:38.893783 395713 linux_headers.cc:257] Looking for host Linux headers at /host/lib/modules/6.8.0-1015-gcp/source.
```
- [x] Verified on Ubuntu that using a relative symlink (modified by hand with reproduction steps in #2037)
```
# Verify build is a relative symlink and resolves outside a container
ddelnano@dev-vm:/lib/modules/6.8.0-1015-gcp$ ls -l
total 1480
lrwxrwxrwx  1 root root     48 Oct 11 20:39 build -> ../../../../usr/src/linux-headers-6.8.0-1015-gcp

# Verify custom built stirling_wrapper identifies relative headers
$ sudo docker run -v /:/host -v /sys:/sys -v /var/lib/docker:/var/lib/docker --pid=host --cgroupns host --env "PL_HOST_PATH=/host"  bazel/src/stirling/binaries:stirling_wrapper_image

I20241011 21:30:16.825937 395471 linux_headers.cc:257] Looking for host Linux headers at /host/lib/modules/6.8.0-1015-gcp/build.
I20241011 21:30:16.825973 395471 linux_headers.cc:242] Symlink target is a relative path. Concatenating it to parent directory: /host/lib/modules/6.8.0-1015-gcp/../../../../usr/src/linux-headers-6.8.0-1015-gcp
I20241011 21:30:16.826067 395471 linux_headers.cc:261] Linked host headers at /host/lib/modules/6.8.0-1015-gcp/../../../../usr/src/linux-headers-6.8.0-1015-gcp to symlink in pem namespace at /lib/modules/6.8.0-1015-gcp/build.
```

Changelog Message: Fixed an issue where certain linux upstream distro's header packages would fail to be identified