### PR TITLE
Ensure etcd stateful set has required capabilities to run on OpenShift

### DIFF
--- a/k8s/vizier_deps/base/etcd/etcd_statefulset.yaml
+++ b/k8s/vizier_deps/base/etcd/etcd_statefulset.yaml
@@ -106,6 +106,12 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+          securityContext:
+            capabilities:
+              add:
+              - NET_RAW
+            seccompProfile:
+              type: RuntimeDefault
         volumeMounts:
         - mountPath: /var/run/etcd
           name: etcd-data
@@ -132,6 +138,9 @@ spec:
           secretName: etcd-client-tls-certs
       - emptyDir: {}
         name: etcd-data
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: "kubernetes.io/arch"
         operator: "Equal"


### PR DESCRIPTION
Summary: Ensure etcd stateful set has required capabilities to run on OpenShift

When using the etcd metadata store on an Openshift cluster, the container gets stuck in its start up script and continuously prints the following error.
```
Waiting for pl-etcd-1.pl-etcd.pl to come up
ping: permission denied (are you root?)

Waiting for pl-etcd-1.pl-etcd.pl to come up
ping: permission denied (are you root?)
```

The etcd stateful set requires an additional capability, which was missed when the other services had stricter security context settings added. This change also requires the following `SecurityContextConstraints` changes (https://github.com/pixie-io/docs.px.dev/pull/292)

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Deployed the non-operator version of Pixie to an Openshift cluster and verified etcd is scheduled now
- [x] Verified etcd metadata deployment with these changes works on GKE cluster

Changelog Message: Fixed an issue where the etcd metadata store wouldn't schedule on Openshift clusters