### PR TITLE
Add missing protocol contribution marker

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -94,6 +94,7 @@ enum TraceMode : int32_t {
 class SocketTraceConnector : public BCCSourceConnector {
  public:
   static constexpr std::string_view kName = "socket_tracer";
+  // PROTOCOL_LIST
   static constexpr auto kTables =
       MakeArray(kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable,
                 kRedisTable, kNATSTable, kKafkaTable, kMuxTable, kAMQPTable, kMongoDBTable);


### PR DESCRIPTION
Summary: Add missing protocol contribution marker

I've been working on a new protocol parser and through that I realized there was a missing [PROTOCOL_LIST marker](https://github.com/pixie-io/pixie/blob/03184ccb3014dfea45058af7e077d090534ca975/src/stirling/protocol_contribution_guide_part2.md?plain=1#L60).

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Verified there was no marker in the `socket_trace_connector.h` file

