### PR TITLE
Remove `DwarfReader::DetectSourceLanguage` API to address issues with multi language binaries

### DIFF
--- a/src/stirling/obj_tools/dwarf_reader.cc
+++ b/src/stirling/obj_tools/dwarf_reader.cc
@@ -92,8 +92,6 @@ StatusOr<std::unique_ptr<DwarfReader>> DwarfReader::CreateWithoutIndexing(
   auto dwarf_reader = std::unique_ptr<DwarfReader>(
       new DwarfReader(std::move(buffer), DWARFContext::create(*obj_file)));
 
-  PX_RETURN_IF_ERROR(dwarf_reader->DetectSourceLanguage());
-
   return dwarf_reader;
 }
 
@@ -154,36 +152,29 @@ bool IsNamespace(llvm::dwarf::Tag tag) { return tag == llvm::dwarf::DW_TAG_names
 
 }  // namespace
 
-Status DwarfReader::DetectSourceLanguage() {
-  for (size_t i = 0; i < dwarf_context_->getNumCompileUnits(); ++i) {
-    const auto& unit_die = dwarf_context_->getUnitAtIndex(i)->getUnitDIE();
-    if (unit_die.getTag() != llvm::dwarf::DW_TAG_compile_unit) {
-      // Skip over DW_TAG_partial_unit, and potentially other tags.
-      continue;
-    }
-
-    PX_ASSIGN_OR(const DWARFFormValue& lang_attr,
-                 GetAttribute(unit_die, llvm::dwarf::DW_AT_language), continue);
-    source_language_ =
-        static_cast<llvm::dwarf::SourceLanguage>(lang_attr.getAsUnsignedConstant().getValue());
-
-    const DWARFFormValue& producer_attr =
-        GetAttribute(unit_die, llvm::dwarf::DW_AT_producer).ValueOr({});
-
-    auto s = producer_attr.getAsCString();
-#if LLVM_VERSION_MAJOR >= 14
-    if (!s.takeError()) {
-      compiler_ = s.get();
-    }
-#else
-    compiler_ = s.getValueOr("");
-#endif
-
-    return Status::OK();
+StatusOr<std::pair<llvm::dwarf::SourceLanguage, std::string>>
+DwarfReader::DetectSourceLanguageFromCUDIE(const llvm::DWARFDie& unit_die) {
+  if (unit_die.getTag() != llvm::dwarf::DW_TAG_compile_unit) {
+    // Skip over DW_TAG_partial_unit, and potentially other tags.
+    return error::NotFound("Expected DW_TAG_compile_unit, but got DW_TAG=$0 for unit DIE: $1",
+                           magic_enum::enum_name(unit_die.getTag()), Dump(unit_die));
   }
-  return error::Internal(
-      "Could not determine the source language of the DWARF info. DW_AT_language not found on "
-      "any compilation unit.");
+  const DWARFFormValue& producer_attr =
+      GetAttribute(unit_die, llvm::dwarf::DW_AT_producer).ValueOr({});
+  auto s = producer_attr.getAsCString();
+  std::string compiler;
+#if LLVM_VERSION_MAJOR >= 14
+  if (!s.takeError()) {
+    compiler = s.get();
+  }
+#else
+  compiler = s.getValueOr("");
+#endif
+  PX_ASSIGN_OR_RETURN(const DWARFFormValue& lang_attr,
+                      GetAttribute(unit_die, llvm::dwarf::DW_AT_language));
+  auto source_language =
+      static_cast<llvm::dwarf::SourceLanguage>(lang_attr.getAsUnsignedConstant().getValue());
+  return std::make_pair(source_language, compiler);
 }
 
 void DwarfReader::IndexDIEs(
@@ -923,15 +914,19 @@ StatusOr<std::map<std::string, ArgInfo>> DwarfReader::GetFunctionArgInfo(
   // but DW_AT_location has been found to be blank in some cases, making it unreliable.
   // Instead, we use a FunctionArgTracker that tries to reverse engineer the calling convention.
 
-  ABI abi = LanguageToABI(source_language_, compiler_);
-  if (abi == ABI::kUnknown) {
-    return error::Unimplemented("Unable to determine ABI from language: $0",
-                                magic_enum::enum_name(source_language_));
-  }
-  std::unique_ptr<ABICallingConventionModel> arg_tracker = ABICallingConventionModel::Create(abi);
-
   PX_ASSIGN_OR_RETURN(const DWARFDie& function_die,
                       GetMatchingDIE(function_symbol_name, llvm::dwarf::DW_TAG_subprogram));
+  // Certain binaries can have DW_TAG_compile_units with different source languages. When compiling
+  // programs with ASAN/TSAN enabled this is common.
+  llvm::DWARFUnit* cu = function_die.getDwarfUnit();
+  llvm::DWARFDie unit_die = cu->getUnitDIE();
+  PX_ASSIGN_OR_RETURN(auto p, DetectSourceLanguageFromCUDIE(unit_die));
+  ABI abi = LanguageToABI(p.first, p.second);
+  if (abi == ABI::kUnknown) {
+    return error::Unimplemented("Unable to determine ABI from language: $0",
+                                magic_enum::enum_name(p.first));
+  }
+  std::unique_ptr<ABICallingConventionModel> arg_tracker = ABICallingConventionModel::Create(abi);
 
   // If function has a return value, process that first.
   // This is important, because in some ABIs (e.g. SystemV ABI),
@@ -968,7 +963,7 @@ StatusOr<std::map<std::string, ArgInfo>> DwarfReader::GetFunctionArgInfo(
     PX_ASSIGN_OR_RETURN(const DWARFDie type_die, GetTypeDie(die));
     PX_ASSIGN_OR_RETURN(arg.type_info, GetTypeInfo(die, type_die));
 
-    if (source_language_ == llvm::dwarf::DW_LANG_Go) {
+    if (p.first == llvm::dwarf::DW_LANG_Go) {
       arg.retarg = IsGolangRetArg(die).ValueOr(false);
     }
 

--- a/src/stirling/obj_tools/elf_reader.h
+++ b/src/stirling/obj_tools/elf_reader.h
@@ -62,6 +62,7 @@ class ElfReader {
       const std::string& binary_path, const std::filesystem::path& debug_file_dir = kDebugFileDir);
 
   std::filesystem::path& debug_symbols_path() { return debug_symbols_path_; }
+  const std::string& binary_path() const { return binary_path_; }
 
   struct SymbolInfo {
     std::string name;

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen.h
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "src/common/base/base.h"
 #include "src/stirling/obj_tools/dwarf_reader.h"
 #include "src/stirling/obj_tools/elf_reader.h"
@@ -32,17 +34,20 @@ namespace dynamic_tracing {
  * Uses ELF or DWARF information to detect the source language.
  * Populates the tracepoint program's language field in input_program.
  */
-void DetectSourceLanguage(obj_tools::ElfReader* elf_reader, obj_tools::DwarfReader* dwarf_reader,
-                          ir::logical::TracepointDeployment* input_program);
+Status DetectSourceLanguage(obj_tools::ElfReader* elf_reader, obj_tools::DwarfReader* dwarf_reader,
+                            ir::logical::TracepointSpec* program, const std::string& symbol_name);
 
 /**
  * Uses ELF information to check if the provided symbol exists.
  * If it does not exist, it checks whether it is a short-hand (suffix) of a full symbol.
  * If it is a short-hand reference to a symbol, the symbol is replaced with the full-form.
- * Potentially modifies each tracepoint's symbol field in input_program.
+ * Also detects the source language for each resolved symbol using DWARF or ELF information.
+ * Potentially modifies each tracepoint's symbol field and program's language field in
+ * input_program.
  */
-Status ResolveProbeSymbol(obj_tools::ElfReader* elf_reader,
-                          ir::logical::TracepointDeployment* input_program);
+Status ResolveProbeSymbolAndLanguage(obj_tools::ElfReader* elf_reader,
+                                     obj_tools::DwarfReader* dwarf_reader,
+                                     ir::logical::TracepointDeployment* input_program);
 
 /**
  * If any tracepoint in input_program contains no fields to trace, this function uses DWARF info

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen.h
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen.h
@@ -33,9 +33,10 @@ namespace dynamic_tracing {
 /**
  * Uses ELF or DWARF information to detect the source language.
  * Populates the tracepoint program's language field in input_program.
+ * If the language cannot be determined, it assumes a C/C++ language ABI.
  */
-Status DetectSourceLanguage(obj_tools::ElfReader* elf_reader, obj_tools::DwarfReader* dwarf_reader,
-                            ir::logical::TracepointSpec* program, const std::string& symbol_name);
+void DetectSourceLanguage(obj_tools::ElfReader* elf_reader, obj_tools::DwarfReader* dwarf_reader,
+                          ir::logical::TracepointSpec* program, const std::string& symbol_name);
 
 /**
  * Uses ELF information to check if the provided symbol exists.

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen_test.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/autogen_test.cc
@@ -211,10 +211,9 @@ TEST_P(DetectSourceLanguageTest, Transform) {
 
   std::string expected_output = absl::Substitute(p.expected_output, binary_path_);
 
-  auto s = DetectSourceLanguage(elf_reader_.get(), dwarf_reader_.get(),
-                                program.mutable_tracepoints(0)->mutable_program(),
-                                program.tracepoints(0).program().probes(0).tracepoint().symbol());
-  ASSERT_OK(s);
+  DetectSourceLanguage(elf_reader_.get(), dwarf_reader_.get(),
+                       program.mutable_tracepoints(0)->mutable_program(),
+                       program.tracepoints(0).program().probes(0).tracepoint().symbol());
   ASSERT_THAT(program, EqualsProto(expected_output));
 }
 

--- a/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dynamic_tracer.cc
+++ b/src/stirling/source_connectors/dynamic_tracer/dynamic_tracing/dynamic_tracer.cc
@@ -141,11 +141,9 @@ StatusOr<BCCProgram> CompileProgram(ir::logical::TracepointDeployment* input_pro
   // Pre-processing pipeline
   // --------------------------
 
-  // Populate source language.
-  DetectSourceLanguage(obj_info.elf_reader.get(), obj_info.dwarf_reader.get(), input_program);
-
-  // Expand symbol.
-  PX_RETURN_IF_ERROR(ResolveProbeSymbol(obj_info.elf_reader.get(), input_program));
+  // Expand symbols and populate source language.
+  PX_RETURN_IF_ERROR(ResolveProbeSymbolAndLanguage(obj_info.elf_reader.get(),
+                                                   obj_info.dwarf_reader.get(), input_program));
 
   LOG_IF(INFO, FLAGS_debug_dt_pipeline) << input_program->DebugString();
 

--- a/src/stirling/source_connectors/socket_tracer/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/BUILD.bazel
@@ -70,7 +70,7 @@ pl_cc_test(
     name = "uprobe_symaddrs_test",
     srcs = ["uprobe_symaddrs_test.cc"],
     data = [
-        "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_19_grpc_tls_server_binary",
+        "//src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_24_grpc_tls_server_binary",
         "//src/stirling/testing/demo_apps/node:node_debug",
     ],
     deps = [

--- a/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc
@@ -44,7 +44,7 @@ class UprobeSymaddrsTest : public ::testing::Test {
   }
 
   static inline constexpr std::string_view kGoGRPCServer =
-      "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_19_grpc_tls_server_binary";
+      "src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_24_grpc_tls_server_binary";
 
   std::unique_ptr<DwarfReader> dwarf_reader_;
   std::unique_ptr<ElfReader> elf_reader_;
@@ -63,7 +63,7 @@ TEST_F(UprobeSymaddrsTest, GoCommonSymAddrs) {
   // If the test breaks because of that, just update the numbers here.
   EXPECT_EQ(symaddrs.FD_Sysfd_offset, 16);
   EXPECT_EQ(symaddrs.tlsConn_conn_offset, 0);
-  EXPECT_EQ(symaddrs.g_goid_offset, 152);
+  EXPECT_EQ(symaddrs.g_goid_offset, 160);
 }
 
 TEST_F(UprobeSymaddrsTest, GoHTTP2SymAddrs) {


### PR DESCRIPTION
Summary: Remove `DwarfReader::DetectSourceLanguage` API to address issues with multi language binaries

Our previous `DwarfReader::DetectSourceLanguage` API assumes that a binary contains a single type of `DW_AT_language` attribute -- meaning a Go binary would include only DIEs with `DW_AT_language=DW_LANG_Go`. With our upgrade to Go 1.24, this assumption is no longer true. For example, Go binaries built under ASAN contain a variety of `DW_AT_language` attribute values depending on the DIE compile unit (see Test plan output).

This PR removes this API and updates all callers to determine their use case's language from the relevant compile unit DIE.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Verified that the tests introduced in commit 1 fail w/ ASAN enabled. New APIs fix the build
<details><summary>verification steps</summary>

```
# Tests fail under ASAN since C/C++ ABI is incorrectly assumed
(17a0121d7...)$ bazel test --config asan  src/stirling/source_connectors/socket_tracer:uprobe_symaddrs_test --test_output=all --nocache_test_results

[==========] Running 4 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from UprobeSymaddrsTest
[ RUN      ] UprobeSymaddrsTest.GoCommonSymAddrs
[       OK ] UprobeSymaddrsTest.GoCommonSymAddrs (1768 ms)
[ RUN      ] UprobeSymaddrsTest.GoHTTP2SymAddrs
src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc:83: Failure
Expected equality of these values:
  symaddrs.writeHeader_hf_ptr_loc
    Which is: type=kLocationTypeStack offset=8
  (location_t{.type = kLocationTypeRegisters, .offset = 24})
    Which is: type=kLocationTypeRegisters offset=24
[  FAILED  ] UprobeSymaddrsTest.GoHTTP2SymAddrs (1728 ms)
[ RUN      ] UprobeSymaddrsTest.GoTLSSymAddrs
src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc:94: Failure
Expected equality of these values:
  symaddrs.Write_b_loc
    Which is: type=kLocationTypeStack offset=8
  (location_t{.type = kLocationTypeRegisters, .offset = 8})
    Which is: type=kLocationTypeRegisters offset=8
src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test.cc:96: Failure
Expected equality of these values:
  symaddrs.Read_b_loc
    Which is: type=kLocationTypeStack offset=8
  (location_t{.type = kLocationTypeRegisters, .offset = 8})
    Which is: type=kLocationTypeRegisters offset=8
[  FAILED  ] UprobeSymaddrsTest.GoTLSSymAddrs (1613 ms)
[----------] 3 tests from UprobeSymaddrsTest (5110 ms total)

[----------] 1 test from UprobeSymaddrsNodeTest
[ RUN      ] UprobeSymaddrsNodeTest.TLSWrapSymAddrsFromDwarfInfo
[       OK ] UprobeSymaddrsNodeTest.TLSWrapSymAddrsFromDwarfInfo (1 ms)
[----------] 1 test from UprobeSymaddrsNodeTest (1 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 2 test suites ran. (5111 ms total)
[  PASSED  ] 2 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] UprobeSymaddrsTest.GoHTTP2SymAddrs
[  FAILED  ] UprobeSymaddrsTest.GoTLSSymAddrs

 2 FAILED TESTS
I20250710 06:18:14.281155    12 env.cc:51] Shutting down
================================================================================
Target //src/stirling/source_connectors/socket_tracer:uprobe_symaddrs_test up-to-date:
  bazel-bin/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test
INFO: Elapsed time: 5.657s, Critical Path: 5.38s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed, 1 test FAILED, 2 total actions
//src/stirling/source_connectors/socket_tracer:uprobe_symaddrs_test      FAILED in 5.4s
  /home/ddelnano/.cache/bazel/_bazel_ddelnano/fa8604ca46879b9b1ffd44d337c531f3/execroot/px/bazel-out/k8-fastbuild/testlogs/src/stirling/source_connectors/socket_tracer/uprobe_symaddrs_test/test.log

Executed 1 out of 1 test: 1 fails locally.

# Verify ASAN build has DIEs with different DW_AT_language attributes

(17a0121d7...) $ bazel build --config asan src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_24_grpc_tls_server_binary
(17a0121d7...) $ llvm-dwarfdump bazel-bin/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_24_grpc_tls_server_binary | grep DW_AT_lang | uniq -c
      1               DW_AT_language    (DW_LANG_C_plus_plus_14)
      1               DW_AT_language    (DW_LANG_Mips_Assembler)
     22               DW_AT_language    (DW_LANG_C_plus_plus_14)
      1               DW_AT_language    (DW_LANG_Mips_Assembler)
     48               DW_AT_language    (DW_LANG_C_plus_plus_14)
    280               DW_AT_language    (DW_LANG_Go)

# Verify non ASAN builds have only one DW_AT_language attribute
(17a0121d7...) $ bazel build  src/stirling/testing/demo_apps/go_grpc_tls_pl/server:golang_1_24_grpc_tls_server_binary
(17a0121d7...) $ llvm-dwarfdump bazel-bin/src/stirling/testing/demo_apps/go_grpc_tls_pl/server/golang_1_24_grpc_tls_server_binary | grep DW_AT_lang | uniq -c
    281               DW_AT_language    (DW_LANG_Go)
```

</details>