### PR TITLE
Prevent cli release from mutating previously uploaded artifact

### DIFF
--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -152,7 +152,7 @@ jobs:
         ./ci/cli_upload_signed.sh
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
-        name: macos-artifacts
+        name: macos-signed-artifacts
         path: artifacts/
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:


### PR DESCRIPTION
Summary: Prevent cli release from mutating previously uploaded artifact

The v3 artifacts Action was deprecated and migrated from in #2079. The new API has [breaking changes](https://github.com/actions/upload-artifact/tree/main?tab=readme-ov-file#breaking-changes) including that artifacts are now immutable. During #2079, I missed that the cli release uploads to the same name twice (see grep below) and caused the following [build failure](https://github.com/pixie-io/pixie/actions/runs/12818680277/job/35745089942).

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Verified that the `macos-artifacts` artifact name is no longer used multiple times
- [x] Double checked other actions to verify that they aren't trying to mutate an artifact
```
# on main w/o this change
(main) $ git grep -A2 upload-artifact | grep name | uniq -c
      1 .github/workflows/build_and_test.yaml-        name: target_files
      1 .github/workflows/cli_release.yaml-        name: linux-artifacts
      1 .github/workflows/cli_release.yaml-        name: artifact-upload-log
      2 .github/workflows/cli_release.yaml-        name: macos-artifacts            <------ the only offender
      1 .github/workflows/cli_release.yaml-        name: manifest-updates
      1 .github/workflows/cloud_release.yaml-        name: cloud-artifacts
      1 .github/workflows/operator_release.yaml-        name: manifest-updates
      1 .github/workflows/operator_release.yaml-        name: operator-artifacts
      1 .github/workflows/operator_release.yaml-        name: index-artifacts
      1 .github/workflows/perf_common.yaml-        name: ${{ hashFiles('run_output') }}
      1 .github/workflows/release_update_docs_px_dev.yaml-        name: pxl_documentation
      1 .github/workflows/update_script_bundle.yaml-        name: bundle
      1 .github/workflows/vizier_release.yaml-        name: manifest-updates
      1 .github/workflows/vizier_release.yaml-        name: vizier-artifacts
      1 .github/workflows/vizier_release.yaml-        name: index-artifacts
```