### PR TITLE
Make PEM heap dump scripts compatible with Kelvin

### DIFF
--- a/scripts/collect_heap_pprofs.sh
+++ b/scripts/collect_heap_pprofs.sh
@@ -19,43 +19,68 @@
 usage() {
   echo "This script downloads all of the files listed in the mappings section of a heap profile."
   echo ""
-  echo "Usage: $0 <heap_profile_dir> <vizier_cluster_id> [<gcloud ssh opts>...]"
+  echo "Usage: $0 <heap_profile_dir> <vizier_cluster_id> [--gcloud-common-args] [--gcloud-ssh-args...]"
   echo "<heap_profile_dir> : the directory where the heap profile and memory mapped files will be stored. It will be created if it does not exist."
   echo "<vizier_cluster_id> : the ID of the Vizier cluster to connect to."
-  echo "Common gcloud ssh options include --project."
+  echo "[--gcloud-common-args] : common arguments to pass to gcloud commands, such as --project."
+  echo "[--gcloud-ssh-args] : additional arguments to pass to gcloud compute ssh commands, such as --internal-ip."
   exit 1
 }
 
-heap_profile_dir="$1"
-cluster_id="$2"
+parse_args() {
+  if [ $# -lt 2 ]; then
+    usage
+  fi
+
+  heap_profile_dir="$1"
+  shift
+
+  cluster_id="$1"
+  shift
+}
+
+check_args() {
+  if [ -z "$heap_profile_dir" ] || [ -z "$cluster_id" ]; then
+    usage
+  fi
+}
+
+parse_args "${@}"
+check_args
+
 script_dir=$(dirname "$(realpath "$0")")
 repo_root=$(git rev-parse --show-toplevel)
 
-if [ -z "$heap_profile_dir" ] || [ -z "$cluster_id" ]; then
-  usage
-fi
-
 mkdir -p "$heap_profile_dir"
 
-pxl_heap_output_file="${heap_profile_dir}/raw_output_from_hot_table_test.json"
+pxl_heap_output_file="${heap_profile_dir}/heap_dump_raw_output.json"
 
 px run -o json -c "$cluster_id" -f "${repo_root}/src/pxl_scripts/px/collect_heap_dumps.pxl"  > "$pxl_heap_output_file"
 
 while IFS= read -r line; do
+    asid=$(echo "$line" | jq -r '.asid')
     hostname=$(echo "$line" | jq -r '.hostname')
     heap_content=$(echo "$line" | jq -r '.heap')
-    echo "$heap_content" > "${heap_profile_dir}/${hostname}.txt"
-    echo "Wrote ${heap_profile_dir}/${hostname}.txt"
+    filename="${heap_profile_dir}/${hostname}-${asid}.txt"
+    echo "$heap_content" > "$filename"
+    echo "Wrote heap profile for ASID $asid on host $hostname to $filename"
 done < "$pxl_heap_output_file"
 
-nodes=()
+declare -a agents
 for file in "${heap_profile_dir}"/*.txt; do
-  hostname=$(basename "${file%.*}")
-  nodes+=("$hostname")
-  hostname_dir="${heap_profile_dir}/${hostname}"
-  mkdir -p "$hostname_dir"
+  filename=$(basename "$file")
+  filename_noext="${filename%.txt}"
+  hostname="${filename_noext%-*}"
+  asid="${filename_noext##*-}"
+
+  agents["$asid"]="$hostname"
+  agent_dir="${heap_profile_dir}/${hostname}-${asid}"
+  mkdir -p "$agent_dir"
 done
 
-for node in "${nodes[@]}"; do
-  "${script_dir}/download_heap_prof_mapped_files.sh" "${heap_profile_dir}/${node}.txt" "$node" "${@:3}"
+for agent in "${!agents[@]}"; do
+  asid="${agent}"
+  hostname="${agents[$agent]}"
+  filename="${heap_profile_dir}/${hostname}-${asid}.txt"
+  "${script_dir}/download_heap_prof_mapped_files.sh" "$filename" "$hostname" "${@:3}"
 done

--- a/src/pxl_scripts/px/collect_heap_dumps.pxl
+++ b/src/pxl_scripts/px/collect_heap_dumps.pxl
@@ -16,9 +16,13 @@
 
 import px
 
-df = px.GetAgentStatus(False)
+df = px.GetAgentStatus()
+df.ip_address = px.pluck_array(px.split(df.ip_address, ":"), 0)
+df.hostname_by_ip = px.pod_id_to_node_name(px.ip_to_pod_id(df.ip_address))
+df.hostname = px.select(df.hostname_by_ip == "", df.hostname, df.hostname_by_ip)
 df = df[['asid', 'hostname']]
 heap_stats = px._HeapGrowthStacks()
 df = df.merge(heap_stats, how='inner', left_on='asid', right_on='asid')
-df = df[['hostname', 'heap']]
+df.asid = df.asid_x
+df = df[['asid', 'hostname', 'heap']]
 px.display(df)


### PR DESCRIPTION
Summary: Make PEM heap dump scripts compatible with Kelvin

A community member reported their kelvin instances having a significantly large memory footprint. This updates our existing tooling to support kelvin to aid debugging these types of issues.

Relevant Issues: N/A

Type of change: /kind feature

Test Plan: Ran the heap dump script for a single node cluster (1 PEM, 1 Kelvin) and verified the pprofs rendered in a browser
```
$ ./scripts/collect_heap_pprofs.sh new_test  97838d18-bfa1-4ee4-9ee5-28332354c994 --gcloud-common-args '--project=csmc-dev' --gcloud-ssh-args '--internal-ip'

Wrote heap profile for ASID 3 on host gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9 to new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-3.txt
Wrote heap profile for ASID 1 on host gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9 to new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-1.txt
Using PID (11548) of /app/src/vizier/services/agent/kelvin/kelvin.runfiles/px/src/vizier/services/agent/kelvin/kelvin
Dumped mapped binaries to new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-1
Run 'PPROF_BINARY_PATH=new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-1 pprof -http=localhost:8888 new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-1.txt' to visualize the profile.
Using PID (761750) of /app/src/vizier/services/agent/pem/pem.runfiles/px/src/vizier/services/agent/pem/pem
Dumped mapped binaries to new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-3
Run 'PPROF_BINARY_PATH=new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-3 pprof -http=localhost:8888 new_test/gke-dev-cluster-ddelnano-default-pool-193a440d-1fz9-3.txt' to visualize the profile.

```