### PR TITLE
Upgrade linux_headers to artifact that includes 6.6 kernel support

### DIFF
--- a/bazel/linux_headers.bzl
+++ b/bazel/linux_headers.bzl
@@ -28,19 +28,19 @@ def linux_headers():
     http_file(
         name = "linux_headers_merged_x86_64_tar_gz",
         urls = [
-            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl6/linux-headers-merged-x86_64-pl6.tar.gz",
-            "https://storage.googleapis.com/pixie-dev-public/linux-headers/pl6/linux-headers-merged-x86_64-pl6.tar.gz",
+            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl7/linux-headers-merged-x86_64-pl7.tar.gz",
+            "https://storage.googleapis.com/pixie-dev-public/linux-headers/pl7/linux-headers-merged-x86_64-pl7.tar.gz",
         ],
-        sha256 = "b99ac9def26c0c1ef03f34583a1e62b96b3b5f8b038428fa582ed28aacbe0ac3",
+        sha256 = "e4635db60d7f4139a8fea1b0490a0d0159e1edb9f3272ba2bcf40f8ea933bf93",
         downloaded_file_path = "linux-headers-merged-x86_64.tar.gz",
     )
     http_file(
         name = "linux_headers_merged_arm64_tar_gz",
         urls = [
-            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl6/linux-headers-merged-arm64-pl6.tar.gz",
-            "https://storage.googleapis.com/pixie-dev-public/linux-headers/pl6/linux-headers-merged-arm64-pl6.tar.gz",
+            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl7/linux-headers-merged-arm64-pl7.tar.gz",
+            "https://storage.googleapis.com/pixie-dev-public/linux-headers/pl7/linux-headers-merged-arm64-pl7.tar.gz",
         ],
-        sha256 = "3daa69cc0e0516c2e9190b6c90ed42cbd8cdabc377c30571fc7037354dc5c57f",
+        sha256 = "c2a99ad6462dd1211c4e2f54f7279b7cf526e73918148350ccba988b95ca6115",
         downloaded_file_path = "linux-headers-merged-arm64.tar.gz",
     )
 


### PR DESCRIPTION
Summary: Upgrade linux_headers to artifact that includes 6.6 kernel support

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Build should pass

Changelog Message: Fixes an issue where ARM Container OS (COS) clusters running a 6.6.x kernel failed to start the socket tracer