### PR TITLE
Migrate the deprecated (v3) download/upload artifact actions to v4

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -112,7 +112,7 @@ jobs:
         echo "Build & Test matrix: ${matrix}"
         echo "matrix=${matrix}" >> $GITHUB_OUTPUT
     - name: Upload Target Files
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: target_files
         path: |
@@ -138,7 +138,7 @@ jobs:
         ref: ${{ needs.env-protect-setup.outputs.ref }}
     - name: Add pwd to git safe dir
       run: git config --global --add safe.directory `pwd`
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: get bazel config
       uses: ./.github/actions/bazelrc
       with:

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -62,7 +62,7 @@ jobs:
         ./ci/save_version_info.sh
         ./ci/cli_build_release.sh
     - name: Upload Github Artifacts
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: linux-artifacts
         path: artifacts/
@@ -73,7 +73,7 @@ jobs:
         MANIFEST_UPDATES: ""
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: artifact-upload-log
         path: ${{ env.ARTIFACT_UPLOAD_LOG }}
@@ -104,7 +104,7 @@ jobs:
         mkdir -p "artifacts/"
         export ARTIFACTS_DIR="$(pwd)/artifacts"
         ./ci/cli_merge_sign.sh
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: macos-artifacts
         path: artifacts/
@@ -120,10 +120,10 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: macos-artifacts
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: artifact-upload-log
     - name: Import GPG key
@@ -150,11 +150,11 @@ jobs:
         mkdir -p "artifacts/"
         export ARTIFACTS_DIR="$(pwd)/artifacts"
         ./ci/cli_upload_signed.sh
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: macos-artifacts
         path: artifacts/
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: manifest-updates
         path: ${{ env.MANIFEST_UPDATES }}
@@ -168,7 +168,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
@@ -221,7 +221,7 @@ jobs:
         git config --global user.email 'build@pixielabs.ai'
         git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
         git config --global commit.gpgsign true
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       id: download-artifact
       with:
         name: manifest-updates

--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -56,7 +56,7 @@ jobs:
         mkdir -p "${ARTIFACTS_DIR}"
         ./ci/save_version_info.sh
         ./ci/cloud_build_release.sh
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: cloud-artifacts
         path: artifacts/
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -67,15 +67,15 @@ jobs:
         MANIFEST_UPDATES: ""
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: manifest-updates
         path: ${{ env.MANIFEST_UPDATES }}
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: operator-artifacts
         path: artifacts/
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: index-artifacts
         path: index.yaml
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
@@ -121,7 +121,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: gh-pages
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Setup git
       shell: bash
       env:
@@ -175,7 +175,7 @@ jobs:
         git config --global user.email 'build@pixielabs.ai'
         git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
         git config --global commit.gpgsign true
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       id: download-artifact
       with:
         name: manifest-updates

--- a/.github/workflows/perf_common.yaml
+++ b/.github/workflows/perf_common.yaml
@@ -107,7 +107,7 @@ jobs:
       run: gcloud auth revoke
     # Github actions doesn't have native support for gathering outputs from matrix runs.
     # So we upload an artifact for each one and gather them ourselves in `get-perf-outputs`.
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: ${{ hashFiles('run_output') }}
         path: run_output
@@ -119,7 +119,7 @@ jobs:
     outputs:
       experiments: ${{ steps.get-outputs.outputs.run_output }}
     steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - id: get-outputs
       run: |
         all_run_output="$(cat */run_output | jq --slurp -c '.[]')"

--- a/.github/workflows/release_update_docs_px_dev.yaml
+++ b/.github/workflows/release_update_docs_px_dev.yaml
@@ -30,7 +30,7 @@ jobs:
       run: |
         bazel run src/carnot/docstring:docstring -- \
         --output_json=$(pwd)/pxl_documentation.json
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: pxl_documentation
         path: pxl_documentation.json
@@ -68,7 +68,7 @@ jobs:
         git config --global user.name 'pixie-io-buildbot'
         git config --global user.email 'build@pixielabs.ai'
         git remote add fork git@github.com:pixie-io-buildbot/docs.px.dev.git
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: pxl_documentation
         path: external/

--- a/.github/workflows/update_script_bundle.yaml
+++ b/.github/workflows/update_script_bundle.yaml
@@ -34,7 +34,7 @@ jobs:
         export PATH="$PATH:$(pwd)"
         cd src/pxl_scripts
         make bundle-oss.json
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: bundle
         path: src/pxl_scripts/bundle-oss.json
@@ -50,7 +50,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: gh-pages
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Import GPG key
       env:
         BUILDBOT_GPG_KEY_B64: ${{ secrets.BUILDBOT_GPG_KEY_B64 }}

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -74,15 +74,15 @@ jobs:
         MANIFEST_UPDATES: ""
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcloud-creds.outputs.gcloud-creds }}
       run: ./ci/update_artifact_manifest.sh
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: manifest-updates
         path: ${{ env.MANIFEST_UPDATES }}
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: vizier-artifacts
         path: artifacts/
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: index-artifacts
         path: index.yaml
@@ -96,7 +96,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # v3.5.0
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Create Release
       env:
         REF: ${{ github.event.ref }}
@@ -128,7 +128,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: gh-pages
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
     - name: Setup git
       shell: bash
       env:
@@ -182,7 +182,7 @@ jobs:
         git config --global user.email 'build@pixielabs.ai'
         git config --global user.signingkey "${BUILDBOT_GPG_KEY_ID}"
         git config --global commit.gpgsign true
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       id: download-artifact
       with:
         name: manifest-updates


### PR DESCRIPTION
Summary: Migrate the deprecated (v3) download/upload artifact actions to v4

These are slated for deprecation on Jan 30th, but GitHub is failing builds already for using these old versions (output copied below).

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: 0b7f8abb1508181956e8e162db84b466c27e18ce`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The breaking changes are described [here](https://github.com/actions/download-artifact/blob/7fba95161a0924506ed1ae69cdbae8371ee00b3f/docs/MIGRATION.md#migration) and upon review I don't believe those cases are relevant to our workflows.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: PR build should succeed. As for others, I was planning to wait until releases happen