### PR TITLE
Update `GetAgentStatus` and kernel header UDTF to allow kelvin filtering

### DIFF
--- a/src/carnot/planner/logical_planner_test.cc
+++ b/src/carnot/planner/logical_planner_test.cc
@@ -272,6 +272,24 @@ TEST_F(LogicalPlannerTest, AppendSelfTest) {
   EXPECT_OK(plan->ToProto());
 }
 
+constexpr char kAgentStatusQuery[] = R"pxl(
+import px
+
+# GetAgentStatus takes an include_kelvin argument. This defaults to True
+# to preserve backwards compatibility.
+px.display(px.GetAgentStatus())
+)pxl";
+
+TEST_F(LogicalPlannerTest, UDTFDefaultArgumentTest) {
+  auto planner = LogicalPlanner::Create(info_).ConsumeValueOrDie();
+  auto plan_or_s = planner->Plan(
+      MakeQueryRequest(testutils::CreateTwoPEMsOneKelvinPlannerState(testutils::kHttpEventsSchema),
+                       kAgentStatusQuery));
+  EXPECT_OK(plan_or_s);
+  auto plan = plan_or_s.ConsumeValueOrDie();
+  EXPECT_OK(plan->ToProto());
+}
+
 constexpr char kPlannerQueryError[] = R"pxl(
 import px
 

--- a/src/carnot/udf/registry.cc
+++ b/src/carnot/udf/registry.cc
@@ -92,21 +92,25 @@ void DefaultToScalarValue(const UDTFArg&, planpb::ScalarValue*) {
 template <>
 void DefaultToScalarValue<types::BOOLEAN>(const UDTFArg& arg, planpb::ScalarValue* out) {
   out->set_bool_value(arg.GetDefaultValue<types::BOOLEAN>().val);
+  out->set_data_type(types::BOOLEAN);
 }
 
 template <>
 void DefaultToScalarValue<types::INT64>(const UDTFArg& arg, planpb::ScalarValue* out) {
   out->set_int64_value(arg.GetDefaultValue<types::INT64>().val);
+  out->set_data_type(types::INT64);
 }
 
 template <>
 void DefaultToScalarValue<types::TIME64NS>(const UDTFArg& arg, planpb::ScalarValue* out) {
   out->set_time64_ns_value(arg.GetDefaultValue<types::TIME64NS>().val);
+  out->set_data_type(types::TIME64NS);
 }
 
 template <>
 void DefaultToScalarValue<types::FLOAT64>(const UDTFArg& arg, planpb::ScalarValue* out) {
   out->set_float64_value(arg.GetDefaultValue<types::FLOAT64>().val);
+  out->set_data_type(types::FLOAT64);
 }
 
 template <>
@@ -116,11 +120,13 @@ void DefaultToScalarValue<types::UINT128>(const UDTFArg& arg, planpb::ScalarValu
 
   out_val->set_high(casted_arg.High64());
   out_val->set_high(casted_arg.Low64());
+  out->set_data_type(types::UINT128);
 }
 
 template <>
 void DefaultToScalarValue<types::STRING>(const UDTFArg& arg, planpb::ScalarValue* out) {
   out->set_string_value(std::string(arg.GetDefaultValue<types::STRING>()));
+  out->set_data_type(types::STRING);
 }
 }  // namespace
 

--- a/src/carnot/udf/registry_test.cc
+++ b/src/carnot/udf/registry_test.cc
@@ -421,6 +421,7 @@ udtfs {
     semantic_type: ST_NONE
     default_value {
       int64_value: 123
+      data_type: INT64
     }
   }
   args {


### PR DESCRIPTION
Summary: Update `GetAgentStatus` and kernel header UDTF to allow kelvin filtering

In order to leverage the `GetAgentStatus`'s `kernel_headers_installed` column for #2051, it would be convenient for the the UDTF to provide the ability to filter kelvins out -- they don't have access to kernel headers since they don't have the host filesystem volume mounted. This change introduces an `include_kelvin` init argument to the UDTFs with a default of `true` to preserve the existing behavior.

This change also fixes a bug with UDTF's init arg default values, which didn't work prior to this change. Please review commit by commit to see the default arg bug fix followed by the UDTF changes.

Relevant Issues: #2051

Type of change: /kind bug

Test Plan: New logical planner test no longer fails with the following error
```
$ bazel test -c opt src/carnot/planner:logical_planner_test --test_output=all

[ RUN      ] LogicalPlannerTest.one_pems_one_kelvin
src/carnot/planner/logical_planner_test.cc:64: Failure
Value of: IsOK(::px::StatusAdapter(__status_or_value__64))
  Actual: false (Invalid Argument : DATA_TYPE_UNKNOWN not handled as a default value)
Expected: true
```