### PR TITLE
Make metadata pod lookups more resilient to short lived processes

### DIFF
--- a/src/carnot/funcs/metadata/metadata_ops.cc
+++ b/src/carnot/funcs/metadata/metadata_ops.cc
@@ -45,6 +45,7 @@ void RegisterMetadataOpsOrDie(px::carnot::udf::Registry* registry) {
   registry->RegisterOrDie<HasServiceNameUDF>("has_service_name");
   registry->RegisterOrDie<HasValueUDF>("has_value");
   registry->RegisterOrDie<IPToPodIDUDF>("ip_to_pod_id");
+  registry->RegisterOrDie<UPIDtoPodNameLocalAddrFallback>("_upid_to_podname_local_addr_fallback");
   registry->RegisterOrDie<IPToPodIDAtTimeUDF>("ip_to_pod_id");
   registry->RegisterOrDie<PodIDToPodNameUDF>("pod_id_to_pod_name");
   registry->RegisterOrDie<PodIDToPodLabelsUDF>("pod_id_to_pod_labels");

--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -2987,7 +2987,8 @@ class UPIDtoPodNameLocalAddrFallback : public ScalarUDF {
   /**
    * @brief Gets the pod name from UPID or from local addr if first lookup fails
    */
-  StringValue Exec(FunctionContext* ctx, UInt128Value upid_value, StringValue pod_ip, Time64NSValue time) {
+  StringValue Exec(FunctionContext* ctx, UInt128Value upid_value, StringValue pod_ip,
+                   Time64NSValue time) {
     auto md = GetMetadataState(ctx);
     auto pod_info = UPIDtoPod(md, upid_value);
     if (pod_info == nullptr) {
@@ -3003,7 +3004,8 @@ class UPIDtoPodNameLocalAddrFallback : public ScalarUDF {
   static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_PEM; }
 
   static udf::InfRuleVec SemanticInferenceRules() {
-    return {udf::ExplicitRule::Create<UPIDtoPodNameLocalAddrFallback>(types::ST_POD_NAME, {types::ST_NONE, types::ST_NONE, types::ST_NONE})};
+    return {udf::ExplicitRule::Create<UPIDtoPodNameLocalAddrFallback>(
+        types::ST_POD_NAME, {types::ST_NONE, types::ST_NONE, types::ST_NONE})};
   }
 };
 

--- a/src/carnot/funcs/metadata/metadata_ops.h
+++ b/src/carnot/funcs/metadata/metadata_ops.h
@@ -2977,6 +2977,36 @@ class IPToPodIDUDF : public ScalarUDF {
   static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_KELVIN; }
 };
 
+/**
+ * This UDF is a compiler internal function. It should only be used on local IP addresses
+ * since this function is forced to run on PEMs. In cases where the IP could be a remote address,
+ * then it is more correct to have the function run on Kelvin (IPToPodIDUDF or IPToPodIDAtTimeUDF).
+ */
+class UPIDtoPodNameLocalAddrFallback : public ScalarUDF {
+ public:
+  /**
+   * @brief Gets the pod name from UPID or from local addr if first lookup fails
+   */
+  StringValue Exec(FunctionContext* ctx, UInt128Value upid_value, StringValue pod_ip, Time64NSValue time) {
+    auto md = GetMetadataState(ctx);
+    auto pod_info = UPIDtoPod(md, upid_value);
+    if (pod_info == nullptr) {
+      auto pod_id = md->k8s_metadata_state().PodIDByIPAtTime(pod_ip, time.val);
+      pod_info = md->k8s_metadata_state().PodInfoByID(pod_id);
+      if (pod_info == nullptr) {
+        return "";
+      }
+    }
+    return absl::Substitute("$0/$1", pod_info->ns(), pod_info->name());
+  }
+
+  static udfspb::UDFSourceExecutor Executor() { return udfspb::UDFSourceExecutor::UDF_PEM; }
+
+  static udf::InfRuleVec SemanticInferenceRules() {
+    return {udf::ExplicitRule::Create<UPIDtoPodNameLocalAddrFallback>(types::ST_POD_NAME, {types::ST_NONE, types::ST_NONE, types::ST_NONE})};
+  }
+};
+
 class IPToPodIDAtTimeUDF : public ScalarUDF {
  public:
   /**

--- a/src/carnot/planner/compiler/analyzer/convert_metadata_rule.cc
+++ b/src/carnot/planner/compiler/analyzer/convert_metadata_rule.cc
@@ -108,16 +108,15 @@ StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
   // (upid_to_pod_name) fails.
   if (backup_conversion_available) {
     func_name = "_upid_to_podname_local_addr_fallback";
-    PX_ASSIGN_OR_RETURN(
-        ColumnIR * local_addr_column,
-        graph->CreateNode<ColumnIR>(ir_node->ast(), "local_addr", parent_op_idx));
-    PX_ASSIGN_OR_RETURN(
-        ColumnIR * time_column,
-        graph->CreateNode<ColumnIR>(ir_node->ast(), "time_", parent_op_idx));
+    PX_ASSIGN_OR_RETURN(ColumnIR * local_addr_column,
+                        graph->CreateNode<ColumnIR>(ir_node->ast(), "local_addr", parent_op_idx));
+    PX_ASSIGN_OR_RETURN(ColumnIR * time_column,
+                        graph->CreateNode<ColumnIR>(ir_node->ast(), "time_", parent_op_idx));
     PX_ASSIGN_OR_RETURN(
         conversion_func,
-        graph->CreateNode<FuncIR>(ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", func_name},
-                                  std::vector<ExpressionIR*>{key_column, local_addr_column, time_column}));
+        graph->CreateNode<FuncIR>(
+            ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", func_name},
+            std::vector<ExpressionIR*>{key_column, local_addr_column, time_column}));
   } else {
     PX_ASSIGN_OR_RETURN(
         conversion_func,

--- a/src/carnot/planner/compiler/analyzer/convert_metadata_rule.cc
+++ b/src/carnot/planner/compiler/analyzer/convert_metadata_rule.cc
@@ -70,6 +70,12 @@ StatusOr<std::string> ConvertMetadataRule::FindKeyColumn(std::shared_ptr<TableTy
       absl::StrJoin(parent_type->ColumnNames(), ","));
 }
 
+bool CheckBackupConversionAvailable(std::shared_ptr<TableType> parent_type,
+                                    const std::string& func_name) {
+  return parent_type->HasColumn("time_") && parent_type->HasColumn("local_addr") &&
+         func_name == "upid_to_pod_name";
+}
+
 StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
   if (!Match(ir_node, Metadata())) {
     return false;
@@ -85,17 +91,39 @@ StatusOr<bool> ConvertMetadataRule::Apply(IRNode* ir_node) {
   PX_ASSIGN_OR_RETURN(auto parent, metadata->ReferencedOperator());
   PX_ASSIGN_OR_RETURN(auto containing_ops, metadata->ContainingOperators());
 
+  auto resolved_table_type = parent->resolved_table_type();
   PX_ASSIGN_OR_RETURN(std::string key_column_name,
-                      FindKeyColumn(parent->resolved_table_type(), md_property, ir_node));
+                      FindKeyColumn(resolved_table_type, md_property, ir_node));
 
   PX_ASSIGN_OR_RETURN(ColumnIR * key_column,
                       graph->CreateNode<ColumnIR>(ir_node->ast(), key_column_name, parent_op_idx));
 
   PX_ASSIGN_OR_RETURN(std::string func_name, md_property->UDFName(key_column_name));
-  PX_ASSIGN_OR_RETURN(
-      FuncIR * conversion_func,
-      graph->CreateNode<FuncIR>(ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", func_name},
-                                std::vector<ExpressionIR*>{key_column}));
+  auto backup_conversion_available = CheckBackupConversionAvailable(resolved_table_type, func_name);
+
+  FuncIR* conversion_func;
+
+  // TODO(ddelnano): Until the short lived process issue (gh#1638) is resolved, use a
+  // conversion function that uses local_addr for pod lookups when the upid based default
+  // (upid_to_pod_name) fails.
+  if (backup_conversion_available) {
+    func_name = "_upid_to_podname_local_addr_fallback";
+    PX_ASSIGN_OR_RETURN(
+        ColumnIR * local_addr_column,
+        graph->CreateNode<ColumnIR>(ir_node->ast(), "local_addr", parent_op_idx));
+    PX_ASSIGN_OR_RETURN(
+        ColumnIR * time_column,
+        graph->CreateNode<ColumnIR>(ir_node->ast(), "time_", parent_op_idx));
+    PX_ASSIGN_OR_RETURN(
+        conversion_func,
+        graph->CreateNode<FuncIR>(ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", func_name},
+                                  std::vector<ExpressionIR*>{key_column, local_addr_column, time_column}));
+  } else {
+    PX_ASSIGN_OR_RETURN(
+        conversion_func,
+        graph->CreateNode<FuncIR>(ir_node->ast(), FuncIR::Op{FuncIR::Opcode::non_op, "", func_name},
+                                  std::vector<ExpressionIR*>{key_column}));
+  }
   for (int64_t parent_id : graph->dag().ParentsOf(metadata->id())) {
     // For each container node of the metadata expression, update it to point to the
     // new conversion func instead.

--- a/src/carnot/planner/logical_planner_test.cc
+++ b/src/carnot/planner/logical_planner_test.cc
@@ -54,6 +54,19 @@ class LogicalPlannerTest : public ::testing::Test {
     *query_request.mutable_logical_planner_state() = state;
     return query_request;
   }
+  plannerpb::QueryRequest MakeQueryRequestWithExecArgs(
+      const distributedpb::LogicalPlannerState& state, const std::string& query,
+      const std::vector<std::string>& exec_funcs) {
+    plannerpb::QueryRequest query_request;
+    query_request.set_query_str(query);
+    *query_request.mutable_logical_planner_state() = state;
+    for (const auto& exec_func : exec_funcs) {
+      auto f = query_request.add_exec_funcs();
+      f->set_func_name(exec_func);
+      f->set_output_table_prefix(exec_func);
+    }
+    return query_request;
+  }
   udfspb::UDFInfo info_;
 };
 
@@ -767,6 +780,73 @@ TEST_F(LogicalPlannerTest, filter_pushdown_bug) {
   auto planner = LogicalPlanner::Create(info_).ConsumeValueOrDie();
   auto state = testutils::CreateTwoPEMsOneKelvinPlannerState(testutils::kHttpEventsSchema);
   ASSERT_OK_AND_ASSIGN(auto plan, planner->Plan(MakeQueryRequest(state, kFilterPushDownBugQuery)));
+  ASSERT_OK(plan->ToProto());
+}
+
+const char kPodNameFallbackConversion[] = R"pxl(
+import px
+
+df = px.DataFrame(table='http_events', start_time='-6m')
+df.pod = df.ctx['pod']
+
+px.display(df)
+)pxl";
+TEST_F(LogicalPlannerTest, pod_name_fallback_conversion) {
+  auto planner = LogicalPlanner::Create(info_).ConsumeValueOrDie();
+  auto state = testutils::CreateTwoPEMsOneKelvinPlannerState(testutils::kHttpEventsSchema);
+  ASSERT_OK_AND_ASSIGN(auto plan,
+                       planner->Plan(MakeQueryRequest(state, kPodNameFallbackConversion)));
+  ASSERT_OK(plan->ToProto());
+}
+
+const char kPodNameFallbackConversionWithFilter[] = R"pxl(
+import px
+
+df = px.DataFrame(table='http_events', start_time='-6m')
+df[df.ctx['pod'] != ""]
+
+px.display(df)
+)pxl";
+TEST_F(LogicalPlannerTest, pod_name_fallback_conversion_with_filter) {
+  auto planner = LogicalPlanner::Create(info_).ConsumeValueOrDie();
+  auto state = testutils::CreateTwoPEMsOneKelvinPlannerState(testutils::kHttpEventsSchema);
+  ASSERT_OK_AND_ASSIGN(
+      auto plan, planner->Plan(MakeQueryRequest(state, kPodNameFallbackConversionWithFilter)));
+  ASSERT_OK(plan->ToProto());
+}
+
+// Use a data table that doesn't contain local_addr to test df.ctx['pod'] conversion without
+// the fallback conversion.
+const char kPodNameConversionWithoutFallback[] = R"pxl(
+import px
+
+def cql_flow_graph():
+    df = px.DataFrame('cql_events', start_time='-5m')
+    df.pod = df.ctx['pod']
+
+    df.ra_pod = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
+    df.is_ra_pod = df.ra_pod != ''
+    df.ra_name = px.select(df.is_ra_pod, df.ra_pod, df.remote_addr)
+
+    df.is_server_tracing = df.trace_role == 2
+
+    df.source = px.select(df.is_server_tracing, df.ra_name, df.pod)
+    df.destination = px.select(df.is_server_tracing, df.pod, df.ra_name)
+
+    return df
+
+
+def cql_summary_with_links():
+    df = cql_flow_graph()
+
+    return df
+)pxl";
+TEST_F(LogicalPlannerTest, pod_name_conversion_without_fallback) {
+  auto planner = LogicalPlanner::Create(info_).ConsumeValueOrDie();
+  auto state = testutils::CreateTwoPEMsOneKelvinPlannerState(testutils::kHttpEventsSchema);
+  ASSERT_OK_AND_ASSIGN(auto plan, planner->Plan(MakeQueryRequestWithExecArgs(
+                                      state, kPodNameConversionWithoutFallback,
+                                      {"cql_flow_graph", "cql_summary_with_links"})));
   ASSERT_OK(plan->ToProto());
 }
 

--- a/src/carnot/planner/test_utils.h
+++ b/src/carnot/planner/test_utils.h
@@ -103,6 +103,16 @@ relation_map {
       column_semantic_type: ST_UPID
     }
     columns {
+      column_name: "local_addr"
+      column_type: STRING
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "local_port"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
       column_name: "remote_addr"
       column_type: STRING
       column_semantic_type: ST_NONE
@@ -169,6 +179,46 @@ relation_map {
     }
     columns {
       column_name: "resp_latency_ns"
+      column_type: INT64
+      column_semantic_type: ST_DURATION_NS
+    }
+  }
+}
+relation_map {
+  key: "cql_events"
+  value {
+    columns {
+      column_name: "time_"
+      column_type: TIME64NS
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "upid"
+      column_type: UINT128
+      column_semantic_type: ST_UPID
+    }
+    columns {
+      column_name: "remote_addr"
+      column_type: STRING
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "remote_port"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "trace_role"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "major_version"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "latency"
       column_type: INT64
       column_semantic_type: ST_DURATION_NS
     }
@@ -968,6 +1018,53 @@ schema_info {
   }
 }
 schema_info {
+  name: "cql_events"
+  relation {
+    columns {
+      column_name: "time_"
+      column_type: TIME64NS
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "upid"
+      column_type: UINT128
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "remote_addr"
+      column_type: STRING
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "remote_port"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "trace_role"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "latency"
+      column_type: INT64
+      column_semantic_type: ST_NONE
+    }
+  }
+  agent_list {
+    high_bits: 0x0000000100000000
+    low_bits: 0x0000000000000001
+  }
+  agent_list {
+    high_bits: 0x0000000100000000
+    low_bits: 0x0000000000000002
+  }
+  agent_list {
+    high_bits: 0x0000000100000000
+    low_bits: 0x0000000000000003
+  }
+}
+schema_info {
   name: "http_events"
   relation {
     columns {
@@ -978,6 +1075,11 @@ schema_info {
     columns {
       column_name: "upid"
       column_type: UINT128
+      column_semantic_type: ST_NONE
+    }
+    columns {
+      column_name: "local_addr"
+      column_type: STRING
       column_semantic_type: ST_NONE
     }
   }


### PR DESCRIPTION
Summary: Make metadata pod lookups more resilient to short lived processes

This is a continuation of the work started from #1989. Since the `local_addr` column is populated for client side traces, it can be used as a fallback lookup for these traces. This doesn't solve all of the permutations of  missing short lived processes (#1638), but provides more coverage than before.

Relevant Issues: #1638

Type of change: /kind bugfix

Test Plan: Verified the following
- [x] Compared the performance with and without this change with `src/e2e_test/vizier/exectime:exectime`. This change has a minor performance impact, but it closes the gap on certain situations that previously caused users to distrust Pixie's instrumentation
```
# Performance baseline
$ ./exectime benchmark -a testing.getcosmic.ai:443 -c <cluster_id> 2>&1 | tee baseline_for_simple_udf_swap_e20880ffd.txt
# Performance of this change
./exectime benchmark -a testing.getcosmic.ai:443 -c <cluster_id> 2>&1 | tee simple_udf_swap_cd217c05c.txt
```
[simple_udf_swap_cd217c05c.txt](https://github.com/user-attachments/files/18497709/simple_udf_swap_cd217c05c.txt)
[baseline_for_simple_udf_swap_e20880ffd.txt](https://github.com/user-attachments/files/18497710/baseline_for_simple_udf_swap_e20880ffd.txt)
- [x] Ran `for i in $(seq 0 1000); do curl http://google.com/$i; sleep 2; done` within a pod and verified that with this change all traces are shown, without this change a significant number of traces are missed. See before and after screenshots below:

![vizier-0 14 14-curl-with-missing-data](https://github.com/user-attachments/assets/035b5dcf-d87a-4134-84c1-9e478594927b)
![traces-with-new-fallback](https://github.com/user-attachments/assets/2a84ecbb-83cb-45ae-af85-77b1773efb59)

Changelog Message: Fix a certain class of cases where Pixie previously missed protocol traces from short lived connections