### PR TITLE
Ensure Artifact tracker versions aren't "v" prefixed

### DIFF
--- a/ci/update_files_with_release_versions.sh
+++ b/ci/update_files_with_release_versions.sh
@@ -29,6 +29,8 @@ version="$2"
 url="$3"
 
 readme_path="README.md"
+# Strip the leading v from the version string
+at_version="${version#v}"
 at_versions_path="k8s/cloud/public/base/artifact_tracker_versions.yaml"
 
 latest_release_comment="<!--${artifact_type}-latest-release-->"
@@ -49,7 +51,7 @@ latest_release_line() {
 # environment variable is uppercased
 artifact_tracker_env_name="PL_${artifact_type^^}_VERSION"
 
-yq -i ".spec.template.spec.containers[] |= select(.name == \"artifact-tracker-server\").env[] |= select(.name == \"${artifact_tracker_env_name}\").value = \"${version}\"" "${at_versions_path}"
+yq -i ".spec.template.spec.containers[] |= select(.name == \"artifact-tracker-server\").env[] |= select(.name == \"${artifact_tracker_env_name}\").value = \"${at_version}\"" "${at_versions_path}"
 
 sed -i 's|.*'"${latest_release_comment}"'.*|'"$(latest_release_line)"'|' "${readme_path}"
 


### PR DESCRIPTION
Summary: Ensure Artifact tracker versions aren't "v" prefixed

This job ran for the first time and it accidentally added a version string prefixed with a "v". See the commits from https://github.com/pixie-io/pixie/pull/2089. This change fixes that minor error.

Relevant Issues: Closes #1907

Type of change: /kind bugfix

Test Plan: Verified the script works with or without a leading "v"
```
# Test case without a v prefixed version 
$ ./ci/update_files_with_release_versions.sh vizier 0.14.15 '<!--vizier-latest-release'
$ git diff k8s/
diff --git a/k8s/cloud/public/base/artifact_tracker_versions.yaml b/k8s/cloud/public/base/artifact_tracker_versions.yaml
index 6b8497ad1..17995a8bb 100644
--- a/k8s/cloud/public/base/artifact_tracker_versions.yaml
+++ b/k8s/cloud/public/base/artifact_tracker_versions.yaml
@@ -11,7 +11,7 @@ spec:
         - name: artifact-tracker-server # yamllint disable rule:indentation
           env:
             - name: PL_VIZIER_VERSION
-              value: "0.14.14"
+              value: "0.14.15"
             - name: PL_CLI_VERSION
               value: "0.8.5"
             - name: PL_OPERATOR_VERSION

# Test case with v prefixed version
$ ./ci/update_files_with_release_versions.sh vizier v0.14.16 '<!--vizier-latest-release'
$ git diff k8s/
diff --git a/k8s/cloud/public/base/artifact_tracker_versions.yaml b/k8s/cloud/public/base/artifact_tracker_versions.yaml
index 6b8497ad1..b917a0bfb 100644
--- a/k8s/cloud/public/base/artifact_tracker_versions.yaml
+++ b/k8s/cloud/public/base/artifact_tracker_versions.yaml
@@ -11,7 +11,7 @@ spec:
         - name: artifact-tracker-server # yamllint disable rule:indentation
           env:
             - name: PL_VIZIER_VERSION
-              value: "0.14.14"
+              value: "0.14.16"
             - name: PL_CLI_VERSION
               value: "0.8.5"
             - name: PL_OPERATOR_VERSION
```