### PR TITLE
Provide configurable memory limit for Conn tracker buffer usage

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.h
@@ -213,7 +213,7 @@ class SocketTraceConnector : public BCCSourceConnector {
       /* OUT */ struct go_grpc_http2_header_event_t* header_event_data_go_style);
 
   template <typename TProtocolTraits>
-  void TransferStream(ConnectorContext* ctx, ConnTracker* tracker, DataTable* data_table);
+  size_t TransferStream(ConnectorContext* ctx, ConnTracker* tracker, DataTable* data_table);
   void TransferConnStats(ConnectorContext* ctx, DataTable* data_table);
 
   void set_iteration_time(std::chrono::time_point<std::chrono::steady_clock> time) {
@@ -256,7 +256,7 @@ class SocketTraceConnector : public BCCSourceConnector {
     int32_t trace_mode = TraceMode::Off;
     uint32_t table_num = 0;
     std::vector<endpoint_role_t> trace_roles;
-    std::function<void(SocketTraceConnector&, ConnectorContext*, ConnTracker*, DataTable*)>
+    std::function<size_t(SocketTraceConnector&, ConnectorContext*, ConnTracker*, DataTable*)>
         transfer_fn = nullptr;
     bool enabled = false;
   };
@@ -300,6 +300,8 @@ class SocketTraceConnector : public BCCSourceConnector {
 
   UProbeManager uprobe_mgr_;
 
+  size_t total_conn_tracker_mem_usage_ = 0;
+
   enum class StatKey {
     kLossSocketDataEvent,
     kLossSocketControlEvent,
@@ -314,6 +316,8 @@ class SocketTraceConnector : public BCCSourceConnector {
     kPollSocketDataEventAttrSize,
     kPollSocketDataEventDataSize,
     kPollSocketDataEventSize,
+
+    kDroppedSocketDataEvent,
   };
 
   utils::StatCounter<StatKey> stats_;


### PR DESCRIPTION
Summary: Provide configurable memory limit for Conn tracker buffer usage

Some memory conscious users want to prevent PEM's from having unbounded memory use. The socket tracer's conn tracker component allows unbounded memory growth due to storing an uncapped amount of socket data. From profiling the [PEM's heap use](https://github.com/pixie-io/pixie/blob/301198f2af6739f0de8b01e1cbcb3451b3075e28/scripts/collect_heap_pprofs.sh), this memory growth is a significant contributor to the PEM's memory footprint.

By leveraging the existing [table store limit](https://github.com/pixie-io/pixie/blob/301198f2af6739f0de8b01e1cbcb3451b3075e28/src/table_store/table/table.cc#L44) and this new configuration option, these memory conscious users run Pixie with a smaller and more predictable steady state memory usage.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: Ran perf_tool and k9s based load tests to verify the following:
- [x] Verified results by running PEM's with a 0.5-1 GiB memory limit
- [x] Verified Conn tracker buffers no longer showed up as significant memory contributors in heap profiles.

Changelog Message: PEM's can now limit the total memory used by Pixie's socket tracer buffers through the `--total_conn_tracker_mem_usage` command line flag or the `PX_TOTAL_CONN_TRACKER_MEM_USAGE` env var. This allows memory conscious users to have more predictable memory use when paired with `PL_TABLE_STORE_TABLE_SIZE_LIMIT`.