### PR TITLE
Upgrade bcc and libbpf to fix BPF program compilation on 6.10 and later kernels

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -127,10 +127,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/h2o/picohttpparser/archive/1d2b8a184e7ebe6651c30dcede37ba1d89691351.tar.gz"],
     ),
     com_github_iovisor_bcc = dict(
-        sha256 = "d34f9484588a9c25be936c910c86f8b25b04e5b0c802d0630e77cc9a8a272aed",
-        strip_prefix = "bcc-e0698be7b797129cb113912e96ad741a551e2291",
+        sha256 = "416426fbe22d617d8aed088062f4489e69176136e99dc0b933df58e83d9175da",
+        strip_prefix = "bcc-e57be8465b9cf238f1c04b1c7e154fd1db85326d",
         urls = [
-            "https://github.com/pixie-io/bcc/archive/e0698be7b797129cb113912e96ad741a551e2291.tar.gz",
+            "https://github.com/pixie-io/bcc/archive/e57be8465b9cf238f1c04b1c7e154fd1db85326d.tar.gz",
         ],
     ),
     com_github_iovisor_bpftrace = dict(
@@ -146,10 +146,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/jupp0r/prometheus-cpp/archive/81e208c250748657f1d5dab247e82c4429a931af.tar.gz"],
     ),
     com_github_libbpf_libbpf = dict(
-        sha256 = "4d503428c7aead070a59630dd0906318a430b3e279a35f51ec601fbdd7d31eb6",
-        strip_prefix = "libbpf-3b0973892891744d20ae79e99c0d1a26a59c4222",
+        sha256 = "859a31e9101237338d46eb62a62cb8fcb342c9ce0f9b9137e5a3a728c088c338",
+        strip_prefix = "libbpf-42065ea6627ff6e1ab4c65e51042a70fbf30ff7c",
         urls = [
-            "https://github.com/libbpf/libbpf/archive/3b0973892891744d20ae79e99c0d1a26a59c4222.tar.gz",
+            "https://github.com/libbpf/libbpf/archive/42065ea6627ff6e1ab4c65e51042a70fbf30ff7c.tar.gz",
         ],
     ),
     com_github_libuv_libuv = dict(


### PR DESCRIPTION
Summary: Upgrade bcc and libbpf to fix BPF program compilation on 6.10 and later kernels

Bcc provides some "[virtual](https://github.com/iovisor/bcc/blob/cb1ba20f4800f556dc940682ba7016c50bd0a3ac/src/cc/exported_files.cc#L28-L48)" includes to BPF programs. The `compat/linux/virtual_bpf.h` file in particular needs to be kept in sync with libbpf and matches the [header guard](https://github.com/iovisor/bcc/blob/cb1ba20f4800f556dc940682ba7016c50bd0a3ac/src/cc/compat/linux/virtual_bpf.h#L9) of the `include/uapi/linux/bpf.h` file. This means that while our linux headers were updated, our older bcc install was inserting an older copy of the `uapi/linux/bpf.h` file -- one that didn't contain the `bpf_wq` declaration.

```
  include/linux/bpf.h:348:10: error: invalid application of 'sizeof' to an incomplete type 'struct bpf_wq'
                  return sizeof(struct bpf_wq);
                         ^     ~~~~~~~~~~~~~~~
  include/linux/bpf.h:348:24: note: forward declaration of 'struct bpf_wq'
                  return sizeof(struct bpf_wq);
                                       ^
  include/linux/bpf.h:377:10: error: invalid application of '__alignof' to an incomplete type 'struct bpf_wq'
                  return __alignof__(struct bpf_wq);
                         ^          ~~~~~~~~~~~~~~~
  include/linux/bpf.h:377:29: note: forward declaration of 'struct bpf_wq'
                  return __alignof__(struct bpf_wq);
```

Note: while this fixes the 6.10 compilation issue, our 6.10 qemu build fails without disabling [this logic](https://github.com/pixie-io/pixie/blob/3c41d554215528e688328aef94192e696db617dc/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc#L464-L472). 6.10 kernels added BPF token support. This changes the BPF permission model slightly and causes the BPF instruction limit to be dependent on the permissions of the BPF syscall caller ([linux source](https://elixir.bootlin.com/linux/v6.11.1/source/kernel/bpf/syscall.c#L2757)).

This new BPF token logic coupled with our qemu setup, causes our 6.10 build to fallback to the 4096 instruction limit. I'll be addressing this in #2040 and #2042. Those issues shouldn't block this change since that loop limit code can be bypasses at runtime with our current cli flags.

Relevant Issues: Closes #2035

Type of change: /kind bugfix

Test Plan: Built 6.10 and 6.11 kernels and the associated linux headers from #2036 and verified that a local qemu build passes
- [x] Verify `#ci:bpf-build-all-kernels` build passes

Changelog Message: Upgraded bcc and libbpf to support kernels 6.10 and later