### PR TITLE
Add GoOffsetLocator that fulfills DwarfReader API. Use as shim for Go Uprobes

### DIFF
--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.cc
@@ -174,10 +174,10 @@ Status UProbeManager::UpdateOpenSSLSymAddrs(obj_tools::RawFptrManager* fptr_mana
   return Status::OK();
 }
 
-Status UProbeManager::UpdateGoCommonSymAddrs(ElfReader* elf_reader, DwarfReader* dwarf_reader,
+Status UProbeManager::UpdateGoCommonSymAddrs(ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                                              const std::vector<int32_t>& pids) {
   PX_ASSIGN_OR_RETURN(struct go_common_symaddrs_t symaddrs,
-                      GoCommonSymAddrs(elf_reader, dwarf_reader));
+                      GoCommonSymAddrs(elf_reader, offset_locator));
 
   for (auto& pid : pids) {
     PX_RETURN_IF_ERROR(go_common_symaddrs_map_->SetValue(pid, symaddrs));
@@ -186,10 +186,10 @@ Status UProbeManager::UpdateGoCommonSymAddrs(ElfReader* elf_reader, DwarfReader*
   return Status::OK();
 }
 
-Status UProbeManager::UpdateGoHTTP2SymAddrs(ElfReader* elf_reader, DwarfReader* dwarf_reader,
+Status UProbeManager::UpdateGoHTTP2SymAddrs(ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                                             const std::vector<int32_t>& pids) {
   PX_ASSIGN_OR_RETURN(struct go_http2_symaddrs_t symaddrs,
-                      GoHTTP2SymAddrs(elf_reader, dwarf_reader));
+                      GoHTTP2SymAddrs(elf_reader, offset_locator));
 
   for (auto& pid : pids) {
     PX_RETURN_IF_ERROR(go_http2_symaddrs_map_->SetValue(pid, symaddrs));
@@ -198,9 +198,9 @@ Status UProbeManager::UpdateGoHTTP2SymAddrs(ElfReader* elf_reader, DwarfReader* 
   return Status::OK();
 }
 
-Status UProbeManager::UpdateGoTLSSymAddrs(ElfReader* elf_reader, DwarfReader* dwarf_reader,
+Status UProbeManager::UpdateGoTLSSymAddrs(ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                                           const std::vector<int32_t>& pids) {
-  PX_ASSIGN_OR_RETURN(struct go_tls_symaddrs_t symaddrs, GoTLSSymAddrs(elf_reader, dwarf_reader));
+  PX_ASSIGN_OR_RETURN(struct go_tls_symaddrs_t symaddrs, GoTLSSymAddrs(elf_reader, offset_locator));
 
   for (auto& pid : pids) {
     PX_RETURN_IF_ERROR(go_tls_symaddrs_map_->SetValue(pid, symaddrs));
@@ -524,10 +524,10 @@ StatusOr<int> UProbeManager::AttachNodeJsOpenSSLUprobes(const uint32_t pid,
 
 StatusOr<int> UProbeManager::AttachGoTLSUProbes(const std::string& binary,
                                                 obj_tools::ElfReader* elf_reader,
-                                                obj_tools::DwarfReader* dwarf_reader,
+                                                GoOffsetLocator* offset_locator,
                                                 const std::vector<int32_t>& pids) {
   // Step 1: Update BPF symbols_map on all new PIDs.
-  Status s = UpdateGoTLSSymAddrs(elf_reader, dwarf_reader, pids);
+  Status s = UpdateGoTLSSymAddrs(elf_reader, offset_locator, pids);
   if (!s.ok()) {
     // Doesn't appear to be a binary with the mandatory symbols.
     // Might not even be a golang binary.
@@ -546,10 +546,10 @@ StatusOr<int> UProbeManager::AttachGoTLSUProbes(const std::string& binary,
 
 StatusOr<int> UProbeManager::AttachGoHTTP2UProbes(const std::string& binary,
                                                   obj_tools::ElfReader* elf_reader,
-                                                  obj_tools::DwarfReader* dwarf_reader,
+                                                  GoOffsetLocator* offset_locator,
                                                   const std::vector<int32_t>& pids) {
   // Step 1: Update BPF symaddrs for this binary.
-  Status s = UpdateGoHTTP2SymAddrs(elf_reader, dwarf_reader, pids);
+  Status s = UpdateGoHTTP2SymAddrs(elf_reader, offset_locator, pids);
   if (!s.ok()) {
     return 0;
   }
@@ -886,8 +886,21 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
           binary, dwarf_reader_status.msg());
       continue;
     }
+
+    auto build_info_s = ReadGoBuildInfo(elf_reader.get());
+    if (!build_info_s.ok()) {
+      VLOG(1) << absl::Substitute(
+          "Failed to read build info from binary $0. Cannot deploy uprobes. "
+          "Message = $1",
+          binary, build_info_s.status().msg());
+      continue;
+    }
+    auto& [go_version, build_info] = build_info_s.ValueOrDie();
+
     std::unique_ptr<DwarfReader> dwarf_reader = dwarf_reader_status.ConsumeValueOrDie();
-    Status s = UpdateGoCommonSymAddrs(elf_reader.get(), dwarf_reader.get(), pid_vec);
+    std::unique_ptr<GoOffsetLocator> offset_locator =
+        std::make_unique<GoOffsetLocator>(dwarf_reader.get(), build_info, go_version);
+    Status s = UpdateGoCommonSymAddrs(elf_reader.get(), offset_locator.get(), pid_vec);
     if (!s.ok()) {
       VLOG(1) << absl::Substitute(
           "Golang binary $0 does not have the mandatory symbols (e.g. TCPConn).", binary);
@@ -898,7 +911,7 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
     if (!cfg_disable_go_tls_tracing_) {
       VLOG(1) << absl::Substitute("Attempting to attach Go TLS uprobes to binary $0", binary);
       StatusOr<int> attach_status =
-          AttachGoTLSUProbes(binary, elf_reader.get(), dwarf_reader.get(), pid_vec);
+          AttachGoTLSUProbes(binary, elf_reader.get(), offset_locator.get(), pid_vec);
       if (!attach_status.ok()) {
         monitor_.AppendSourceStatusRecord("socket_tracer", attach_status.status(),
                                           "AttachGoTLSUProbes");
@@ -912,7 +925,7 @@ int UProbeManager::DeployGoUProbes(const absl::flat_hash_set<md::UPID>& pids) {
     // Go HTTP2 Probes.
     if (!cfg_disable_go_tls_tracing_ && cfg_enable_http2_tracing_) {
       StatusOr<int> attach_status =
-          AttachGoHTTP2UProbes(binary, elf_reader.get(), dwarf_reader.get(), pid_vec);
+          AttachGoHTTP2UProbes(binary, elf_reader.get(), offset_locator.get(), pid_vec);
       if (!attach_status.ok()) {
         monitor_.AppendSourceStatusRecord("socket_tracer", attach_status.status(),
                                           "AttachGoHTTP2UProbes");

--- a/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_manager.h
@@ -493,7 +493,7 @@ class UProbeManager {
    *
    * @param binary The path to the binary on which to deploy Go HTTP2 probes.
    * @param elf_reader ELF reader for the binary.
-   * @param dwarf_reader DWARF reader for the binary.
+   * @param offset_locator DWARF reader for the binary.
    * @param pids The list of PIDs that are new instances of the binary. Used to populate symbol
    *             addresses.
    * @return The number of uprobes deployed, or error. It is not considered an error if the binary
@@ -501,7 +501,7 @@ class UProbeManager {
    *         zero.
    */
   StatusOr<int> AttachGoHTTP2UProbes(const std::string& binary, obj_tools::ElfReader* elf_reader,
-                                     obj_tools::DwarfReader* dwarf_reader,
+                                     GoOffsetLocator* offset_locator,
                                      const std::vector<int32_t>& pids);
 
   /**
@@ -510,14 +510,14 @@ class UProbeManager {
    *
    * @param binary The path to the binary on which to deploy Go HTTP2 probes.
    * @param elf_reader ELF reader for the binary.
-   * @param dwarf_reader DWARF reader for the binary.
+   * @param offset_locator DWARF reader for the binary.
    * @param pids The list of PIDs that are new instances of the binary. Used to populate symbol
    *             addresses.
    * @return The number of uprobes deployed, or error. It is not an error if the binary
    *         is not a Go binary or doesn't use Go TLS; instead the return value will be zero.
    */
   StatusOr<int> AttachGoTLSUProbes(const std::string& binary, obj_tools::ElfReader* elf_reader,
-                                   obj_tools::DwarfReader* dwarf_reader,
+                                   GoOffsetLocator* offset_locator,
                                    const std::vector<int32_t>& new_pids);
 
   /**
@@ -579,13 +579,11 @@ class UProbeManager {
 
   Status UpdateOpenSSLSymAddrs(px::stirling::obj_tools::RawFptrManager* fptrManager,
                                std::filesystem::path container_lib, uint32_t pid);
-  Status UpdateGoCommonSymAddrs(obj_tools::ElfReader* elf_reader,
-                                obj_tools::DwarfReader* dwarf_reader,
+  Status UpdateGoCommonSymAddrs(obj_tools::ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                                 const std::vector<int32_t>& pids);
-  Status UpdateGoHTTP2SymAddrs(obj_tools::ElfReader* elf_reader,
-                               obj_tools::DwarfReader* dwarf_reader,
+  Status UpdateGoHTTP2SymAddrs(obj_tools::ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                                const std::vector<int32_t>& pids);
-  Status UpdateGoTLSSymAddrs(obj_tools::ElfReader* elf_reader, obj_tools::DwarfReader* dwarf_reader,
+  Status UpdateGoTLSSymAddrs(obj_tools::ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                              const std::vector<int32_t>& pids);
   Status UpdateNodeTLSWrapSymAddrs(int32_t pid, const std::filesystem::path& node_exe,
                                    const SemVer& ver);

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.cc
@@ -186,20 +186,20 @@ Status PopulateCommonTypeAddrs(ElfReader* elf_reader, std::string_view vendor_pr
   return Status::OK();
 }
 
-Status PopulateCommonDebugSymbols(DwarfReader* dwarf_reader, std::string_view vendor_prefix,
+Status PopulateCommonDebugSymbols(GoOffsetLocator* offset_locator, std::string_view vendor_prefix,
                                   struct go_common_symaddrs_t* symaddrs) {
 #define VENDOR_SYMBOL(symbol) absl::StrCat(vendor_prefix, symbol)
 
   LOG_ASSIGN_STATUSOR(symaddrs->FD_Sysfd_offset,
-                      dwarf_reader->GetStructMemberOffset("internal/poll.FD", "Sysfd"));
+                      offset_locator->GetStructMemberOffset("internal/poll.FD", "Sysfd"));
   LOG_ASSIGN_STATUSOR(symaddrs->tlsConn_conn_offset,
-                      dwarf_reader->GetStructMemberOffset("crypto/tls.Conn", "conn"));
+                      offset_locator->GetStructMemberOffset("crypto/tls.Conn", "conn"));
   LOG_ASSIGN_STATUSOR(
       symaddrs->syscallConn_conn_offset,
-      dwarf_reader->GetStructMemberOffset(
+      offset_locator->GetStructMemberOffset(
           VENDOR_SYMBOL("google.golang.org/grpc/credentials/internal.syscallConn"), "conn"));
   LOG_ASSIGN_STATUSOR(symaddrs->g_goid_offset,
-                      dwarf_reader->GetStructMemberOffset("runtime.g", "goid"));
+                      offset_locator->GetStructMemberOffset("runtime.g", "goid"));
 #undef VENDOR_SYMBOL
 
   // List mandatory symaddrs here (symaddrs without which all probes become useless).
@@ -228,7 +228,7 @@ Status PopulateHTTP2TypeAddrs(ElfReader* elf_reader, std::string_view vendor_pre
   return Status::OK();
 }
 
-Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view vendor_prefix,
+Status PopulateHTTP2DebugSymbols(GoOffsetLocator* offset_locator, std::string_view vendor_prefix,
                                  struct go_http2_symaddrs_t* symaddrs) {
   // Note: we only return error if a *mandatory* symbol is missing. Currently none are mandatory,
   // because these multiple probes for multiple HTTP2/GRPC libraries. Even if a symbol for one
@@ -238,111 +238,111 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
 
   // clang-format off
   LOG_ASSIGN_STATUSOR(symaddrs->HeaderField_Name_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2/hpack.HeaderField"),
                             "Name"));
   LOG_ASSIGN_STATUSOR(symaddrs->HeaderField_Value_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2/hpack.HeaderField"),
                             "Value"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2Server_conn_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.http2Server"),
                             "conn"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2Client_conn_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.http2Client"),
                             "conn"));
   LOG_ASSIGN_STATUSOR(symaddrs->loopyWriter_framer_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.loopyWriter"),
                             "framer"));
   LOG_ASSIGN_STATUSOR(symaddrs->Framer_w_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.Framer"),
                             "w"));
   LOG_ASSIGN_STATUSOR(symaddrs->MetaHeadersFrame_HeadersFrame_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.MetaHeadersFrame"),
                             "HeadersFrame"));
   LOG_ASSIGN_STATUSOR(symaddrs->MetaHeadersFrame_Fields_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.MetaHeadersFrame"),
                             "Fields"));
   LOG_ASSIGN_STATUSOR(symaddrs->HeadersFrame_FrameHeader_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.HeadersFrame"),
                             "FrameHeader"));
   LOG_ASSIGN_STATUSOR(symaddrs->FrameHeader_Type_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.FrameHeader"),
                             "Type"));
   LOG_ASSIGN_STATUSOR(symaddrs->FrameHeader_Flags_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.FrameHeader"),
                             "Flags"));
   LOG_ASSIGN_STATUSOR(symaddrs->FrameHeader_StreamID_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.FrameHeader"),
                             "StreamID"));
   LOG_ASSIGN_STATUSOR(symaddrs->DataFrame_data_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("golang.org/x/net/http2.DataFrame"),
                             "data"));
   LOG_ASSIGN_STATUSOR(symaddrs->bufWriter_conn_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.bufWriter"),
                             "conn"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2serverConn_conn_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2serverConn",
                             "conn"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2serverConn_hpackEncoder_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2serverConn",
                             "hpackEncoder"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2HeadersFrame_http2FrameHeader_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2HeadersFrame",
                             "http2FrameHeader"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2FrameHeader_Type_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2FrameHeader",
                             "Type"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2FrameHeader_Flags_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2FrameHeader",
                             "Flags"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2FrameHeader_StreamID_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2FrameHeader",
                             "StreamID"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2DataFrame_data_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2DataFrame",
                             "data"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2writeResHeaders_streamID_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2writeResHeaders",
                             "streamID"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2writeResHeaders_endStream_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2writeResHeaders",
                             "endStream"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2MetaHeadersFrame_http2HeadersFrame_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2MetaHeadersFrame",
                             "http2HeadersFrame"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2MetaHeadersFrame_Fields_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2MetaHeadersFrame",
                             "Fields"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2Framer_w_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2Framer",
                             "w"));
   LOG_ASSIGN_STATUSOR(symaddrs->http2bufferedWriter_w_offset,
-                    dwarf_reader->GetStructMemberOffset(
+                    offset_locator->GetStructMemberOffset(
                             "net/http.http2bufferedWriter",
                             "w"));
   // clang-format on
@@ -352,7 +352,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of net/http.(*http2Framer).WriteDataPadded.
   {
     std::string_view fn = "net/http.(*http2Framer).WriteDataPadded";
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->http2Framer_WriteDataPadded_f_loc, GetArgOffset(args_map, "f"));
     LOG_ASSIGN(symaddrs->http2Framer_WriteDataPadded_streamID_loc,
                GetArgOffset(args_map, "streamID"));
@@ -369,7 +369,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of golang.org/x/net/http2.(*Framer).WriteDataPadded.
   {
     std::string fn = VENDOR_SYMBOL("golang.org/x/net/http2.(*Framer).WriteDataPadded");
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->http2_WriteDataPadded_f_loc, GetArgOffset(args_map, "f"));
     LOG_ASSIGN(symaddrs->http2_WriteDataPadded_streamID_loc, GetArgOffset(args_map, "streamID"));
     LOG_ASSIGN(symaddrs->http2_WriteDataPadded_endStream_loc, GetArgOffset(args_map, "endStream"));
@@ -384,7 +384,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of net/http.(*http2Framer).checkFrameOrder.
   {
     std::string_view fn = "net/http.(*http2Framer).checkFrameOrder";
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->http2Framer_checkFrameOrder_fr_loc, GetArgOffset(args_map, "fr"));
     LOG_ASSIGN(symaddrs->http2Framer_checkFrameOrder_f_loc, GetArgOffset(args_map, "f"));
   }
@@ -392,7 +392,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of golang.org/x/net/http2.(*Framer).checkFrameOrder.
   {
     std::string fn = VENDOR_SYMBOL("golang.org/x/net/http2.(*Framer).checkFrameOrder");
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->http2_checkFrameOrder_fr_loc, GetArgOffset(args_map, "fr"));
     LOG_ASSIGN(symaddrs->http2_checkFrameOrder_f_loc, GetArgOffset(args_map, "f"));
   }
@@ -400,7 +400,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of net/http.(*http2writeResHeaders).writeFrame.
   {
     std::string_view fn = "net/http.(*http2writeResHeaders).writeFrame";
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->writeFrame_w_loc, GetArgOffset(args_map, "w"));
     LOG_ASSIGN(symaddrs->writeFrame_ctx_loc, GetArgOffset(args_map, "ctx"));
   }
@@ -408,7 +408,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of golang.org/x/net/http2/hpack.(*Encoder).WriteField.
   {
     std::string fn = VENDOR_SYMBOL("golang.org/x/net/http2/hpack.(*Encoder).WriteField");
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->WriteField_e_loc, GetArgOffset(args_map, "e"));
     LOG_ASSIGN(symaddrs->WriteField_f_name_loc, GetArgOffset(args_map, "f"));
     symaddrs->WriteField_f_name_loc.offset += 0;
@@ -420,7 +420,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   // Arguments of net/http.(*http2serverConn).processHeaders.
   {
     std::string_view fn = "net/http.(*http2serverConn).processHeaders";
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->processHeaders_sc_loc, GetArgOffset(args_map, "sc"));
     LOG_ASSIGN(symaddrs->processHeaders_f_loc, GetArgOffset(args_map, "f"));
   }
@@ -429,7 +429,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   {
     std::string fn =
         VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders");
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->http2Server_operateHeaders_t_loc, GetArgOffset(args_map, "t"));
     LOG_ASSIGN(symaddrs->http2Server_operateHeaders_frame_loc, GetArgOffset(args_map, "frame"));
   }
@@ -438,7 +438,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   {
     std::string fn =
         VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.(*http2Client).operateHeaders");
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->http2Client_operateHeaders_t_loc, GetArgOffset(args_map, "t"));
     LOG_ASSIGN(symaddrs->http2Client_operateHeaders_frame_loc, GetArgOffset(args_map, "frame"));
   }
@@ -447,7 +447,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
   {
     std::string fn =
         VENDOR_SYMBOL("google.golang.org/grpc/internal/transport.(*loopyWriter).writeHeader");
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->writeHeader_l_loc, GetArgOffset(args_map, "l"));
     LOG_ASSIGN(symaddrs->writeHeader_streamID_loc, GetArgOffset(args_map, "streamID"));
     LOG_ASSIGN(symaddrs->writeHeader_endStream_loc, GetArgOffset(args_map, "endStream"));
@@ -466,7 +466,7 @@ Status PopulateHTTP2DebugSymbols(DwarfReader* dwarf_reader, std::string_view ven
 
 }  // namespace
 
-Status PopulateGoTLSDebugSymbols(ElfReader* elf_reader, DwarfReader* dwarf_reader,
+Status PopulateGoTLSDebugSymbols(ElfReader* elf_reader, GoOffsetLocator* offset_locator,
                                  struct go_tls_symaddrs_t* symaddrs) {
   PX_ASSIGN_OR_RETURN(auto build_info, ReadGoBuildInfo(elf_reader));
   PX_ASSIGN_OR_RETURN(SemVer go_version, GetSemVer(build_info.first, false));
@@ -485,7 +485,7 @@ Status PopulateGoTLSDebugSymbols(ElfReader* elf_reader, DwarfReader* dwarf_reade
   // Arguments of crypto/tls.(*Conn).Write.
   {
     std::string_view fn = "crypto/tls.(*Conn).Write";
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->Write_c_loc, GetArgOffset(args_map, "c"));
     LOG_ASSIGN(symaddrs->Write_b_loc, GetArgOffset(args_map, "b"));
     LOG_ASSIGN(symaddrs->Write_retval0_loc, GetArgOffset(args_map, retval0_arg));
@@ -495,7 +495,7 @@ Status PopulateGoTLSDebugSymbols(ElfReader* elf_reader, DwarfReader* dwarf_reade
   // Arguments of crypto/tls.(*Conn).Read.
   {
     std::string fn = "crypto/tls.(*Conn).Read";
-    auto args_map = dwarf_reader->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
+    auto args_map = offset_locator->GetFunctionArgInfo(fn).ValueOr(kEmptyMap);
     LOG_ASSIGN(symaddrs->Read_c_loc, GetArgOffset(args_map, "c"));
     LOG_ASSIGN(symaddrs->Read_b_loc, GetArgOffset(args_map, "b"));
     LOG_ASSIGN(symaddrs->Read_retval0_loc, GetArgOffset(args_map, retval0_arg));
@@ -513,33 +513,34 @@ Status PopulateGoTLSDebugSymbols(ElfReader* elf_reader, DwarfReader* dwarf_reade
 }
 
 StatusOr<struct go_common_symaddrs_t> GoCommonSymAddrs(ElfReader* elf_reader,
-                                                       DwarfReader* dwarf_reader) {
+                                                       GoOffsetLocator* offset_locator) {
   struct go_common_symaddrs_t symaddrs;
 
   PX_ASSIGN_OR_RETURN(std::string vendor_prefix, InferHTTP2SymAddrVendorPrefix(elf_reader));
 
   PX_RETURN_IF_ERROR(PopulateCommonTypeAddrs(elf_reader, vendor_prefix, &symaddrs));
-  PX_RETURN_IF_ERROR(PopulateCommonDebugSymbols(dwarf_reader, vendor_prefix, &symaddrs));
+  PX_RETURN_IF_ERROR(PopulateCommonDebugSymbols(offset_locator, vendor_prefix, &symaddrs));
 
   return symaddrs;
 }
 
 StatusOr<struct go_http2_symaddrs_t> GoHTTP2SymAddrs(ElfReader* elf_reader,
-                                                     DwarfReader* dwarf_reader) {
+                                                     GoOffsetLocator* offset_locator) {
   struct go_http2_symaddrs_t symaddrs;
 
   PX_ASSIGN_OR_RETURN(std::string vendor_prefix, InferHTTP2SymAddrVendorPrefix(elf_reader));
 
   PX_RETURN_IF_ERROR(PopulateHTTP2TypeAddrs(elf_reader, vendor_prefix, &symaddrs));
-  PX_RETURN_IF_ERROR(PopulateHTTP2DebugSymbols(dwarf_reader, vendor_prefix, &symaddrs));
+  PX_RETURN_IF_ERROR(PopulateHTTP2DebugSymbols(offset_locator, vendor_prefix, &symaddrs));
 
   return symaddrs;
 }
 
-StatusOr<struct go_tls_symaddrs_t> GoTLSSymAddrs(ElfReader* elf_reader, DwarfReader* dwarf_reader) {
+StatusOr<struct go_tls_symaddrs_t> GoTLSSymAddrs(ElfReader* elf_reader,
+                                                 GoOffsetLocator* offset_locator) {
   struct go_tls_symaddrs_t symaddrs;
 
-  PX_RETURN_IF_ERROR(PopulateGoTLSDebugSymbols(elf_reader, dwarf_reader, &symaddrs));
+  PX_RETURN_IF_ERROR(PopulateGoTLSDebugSymbols(elf_reader, offset_locator, &symaddrs));
 
   return symaddrs;
 }

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.h
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs.h
@@ -18,11 +18,14 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
 #include <string>
 
 #include "src/common/base/base.h"
 #include "src/stirling/obj_tools/dwarf_reader.h"
 #include "src/stirling/obj_tools/elf_reader.h"
+#include "src/stirling/obj_tools/go_syms.h"
 #include "src/stirling/obj_tools/raw_fptr_manager.h"
 #include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h"
 #include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/symaddrs.h"
@@ -36,26 +39,144 @@ namespace stirling {
 
 constexpr std::string_view kLibNettyTcnativePrefix = "libnetty_tcnative_linux_x86";
 
+using StructOffsetMap =
+    std::map<std::string, std::map<std::string, std::map<std::string, int32_t>>>;
+using FunctionArgMap =
+    std::map<std::string,
+             std::map<std::string, std::map<std::string, std::unique_ptr<obj_tools::VarLocation>>>>;
+
+class GoOffsetLocator {
+ public:
+  // TODO(ddelnano): Remove this constructor once the scaffolding to populate StructOffsetMap
+  // and FunctionArgMap is available.
+  GoOffsetLocator(obj_tools::DwarfReader* dwarf_reader, const obj_tools::BuildInfo& build_info,
+                  const std::string& go_version)
+      : GoOffsetLocator(dwarf_reader, StructOffsetMap{}, FunctionArgMap{}, build_info, go_version) {
+  }
+
+  GoOffsetLocator(obj_tools::DwarfReader* dwarf_reader, const StructOffsetMap& struct_offsets,
+                  const FunctionArgMap& function_args, const obj_tools::BuildInfo& build_info,
+                  const std::string& go_version)
+      : dwarf_reader_(dwarf_reader),
+        struct_offsets_(struct_offsets),
+        function_args_(function_args),
+        go_version_(go_version) {
+    PopulateModuleVersions(build_info);
+  }
+
+  StatusOr<std::map<std::string, obj_tools::ArgInfo>> GetFunctionArgInfo(
+      std::string_view function_symbol_name) {
+    if (dwarf_reader_ != nullptr) {
+      return dwarf_reader_->GetFunctionArgInfo(function_symbol_name);
+    }
+    return GetFunctionArgInfoFromOffsets(function_symbol_name);
+  }
+
+  StatusOr<obj_tools::VarLocation> GetArgumentLocation(std::string_view /*function_symbol_name*/,
+                                                       std::string_view /*arg_name*/) {
+    return error::Internal(
+        "GetArgumentLocation is not implemented for GoOffsetLocator. Use GetFunctionArgInfo "
+        "instead.");
+  }
+
+  StatusOr<uint64_t> GetStructMemberOffset(std::string_view struct_name,
+                                           std::string_view member_name) {
+    if (dwarf_reader_ != nullptr) {
+      return dwarf_reader_->GetStructMemberOffset(struct_name, member_name);
+    }
+    return GetStructMemberOffsetFromOffsets(struct_name, member_name);
+  }
+
+ private:
+  StatusOr<std::map<std::string, obj_tools::ArgInfo>> GetFunctionArgInfoFromOffsets(
+      std::string_view function_symbol_name) {
+    auto fn_map = function_args_.find(std::string(function_symbol_name));
+    if (fn_map == function_args_.end()) {
+      return error::Internal("Unable to find function location for $0", function_symbol_name);
+    }
+    std::map<std::string, obj_tools::ArgInfo> result;
+    for (const auto& [arg_name, version_info_map] : fn_map->second) {
+      std::string version_key = go_version_;
+      auto version_map = version_info_map.find(version_key);
+      if (version_map == version_info_map.end()) {
+        return error::Internal("Unable to find function location for arg=$0 version=$1", arg_name,
+                               version_key);
+      }
+      auto var_loc_ptr = version_map->second.get();
+      if (var_loc_ptr == nullptr) {
+        return error::Internal("Function location for arg=$0 version=$1 is missing", arg_name,
+                               version_key);
+      }
+      result.insert({arg_name, obj_tools::ArgInfo{obj_tools::TypeInfo{}, *var_loc_ptr}});
+    }
+    return result;
+  }
+
+  StatusOr<uint64_t> GetStructMemberOffsetFromOffsets(std::string_view struct_name,
+                                                      std::string_view member_name) {
+    auto struct_map = struct_offsets_.find(std::string(struct_name));
+    if (struct_map == struct_offsets_.end()) {
+      return error::Internal("Unable to find offsets for struct=$0", struct_name);
+    }
+    auto member_map = struct_map->second.find(std::string(member_name));
+    if (member_map == struct_map->second.end()) {
+      return error::Internal("Unable to find offsets for struct member=$0.$1", struct_name,
+                             member_name);
+    }
+
+    std::string version_key = go_version_;
+    auto version_map = member_map->second.find(version_key);
+    if (version_map == member_map->second.end()) {
+      return error::Internal("Unable to find offsets for struct member=$0.$1 for version $2",
+                             struct_name, member_name, version_key);
+    }
+    return version_map->second;
+  }
+
+  void PopulateModuleVersions(const obj_tools::BuildInfo& build_info) {
+    for (const auto& dep : build_info.deps) {
+      // Find the related dependencies and strip the "v" prefix
+      if (dep.path == "golang.org/x/net") {
+        golang_x_net_version_ = dep.version.substr(1);
+      } else if (dep.path == "google.golang.org/grpc") {
+        google_golang_grpc_version_ = dep.version.substr(1);
+      }
+    }
+    VLOG(1) << "golang.org/x/net module version: " << golang_x_net_version_;
+    VLOG(1) << "google.golang.org/grpc module version: " << google_golang_grpc_version_;
+  }
+
+  obj_tools::DwarfReader* dwarf_reader_;
+
+  const StructOffsetMap& struct_offsets_;
+  const FunctionArgMap& function_args_;
+
+  const std::string& go_version_;
+
+  std::string golang_x_net_version_;
+  std::string google_golang_grpc_version_;
+};
+
 /**
  * Uses ELF and DWARF information to return the locations of all relevant symbols for general Go
  * uprobe deployment.
  */
 StatusOr<struct go_common_symaddrs_t> GoCommonSymAddrs(obj_tools::ElfReader* elf_reader,
-                                                       obj_tools::DwarfReader* dwarf_reader);
+                                                       GoOffsetLocator* offset_locator);
 
 /**
  * Uses ELF and DWARF information to return the locations of all relevant symbols for Go HTTP2
  * uprobe deployment.
  */
 StatusOr<struct go_http2_symaddrs_t> GoHTTP2SymAddrs(obj_tools::ElfReader* elf_reader,
-                                                     obj_tools::DwarfReader* dwarf_reader);
+                                                     GoOffsetLocator* offset_locator);
 
 /**
  * Uses ELF and DWARF information to return the locations of all relevant symbols for Go TLS
  * uprobe deployment.
  */
 StatusOr<struct go_tls_symaddrs_t> GoTLSSymAddrs(obj_tools::ElfReader* elf_reader,
-                                                 obj_tools::DwarfReader* dwarf_reader);
+                                                 GoOffsetLocator* offset_locator);
 
 /**
  * Detects the version of OpenSSL to return the locations of all relevant symbols for OpenSSL uprobe
@@ -74,7 +195,7 @@ StatusOr<struct node_tlswrap_symaddrs_t> NodeTLSWrapSymAddrs(const std::filesyst
                                                              const SemVer& ver);
 
 px::Status PopulateGoTLSDebugSymbols(obj_tools::ElfReader* elf_reader,
-                                     obj_tools::DwarfReader* dwarf_reader,
+                                     GoOffsetLocator* offset_locator,
                                      struct go_tls_symaddrs_t* symaddrs);
 
 }  // namespace stirling


### PR DESCRIPTION
Summary: Add GoOffsetLocator that fulfills DwarfReader APIs. Use as shim for Go Uprobes

Our current Go uprobe implementation relies on parsing DWARF information. This is memory intensive and is not ideal if end users want to keep the PEM's memory usage low (results in 100-150MB memory spikes).

In order to support lower memory uprobes and to expand our Go TLS support for binaries without DWARF, we can introduce a shim for the existing DwarfReader API that can read the offsets from a file (via openteletrmy-go-instrumentation generated offsets) or through our existing DwarfReader interface.

The next set of changes will use the `offset_results.json` file from https://github.com/pixie-io/opentelemetry-go-instrumentation/pull/1.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: Existing Go bpf trace tests should pass