### PR TITLE
Update dynamic logging to work with Go's 1.17+ calling convention

### DIFF
--- a/src/stirling/obj_tools/testdata/cc/test_exe.cc
+++ b/src/stirling/obj_tools/testdata/cc/test_exe.cc
@@ -72,6 +72,17 @@ ABCStruct64 ABCSumMixed(ABCStruct32 x, ABCStruct64 y, int32_t z_a, int64_t z_b, 
   return ABCStruct64{x.a + y.a + z_a + w.a, x.b + y.b + z_b + w.b, x.c + y.c + z_c + w.c};
 }
 
+void OuterStructFunc(OuterStruct x) {
+  x.O0++;
+  x.O1.M0.L0 = !x.O1.M0.L0;
+  x.O1.M0.L1++;
+  x.O1.M0.L2++;
+  x.O1.M1 = !x.O1.M1;
+  x.O1.M2.L0 = !x.O1.M2.L0;
+  x.O1.M2.L1++;
+  x.O1.M2.L2++;
+}
+
 void SomeFunctionWithPointerArgs(int* a, ABCStruct32* x) {
   x->a = *a;
   a++;
@@ -113,6 +124,7 @@ int main() {
 
     sleep(1);
   }
+  OuterStructFunc(OuterStruct{1, MidStruct{{true, 2, nullptr}, false, {true, 3, nullptr}}});
 
   return 0;
 }

--- a/src/stirling/source_connectors/dynamic_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_tracer/BUILD.bazel
@@ -49,7 +49,9 @@ pl_cc_bpf_test(
     srcs = ["dynamic_trace_bpf_test.cc"],
     data = [
         "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client:golang_1_16_grpc_client",
+        "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client:golang_1_21_grpc_client",
         "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server:golang_1_16_grpc_server_with_certs",
+        "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server:golang_1_21_grpc_server_with_certs",
     ],
     tags = [
         "cpu:16",
@@ -69,7 +71,7 @@ pl_cc_bpf_test(
     srcs = ["stirling_dt_bpf_test.cc"],
     data = [
         "//src/stirling/obj_tools/testdata/cc:test_exe",
-        "//src/stirling/obj_tools/testdata/go:test_go_1_16_binary",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
         "//src/stirling/testing/dns:dns_hammer",
         "//src/stirling/testing/dns:dns_hammer_image.tar",
     ],

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_trace_bpf_test.cc
@@ -32,11 +32,12 @@
 
 constexpr std::string_view kClientPath =
     "src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client/"
-    "golang_1_16_grpc_client";
+    "golang_1_21_grpc_client";
 constexpr std::string_view kServerPath =
     "src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server/"
-    "golang_1_16_grpc_server";
+    "golang_1_21_grpc_server";
 
+DECLARE_bool(debug_dt_pipeline);
 namespace px {
 namespace stirling {
 

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/BUILD.bazel
@@ -45,7 +45,7 @@ pl_cc_test(
     name = "code_gen_test",
     srcs = ["code_gen_test.cc"],
     data = [
-        "//src/stirling/obj_tools/testdata/go:test_go_1_16_binary",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
     ],
     deps = [
         ":cc_library",
@@ -56,7 +56,7 @@ pl_cc_test(
     name = "dwarvifier_test",
     srcs = ["dwarvifier_test.cc"],
     data = [
-        "//src/stirling/obj_tools/testdata/go:test_go_1_16_binary",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
     ],
     deps = [
         ":cc_library",
@@ -67,7 +67,7 @@ pl_cc_test(
     name = "probe_transformer_test",
     srcs = ["probe_transformer_test.cc"],
     data = [
-        "//src/stirling/obj_tools/testdata/go:test_go_1_16_binary",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
     ],
     deps = [
         ":cc_library",
@@ -79,7 +79,7 @@ pl_cc_test(
     name = "autogen_test",
     srcs = ["autogen_test.cc"],
     data = [
-        "//src/stirling/obj_tools/testdata/go:test_go_1_16_binary",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
     ],
     deps = [
         ":cc_library",
@@ -91,9 +91,9 @@ pl_cc_test(
     name = "dynamic_tracer_test",
     srcs = ["dynamic_tracer_test.cc"],
     data = [
-        "//src/stirling/obj_tools/testdata/go:test_go_1_16_binary",
-        "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client:golang_1_16_grpc_client",
-        "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server:golang_1_16_grpc_server_with_certs",
+        "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
+        "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client:golang_1_21_grpc_client",
+        "//src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server:golang_1_21_grpc_server_with_certs",
     ],
     tags = [
         "exclusive",

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/BUILD.bazel
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/BUILD.bazel
@@ -56,6 +56,7 @@ pl_cc_test(
     name = "dwarvifier_test",
     srcs = ["dwarvifier_test.cc"],
     data = [
+        "//src/stirling/obj_tools/testdata/cc:test_exe",
         "//src/stirling/obj_tools/testdata/go:test_go_1_21_binary",
     ],
     deps = [

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen_test.cc
@@ -22,7 +22,7 @@
 #include "src/common/testing/testing.h"
 #include "src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen.h"
 
-constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_16_binary";
+constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_21_binary";
 
 namespace px {
 namespace stirling {
@@ -111,8 +111,8 @@ tracepoints {
       fields: "i1"
       fields: "i2"
       fields: "i3"
-      fields: "__tilde__r6"
-      fields: "__tilde__r7"
+      fields: "__tilde__r0"
+      fields: "__tilde__r1"
       fields: "latency"
     }
     probes {
@@ -147,13 +147,15 @@ tracepoints {
       }
       ret_vals {
         id: "retval6"
-        expr: "~r6"
+        expr: "~r0"
       }
       ret_vals {
         id: "retval7"
-        expr: "~r7"
+        expr: "~r1"
       }
-      function_latency { id: "fn_latency" }
+      function_latency {
+        id: "fn_latency"
+      }
       output_actions {
         output_name: "main__d__MixedArgTypes_table"
         variable_names: "arg0"

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/code_gen_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/code_gen_test.cc
@@ -22,7 +22,7 @@
 
 #include "src/common/testing/testing.h"
 
-constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_16_binary";
+constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_21_binary";
 
 namespace px {
 namespace stirling {

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.cc
@@ -97,8 +97,9 @@ class Dwarvifier {
                                                       uint64_t offset, const TypeInfo& type_info);
 
   // Used by ProcessVarExpr() to handle a Struct variable.
-  Status ProcessStructBlob(const std::string& base, uint64_t offset, const TypeInfo& type_info,
-                           const std::string& var_name, ir::physical::Probe* output_probe);
+  Status ProcessStructBlob(const ArgInfo& arg_info, const std::string& base, uint64_t offset,
+                           const TypeInfo& type_info, const std::string& var_name,
+                           ir::physical::Probe* output_probe);
 
   // The input components describes a sequence of field of nesting structures. The first component
   // is the name of an input argument of a function, or an expression to describe the index of an
@@ -569,11 +570,11 @@ void Dwarvifier::AddEntryProbeVariables(ir::physical::Probe* output_probe) {
     auto* parm_ptr_var =
         AddVariable<ScalarVariable>(output_probe, kParmPtrVarName, ir::shared::VOID_POINTER);
     parm_ptr_var->set_reg(ir::physical::Register::SYSV_AMD64_ARGS_PTR);
+  } else if (language_ == ir::shared::GOLANG) {
+    auto* parm_ptr_var =
+        AddVariable<ScalarVariable>(output_probe, kParmPtrVarName, ir::shared::VOID_POINTER);
+    parm_ptr_var->set_reg(ir::physical::Register::GOLANG_ARGS_PTR);
   }
-  // TODO(oazizi): For Golang 1.17+, will need the following:
-  //  auto* parm_ptr_var =
-  //          AddVariable<ScalarVariable>(output_probe, kParmPtrVarName, ir::shared::VOID_POINTER);
-  //  parm_ptr_var->set_reg(ir::physical::Register::GOLANG_ARGS_PTR);
 }
 
 void Dwarvifier::AddRetProbeVariables(ir::physical::Probe* output_probe) {
@@ -585,6 +586,10 @@ void Dwarvifier::AddRetProbeVariables(ir::physical::Probe* output_probe) {
     auto* rc_ptr_var =
         AddVariable<ScalarVariable>(output_probe, kRCPtrVarName, ir::shared::VOID_POINTER);
     rc_ptr_var->set_reg(ir::physical::Register::RC_PTR);
+  } else if (language_ == ir::shared::GOLANG) {
+    auto* parm_ptr_var =
+        AddVariable<ScalarVariable>(output_probe, kParmPtrVarName, ir::shared::VOID_POINTER);
+    parm_ptr_var->set_reg(ir::physical::Register::GOLANG_ARGS_PTR);
   }
 }
 
@@ -788,11 +793,17 @@ Status Dwarvifier::ProcessGolangInterfaceExpr(const std::string& base, uint64_t 
   return Status::OK();
 }
 
-Status Dwarvifier::ProcessStructBlob(const std::string& base, uint64_t offset,
-                                     const TypeInfo& type_info, const std::string& var_name,
+Status Dwarvifier::ProcessStructBlob(const ArgInfo& arg_info, const std::string& base,
+                                     uint64_t offset, const TypeInfo& type_info,
+                                     const std::string& var_name,
                                      ir::physical::Probe* output_probe) {
   PX_ASSIGN_OR_RETURN(std::vector<StructSpecEntry> struct_spec_entires,
                       dwarf_reader_->GetStructSpec(type_info.type_name));
+  VLOG(1) << arg_info.ToString();
+  // TODO(ddelnano): Remove once structs in registers are supported (gh#2106)
+  DCHECK(arg_info.type_info.type != VarType::kStruct ||
+         arg_info.location.loc_type == LocationType::kStack)
+      << "StructBlob should be a stack variable. Structs in registers aren't supported yet.";
   PX_ASSIGN_OR_RETURN(ir::physical::StructSpec struct_spec_proto,
                       CreateStructSpecProto(struct_spec_entires, language_));
 
@@ -917,7 +928,8 @@ Status Dwarvifier::ProcessVarExpr(const std::string& var_name, const ArgInfo& ar
       PX_RETURN_IF_ERROR(
           ProcessGolangInterfaceExpr(base, offset, type_info, var_name, output_probe));
     } else {
-      PX_RETURN_IF_ERROR(ProcessStructBlob(base, offset, type_info, var_name, output_probe));
+      PX_RETURN_IF_ERROR(
+          ProcessStructBlob(arg_info, base, offset, type_info, var_name, output_probe));
     }
   } else {
     return error::Internal("Expected struct or base type, but got type: $0", type_info.ToString());
@@ -936,13 +948,23 @@ Status Dwarvifier::ProcessArgExpr(const ir::logical::Argument& arg,
 
   PX_ASSIGN_OR_RETURN(ArgInfo arg_info, GetArgInfo(args_map_, components.front()));
 
+  std::string base_var;
   switch (language_) {
     case ir::shared::GOLANG:
-      return ProcessVarExpr(arg.id(), arg_info, kSPVarName, components, output_probe);
+      switch (arg_info.location.loc_type) {
+        case LocationType::kStack:
+          base_var = kSPVarName;
+          break;
+        case LocationType::kRegister:
+          base_var = kParmPtrVarName;
+          break;
+        default:
+          return error::Internal("Unsupported argument LocationType $0",
+                                 magic_enum::enum_name(arg_info.location.loc_type));
+      }
+      return ProcessVarExpr(arg.id(), arg_info, base_var, components, output_probe);
     case ir::shared::CPP:
     case ir::shared::C: {
-      std::string base_var;
-
       switch (arg_info.location.loc_type) {
         case LocationType::kStack:
           base_var = kSPVarName;
@@ -999,7 +1021,7 @@ Status Dwarvifier::ProcessRetValExpr(const ir::logical::ReturnValue& ret_val,
 
   switch (language_) {
     case ir::shared::GOLANG: {
-      // This represents the actualy return value being returned,
+      // This represents the actual return value being returned,
       // without sub-field accesses.
       std::string ret_val_name(components.front());
 
@@ -1029,8 +1051,15 @@ Status Dwarvifier::ProcessRetValExpr(const ir::logical::ReturnValue& ret_val,
 
       // Golang return values are really arguments located on the stack, so get the arg info.
       PX_ASSIGN_OR_RETURN(ArgInfo arg_info, GetArgInfo(args_map_, ret_val_name));
-
-      return ProcessVarExpr(ret_val.id(), arg_info, kSPVarName, components, output_probe);
+      switch (arg_info.location.loc_type) {
+        case LocationType::kStack:
+          return ProcessVarExpr(ret_val.id(), arg_info, kSPVarName, components, output_probe);
+        case LocationType::kRegister:
+          return ProcessVarExpr(ret_val.id(), arg_info, kParmPtrVarName, components, output_probe);
+        default:
+          return error::Internal("Unsupported return value LocationType $0",
+                                 magic_enum::enum_name(arg_info.location.loc_type));
+      }
     }
     case ir::shared::CPP:
     case ir::shared::C: {

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.cc
@@ -803,7 +803,7 @@ Status Dwarvifier::ProcessStructBlob(const ArgInfo& arg_info, const std::string&
   // TODO(ddelnano): Remove once structs in registers are supported (gh#2106)
   if (arg_info.location.loc_type == LocationType::kRegister) {
     auto message = absl::Substitute(
-        "Structs variables from registers aren't supported yet. Udd an expr to '$0' to access an "
+        "Structs variables from registers aren't supported yet. Add an expr to '$0' to access an "
         "individual, non struct field (e.g. expr: \"struct_name.field_a\") until this is supported "
         "(gh#2106).",
         var_name);

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.cc
@@ -801,9 +801,14 @@ Status Dwarvifier::ProcessStructBlob(const ArgInfo& arg_info, const std::string&
                       dwarf_reader_->GetStructSpec(type_info.type_name));
   VLOG(1) << arg_info.ToString();
   // TODO(ddelnano): Remove once structs in registers are supported (gh#2106)
-  DCHECK(arg_info.type_info.type != VarType::kStruct ||
-         arg_info.location.loc_type == LocationType::kStack)
-      << "StructBlob should be a stack variable. Structs in registers aren't supported yet.";
+  if (arg_info.location.loc_type == LocationType::kRegister) {
+    auto message = absl::Substitute(
+        "Structs variables from registers aren't supported yet. Udd an expr to '$0' to access an "
+        "individual, non struct field (e.g. expr: \"struct_name.field_a\") until this is supported "
+        "(gh#2106).",
+        var_name);
+    return error::InvalidArgument(message);
+  }
   PX_ASSIGN_OR_RETURN(ir::physical::StructSpec struct_spec_proto,
                       CreateStructSpecProto(struct_spec_entires, language_));
 

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier_test.cc
@@ -1984,7 +1984,8 @@ INSTANTIATE_TEST_SUITE_P(
         DwarfInfoTestParam{kBinaryPath, kActionProbeIn, kActionProbeOut},
         DwarfInfoTestParam{kBinaryPath, kStructProbeIn, kStructProbeOut, kStructRegErrorPrefix},
         DwarfInfoTestParam{kCPPBinaryPath, kCPPStackStructProbeIn, kCPPStackStructProbeOut},
-        DwarfInfoTestParam{kCPPBinaryPath, kCPPRegStructProbeIn, kCPPRegStructProbeOut, kStructRegErrorPrefix},
+        DwarfInfoTestParam{kCPPBinaryPath, kCPPRegStructProbeIn, kCPPRegStructProbeOut,
+                           kStructRegErrorPrefix},
         DwarfInfoTestParam{kBinaryPath, kGolangErrorInterfaceProbeIn,
                            kGolangErrorInterfaceProbeOut}));
 

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier_test.cc
@@ -22,7 +22,7 @@
 #include "src/common/testing/testing.h"
 #include "src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dwarvifier.h"
 
-constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_16_binary";
+constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_21_binary";
 
 namespace px {
 namespace stirling {
@@ -130,11 +130,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "arg0"
       type: INT
       memory {
-        base: "sp_"
-        offset: 8
+        base: "parm__"
       }
     }
   }
@@ -143,8 +149,8 @@ probes {
       name: "arg1"
       type: INT
       memory {
-        base: "sp_"
-        offset: 24
+        base: "parm__"
+        offset: 48
       }
     }
   }
@@ -153,8 +159,8 @@ probes {
       name: "arg2"
       type: INT
       memory {
-        base: "sp_"
-        offset: 32
+        base: "parm__"
+        offset: 56
       }
     }
   }
@@ -163,8 +169,8 @@ probes {
       name: "arg3"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 16
+        base: "parm__"
+        offset: 8
       }
     }
   }
@@ -173,8 +179,8 @@ probes {
       name: "arg4"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 17
+        base: "parm__"
+        offset: 16
       }
     }
   }
@@ -183,8 +189,8 @@ probes {
       name: "arg5"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 20
+        base: "parm__"
+        offset: 19
       }
     }
   }
@@ -274,11 +280,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "retval0"
       type: INT
       memory {
-        base: "sp_"
-        offset: 48
+        base: "parm__"
       }
     }
   }
@@ -287,8 +299,8 @@ probes {
       name: "retval1"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 57
+        base: "parm__"
+        offset: 9
       }
     }
   }
@@ -311,11 +323,11 @@ tracepoints {
       }
       ret_vals {
         id: "retval0"
-        expr: "~r6"
+        expr: "~r0"
       }
       ret_vals {
         id: "retval1"
-        expr: "~r7.B1"
+        expr: "~r1.B1"
       }
     }
   }
@@ -378,11 +390,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "retval0"
       type: INT
       memory {
-        base: "sp_"
-        offset: 48
+        base: "parm__"
       }
     }
   }
@@ -391,8 +409,8 @@ probes {
       name: "retval1"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 57
+        base: "parm__"
+        offset: 9
       }
     }
   }
@@ -482,11 +500,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "retval0"
       type: INT
       memory {
-        base: "sp_"
-        offset: 48
+        base: "parm__"
       }
     }
   }
@@ -495,8 +519,8 @@ probes {
       name: "retval1"
       type: STRUCT_BLOB
       memory {
-        base: "sp_"
-        offset: 56
+        base: "parm__"
+        offset: 8
         size: 4
       }
     }
@@ -587,11 +611,18 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "arg0_D_Ptr_X_"
       type: VOID_POINTER
       memory {
-        base: "sp_"
-        offset: 16
+        base: "parm__"
+        offset: 8
       }
     }
   }
@@ -619,8 +650,8 @@ probes {
       name: "arg1_D_Ptr_X_"
       type: VOID_POINTER
       memory {
-        base: "sp_"
-        offset: 16
+        base: "parm__"
+        offset: 8
       }
     }
   }
@@ -862,11 +893,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "arg0"
       type: INT
       memory {
-        base: "sp_"
-        offset: 8
+        base: "parm__"
       }
     }
   }
@@ -875,8 +912,8 @@ probes {
       name: "arg1"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 16
+        base: "parm__"
+        offset: 8
       }
     }
   }
@@ -885,8 +922,8 @@ probes {
       name: "arg2"
       type: BOOL
       memory {
-        base: "sp_"
-        offset: 17
+        base: "parm__"
+        offset: 16
       }
     }
   }
@@ -972,6 +1009,13 @@ probes {
     }
   }
   vars {
+    scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
     map_var {
       name: "my_stash_ptr"
       type: "my_stash_value_t"
@@ -1003,7 +1047,6 @@ probes {
   }
   output_actions {
     perf_buffer_name: "out_table2"
-    data_buffer_array_name: "out_table2_data_buffer_array"
     output_struct_name: "out_table2_value_t"
     variable_names: "tgid_"
     variable_names: "tgid_start_time_"
@@ -1011,6 +1054,7 @@ probes {
     variable_names: "goid_"
     variable_names: "arg0"
     variable_names: "arg1"
+    data_buffer_array_name: "out_table2_data_buffer_array"
   }
   map_delete_actions {
     map_name: "my_stash"
@@ -1197,11 +1241,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "arg0"
       type: STRUCT_BLOB
       memory {
-        base: "sp_"
-        offset: 8
+        base: "parm__"
         size: 48
       }
     }
@@ -1324,6 +1374,8 @@ structs {
         path: "/len"
       }
     }
+    blob_decoders {
+    }
   }
 }
 outputs {
@@ -1380,11 +1432,17 @@ probes {
   }
   vars {
     scalar_var {
+      name: "parm__"
+      type: VOID_POINTER
+      reg: GOLANG_ARGS_PTR
+    }
+  }
+  vars {
+    scalar_var {
       name: "retval_intf_tab"
       type: UINT64
       memory {
-        base: "sp_"
-        offset: 8
+        base: "parm__"
       }
     }
   }
@@ -1393,8 +1451,8 @@ probes {
       name: "retval_intf_data"
       type: VOID_POINTER
       memory {
-        base: "sp_"
-        offset: 16
+        base: "parm__"
+        offset: 8
       }
     }
   }
@@ -1402,14 +1460,21 @@ probes {
     scalar_var {
       name: "main__IntStruct_sym_addr1"
       type: UINT64
-      constant: "5104328"
+      constant: "4989600"
     }
   }
   vars {
     scalar_var {
       name: "runtime__errorString_sym_addr2"
       type: UINT64
-      constant: "5104360"
+      constant: "4989792"
+    }
+  }
+  vars {
+    scalar_var {
+      name: "internal___poll__errNetClosing_sym_addr3"
+      type: UINT64
+      constant: "4989824"
     }
   }
   vars {
@@ -1426,8 +1491,7 @@ probes {
       name: "retval"
       type: STRUCT_BLOB
       memory {
-        base: "sp_"
-        offset: 8
+        base: "parm__"
         size: 16
         op: ASSIGN_ONLY
       }
@@ -1435,13 +1499,13 @@ probes {
   }
   output_actions {
     perf_buffer_name: "out_table"
-    data_buffer_array_name: "out_table_data_buffer_array"
     output_struct_name: "out_table_value_t"
     variable_names: "tgid_"
     variable_names: "tgid_start_time_"
     variable_names: "time_"
     variable_names: "goid_"
     variable_names: "retval"
+    data_buffer_array_name: "out_table_data_buffer_array"
   }
   cond_blocks {
     cond {
@@ -1476,6 +1540,25 @@ probes {
           base: "retval_intf_data"
           size: 16
           decoder_idx: 2
+          op: ASSIGN_ONLY
+        }
+      }
+    }
+  }
+  cond_blocks {
+    cond {
+      op: EQUAL
+      vars: "retval_intf_tab"
+      vars: "internal___poll__errNetClosing_sym_addr3"
+    }
+    vars {
+      scalar_var {
+        name: "retval"
+        type: STRUCT_BLOB
+        memory {
+          base: "retval_intf_data"
+          size: 16
+          decoder_idx: 3
           op: ASSIGN_ONLY
         }
       }

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dynamic_tracer_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dynamic_tracer_test.cc
@@ -26,7 +26,7 @@
 #include "src/common/testing/testing.h"
 #include "src/stirling/testing/common.h"
 
-constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_16_binary";
+constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_21_binary";
 
 namespace px {
 namespace stirling {
@@ -45,7 +45,7 @@ using ::testing::SizeIs;
 
 constexpr char kClientPath[] =
     "src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client/"
-    "golang_1_16_grpc_client";
+    "golang_1_21_grpc_client";
 
 constexpr char kClientPathExpected[] =
     "src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_client/"
@@ -53,7 +53,7 @@ constexpr char kClientPathExpected[] =
 
 constexpr char kServerPath[] =
     "src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server/"
-    "golang_1_16_grpc_server";
+    "golang_1_21_grpc_server";
 
 constexpr char kServerPathExpected[] =
     "src/stirling/source_connectors/socket_tracer/protocols/http2/testing/go_grpc_server/"
@@ -347,7 +347,7 @@ const std::vector<std::string> kExpectedBCC = {
     "  uint8_t truncated;",
     "};",
     "struct pid_goid_map_value_t {",
-    "  int64_t goid;",
+    "  uint64_t goid;",
     "} __attribute__((packed, aligned(1)));",
     "struct probe0_argstash_value_t {",
     "  int arg0;",
@@ -382,13 +382,16 @@ const std::vector<std::string> kExpectedBCC = {
     "uint64_t tgid_start_time_ = pl_tgid_start_time();",
     "uint64_t time_ = bpf_ktime_get_ns();",
     "int64_t goid_ = pl_goid();",
+    "uint64_t parm___[9];parm___[0] = ctx->ax;parm___[1] = ctx->bx;parm___[2] = ctx->cx;parm___[3] "
+    "= ctx->di;parm___[4] = ctx->si;parm___[5] = ctx->r8;parm___[6] = ctx->r9;parm___[7] = "
+    "ctx->r10;parm___[8] = ctx->r11;void* parm__ = &parm___;",
     "int64_t kGRunningState = 2;",
     "void* goid_X_;",
-    "bpf_probe_read(&goid_X_, sizeof(void*), sp_ + 8);",
-    "int64_t goid;",
-    "bpf_probe_read(&goid, sizeof(int64_t), goid_X_ + 152);",
+    "bpf_probe_read(&goid_X_, sizeof(void*), parm__ + 0);",
+    "uint64_t goid;",
+    "bpf_probe_read(&goid, sizeof(uint64_t), goid_X_ + 152);",
     "uint32_t newval;",
-    "bpf_probe_read(&newval, sizeof(uint32_t), sp_ + 20);",
+    "bpf_probe_read(&newval, sizeof(uint32_t), parm__ + 16);",
     "struct pid_goid_map_value_t pid_goid_map_value = {};",
     "pid_goid_map_value.goid = goid;",
     "if (newval == kGRunningState) {",
@@ -403,12 +406,15 @@ const std::vector<std::string> kExpectedBCC = {
     "uint64_t tgid_start_time_ = pl_tgid_start_time();",
     "uint64_t time_ = bpf_ktime_get_ns();",
     "int64_t goid_ = pl_goid();",
+    "uint64_t parm___[9];parm___[0] = ctx->ax;parm___[1] = ctx->bx;parm___[2] = ctx->cx;parm___[3] "
+    "= ctx->di;parm___[4] = ctx->si;parm___[5] = ctx->r8;parm___[6] = ctx->r9;parm___[7] = "
+    "ctx->r10;parm___[8] = ctx->r11;void* parm__ = &parm___;",
     "int arg0;",
-    "bpf_probe_read(&arg0, sizeof(int), sp_ + 8);",
+    "bpf_probe_read(&arg0, sizeof(int), parm__ + 0);",
     "int arg1;",
-    "bpf_probe_read(&arg1, sizeof(int), sp_ + 24);",
+    "bpf_probe_read(&arg1, sizeof(int), parm__ + 48);",
     "int arg2;",
-    "bpf_probe_read(&arg2, sizeof(int), sp_ + 32);",
+    "bpf_probe_read(&arg2, sizeof(int), parm__ + 56);",
     "struct probe0_argstash_value_t probe0_argstash_value = {};",
     "probe0_argstash_value.arg0 = arg0;",
     "probe0_argstash_value.arg1 = arg1;",
@@ -424,8 +430,11 @@ const std::vector<std::string> kExpectedBCC = {
     "uint64_t tgid_start_time_ = pl_tgid_start_time();",
     "uint64_t time_ = bpf_ktime_get_ns();",
     "int64_t goid_ = pl_goid();",
+    "uint64_t parm___[9];parm___[0] = ctx->ax;parm___[1] = ctx->bx;parm___[2] = ctx->cx;parm___[3] "
+    "= ctx->di;parm___[4] = ctx->si;parm___[5] = ctx->r8;parm___[6] = ctx->r9;parm___[7] = "
+    "ctx->r10;parm___[8] = ctx->r11;void* parm__ = &parm___;",
     "int retval0;",
-    "bpf_probe_read(&retval0, sizeof(int), sp_ + 48);",
+    "bpf_probe_read(&retval0, sizeof(int), parm__ + 0);",
     "struct probe0_argstash_value_t* probe0_argstash_ptr = probe0_argstash.lookup(&goid_);",
     "if (probe0_argstash_ptr == NULL) { return 0; }",
     "int arg0 = probe0_argstash_ptr->arg0;",
@@ -467,7 +476,7 @@ TEST(DynamicTracerTest, Compile) {
 
   const auto& spec = bcc_program.uprobe_specs[0];
 
-  EXPECT_THAT(spec, Field(&UProbeSpec::binary_path, ::testing::EndsWith("test_go_1_16_binary")));
+  EXPECT_THAT(spec, Field(&UProbeSpec::binary_path, ::testing::EndsWith("test_go_1_21_binary")));
   EXPECT_THAT(spec, Field(&UProbeSpec::symbol, "runtime.casgstatus"));
   EXPECT_THAT(spec, Field(&UProbeSpec::attach_type, bpf_tools::BPFProbeAttachType::kEntry));
   EXPECT_THAT(spec, Field(&UProbeSpec::probe_fn, "probe_entry_runtime_casgstatus"));

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/probe_transformer_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/probe_transformer_test.cc
@@ -21,7 +21,7 @@
 #include "src/common/testing/testing.h"
 #include "src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/probe_transformer.h"
 
-constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_16_binary";
+constexpr std::string_view kBinaryPath = "src/stirling/obj_tools/testdata/go/test_go_1_21_binary";
 
 namespace px {
 namespace stirling {
@@ -212,7 +212,14 @@ tracepoints {
         symbol: "main.MixedArgTypes"
         type: RETURN
       }
-      function_latency { id: "fn_latency" }
+      ret_vals {
+        id: "retval0"
+        expr: "$$0"
+      }
+      ret_vals {
+        id: "retval1"
+        expr: "$$1"
+      }
       map_vals {
         map_name: "probe0_argstash"
         key: GOID
@@ -224,13 +231,8 @@ tracepoints {
         value_ids: "arg5"
         value_ids: "start_ktime_ns"
       }
-      ret_vals {
-        id: "retval0"
-        expr: "$$0"
-      }
-      ret_vals {
-        id: "retval1"
-        expr: "$$1"
+      function_latency {
+        id: "fn_latency"
       }
       output_actions {
         output_name: "probe0_table"


### PR DESCRIPTION
Summary: Update dynamic logging to work with Go's 1.17+ calling convention

Despite our earlier messaging that dynamic logging would be deprecated in #2105, I decided that it was easier to handle the new ABI instead of deprecating the Go parts of the dynamic tracer. My rationale for this is that the blocker for achieving feature parity for the new Go ABI, handling `STRUCT_BLOB` variables, is actually a concern for c/c++ tracepoint programs as well. I felt it was important to keep the dynamic tracer rather than deprecate it entirely.

As mentioned above, this change does not have full feature parity with the legacy ABI since `STRUCT_BLOB` variables don't work with register based calling conventions -- these variables copy a blob of memory with the assumption that a packed struct exists in a contiguous chunk of memory. However, this isn't unique to Go binaries as c/c++ applications can pass certain structs via [registers](https://github.com/pixie-io/pixie/blob/b0001dab6288508295c54f36c81b3ed80c2677e1/src/stirling/obj_tools/testdata/cc/test_exe.cc#L66-L69) as well.

This change replaces the previous Go `STRUCT_BLOB` tests with C equivalents that pass the variable on the stack. When a struct variable will be passed via a register, dynamic logging will now return an error and suggest to the user to access struct fields individually. This error and the test cases that assert the error is returned can be reverted to their original form once #2106 is complete.

Relevant Issues: #2105

Type of change: /kind cleanup

Test Plan: Existing tests pass and new ones were added where coverage was needed

Changelog Message: Update Go dynamic logging feature to support Go 1.17+ binaries