### PR TITLE
Make metadata pod lookups more resilient to short lived processes

### DIFF
--- a/src/carnot/funcs/metadata/metadata_ops.cc
+++ b/src/carnot/funcs/metadata/metadata_ops.cc
@@ -45,6 +45,7 @@ void RegisterMetadataOpsOrDie(px::carnot::udf::Registry* registry) {
   registry->RegisterOrDie<HasServiceNameUDF>("has_service_name");
   registry->RegisterOrDie<HasValueUDF>("has_value");
   registry->RegisterOrDie<IPToPodIDUDF>("ip_to_pod_id");
+  registry->RegisterOrDie<IPToPodIDAtTimePEMExecUDF>("_ip_to_pod_id_pem_exec");
   registry->RegisterOrDie<IPToPodIDAtTimeUDF>("ip_to_pod_id");
   registry->RegisterOrDie<PodIDToPodNameUDF>("pod_id_to_pod_name");
   registry->RegisterOrDie<PodIDToPodLabelsUDF>("pod_id_to_pod_labels");

--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -2977,6 +2977,25 @@ class IPToPodIDUDF : public ScalarUDF {
   static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_KELVIN; }
 };
 
+/**
+ * This UDF is a compiler internal function. It should only be used when the IP address is
+ * guaranteed to be a local address since this function is forced to run on PEMs. In cases
+ * where the IP could be a remote address, then it is more correct to have the function run on
+ * Kelvin (IPToPodIDUDF or IPToPodIDAtTimeUDF).
+ */
+class IPToPodIDAtTimePEMExecUDF : public ScalarUDF {
+ public:
+  /**
+   * @brief Gets the pod id of pod with given pod_ip and time
+   */
+  StringValue Exec(FunctionContext* ctx, StringValue pod_ip, Time64NSValue time) {
+    auto md = GetMetadataState(ctx);
+    return md->k8s_metadata_state().PodIDByIPAtTime(pod_ip, time.val);
+  }
+
+  static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_PEM; }
+};
+
 class IPToPodIDAtTimeUDF : public ScalarUDF {
  public:
   /**

--- a/src/carnot/planner/compiler/analyzer/convert_metadata_rule.cc
+++ b/src/carnot/planner/compiler/analyzer/convert_metadata_rule.cc
@@ -31,6 +31,58 @@ namespace carnot {
 namespace planner {
 namespace compiler {
 
+namespace {
+std::string GetUniquePodNameCol(std::shared_ptr<TableType> parent_type,
+                                absl::flat_hash_set<std::string>* used_column_names) {
+  auto col_name_counter = 0;
+  do {
+    auto new_col = absl::StrCat("pod_name_", col_name_counter++);
+    if (!used_column_names->contains(new_col) && !parent_type->HasColumn(new_col)) {
+      used_column_names->insert(new_col);
+      return new_col;
+    }
+  } while (true);
+}
+}  // namespace
+
+Status ConvertMetadataRule::AddPodNameConversionMapsWithFallback(
+    IR* graph, IRNode* container, ExpressionIR* metadata_expr, ExpressionIR* fallback_expr,
+    const std::pair<std::string, std::string>& col_names) const {
+  if (Match(container, Func())) {
+    for (int64_t parent_id : graph->dag().ParentsOf(container->id())) {
+      PX_RETURN_IF_ERROR(AddPodNameConversionMapsWithFallback(
+          graph, graph->Get(parent_id), metadata_expr, fallback_expr, col_names));
+    }
+  } else if (Match(container, Operator())) {
+    auto container_op = static_cast<OperatorIR*>(container);
+    for (auto parent_op : container_op->parents()) {
+      auto metadata_col_expr = ColumnExpression(col_names.first, metadata_expr);
+      auto fallback_col_expr = ColumnExpression(col_names.second, fallback_expr);
+      PX_ASSIGN_OR_RETURN(
+          auto md_map_ir,
+          graph->CreateNode<MapIR>(container->ast(), parent_op,
+                                   std::vector<ColumnExpression>{metadata_col_expr}, true));
+      PX_ASSIGN_OR_RETURN(
+          auto fallback_md_map_ir,
+          graph->CreateNode<MapIR>(container->ast(), static_cast<OperatorIR*>(md_map_ir),
+                                   std::vector<ColumnExpression>{fallback_col_expr}, true));
+      PX_RETURN_IF_ERROR(container_op->ReplaceParent(parent_op, fallback_md_map_ir));
+
+      for (auto child : parent_op->Children()) {
+        if (child == md_map_ir) {
+          continue;
+        }
+        PX_RETURN_IF_ERROR(child->ReplaceParent(parent_op, md_map_ir));
+      }
+
+      PX_RETURN_IF_ERROR(PropagateTypeChangesFromNode(graph, md_map_ir, compiler_state_));
+      PX_RETURN_IF_ERROR(PropagateTypeChangesFromNode(graph, fallback_md_map_ir, compiler_state_));
+    }
+  }
+
+  return Status::OK();
+}
+
 Status ConvertMetadataRule::UpdateMetadataContainer(IRNode* container, MetadataIR* metadata,
                                                     ExpressionIR* metadata_expr) const {
   if (Match(container, Func())) {
@@ -70,6 +122,12 @@ StatusOr<std::string> ConvertMetadataRule::FindKeyColumn(std::shared_ptr<TableTy
       absl::StrJoin(parent_type->ColumnNames(), ","));
 }
 
+bool CheckBackupConversionAvailable(std::shared_ptr<TableType> parent_type,
+                                    const std::string& func_name) {
+  return parent_type->HasColumn("time_") && parent_type->HasColumn("local_addr") &&
+         func_name == "upid_to_pod_name";
+}
+
 StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
   if (!Match(ir_node, Metadata())) {
     return false;
@@ -85,8 +143,9 @@ StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
   PX_ASSIGN_OR_RETURN(auto parent, metadata->ReferencedOperator());
   PX_ASSIGN_OR_RETURN(auto containing_ops, metadata->ContainingOperators());
 
+  auto resolved_table_type = parent->resolved_table_type();
   PX_ASSIGN_OR_RETURN(std::string key_column_name,
-                      FindKeyColumn(parent->resolved_table_type(), md_property, ir_node));
+                      FindKeyColumn(resolved_table_type, md_property, ir_node));
 
   PX_ASSIGN_OR_RETURN(ColumnIR * key_column,
                       graph->CreateNode<ColumnIR>(ir_node->ast(), key_column_name, parent_op_idx));
@@ -96,10 +155,74 @@ StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
       FuncIR * conversion_func,
       graph->CreateNode<FuncIR>(ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", func_name},
                                 std::vector<ExpressionIR*>{key_column}));
+  FuncIR* orig_conversion_func = conversion_func;
+  ExpressionIR* conversion_expr = static_cast<ExpressionIR*>(conversion_func);
+
+  // TODO(ddelnano): Until the short lived process issue (gh#1638) is resolved, add a fallback
+  // conversion function that uses local_addr for pod lookups when the upid based default
+  // (upid_to_pod_name) fails. This turns the `df.ctx["pod"]` lookup into the following pseudo code:
+  //
+  //  fallback = px.pod_id_to_pod_name(px.ip_to_pod_id(df.ctx["local_addr"]))
+  //  df.pod = px.select(px.upid_to_pod_name(df.upid) == "", fallback, px.upid_to_pod_name(df.upid))
+  FuncIR* backup_conversion_func = nullptr;
+  auto backup_conversion_available = CheckBackupConversionAvailable(resolved_table_type, func_name);
+  std::pair<std::string, std::string> col_names;
+  if (backup_conversion_available) {
+    absl::flat_hash_set<std::string> used_column_names;
+    col_names = std::make_pair(GetUniquePodNameCol(resolved_table_type, &used_column_names),
+                               GetUniquePodNameCol(resolved_table_type, &used_column_names));
+    PX_ASSIGN_OR_RETURN(ColumnIR * local_addr_col,
+                        graph->CreateNode<ColumnIR>(ir_node->ast(), "local_addr", parent_op_idx));
+    PX_ASSIGN_OR_RETURN(ColumnIR * time_col,
+                        graph->CreateNode<ColumnIR>(ir_node->ast(), "time_", parent_op_idx));
+    PX_ASSIGN_OR_RETURN(
+        ColumnIR * md_expr_col,
+        graph->CreateNode<ColumnIR>(ir_node->ast(), col_names.first, parent_op_idx));
+    PX_ASSIGN_OR_RETURN(
+        FuncIR * ip_conversion_func,
+        graph->CreateNode<FuncIR>(ir_node->ast(),
+                                  FuncIR::Op{FuncIR::Opcode::non_op, "", "_ip_to_pod_id_pem_exec"},
+                                  std::vector<ExpressionIR*>{local_addr_col, time_col}));
+
+    // This doesn't need to have a "pem exec" equivalent function as long as the metadata
+    // annotation is set as done below
+    PX_ASSIGN_OR_RETURN(
+        backup_conversion_func,
+        graph->CreateNode<FuncIR>(
+            ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", "pod_id_to_pod_name"},
+            std::vector<ExpressionIR*>{static_cast<ExpressionIR*>(ip_conversion_func)}));
+
+    backup_conversion_func->set_annotations(ExpressionIR::Annotations(md_type));
+
+    PX_ASSIGN_OR_RETURN(ExpressionIR * empty_string,
+                        graph->CreateNode<StringIR>(ir_node->ast(), ""));
+    PX_ASSIGN_OR_RETURN(
+        FuncIR * select_expr,
+        graph->CreateNode<FuncIR>(
+            ir_node->ast(), FuncIR::Op{FuncIR::Opcode::eq, "==", "equal"},
+            std::vector<ExpressionIR*>{static_cast<ExpressionIR*>(md_expr_col), empty_string}));
+    PX_ASSIGN_OR_RETURN(auto duplicate_md_expr_col, graph->CopyNode<ColumnIR>(md_expr_col));
+    PX_ASSIGN_OR_RETURN(
+        FuncIR * select_func,
+        graph->CreateNode<FuncIR>(
+            ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", "select"},
+            std::vector<ExpressionIR*>{static_cast<ExpressionIR*>(select_expr),
+                                       backup_conversion_func, duplicate_md_expr_col}));
+
+    conversion_func = select_func;
+    PX_ASSIGN_OR_RETURN(conversion_expr, graph->CreateNode<ColumnIR>(
+                                             ir_node->ast(), col_names.second, parent_op_idx));
+  }
+
   for (int64_t parent_id : graph->dag().ParentsOf(metadata->id())) {
     // For each container node of the metadata expression, update it to point to the
     // new conversion func instead.
-    PX_RETURN_IF_ERROR(UpdateMetadataContainer(graph->Get(parent_id), metadata, conversion_func));
+    auto container = graph->Get(parent_id);
+    PX_RETURN_IF_ERROR(UpdateMetadataContainer(container, metadata, conversion_expr));
+    if (backup_conversion_available) {
+      PX_RETURN_IF_ERROR(AddPodNameConversionMapsWithFallback(
+          graph, container, orig_conversion_func, conversion_func, col_names));
+    }
   }
 
   // Propagate type changes from the new conversion_func.
@@ -107,8 +230,7 @@ StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
 
   DCHECK_EQ(conversion_func->EvaluatedDataType(), column_type)
       << "Expected the parent key column type and metadata property type to match.";
-  conversion_func->set_annotations(ExpressionIR::Annotations(md_type));
-
+  orig_conversion_func->set_annotations(ExpressionIR::Annotations(md_type));
   return true;
 }
 

--- a/src/carnot/planner/compiler/test_utils.h
+++ b/src/carnot/planner/compiler/test_utils.h
@@ -860,10 +860,15 @@ class RulesTest : public OperatorTests {
         std::vector<types::DataType>({types::DataType::INT64, types::DataType::FLOAT64,
                                       types::DataType::FLOAT64, types::DataType::FLOAT64}),
         std::vector<std::string>({"count", "cpu0", "cpu1", "cpu2"}));
+    http_events_relation = table_store::schema::Relation(
+        std::vector<types::DataType>(
+            {types::DataType::TIME64NS, types::DataType::STRING, types::DataType::INT64}),
+        std::vector<std::string>({"time_", "local_addr", "local_port"}));
     semantic_rel =
         Relation({types::INT64, types::FLOAT64, types::STRING}, {"bytes", "cpu", "str_col"},
                  {types::ST_BYTES, types::ST_PERCENT, types::ST_NONE});
     rel_map->emplace("cpu", cpu_relation);
+    rel_map->emplace("http_events", http_events_relation);
     rel_map->emplace("semantic_table", semantic_rel);
 
     compiler_state_ = std::make_unique<CompilerState>(
@@ -935,6 +940,7 @@ class RulesTest : public OperatorTests {
   std::unique_ptr<RegistryInfo> info_;
   int64_t time_now = 1552607213931245000;
   table_store::schema::Relation cpu_relation;
+  table_store::schema::Relation http_events_relation;
   table_store::schema::Relation semantic_rel;
   std::unique_ptr<MetadataHandler> md_handler;
 };
@@ -1110,6 +1116,8 @@ class ASTVisitorTest : public OperatorTests {
     Relation http_events_relation;
     http_events_relation.AddColumn(types::TIME64NS, "time_");
     http_events_relation.AddColumn(types::UINT128, "upid");
+    http_events_relation.AddColumn(types::STRING, "local_addr");
+    http_events_relation.AddColumn(types::INT64, "local_port");
     http_events_relation.AddColumn(types::STRING, "remote_addr");
     http_events_relation.AddColumn(types::INT64, "remote_port");
     http_events_relation.AddColumn(types::INT64, "major_version");

--- a/src/carnot/planner/logical_planner_test.cc
+++ b/src/carnot/planner/logical_planner_test.cc
@@ -865,17 +865,19 @@ TEST_F(LogicalPlannerTest, pod_name_conversion_without_fallback) {
   ASSERT_OK(plan->ToProto());
 }
 
-// PxL query that contains a GRPC bridge with 2 branches where branch 1 is a blocking node
-// and branch 2 contains a PEM only UDF func (not a metadata expression). This triggers a previous
-// splitter bug where a PEM only UDF is incorrectly placed on the after blocking side of the bridge.
-// Metadata expressions didn't have this problem since md annotations force PEM only scheduling,
-// however, calling UDF only UDFs directly triggers this problem.
-//
-// The PxL below is roughly equivalent to the following problematic bridge:
-//
-// MemSrc  ->  Map ->  Map (w/ PEM only UDF)  ->  GRPC Sink (df return)
-//                \
-//                 ->  GRPC Sink (px.debug)
+/*
+ * PxL query that contains a GRPC bridge with 2 branches where branch 1 is a blocking node
+ * and branch 2 contains a PEM only UDF func (not a metadata expression). This triggers a previous
+ * splitter bug where a PEM only UDF is incorrectly placed on the after blocking side of the bridge.
+ * Metadata expressions didn't have this problem since md annotations force PEM only scheduling,
+ * however, calling UDF only UDFs directly triggers this problem.
+ *
+ * The PxL below is roughly equivalent to the following problematic bridge:
+ *
+ * MemSrc  ->  Map ->  Map (w/ PEM only UDF)  ->  GRPC Sink (df return)
+ *                \
+ *                 ->  GRPC Sink (px.debug)
+ */
 const char kBrokenUpidToPodNameQuery[] = R"pxl(
 import px
 def dns_flow_graph():

--- a/src/carnot/planner/test_utils.h
+++ b/src/carnot/planner/test_utils.h
@@ -103,6 +103,16 @@ relation_map {
       column_semantic_type: ST_UPID
     }
     columns {
+      column_name: "local_addr"
+      column_type: STRING
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "local_port"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
       column_name: "remote_addr"
       column_type: STRING
       column_semantic_type: ST_NONE
@@ -169,6 +179,46 @@ relation_map {
     }
     columns {
       column_name: "resp_latency_ns"
+      column_type: INT64
+      column_semantic_type: ST_DURATION_NS
+    }
+  }
+}
+relation_map {
+  key: "cql_events"
+  value {
+    columns {
+      column_name: "time_"
+      column_type: TIME64NS
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "upid"
+      column_type: UINT128
+      column_semantic_type: ST_UPID
+    }
+    columns {
+      column_name: "remote_addr"
+      column_type: STRING
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "remote_port"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "trace_role"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "major_version"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "latency"
       column_type: INT64
       column_semantic_type: ST_DURATION_NS
     }
@@ -968,6 +1018,53 @@ schema_info {
   }
 }
 schema_info {
+  name: "cql_events"
+  relation {
+    columns {
+      column_name: "time_"
+      column_type: TIME64NS
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "upid"
+      column_type: UINT128
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "remote_addr"
+      column_type: STRING
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "remote_port"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "trace_role"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "latency"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+  }
+  agent_list {
+    high_bits: 0x0000000100000000
+    low_bits: 0x0000000000000001
+  }
+  agent_list {
+    high_bits: 0x0000000100000000
+    low_bits: 0x0000000000000002
+  }
+  agent_list {
+    high_bits: 0x0000000100000000
+    low_bits: 0x0000000000000003
+  }
+}
+schema_info {
   name: "http_events"
   relation {
     columns {
@@ -978,6 +1075,11 @@ schema_info {
     columns {
       column_name: "upid"
       column_type: UINT128
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "local_addr"
+      column_type: STRING
       column_semantic_type: ST_NONE
     }
   }


### PR DESCRIPTION
Summary: Make metadata pod lookups more resilient to short lived processes

To be filled in later

Relevant Issues: #1638

Type of change: /kind bugfix

Test Plan: Details to be added later

Changelog Message: Details to be added later