### PR TITLE
Opt into dependabot GitHub actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,7 @@ updates:
   directory: /
   schedule:
     interval: daily
-  # Disable version updates but keep security updates
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 1
 
 - package-ecosystem: pip
   directory: /bazel/external/ubuntu_packages


### PR DESCRIPTION
Summary: Opt into dependabot GitHub actions version updates

Earlier today, the download/upload artifacts actions were deprecated and started failing builds (#2079). There are other actions will be deprecated soon, so let's opt into dependabots updates to stay ahead of these notices.

> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

There are other alternatives (like Renovatebot). I went for this since it's already in place to get coverage quickly, but open to exploring other options in the future.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Read the docs on the setting changed