### PR TITLE
Fix accidentally malformed yaml in GitHub action

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -112,7 +112,7 @@ jobs:
         echo "Build & Test matrix: ${matrix}"
         echo "matrix=${matrix}" >> $GITHUB_OUTPUT
     - name: Upload Target Files
-    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: target_files
         path: |


### PR DESCRIPTION
Summary: Fix accidentally malformed yaml in GitHub action

This was a minor mistake from #2079.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: GitHub actions on PR builds should pass once this is merged (since `pull_request_target` uses the copy off main)
- Also visually inspected the #2079 change again to verify nothing else was missed.