### PR TITLE
Upgrade twine package version used for pypi upload

### DIFF
--- a/src/api/python/wheel_upload.bzl
+++ b/src/api/python/wheel_upload.bzl
@@ -23,7 +23,7 @@ def _impl(ctx):
         "#!/bin/bash -e",
         "python3 -m venv venv",
         "source venv/bin/activate",
-        "pip install -q twine==3.4.1",
+        "pip install -q twine==6.1.0",
     ]
 
     upload_cmd = [


### PR DESCRIPTION
Summary: TSIA

Figured we should upgrade this while I was working on uploading the new pxapi pypi version.

Relevant Issues: #2140

Type of change: /kind dependency

Test Plan: Ran the upload to test pypi and verified the virtualenv had the new twine version