### PR TITLE
Upgrade rules_go to v0.47.1 for go 1.22 support

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -420,10 +420,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
     ),
     io_bazel_rules_go = dict(
-        sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+        sha256 = "f74c98d6df55217a36859c74b460e774abc0410a47cc100d822be34d5f990f16",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.47.1/rules_go-v0.47.1.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.47.1/rules_go-v0.47.1.zip",
         ],
     ),
     io_bazel_rules_k8s = dict(


### PR DESCRIPTION
Summary: Upgrade rules_go to v0.47.1 for go 1.22 support

The work to remove our dependence on go 1.16 will be complete soon (once #2108 is merged). With that done, we can upgrade our go dependencies and go version. This rules_go change is needed to support go 1.22 as there was an assembler fix in [v0.46.0](https://github.com/bazel-contrib/rules_go/releases/tag/v0.46.0) (https://github.com/bazel-contrib/rules_go/pull/3756 specifically).

This was the most recent rules_go version I could upgrade to without dealing with breaking changes. I'll revisit upgrading this to a newer version soon, but my primary goal was to be able to upgrade go and our go deps.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Existing tests and verified my branch to add go 1.22 as a supported version builds properly