### PR TITLE
Update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -36,7 +36,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
       ref: ${{ needs.env-protect-setup.outputs.ref }}
   clang-tidy:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     needs: [authorize, env-protect-setup, get-dev-image]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
@@ -64,7 +64,7 @@ jobs:
   code-coverage:
     if: github.event_name == 'push'
     needs: [authorize, env-protect-setup, get-dev-image]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     steps:
@@ -88,7 +88,7 @@ jobs:
         ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r pixie-io/pixie
   generate-matrix:
     needs: [authorize, env-protect-setup, get-dev-image]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     outputs:
@@ -120,7 +120,7 @@ jobs:
           bazel_tests_*
   build-and-test:
     needs: [authorize, env-protect-setup, get-dev-image, generate-matrix]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/cacher.yaml
+++ b/.github/workflows/cacher.yaml
@@ -12,7 +12,7 @@ jobs:
     with:
       image-base-name: "dev_image"
   populate-caches:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/.github/workflows/cli_release.yaml
+++ b/.github/workflows/cli_release.yaml
@@ -15,7 +15,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
@@ -188,7 +188,7 @@ jobs:
           --notes $'Pixie CLI Release:\n'"${changelog}"
         gh release upload "${TAG_NAME}" linux-artifacts/* macos-artifacts/*
   update-gh-artifacts-manifest:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: [get-dev-image, create-github-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/.github/workflows/cloud_release.yaml
+++ b/.github/workflows/cloud_release.yaml
@@ -15,7 +15,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 jobs:
   analyze-go:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     permissions:
       actions: read
       contents: read
@@ -28,7 +28,7 @@ jobs:
       with:
         category: "/language:go"
   analyze:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mirror_demos.yaml
+++ b/.github/workflows/mirror_demos.yaml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     steps:
     - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v2
       with:

--- a/.github/workflows/mirror_deps.yaml
+++ b/.github/workflows/mirror_deps.yaml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     steps:
     - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v2
       with:

--- a/.github/workflows/mirror_releases.yaml
+++ b/.github/workflows/mirror_releases.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     steps:
     - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v2
       with:

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -15,7 +15,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
@@ -142,7 +142,7 @@ jobs:
         git commit -s -m "Release Helm chart ${VERSION}"
         git push origin "gh-pages"
   update-gh-artifacts-manifest:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: [get-dev-image, create-github-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/.github/workflows/perf_common.yaml
+++ b/.github/workflows/perf_common.yaml
@@ -34,7 +34,7 @@ jobs:
       ref: ${{ inputs.ref }}
   generate-perf-matrix:
     needs: get-dev-image-with-extras
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     container:
       image: ${{ needs.get-dev-image-with-extras.outputs.image-with-tag }}
     outputs:
@@ -57,7 +57,7 @@ jobs:
         echo "matrix=${matrix}" >> $GITHUB_OUTPUT
   run-perf-eval:
     needs: [get-dev-image-with-extras, generate-perf-matrix]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     container:
       image: ${{ needs.get-dev-image-with-extras.outputs.image-with-tag }}
     strategy:

--- a/.github/workflows/pr_genfiles.yml
+++ b/.github/workflows/pr_genfiles.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       image-base-name: "dev_image"
   run-genfiles:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       image-base-name: "linter_image"
   run-container-lint:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: get-linter-image
     container:
       image: ${{ needs.get-linter-image.outputs.image-with-tag }}

--- a/.github/workflows/release_update_docs_px_dev.yaml
+++ b/.github/workflows/release_update_docs_px_dev.yaml
@@ -13,7 +13,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
   generate-docs:
     needs: get-dev-image
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     steps:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         artifact: [cloud, operator, vizier]
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -15,7 +15,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     needs: get-dev-image
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
@@ -149,7 +149,7 @@ jobs:
         git commit -s -m "Release Helm chart Vizier ${VERSION}"
         git push origin "gh-pages"
   update-gh-artifacts-manifest:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     needs: [get-dev-image, create-github-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}


### PR DESCRIPTION
Summary: CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty.

Type of change: /kind chore

Test Plan: Updated gh actions should not fail due to the runners.