### PR TITLE
Fix out-of-bound symlink for gitops tools

### DIFF
--- a/src/common/system/proc_parser_test.cc
+++ b/src/common/system/proc_parser_test.cc
@@ -289,8 +289,6 @@ TEST_F(ProcParserTest, read_pid_metadata_null) {
               parser_->GetPIDCmdline(456));
 }
 
-// This test does not work because bazel uses symlinks itself,
-// which then causes ReadProcPIDFDLink to resolve the wrong link.
 TEST_F(ProcParserTest, read_proc_fd_link) {
   PX_SET_FOR_SCOPE(FLAGS_proc_path, GetPathToTestDataFile("testdata/proc"));
   {
@@ -299,7 +297,7 @@ TEST_F(ProcParserTest, read_proc_fd_link) {
     ASSERT_OK(
         fs::CreateSymlinkIfNotExists("/dev/null", GetPathToTestDataFile("testdata/proc/123/fd/0")));
     ASSERT_OK(
-        fs::CreateSymlinkIfNotExists("/foobar", GetPathToTestDataFile("testdata/proc/123/fd/1")));
+        fs::CreateSymlinkIfNotExists("./foobar", GetPathToTestDataFile("testdata/proc/123/fd/1")));
     ASSERT_OK(fs::CreateSymlinkIfNotExists("socket:[12345]",
                                            GetPathToTestDataFile("testdata/proc/123/fd/2")));
   }
@@ -313,7 +311,7 @@ TEST_F(ProcParserTest, read_proc_fd_link) {
 
   s = parser_->ReadProcPIDFDLink(123, 1, &out);
   EXPECT_OK(s);
-  EXPECT_EQ("/foobar", out);
+  EXPECT_EQ("./foobar", out);
 
   s = parser_->ReadProcPIDFDLink(123, 2, &out);
   EXPECT_OK(s);

--- a/src/common/system/testdata/proc/123/fd/1
+++ b/src/common/system/testdata/proc/123/fd/1
@@ -1,1 +1,1 @@
-/foobar
+./foobar


### PR DESCRIPTION
Summary: Fix out-of-bound symlink for gitops tools

I'm working on deploying pixie cloud via gitops.
For security reasons argocd block the deployment if an out of bound symlink is detected in the monorepo.
```
Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = 
repository contains out-of-bounds symlinks. file: src/common/system/testdata/proc/123/fd/1
```

Changing the dummy symlink to a relative path that don't leave the root fixes the issue.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: the items below
- [x] Use my fork to test if the updated symlink path still block the argocd app deployment.
- [x] Related unit test still pass

Additional documentation: see the links below
- https://github.com/argoproj/argo-cd/issues/12593#issuecomment-2575569453
- https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.4-2.5/#out-of-bounds-symlinks-now-blocked-at-fetch