### PR TITLE
Update Nginx Ingress to use `ImplementationSpecific` pathType to avoid admission controller issues

### DIFF
--- a/k8s/cloud/overlays/exposed_services_nginx/cloud_ingress_grpcs.yaml
+++ b/k8s/cloud/overlays/exposed_services_nginx/cloud_ingress_grpcs.yaml
@@ -20,21 +20,21 @@ spec:
     http:
       paths:
       - path: /px.services.(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: vzconn-service
             port:
               number: 51600
       - path: /px.cloudapi.(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: api-service
             port:
               number: 51200
       - path: /px.api.(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: cloud-proxy-service
@@ -44,21 +44,21 @@ spec:
     http:
       paths:
       - path: /px.services.(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: vzconn-service
             port:
               number: 51600
       - path: /px.cloudapi.(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: api-service
             port:
               number: 51200
       - path: /px.api.(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: cloud-proxy-service


### PR DESCRIPTION
Summary: Update Nginx Ingress to use `ImplementationSpecific` pathType to avoid admission controller issues

Nginx Ingress [v1.8.0](https://github.com/kubernetes/ingress-nginx/blob/311a2082c5622c7bdaff24273110e6f2a0f3b5da/changelog/controller-1.8.0.md?plain=1#L16) introduced a `strict-validate-path-type` setting that defaults to true. This causes the existing pathType used by Pixie's manifest to be blocked by the Nginx Ingress admission controller. Updating this value to `ImplementationSpecific` side steps this validation, so it can be created successfully.

> For improving security, our 1.8.0 release includes a [new, optional validation ](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#strict-validate-path-type)that limits the characters accepted on ".spec paths.path" when pathType=Exact or pathType=Prefix, to alphanumeric characters only.

Relevant Issues: #2214

Type of change: /kind bugfix

Test Plan: Deployed to a cluster using Nginx Ingress

Changelog Message: Fixed an issue where Nginx Ingress resource creation would be blocked by admission controller (on Nginx Ingress v1.8.0 and later)