### PR TITLE
Add support for TLS protocol tracing

### DIFF
--- a/src/shared/protocols/protocols.h
+++ b/src/shared/protocols/protocols.h
@@ -39,6 +39,7 @@ enum class Protocol {
   kKafka = 10,
   kMux = 11,
   kAMQP = 12,
+  kTLS = 13,
 };
 
 }  // namespace protocols

--- a/src/stirling/binaries/stirling_wrapper.cc
+++ b/src/stirling/binaries/stirling_wrapper.cc
@@ -62,7 +62,7 @@ DEFINE_string(trace, "",
               "Dynamic trace to deploy. Either (1) the path to a file containing PxL or IR trace "
               "spec, or (2) <path to object file>:<symbol_name> for full-function tracing.");
 DEFINE_string(print_record_batches,
-              "http_events,mysql_events,pgsql_events,redis_events,cql_events,dns_events",
+              "http_events,mysql_events,pgsql_events,redis_events,cql_events,dns_events,tls_events",
               "Comma-separated list of tables to print.");
 DEFINE_bool(init_only, false, "If true, only runs the init phase and exits. For testing.");
 DEFINE_int32(timeout_secs, -1,

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -517,6 +517,27 @@ pl_cc_bpf_test(
 )
 
 pl_cc_bpf_test(
+    name = "tls_trace_bpf_test",
+    timeout = "long",
+    srcs = ["tls_trace_bpf_test.cc"],
+    flaky = True,
+    shard_count = 2,
+    tags = [
+        "cpu:16",
+        "no_asan",
+        "requires_bpf",
+    ],
+    deps = [
+        ":cc_library",
+        "//src/common/testing/test_utils:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:curl_container",
+        "//src/stirling/source_connectors/socket_tracer/testing/container_images:nginx_openssl_3_0_8_container",
+        "//src/stirling/testing:cc_library",
+    ],
+)
+
+pl_cc_bpf_test(
     name = "dyn_lib_trace_bpf_test",
     timeout = "moderate",
     srcs = ["dyn_lib_trace_bpf_test.cc"],

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/BUILD.bazel
@@ -82,6 +82,7 @@ pl_cc_test(
         "ENABLE_NATS_TRACING=true",
         "ENABLE_MONGO_TRACING=true",
         "ENABLE_AMQP_TRACING=true",
+        "ENABLE_TLS_TRACING=true",
     ],
     deps = [
         "//src/stirling/bpf_tools/bcc_bpf:headers",

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf/protocol_inference_test.cc
@@ -482,3 +482,27 @@ TEST(ProtocolInferenceTest, AMQPResponse) {
   EXPECT_EQ(protocol_message.protocol, kProtocolAMQP);
   EXPECT_EQ(protocol_message.type, kResponse);
 }
+
+TEST(ProtocolInferenceTest, TLSRequest) {
+  struct conn_info_t conn_info = {};
+  // TLS Client Hello
+  constexpr uint8_t kReqFrame[] = {
+      0x16, 0x03, 0x01, 0x00, 0x01, 0x01, 0x00, 0x01, 0xfc, 0x03, 0x03, 0x7b, 0x7b, 0x7b,
+  };
+  auto protocol_message =
+      infer_protocol(reinterpret_cast<const char*>(kReqFrame), sizeof(kReqFrame), &conn_info);
+  EXPECT_EQ(protocol_message.protocol, kProtocolTLS);
+  EXPECT_EQ(protocol_message.type, kRequest);
+}
+
+TEST(ProtocolInferenceTest, TLSResponse) {
+  struct conn_info_t conn_info = {};
+  // TLS Server Hello
+  constexpr uint8_t kRespFrame[] = {
+      0x16, 0x03, 0x01, 0x00, 0x01, 0x02, 0x00, 0x00, 0xfc, 0x03, 0x03, 0x7b, 0x7b, 0x7b,
+  };
+  auto protocol_message =
+      infer_protocol(reinterpret_cast<const char*>(kRespFrame), sizeof(kRespFrame), &conn_info);
+  EXPECT_EQ(protocol_message.protocol, kProtocolTLS);
+  EXPECT_EQ(protocol_message.type, kResponse);
+}

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h
@@ -51,6 +51,7 @@ enum traffic_protocol_t {
   kProtocolKafka = 10,
   kProtocolMux = 11,
   kProtocolAMQP = 12,
+  kProtocolTLS = 13,
 // We use magic enum to iterate through protocols in C++ land,
 // and don't want the C-enum-size trick to show up there.
 #ifndef __cplusplus

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
@@ -674,6 +674,7 @@ auto CreateTraceRoles() {
   res.Set(kProtocolKafka, {kRoleServer});
   res.Set(kProtocolMux, {kRoleServer});
   res.Set(kProtocolAMQP, {kRoleServer});
+  res.Set(kProtocolTLS, {kRoleServer});
 
   DCHECK(res.AreAllKeysSet());
   return res;

--- a/src/stirling/source_connectors/socket_tracer/data_stream.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream.cc
@@ -215,6 +215,10 @@ template void DataStream::ProcessBytesToFrames<protocols::amqp::channel_id, prot
 template void DataStream::ProcessBytesToFrames<
     protocols::mongodb::stream_id_t, protocols::mongodb::Frame, protocols::mongodb::StateWrapper>(
     message_type_t type, protocols::mongodb::StateWrapper* state);
+
+template void DataStream::ProcessBytesToFrames<protocols::tls::stream_id_t, protocols::tls::Frame,
+                                               protocols::NoState>(message_type_t type,
+                                                                   protocols::NoState* state);
 void DataStream::Reset() {
   data_buffer_.Reset();
   has_new_events_ = false;

--- a/src/stirling/source_connectors/socket_tracer/protocols/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/protocols/BUILD.bazel
@@ -46,5 +46,6 @@ pl_cc_library(
         "//src/stirling/source_connectors/socket_tracer/protocols/nats:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/pgsql:cc_library",
         "//src/stirling/source_connectors/socket_tracer/protocols/redis:cc_library",
+        "//src/stirling/source_connectors/socket_tracer/protocols/tls:cc_library",
     ],
 )

--- a/src/stirling/source_connectors/socket_tracer/protocols/stitchers.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/stitchers.h
@@ -31,3 +31,4 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/nats/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/pgsql/stitcher.h"  // IWYU pragma: export
 #include "src/stirling/source_connectors/socket_tracer/protocols/redis/stitcher.h"  // IWYU pragma: export
+#include "src/stirling/source_connectors/socket_tracer/protocols/tls/stitcher.h"  // IWYU pragma: export

--- a/src/stirling/source_connectors/socket_tracer/protocols/tls/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/tls/parse.cc
@@ -18,6 +18,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/tls/parse.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -41,7 +42,7 @@ constexpr size_t kSNIExtensionMinimumLength = 3;
 // In TLS 1.2 and earlier, gmt_unix_time is 4 bytes and Random is 28 bytes.
 constexpr size_t kRandomStructLength = 32;
 
-StatusOr<ParseState> ExtractSNIExtension(ReqExtensions* exts, BinaryDecoder* decoder) {
+StatusOr<ParseState> ExtractSNIExtension(SharedExtensions* exts, BinaryDecoder* decoder) {
   PX_ASSIGN_OR(auto server_name_list_length, decoder->ExtractBEInt<uint16_t>(),
                return ParseState::kInvalid);
   while (server_name_list_length > 0) {
@@ -75,7 +76,7 @@ StatusOr<ParseState> ExtractSNIExtension(ReqExtensions* exts, BinaryDecoder* dec
  * diagram: https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_record
  */
 
-ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
+ParseState ParseFullFrame(SharedExtensions* extensions, BinaryDecoder* decoder, Frame* frame) {
   PX_ASSIGN_OR(auto raw_content_type, decoder->ExtractBEInt<uint8_t>(),
                return ParseState::kInvalid);
   auto content_type = magic_enum::enum_cast<tls::ContentType>(raw_content_type);
@@ -161,8 +162,6 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
     return ParseState::kSuccess;
   }
 
-  ReqExtensions req_extensions;
-  RespExtensions resp_extensions;
   while (extensions_length > 0) {
     PX_ASSIGN_OR(auto extension_type, decoder->ExtractBEInt<uint16_t>(),
                  return ParseState::kInvalid);
@@ -171,7 +170,7 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
 
     if (extension_length > 0) {
       if (extension_type == 0x00) {
-        if (!ExtractSNIExtension(&req_extensions, decoder).ok()) {
+        if (!ExtractSNIExtension(extensions, decoder).ok()) {
           return ParseState::kInvalid;
         }
       } else {
@@ -183,13 +182,9 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
 
     extensions_length -= kExtensionMinimumLength + extension_length;
   }
-  JSONObjectBuilder req_body_builder;
-  req_body_builder.WriteKVRecursive("extensions", req_extensions);
-  frame->req_body = req_body_builder.GetString();
-
-  JSONObjectBuilder resp_body_builder;
-  resp_body_builder.WriteKVRecursive("extensions", resp_extensions);
-  frame->resp_body = resp_body_builder.GetString();
+  JSONObjectBuilder body_builder;
+  body_builder.WriteKVRecursive("extensions", *extensions);
+  frame->body = body_builder.GetString();
 
   return ParseState::kSuccess;
 }
@@ -197,7 +192,7 @@ ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame) {
 }  // namespace tls
 
 template <>
-ParseState ParseFrame(message_type_t, std::string_view* buf, tls::Frame* frame, NoState*) {
+ParseState ParseFrame(message_type_t type, std::string_view* buf, tls::Frame* frame, NoState*) {
   // TLS record header is 5 bytes. The size of the record is in bytes 4 and 5.
   if (buf->length() < tls::kTLSRecordHeaderLength) {
     return ParseState::kNeedsMoreData;
@@ -208,7 +203,13 @@ ParseState ParseFrame(message_type_t, std::string_view* buf, tls::Frame* frame, 
   }
 
   BinaryDecoder decoder(*buf);
-  auto parse_result = tls::ParseFullFrame(&decoder, frame);
+  std::unique_ptr<tls::SharedExtensions> extensions;
+  if (type == kRequest) {
+    extensions = std::make_unique<tls::ReqExtensions>();
+  } else {
+    extensions = std::make_unique<tls::RespExtensions>();
+  }
+  auto parse_result = tls::ParseFullFrame(extensions.get(), &decoder, frame);
   if (parse_result == ParseState::kSuccess) {
     buf->remove_prefix(length + tls::kTLSRecordHeaderLength);
   }

--- a/src/stirling/source_connectors/socket_tracer/protocols/tls/parse.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/tls/parse.h
@@ -28,7 +28,7 @@ namespace stirling {
 namespace protocols {
 namespace tls {
 
-ParseState ParseFullFrame(BinaryDecoder* decoder, Frame* frame);
+ParseState ParseFullFrame(SharedExtensions* extensions, BinaryDecoder* decoder, Frame* frame);
 
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/tls/parse_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/tls/parse_test.cc
@@ -315,8 +315,7 @@ TEST_F(TLSParserTest, ParseValidClientHello) {
   ASSERT_GT(frame.session_id.size(), 0);
 
   // Validate the SNI extension was parsed properly
-  ASSERT_EQ(frame.extensions.size(), 1);
-  ASSERT_EQ(frame.extensions["server_name"], "[\"argocd-cluster-repo-server\"]");
+  ASSERT_EQ(frame.req_body, R"({"extensions":{"server_name":["argocd-cluster-repo-server"]}})");
   ASSERT_EQ(state, ParseState::kSuccess);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/tls/parse_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/tls/parse_test.cc
@@ -315,7 +315,7 @@ TEST_F(TLSParserTest, ParseValidClientHello) {
   ASSERT_GT(frame.session_id.size(), 0);
 
   // Validate the SNI extension was parsed properly
-  ASSERT_EQ(frame.req_body, R"({"extensions":{"server_name":["argocd-cluster-repo-server"]}})");
+  ASSERT_EQ(frame.body, R"({"extensions":{"server_name":["argocd-cluster-repo-server"]}})");
   ASSERT_EQ(state, ParseState::kSuccess);
 }
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/tls/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/tls/types.h
@@ -195,7 +195,7 @@ struct Frame : public FrameBase {
 
   HandshakeType handshake_type;
 
-  uint24_t handshake_length;
+  uint24_t handshake_length = uint24_t(0);
 
   LegacyVersion handshake_version;
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/types.h
@@ -34,6 +34,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/nats/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/pgsql/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/redis/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/tls/types.h"
 
 namespace px {
 namespace stirling {
@@ -53,7 +54,8 @@ using FrameDequeVariant = std::variant<std::monostate,
                                        absl::flat_hash_map<kafka::correlation_id_t, std::deque<kafka::Packet>>,
                                        absl::flat_hash_map<nats::stream_id_t, std::deque<nats::Message>>,
                                        absl::flat_hash_map<amqp::channel_id, std::deque<amqp::Frame>>,
-                                       absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>>;
+                                       absl::flat_hash_map<mongodb::stream_id_t, std::deque<mongodb::Frame>>,
+                                       absl::flat_hash_map<tls::stream_id_t, std::deque<tls::Frame>>>;
 // clang-format off
 
 }  // namespace protocols

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -203,6 +203,12 @@ using px::utils::ToJSONString;
 // Most HTTP servers support 8K headers, so we truncate after that.
 // https://stackoverflow.com/questions/686217/maximum-on-http-header-values
 constexpr size_t kMaxHTTPHeadersBytes = 8192;
+// TLS records have a maximum size of 16KiB. While there isn't a size limit
+// for the extensions, we limit it to 1 KiB to avoid excessive memory usage.
+// A typical ClientHello from curl is around 500 bytes. This assumes that
+// all extensions are captured, but we won't support capturing all extensions and
+// will avoid large extensions like the padding extension,
+constexpr size_t kMaxTLSExtensionsBytes = 1024;
 
 // Protobuf printer will limit strings to this length.
 constexpr size_t kMaxPBStringLen = 64;
@@ -1717,7 +1723,7 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
   r.Append<r.ColIndex("req_type")>(static_cast<uint64_t>(req_message.content_type));
   r.Append<r.ColIndex("version")>(static_cast<uint64_t>(req_message.legacy_version));
-  r.Append<r.ColIndex("extensions")>(ToJSONString(req_message.extensions), kMaxHTTPHeadersBytes);
+  r.Append<r.ColIndex("extensions")>(ToJSONString(req_message.extensions), kMaxTLSExtensionsBytes);
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(req_message.timestamp_ns, resp_message.timestamp_ns));
 #ifndef NDEBUG

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -1721,10 +1721,9 @@ void SocketTraceConnector::AppendMessage(ConnectorContext* ctx, const ConnTracke
   r.Append<r.ColIndex("local_addr")>(conn_tracker.local_endpoint().AddrStr());
   r.Append<r.ColIndex("local_port")>(conn_tracker.local_endpoint().port());
   r.Append<r.ColIndex("trace_role")>(conn_tracker.role());
-  r.Append<r.ColIndex("content_type")>(static_cast<uint64_t>(req_message.content_type));
-  r.Append<r.ColIndex("version")>(static_cast<uint64_t>(req_message.legacy_version));
-  r.Append<r.ColIndex("req_body")>(req_message.req_body, kMaxTLSBodyBytes);
-  r.Append<r.ColIndex("resp_body")>(resp_message.resp_body, kMaxTLSBodyBytes);
+  r.Append<r.ColIndex("req_type")>(static_cast<uint64_t>(req_message.content_type));
+  r.Append<r.ColIndex("req_body")>(req_message.body, kMaxTLSBodyBytes);
+  r.Append<r.ColIndex("resp_body")>(resp_message.body, kMaxTLSBodyBytes);
   r.Append<r.ColIndex("latency")>(
       CalculateLatency(req_message.timestamp_ns, resp_message.timestamp_ns));
 #ifndef NDEBUG

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -66,6 +66,7 @@ DECLARE_int32(stirling_enable_kafka_tracing);
 DECLARE_int32(stirling_enable_mux_tracing);
 DECLARE_int32(stirling_enable_amqp_tracing);
 DECLARE_int32(stirling_enable_mongodb_tracing);
+DECLARE_int32(stirling_enable_tls_tracing);
 DECLARE_bool(stirling_disable_self_tracing);
 DECLARE_string(stirling_role_to_trace);
 
@@ -95,9 +96,9 @@ class SocketTraceConnector : public BCCSourceConnector {
  public:
   static constexpr std::string_view kName = "socket_tracer";
   // PROTOCOL_LIST
-  static constexpr auto kTables =
-      MakeArray(kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable,
-                kRedisTable, kNATSTable, kKafkaTable, kMuxTable, kAMQPTable, kMongoDBTable);
+  static constexpr auto kTables = MakeArray(
+      kConnStatsTable, kHTTPTable, kMySQLTable, kCQLTable, kPGSQLTable, kDNSTable, kRedisTable,
+      kNATSTable, kKafkaTable, kMuxTable, kAMQPTable, kMongoDBTable, kTLSTable);
 
   static constexpr uint32_t kConnStatsTableNum = TableNum(kTables, kConnStatsTable);
   static constexpr uint32_t kHTTPTableNum = TableNum(kTables, kHTTPTable);
@@ -111,6 +112,7 @@ class SocketTraceConnector : public BCCSourceConnector {
   static constexpr uint32_t kMuxTableNum = TableNum(kTables, kMuxTable);
   static constexpr uint32_t kAMQPTableNum = TableNum(kTables, kAMQPTable);
   static constexpr uint32_t kMongoDBTableNum = TableNum(kTables, kMongoDBTable);
+  static constexpr uint32_t kTLSTableNum = TableNum(kTables, kTLSTable);
 
   static constexpr auto kSamplingPeriod = std::chrono::milliseconds{200};
   // TODO(yzhao): This is not used right now. Eventually use this to control data push frequency.

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_tables.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_tables.h
@@ -32,3 +32,4 @@
 #include "src/stirling/source_connectors/socket_tracer/nats_table.h"
 #include "src/stirling/source_connectors/socket_tracer/pgsql_table.h"
 #include "src/stirling/source_connectors/socket_tracer/redis_table.h"
+#include "src/stirling/source_connectors/socket_tracer/tls_table.h"

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.cc
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.cc
@@ -19,6 +19,7 @@
 #include "src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h"
 
 #include "src/stirling/source_connectors/socket_tracer/http_table.h"
+#include "src/stirling/source_connectors/socket_tracer/tls_table.h"
 #include "src/stirling/testing/common.h"
 
 namespace px {
@@ -28,6 +29,7 @@ namespace testing {
 namespace http = protocols::http;
 namespace mux = protocols::mux;
 namespace mongodb = protocols::mongodb;
+namespace tls = protocols::tls;
 
 //-----------------------------------------------------------------------------
 // HTTP Checkers
@@ -103,6 +105,20 @@ std::vector<mongodb::Record> GetTargetRecords(const types::ColumnWrapperRecordBa
   std::vector<size_t> target_record_indices =
       FindRecordIdxMatchesPID(record_batch, kMongoDBUPIDIdx, pid);
   return ToRecordVector<mongodb::Record>(record_batch, target_record_indices);
+}
+
+template <>
+std::vector<tls::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& rb,
+                                        const std::vector<size_t>& indices) {
+  std::vector<tls::Record> result;
+
+  for (const auto& idx : indices) {
+    auto version = rb[kTLSVersionIdx]->Get<types::Int64Value>(idx);
+    tls::Record r;
+    r.req.legacy_version = static_cast<tls::LegacyVersion>(version.val);
+    result.push_back(r);
+  }
+  return result;
 }
 
 }  // namespace testing

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.cc
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.cc
@@ -113,9 +113,9 @@ std::vector<tls::Record> ToRecordVector(const types::ColumnWrapperRecordBatch& r
   std::vector<tls::Record> result;
 
   for (const auto& idx : indices) {
-    auto version = rb[kTLSVersionIdx]->Get<types::Int64Value>(idx);
     tls::Record r;
-    r.req.legacy_version = static_cast<tls::LegacyVersion>(version.val);
+    r.req.body = rb[kTLSReqBodyIdx]->Get<types::StringValue>(idx);
+    r.resp.body = rb[kTLSRespBodyIdx]->Get<types::StringValue>(idx);
     result.push_back(r);
   }
   return result;

--- a/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
+++ b/src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h
@@ -32,6 +32,7 @@
 #include "src/stirling/source_connectors/socket_tracer/protocols/http/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mongodb/types.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/mux/types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/tls/types.h"
 
 namespace px {
 namespace stirling {

--- a/src/stirling/source_connectors/socket_tracer/tls_table.h
+++ b/src/stirling/source_connectors/socket_tracer/tls_table.h
@@ -37,19 +37,15 @@ static constexpr DataElement kTLSElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
-        {"content_type", "The content type of the TLS record (e.g. handshake, alert, heartbeat, etc)",
+        {"req_type", "The content type of the TLS record (e.g. handshake, alert, heartbeat, etc)",
          types::DataType::INT64,
          types::SemanticType::ST_NONE,
          types::PatternType::GENERAL_ENUM},
-        {"version", "Version of TLS record",
-         types::DataType::INT64,
-         types::SemanticType::ST_NONE,
-         types::PatternType::GENERAL_ENUM},
-        {"req_body", "Request body in JSON format. Structure depends on content type (e.g. handshakes contain TLS extensions)",
+        {"req_body", "Request body in JSON format. Structure depends on content type (e.g. handshakes contain TLS extensions, version negotiated, etc.)",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,
          types::PatternType::STRUCTURED},
-        {"resp_body", "Response body in JSON format. Structure depends on content type (e.g. handshakes contain TLS extensions)",
+        {"resp_body", "Response body in JSON format. Structure depends on content type (e.g. handshakes contain TLS extensions, version negotiated, etc.)",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,
          types::PatternType::STRUCTURED},
@@ -65,9 +61,9 @@ static constexpr auto kTLSTable =
 DEFINE_PRINT_TABLE(TLS)
 
 constexpr int kTLSUPIDIdx = kTLSTable.ColIndex("upid");
-constexpr int kTLSCmdIdx = kTLSTable.ColIndex("content_type");
-constexpr int kTLSVersionIdx = kTLSTable.ColIndex("version");
+constexpr int kTLSCmdIdx = kTLSTable.ColIndex("req_type");
 constexpr int kTLSReqBodyIdx = kTLSTable.ColIndex("req_body");
+constexpr int kTLSRespBodyIdx = kTLSTable.ColIndex("resp_body");
 
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/tls_table.h
+++ b/src/stirling/source_connectors/socket_tracer/tls_table.h
@@ -37,7 +37,7 @@ static constexpr DataElement kTLSElements[] = {
         canonical_data_elements::kLocalAddr,
         canonical_data_elements::kLocalPort,
         canonical_data_elements::kTraceRole,
-        {"req_type", "The type of request from the TLS record (Client/ServerHello, etc.)",
+        {"content_type", "The content type of the TLS record (e.g. handshake, alert, heartbeat, etc)",
          types::DataType::INT64,
          types::SemanticType::ST_NONE,
          types::PatternType::GENERAL_ENUM},
@@ -45,10 +45,14 @@ static constexpr DataElement kTLSElements[] = {
          types::DataType::INT64,
          types::SemanticType::ST_NONE,
          types::PatternType::GENERAL_ENUM},
-        {"extensions", "Extensions in the TLS record",
+        {"req_body", "Request body in JSON format. Structure depends on content type (e.g. handshakes contain TLS extensions)",
          types::DataType::STRING,
          types::SemanticType::ST_NONE,
-         types::PatternType::GENERAL},
+         types::PatternType::STRUCTURED},
+        {"resp_body", "Response body in JSON format. Structure depends on content type (e.g. handshakes contain TLS extensions)",
+         types::DataType::STRING,
+         types::SemanticType::ST_NONE,
+         types::PatternType::STRUCTURED},
         canonical_data_elements::kLatencyNS,
 #ifndef NDEBUG
         canonical_data_elements::kPXInfo,
@@ -61,9 +65,9 @@ static constexpr auto kTLSTable =
 DEFINE_PRINT_TABLE(TLS)
 
 constexpr int kTLSUPIDIdx = kTLSTable.ColIndex("upid");
-constexpr int kTLSCmdIdx = kTLSTable.ColIndex("req_type");
+constexpr int kTLSCmdIdx = kTLSTable.ColIndex("content_type");
 constexpr int kTLSVersionIdx = kTLSTable.ColIndex("version");
-constexpr int kTLSExtensionsIdx = kTLSTable.ColIndex("extensions");
+constexpr int kTLSReqBodyIdx = kTLSTable.ColIndex("req_body");
 
 }  // namespace stirling
 }  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/tls_table.h
+++ b/src/stirling/source_connectors/socket_tracer/tls_table.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <map>
+
+#include "src/stirling/core/output.h"
+#include "src/stirling/core/types.h"
+#include "src/stirling/source_connectors/socket_tracer/canonical_types.h"
+#include "src/stirling/source_connectors/socket_tracer/protocols/tls/types.h"
+
+namespace px {
+namespace stirling {
+
+// clang-format off
+static constexpr DataElement kTLSElements[] = {
+        canonical_data_elements::kTime,
+        canonical_data_elements::kUPID,
+        canonical_data_elements::kRemoteAddr,
+        canonical_data_elements::kRemotePort,
+        canonical_data_elements::kLocalAddr,
+        canonical_data_elements::kLocalPort,
+        canonical_data_elements::kTraceRole,
+        {"req_type", "The type of request from the TLS record (Client/ServerHello, etc.)",
+         types::DataType::INT64,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL_ENUM},
+        {"version", "Version of TLS record",
+         types::DataType::INT64,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL_ENUM},
+        {"extensions", "Extensions in the TLS record",
+         types::DataType::STRING,
+         types::SemanticType::ST_NONE,
+         types::PatternType::GENERAL},
+        canonical_data_elements::kLatencyNS,
+#ifndef NDEBUG
+        canonical_data_elements::kPXInfo,
+#endif
+};
+// clang-format on
+
+static constexpr auto kTLSTable =
+    DataTableSchema("tls_events", "TLS request-response pair events", kTLSElements);
+DEFINE_PRINT_TABLE(TLS)
+
+constexpr int kTLSUPIDIdx = kTLSTable.ColIndex("upid");
+constexpr int kTLSCmdIdx = kTLSTable.ColIndex("req_type");
+constexpr int kTLSVersionIdx = kTLSTable.ColIndex("version");
+constexpr int kTLSExtensionsIdx = kTLSTable.ColIndex("extensions");
+
+}  // namespace stirling
+}  // namespace px

--- a/src/stirling/source_connectors/socket_tracer/tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/tls_trace_bpf_test.cc
@@ -63,7 +63,7 @@ bool Init() {
   // Make sure TLS tracing is enabled.
   FLAGS_stirling_enable_tls_tracing = true;
 
-  // We turn off CQL and NATS tracing to give some BPF instructions back for Mux.
+  // We turn off CQL and NATS tracing to give some BPF instructions back for TLS.
   // This is required for older kernels with only 4096 BPF instructions.
   FLAGS_stirling_enable_cass_tracing = false;
   FLAGS_stirling_enable_nats_tracing = false;

--- a/src/stirling/source_connectors/socket_tracer/tls_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/tls_trace_bpf_test.cc
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "src/common/base/base.h"
+#include "src/common/exec/exec.h"
+#include "src/common/testing/test_environment.h"
+#include "src/shared/types/column_wrapper.h"
+#include "src/shared/types/types.h"
+#include "src/stirling/source_connectors/socket_tracer/socket_trace_connector.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images/curl_container.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/container_images/nginx_openssl_3_0_8_container.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/protocol_checkers.h"
+#include "src/stirling/source_connectors/socket_tracer/testing/socket_trace_bpf_test_fixture.h"
+#include "src/stirling/testing/common.h"
+
+namespace px {
+namespace stirling {
+
+namespace tls = protocols::tls;
+
+using ::px::stirling::testing::FindRecordIdxMatchesPID;
+using ::px::stirling::testing::GetTargetRecords;
+using ::px::stirling::testing::SocketTraceBPFTestFixture;
+using ::px::stirling::testing::ToRecordVector;
+
+using ::testing::IsTrue;
+using ::testing::SizeIs;
+using ::testing::StrEq;
+using ::testing::UnorderedElementsAre;
+
+struct TraceRecords {
+  std::vector<tls::Record> tls_records;
+  std::vector<std::string> tls_extensions;
+};
+
+class NginxOpenSSL_3_0_8_ContainerWrapper
+    : public ::px::stirling::testing::NginxOpenSSL_3_0_8_Container {
+ public:
+  int32_t PID() const { return NginxWorkerPID(); }
+};
+
+bool Init() {
+  // Make sure TLS tracing is enabled.
+  FLAGS_stirling_enable_tls_tracing = true;
+
+  // We turn off CQL and NATS tracing to give some BPF instructions back for Mux.
+  // This is required for older kernels with only 4096 BPF instructions.
+  FLAGS_stirling_enable_cass_tracing = false;
+  FLAGS_stirling_enable_nats_tracing = false;
+  FLAGS_stirling_enable_amqp_tracing = false;
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+// Test Scenarios
+//-----------------------------------------------------------------------------
+
+tls::Record GetExpectedTLSRecord() {
+  tls::Record expected_record;
+  return expected_record;
+}
+
+inline std::vector<std::string> GetExtensions(const types::ColumnWrapperRecordBatch& rb,
+                                              const std::vector<size_t>& indices) {
+  std::vector<std::string> exts;
+  for (size_t idx : indices) {
+    exts.push_back(rb[kTLSExtensionsIdx]->Get<types::StringValue>(idx));
+  }
+  return exts;
+}
+
+class TLSVersionParameterizedTest
+    : public SocketTraceBPFTestFixture</* TClientSideTracing */ false>,
+      public ::testing::WithParamInterface<std::string> {
+ protected:
+  TLSVersionParameterizedTest() {
+    Init();
+
+    // Run the nginx HTTPS server.
+    // The container runner will make sure it is in the ready state before unblocking.
+    // Stirling will run after this unblocks, as part of SocketTraceBPFTest SetUp().
+    constexpr bool kHostPid = false;
+    StatusOr<std::string> run_result = server_.Run(std::chrono::seconds{60}, {}, {}, kHostPid);
+    PX_CHECK_OK(run_result);
+
+    // Sleep an additional second, just to be safe.
+    sleep(1);
+  }
+
+  void TestTLSVersion(const std::string& tls_version, const std::string& tls_max_version) {
+    FLAGS_stirling_conn_trace_pid = this->server_.PID();
+
+    this->StartTransferDataThread();
+
+    // Make an SSL request with curl.
+    ::px::stirling::testing::CurlContainer client;
+    constexpr bool kHostPid = false;
+    ASSERT_OK(
+        client.Run(std::chrono::seconds{60},
+                   {absl::Substitute("--network=container:$0", this->server_.container_name())},
+                   {"--insecure", "-s", "-S", "--resolve", "test-host:443:127.0.0.1",
+                    absl::Substitute("--tlsv$0", tls_version), "--tls-max", tls_max_version,
+                    "https://test-host/index.html"},
+                   kHostPid));
+    client.Wait();
+    this->StopTransferDataThread();
+
+    TraceRecords records = this->GetTraceRecords(this->server_.PID());
+    EXPECT_THAT(records.tls_records, SizeIs(1));
+    EXPECT_THAT(records.tls_extensions, SizeIs(1));
+    auto sni_str = R"({"server_name":"[\"test-host\"]"})";
+    EXPECT_THAT(records.tls_extensions[0], StrEq(sni_str));
+  }
+
+  // Returns the trace records of the process specified by the input pid.
+  TraceRecords GetTraceRecords(int pid) {
+    std::vector<TaggedRecordBatch> tablets =
+        this->ConsumeRecords(SocketTraceConnector::kTLSTableNum);
+    if (tablets.empty()) {
+      return {};
+    }
+    types::ColumnWrapperRecordBatch record_batch = tablets[0].records;
+    std::vector<size_t> server_record_indices =
+        FindRecordIdxMatchesPID(record_batch, kTLSUPIDIdx, pid);
+    std::vector<tls::Record> tls_records =
+        ToRecordVector<tls::Record>(record_batch, server_record_indices);
+    std::vector<std::string> extensions = GetExtensions(record_batch, server_record_indices);
+
+    return {std::move(tls_records), std::move(extensions)};
+  }
+
+  NginxOpenSSL_3_0_8_ContainerWrapper server_;
+};
+
+INSTANTIATE_TEST_SUITE_P(TLSVersions, TLSVersionParameterizedTest, ::testing::Values("1.2"));
+
+TEST_P(TLSVersionParameterizedTest, TestTLSVersions) {
+  const std::string& tls_version = GetParam();
+  TestTLSVersion(tls_version, tls_version);
+}
+
+}  // namespace stirling
+}  // namespace px


### PR DESCRIPTION
Summary: Add support for TLS protocol tracing

This is the final change to wire up the tls protocol parser and stitcher into stirling. I've also filed #2095 to track supporting tracing TLS handshakes and the application data.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: New tests verify functionality works end to end

Changelog Message: Added support for tracing TLS handshakes. This can be enabled with `--stirling_enable_tls_tracing=1` or through the `PX_STIRLING_ENABLE_TLS_TRACING` environment variable. Until #2095 is addressed, this will disable tracing the plaintext within encrypted connections.