### PR TITLE
Add pprof endpoints to vizier go services

### DIFF
--- a/src/shared/services/httpmiddleware/middleware.go
+++ b/src/shared/services/httpmiddleware/middleware.go
@@ -66,6 +66,10 @@ func isMetricsEndpoint(input string) bool {
 	return strings.HasPrefix(input, "/metrics")
 }
 
+func isPprofEndpoint(input string) bool {
+	return strings.HasPrefix(input, "/debug")
+}
+
 // WithBearerAuthMiddleware checks for valid bearer auth or rejects the request.
 // This middleware should be use on all services (except auth/api) to validate our tokens.
 func WithBearerAuthMiddleware(env env.Env, next http.Handler) http.Handler {
@@ -77,6 +81,11 @@ func WithBearerAuthMiddleware(env env.Env, next http.Handler) http.Handler {
 		}
 		if isMetricsEndpoint(r.URL.Path) {
 			// Skip auth for metric endpoints.
+			next.ServeHTTP(w, r)
+			return
+		}
+		if isPprofEndpoint(r.URL.Path) {
+			// Skip auth for pprof endpoints.
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/src/vizier/services/cloud_connector/cloud_connector_server.go
+++ b/src/vizier/services/cloud_connector/cloud_connector_server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -174,6 +175,8 @@ func main() {
 	defer svr.Stop()
 
 	mux := http.NewServeMux()
+	// This handles all the pprof endpoints.
+	mux.Handle("/debug/", http.DefaultServeMux)
 	// Set up healthz endpoint.
 	healthz.RegisterDefaultChecks(mux)
 	// Set up readyz endpoint.

--- a/src/vizier/services/metadata/metadata_server.go
+++ b/src/vizier/services/metadata/metadata_server.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"strings"
@@ -283,6 +284,8 @@ func main() {
 		log.WithError(err).Fatal("Failed to create api environment")
 	}
 	mux := http.NewServeMux()
+	// This handles all the pprof endpoints.
+	mux.Handle("/debug/", http.DefaultServeMux)
 	healthz.RegisterDefaultChecks(mux)
 	metrics.MustRegisterMetricsHandlerNoDefaultMetrics(mux)
 

--- a/src/vizier/services/query_broker/query_broker_server.go
+++ b/src/vizier/services/query_broker/query_broker_server.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -106,6 +107,8 @@ func main() {
 		log.WithError(err).Fatal("Failed to create api environment.")
 	}
 	mux := http.NewServeMux()
+	// This handles all the pprof endpoints.
+	mux.Handle("/debug/", http.DefaultServeMux)
 	healthz.RegisterDefaultChecks(mux)
 	metrics.MustRegisterMetricsHandlerNoDefaultMetrics(mux)
 


### PR DESCRIPTION
Summary: Add pprof endpoints to vizier go services

I'm working with a few community users who are seeing the metadata service consume lots of memory. This change adds the Go pprof endpoints to all vizier Go services to facilitate debugging heap usage.

Relevant Issues: N/A

Type of change: /kind functionality

Test Plan: Skaffolded the change and verified I can use the `/debug/pprof` endpoints without auth