### PR TITLE
Fixup codeql runs

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,21 +27,34 @@ jobs:
     - uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
         category: "/language:go"
-  analyze:
+  analyze-python:
     runs-on: oracle-8cpu-32gb-x86-64
     permissions:
       actions: read
       contents: read
       security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [python, javascript]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
-        languages: ${{ matrix.language }}
+        languages: python
     - uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:python"
+  analyze-javascript:
+    runs-on: oracle-8cpu-32gb-x86-64
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: 18
+    - uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
+      with:
+        languages: javascript
+    - uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
+      with:
+        category: "/language:javascript"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module px.dev/pixie
 
-go 1.24
+go 1.24.0
 
 require (
 	cloud.google.com/go v0.81.0


### PR DESCRIPTION
Summary: There were two issues on main related to codeql. This attempts to address both of them.
1) since go 1.21, the go.mod file is expected to have a version of the form v1.X.Y instead of v1.X codeql warns about this, so this fixes the same.
2) given the recent change in GH action runners, the runners don't seem to have nodejs installed by default, this ensures that nodejs is indeed installed.

Relevant Issues: N/A

Type of change: /kind bug

Test Plan: Tested e2e.
