### PR TITLE
Update self-hosted cloud's cli, operator and vizier versions

### DIFF
--- a/k8s/cloud/public/base/artifact_tracker_versions.yaml
+++ b/k8s/cloud/public/base/artifact_tracker_versions.yaml
@@ -10,8 +10,8 @@ spec:
       - name: artifact-tracker-server
         env:
         - name: PL_VIZIER_VERSION
-          value: "0.14.9"
+          value: "0.14.14"
         - name: PL_CLI_VERSION
-          value: "0.7.17"
+          value: "0.8.5"
         - name: PL_OPERATOR_VERSION
-          value: "0.0.37"
+          value: "0.1.7"


### PR DESCRIPTION
Summary: Update self-hosted cloud's cli, operator and vizier versions

The latest vizier (v0.14.14) and cli (v0.8.5) include support for detect missing kernel headers (#2051). This detection is only enabled when the `px/agent_diagnostic_status` script is present. Since this script will become available in the next release, this change ensures that self hosted users can benefit from this additional diagnostic information as soon as possible.

Relevant Issues: #2051

Type of change: /kind feature

Test Plan: Verified the version numbers