### PR TITLE
Add px/agent_status_diagnostics pxl script

### DIFF
--- a/src/pxl_scripts/px/agent_status_diagnostics/agent_status.pxl
+++ b/src/pxl_scripts/px/agent_status_diagnostics/agent_status.pxl
@@ -1,0 +1,28 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import px
+
+# Exclude kelvins since they don't run BPF programs nor
+# do they have the host linux headers accessible
+df = px.GetAgentStatus(False)
+df = df.agg(
+    installed=('kernel_headers_installed', px.sum),
+    count=('kernel_headers_installed', px.count),
+)
+df.headers_installed_percent = df.installed / df.count
+df = df.drop(['installed', 'count'])
+px.display(df)

--- a/src/pxl_scripts/px/agent_status_diagnostics/manifest.yaml
+++ b/src/pxl_scripts/px/agent_status_diagnostics/manifest.yaml
@@ -1,0 +1,4 @@
+---
+short: Agent status diagnostics
+long: >
+  This script performs diagnostics on the agents' (PEMs/Collectors) status


### PR DESCRIPTION
Summary: Add px/agent_status_diagnostics pxl script

This PR adds a new pxl script that helps identify if linux headers are missing on any PEMs. This can be extended in the future, but the first use cause will be to execute the script during `px deploy` and `px collect-logs`.

Relevant Issues: #2051

Type of change: /kind feature

Test Plan: Ran the script in the UI and tested it as part of the validation for #2065

![Screen Shot 2024-12-18 at 10 51 15 AM](https://github.com/user-attachments/assets/bd4ab6de-ad92-4af3-8714-b044a7df7d65)


Changelog Message: Add `px/agent_status_diagnostics` pxl script for checking common issues