### PR TITLE
[trivy] Include vizier and cloud dependency images in image scan

### DIFF
--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -48,6 +48,21 @@ jobs:
       run: |
         mkdir -p sarif/${{ matrix.artifact }}
         ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
+
+        # TODO(ddelnano): Remove this check once the operator dependency images are supported. This requires rendering helm templates
+        # and requires some additional work.
+        ./scripts/bazel_ignore_codes.sh query //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
+        if [ $? -neq 0 ]; then
+          echo "Bazel built images comprise all images for ${{ matrix.artifact }}."
+          exit 0
+        fi
+
+        echo "Found non bazel images for ${{ matrix.artifact }}."
+        ./scripts/bazel_ignore_codes.sh build \
+          //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
+
+        # Ignore images whose basename is "/${{ matrix.artifact }}" to avoid scanning the bazel built images (e.g. /vizier-, /cloud-)
+        cat ./bazel-bin/k8s/$${ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
     - run: |
         for f in "sarif/${{ matrix.artifact }}/"*; do

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -14,13 +14,16 @@ jobs:
     uses: ./.github/workflows/get_image.yaml
     with:
       image-base-name: "dev_image_with_extras"
-  image-scan:
+  generate-sarif:
     strategy:
       fail-fast: false
       matrix:
         artifact: [cloud, operator, vizier]
     runs-on: oracle-8cpu-32gb-x86-64
     needs: get-dev-image
+    outputs:
+      matrix: ${{ steps.list-sarifs.outputs.matrix }}
+      has-sarifs: ${{ steps.list-sarifs.outputs.has-sarifs }}
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     permissions:
@@ -69,7 +72,55 @@ jobs:
           jq '.runs[].tool.driver.name = "trivy-images"' < "$f" > tmp
           mv tmp "$f"
         done
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: sarif-${{ matrix.artifact }}
+        path: sarif/
+        retention-days: 1
+    - id: list-sarifs
+      run: |
+        # Use jq to build the matrix JSON dynamically
+        # --jsonargs passes each SARIF file as a separate input to jq
+        # For each input file, create an object with file, category, and artifact fields
+        sarif_files=$(find sarif/${{ matrix.artifact }}/ -name "*.sarif" -type f 2>/dev/null || true)
+
+        if [ -z "$sarif_files" ]; then
+          echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+          echo "has-sarifs=false" >> $GITHUB_OUTPUT
+        else
+          matrix_json=$(jq -n --arg artifact "${{ matrix.artifact }}" '
+            {
+              include: [
+                inputs as $f | {
+                  file: $f,
+                  category: ("trivy-images-" + $artifact + "-" + ($f | split("/")[-1] | split(".")[0])),
+                  artifact: ("sarif-" + $artifact)
+                }
+              ]
+            }' --jsonargs $sarif_files | jq -c '.')
+
+          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
+          echo "has-sarifs=true" >> $GITHUB_OUTPUT
+        fi
+
+  upload-sarif:
+    needs: generate-sarif
+    if: needs.generate-sarif.outputs.has-sarifs == 'true'
+    strategy:
+      matrix: ${{ fromJson(needs.generate-sarif.outputs.matrix) }}
+    runs-on: oracle-8cpu-32gb-x86-64
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ matrix.artifact }}
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
-        sarif_file: sarif/${{ matrix.artifact }}
-        category: trivy-images
+        sarif_file: ${{ matrix.file }}
+        category: ${{ matrix.category }}

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -94,6 +94,14 @@ jobs:
         merge-multiple: true
     - id: combine-sarifs
       run: |
+        # Debug: Show what was downloaded
+        echo "Current directory structure"
+        ls -la
+        echo "Looking for sarif directory"
+        ls -la sarif/ || echo "No sarif directory found"
+        echo "All .sarif files"
+        find . -name "*.sarif" -type f || echo "No SARIF files found anywhere"
+
         # With merge-multiple: true, all artifacts are in the same directory
         # Find all SARIF files regardless of subdirectory structure
         all_files=()

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -21,9 +21,6 @@ jobs:
         artifact: [cloud, operator, vizier]
     runs-on: oracle-8cpu-32gb-x86-64
     needs: get-dev-image
-    outputs:
-      matrix: ${{ steps.list-sarifs.outputs.matrix }}
-      has-sarifs: ${{ steps.list-sarifs.outputs.has-sarifs }}
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}
     permissions:
@@ -78,37 +75,59 @@ jobs:
         name: sarif-${{ matrix.artifact }}
         path: sarif/
         retention-days: 1
-    - id: list-sarifs
-      run: |
-        # Use jq to build the matrix JSON dynamically
-        # --jsonargs passes each SARIF file as a separate input to jq
-        # For each input file, create an object with file, category, and artifact fields
-        sarif_files=$(find sarif/${{ matrix.artifact }}/ -name "*.sarif" -type f 2>/dev/null || true)
 
-        if [ -z "$sarif_files" ]; then
+  collect-sarifs:
+    # GitHub Actions matrix job outputs cannot be directly used as job outputs
+    # because matrix jobs create multiple output values (one per matrix combination).
+    # We need a separate job to collect all SARIF files from all artifacts
+    # and create a single unified matrix for the upload job.
+    needs: generate-sarif
+    runs-on: oracle-8cpu-32gb-x86-64
+    outputs:
+      matrix: ${{ steps.combine-sarifs.outputs.matrix }}
+      has-sarifs: ${{ steps.combine-sarifs.outputs.has-sarifs }}
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: sarif-*
+        merge-multiple: true
+    - id: combine-sarifs
+      run: |
+        # Combine all SARIF files from all artifacts into a single matrix
+        all_files=()
+        for artifact in cloud operator vizier; do
+          if [ -d "sarif/$artifact" ]; then
+            for f in sarif/$artifact/*.sarif; do
+              if [ -f "$f" ]; then
+                all_files+=("$f")
+              fi
+            done
+          fi
+        done
+
+        if [ ${#all_files[@]} -eq 0 ]; then
           echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
           echo "has-sarifs=false" >> $GITHUB_OUTPUT
         else
-          matrix_json=$(jq -n --arg artifact "${{ matrix.artifact }}" '
-            {
-              include: [
-                inputs as $f | {
-                  file: $f,
-                  category: ("trivy-images-" + $artifact + "-" + ($f | split("/")[-1] | split(".")[0])),
-                  artifact: ("sarif-" + $artifact)
-                }
-              ]
-            }' --jsonargs $sarif_files | jq -c '.')
+          matrix_json=$(printf '%s\n' "${all_files[@]}" | jq -R -s '
+            split("\n") | map(select(length > 0)) | {
+              include: map({
+                file: .,
+                category: ("trivy-images-" + (split("/")[1]) + "-" + (split("/")[-1] | split(".")[0])),
+                artifact: ("sarif-" + (split("/")[1]))
+              })
+            }' | jq -c '.')
 
           echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
           echo "has-sarifs=true" >> $GITHUB_OUTPUT
         fi
 
   upload-sarif:
-    needs: generate-sarif
-    if: needs.generate-sarif.outputs.has-sarifs == 'true'
+    needs: collect-sarifs
+    if: needs.collect-sarifs.outputs.has-sarifs == 'true'
     strategy:
-      matrix: ${{ fromJson(needs.generate-sarif.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.collect-sarifs.outputs.matrix) }}
     runs-on: oracle-8cpu-32gb-x86-64
     permissions:
       actions: read

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -53,7 +53,8 @@ jobs:
         # TODO(ddelnano): Remove this check once the operator dependency images are supported. This requires rendering helm templates
         # and requires some additional work.
         ./scripts/bazel_ignore_codes.sh query //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
-        if [ $? -neq 0 ]; then
+        query_exit_code=$?
+        if [ $query_exit_code -neq 0 ]; then
           echo "Bazel built images comprise all images for ${{ matrix.artifact }}."
           exit 0
         fi
@@ -63,7 +64,7 @@ jobs:
           //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
 
         # Ignore images whose basename is "/${{ matrix.artifact }}" to avoid scanning the bazel built images (e.g. /vizier-, /cloud-)
-        cat ./bazel-bin/k8s/$${ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
+        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
     - run: |
         for f in "sarif/${{ matrix.artifact }}/"*; do

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/get_image.yaml
     with:
       image-base-name: "dev_image_with_extras"
-  generate-sarif:
+  image-scan:
     strategy:
       fail-fast: false
       matrix:
@@ -67,77 +67,11 @@ jobs:
     - run: |
         for f in "sarif/${{ matrix.artifact }}/"*; do
           jq '.runs[].tool.driver.name = "trivy-images"' < "$f" > tmp
-          mv tmp "$f"
+          # The runAutomationDetails's id field must contain a unique category as required by the CodeQL SARIF uploader
+          # This value will be interpreted like so: "${category}/${run_id}"
+          filename=$(basename "$f")/
+          jq --arg id "$filename" '.runAutomationDetails.id = $id/' < tmp > "$f"
         done
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: sarif-${{ matrix.artifact }}
-        path: sarif/
-        retention-days: 1
-
-  collect-sarifs:
-    # GitHub Actions matrix job outputs cannot be directly used as job outputs
-    # because matrix jobs create multiple output values (one per matrix combination).
-    # We need a separate job to collect all SARIF files from all artifacts
-    # and create a single unified matrix for the upload job.
-    needs: generate-sarif
-    runs-on: oracle-8cpu-32gb-x86-64
-    outputs:
-      matrix: ${{ steps.combine-sarifs.outputs.matrix }}
-      has-sarifs: ${{ steps.combine-sarifs.outputs.has-sarifs }}
-    steps:
-    - name: Download all artifacts
-      uses: actions/download-artifact@v4
-      with:
-        pattern: sarif-*
-        merge-multiple: true
-    - id: combine-sarifs
-      run: |
-        # With merge-multiple: true, all artifacts are in the same directory
-        # Find all SARIF files regardless of subdirectory structure
-        all_files=()
-        while IFS= read -r -d '' file; do
-          echo "Found file: $file"
-          all_files+=("$file")
-        done < <(find . -name "*.sarif" -type f -print0)
-
-        echo "Total files found: ${#all_files[@]}"
-
-        if [ ${#all_files[@]} -eq 0 ]; then
-          echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
-          echo "has-sarifs=false" >> $GITHUB_OUTPUT
-        else
-          matrix_json=$(printf '%s\n' "${all_files[@]}" | jq -R -s '
-            split("\n") | map(select(length > 0)) | {
-              include: map({
-                file: .,
-                category: ("trivy-images-" + (split("/")[1]) + "-" + (split("/")[-1] | split(".")[0])),
-                artifact: ("sarif-" + (split("/")[1]))
-              })
-            }' | jq -c '.')
-
-          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
-          echo "has-sarifs=true" >> $GITHUB_OUTPUT
-        fi
-
-  upload-sarif:
-    needs: collect-sarifs
-    if: needs.collect-sarifs.outputs.has-sarifs == 'true'
-    strategy:
-      matrix: ${{ fromJson(needs.collect-sarifs.outputs.matrix) }}
-    runs-on: oracle-8cpu-32gb-x86-64
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - name: Download artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ matrix.artifact }}
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
-        sarif_file: ${{ matrix.file }}
-        category: ${{ matrix.category }}
+        sarif_file: sarif/${{ matrix.artifact }}

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -94,14 +94,6 @@ jobs:
         merge-multiple: true
     - id: combine-sarifs
       run: |
-        # Debug: Show what was downloaded
-        echo "Current directory structure"
-        ls -la
-        echo "Looking for sarif directory"
-        ls -la sarif/ || echo "No sarif directory found"
-        echo "All .sarif files"
-        find . -name "*.sarif" -type f || echo "No SARIF files found anywhere"
-
         # With merge-multiple: true, all artifacts are in the same directory
         # Find all SARIF files regardless of subdirectory structure
         all_files=()

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -52,10 +52,8 @@ jobs:
 
         # TODO(ddelnano): Remove this check once the operator dependency images are supported. This requires rendering helm templates
         # and requires some additional work.
-        ./scripts/bazel_ignore_codes.sh query //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
-        query_exit_code=$?
-        if [ $query_exit_code -neq 0 ]; then
-          echo "Bazel built images comprise all images for ${{ matrix.artifact }}."
+        if [ "${{ matrix.artifact }}" = "operator" ]; then
+          echo "Skipping operator image scan for now."
           exit 0
         fi
 

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -67,10 +67,10 @@ jobs:
     - run: |
         for f in "sarif/${{ matrix.artifact }}/"*; do
           jq '.runs[].tool.driver.name = "trivy-images"' < "$f" > tmp
-          # The runAutomationDetails's id field must contain a unique category as required by the CodeQL SARIF uploader
-          # This value will be interpreted like so: "${category}/${run_id}"
+          # The runAutomationDetails's object must contain a unique category as required by the CodeQL SARIF uploader
+          # The id value will be interpreted like so: "${category}/${run_id}"
           filename=$(basename "$f")/
-          jq --arg id "$filename" '.runAutomationDetails.id = $id' < tmp > "$f"
+          jq --arg id "$filename" '.automationDetails.id = $id' < tmp > "$f"
         done
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -70,7 +70,7 @@ jobs:
           # The runAutomationDetails's object must contain a unique category as required by the CodeQL SARIF uploader
           # The id value will be interpreted like so: "${category}/${run_id}"
           filename=$(basename "$f")/
-          jq --arg id "$filename" '.automationDetails.id = $id' < tmp > "$f"
+          jq --arg id "$filename" '.runs[].automationDetails.id = $id' < tmp > "$f"
         done
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -48,7 +48,7 @@ jobs:
       # yamllint disable rule:line-length
       run: |
         mkdir -p sarif/${{ matrix.artifact }}
-        ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
+        ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image --scanners vuln {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
 
         # TODO(ddelnano): Remove this check once the operator dependency images are supported.
         # This requires rendering helm templates and requires some additional work.
@@ -65,7 +65,7 @@ jobs:
         # Ignore images whose basename is "/${{ matrix.artifact }}" to avoid scanning the bazel built images (e.g. /vizier-, /cloud-)
         # The deps images must have their file named processed differently to avoid conflicts with the image name. For example,
         # ory/hydra:v1.9.2-alpine and ory/hydra:v1.9.2-sqlite must not conflict.
-        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}_deps/$(basename {} | cut -d"@" -f1 | tr ":" "_").sarif'
+        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image --scanners vuln {} --format=sarif --output=sarif/${{ matrix.artifact }}_deps/$(basename {} | cut -d"@" -f1 | tr ":" "_").sarif'
       # yamllint enable rule:line-length
     - run: |
         # Loop through all ${artifact} and ${artifact}_deps sarif files

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - ddelnano/scan-pixie-deps-with-trivy
   schedule:
   - cron: "37 19 * * *"
 permissions:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -62,10 +62,12 @@ jobs:
           //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
 
         # Ignore images whose basename is "/${{ matrix.artifact }}" to avoid scanning the bazel built images (e.g. /vizier-, /cloud-)
-        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
+        deps_output_dir=sarif/${{ matrix.artifact }}_deps
+        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=${deps_output_dir}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
     - run: |
-        for f in "sarif/${{ matrix.artifact }}/"*; do
+        # Loop through all ${artifact} and ${artifact}_deps sarif files
+        for f in "sarif/${{ matrix.artifact }}"*/*; do
           jq '.runs[].tool.driver.name = "trivy-images"' < "$f" > tmp
           # The runAutomationDetails's object must contain a unique category as required by the CodeQL SARIF uploader
           # The id value will be interpreted like so: "${category}/${run_id}"
@@ -75,3 +77,9 @@ jobs:
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
         sarif_file: sarif/${{ matrix.artifact }}
+    # TODO(ddelnano): Remove this check once the operator dependency images are supported. This requires rendering helm templates
+    # and requires some additional work.
+    - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
+      if: ${{ matrix.artifact != 'operator' }}
+      with:
+        sarif_file: sarif/${{ matrix.artifact }}_deps

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -70,7 +70,7 @@ jobs:
           # The runAutomationDetails's id field must contain a unique category as required by the CodeQL SARIF uploader
           # This value will be interpreted like so: "${category}/${run_id}"
           filename=$(basename "$f")/
-          jq --arg id "$filename" '.runAutomationDetails.id = $id/' < tmp > "$f"
+          jq --arg id "$filename" '.runAutomationDetails.id = $id' < tmp > "$f"
         done
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -50,8 +50,8 @@ jobs:
         mkdir -p sarif/${{ matrix.artifact }}
         ./bazel-bin/k8s/${{ matrix.artifact }}/list_image_bundle | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}/$(basename {} | cut -d":" -f1).sarif'
 
-        # TODO(ddelnano): Remove this check once the operator dependency images are supported. This requires rendering helm templates
-        # and requires some additional work.
+        # TODO(ddelnano): Remove this check once the operator dependency images are supported.
+        # This requires rendering helm templates and requires some additional work.
         if [ "${{ matrix.artifact }}" = "operator" ]; then
           echo "Skipping operator image scan for now."
           exit 0
@@ -61,10 +61,11 @@ jobs:
         ./scripts/bazel_ignore_codes.sh build \
           //k8s/${{ matrix.artifact }}:${{ matrix.artifact }}_image_list
 
+        mkdir -p sarif/${{ matrix.artifact }}_deps
         # Ignore images whose basename is "/${{ matrix.artifact }}" to avoid scanning the bazel built images (e.g. /vizier-, /cloud-)
-        deps_output_dir=sarif/${{ matrix.artifact }}_deps
-        mkdir -p ${deps_output_dir}
-        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=${deps_output_dir}/$(basename {} | cut -d":" -f1).sarif'
+        # The deps images must have their file named processed differently to avoid conflicts with the image name. For example,
+        # ory/hydra:v1.9.2-alpine and ory/hydra:v1.9.2-sqlite must not conflict.
+        cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=sarif/${{ matrix.artifact }}_deps/$(basename {} | cut -d"@" -f1 | tr ":" "_").sarif'
       # yamllint enable rule:line-length
     - run: |
         # Loop through all ${artifact} and ${artifact}_deps sarif files
@@ -78,8 +79,8 @@ jobs:
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       with:
         sarif_file: sarif/${{ matrix.artifact }}
-    # TODO(ddelnano): Remove this check once the operator dependency images are supported. This requires rendering helm templates
-    # and requires some additional work.
+    # TODO(ddelnano): Remove this check once the operator dependency images are supported.
+    # This requires rendering helm templates and requires some additional work.
     - uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841  # v3.28.13
       if: ${{ matrix.artifact != 'operator' }}
       with:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - ddelnano/scan-pixie-deps-with-trivy
   schedule:
   - cron: "37 19 * * *"
 permissions:

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -94,17 +94,15 @@ jobs:
         merge-multiple: true
     - id: combine-sarifs
       run: |
-        # Combine all SARIF files from all artifacts into a single matrix
+        # With merge-multiple: true, all artifacts are in the same directory
+        # Find all SARIF files regardless of subdirectory structure
         all_files=()
-        for artifact in cloud operator vizier; do
-          if [ -d "sarif/$artifact" ]; then
-            for f in sarif/$artifact/*.sarif; do
-              if [ -f "$f" ]; then
-                all_files+=("$f")
-              fi
-            done
-          fi
-        done
+        while IFS= read -r -d '' file; do
+          echo "Found file: $file"
+          all_files+=("$file")
+        done < <(find . -name "*.sarif" -type f -print0)
+
+        echo "Total files found: ${#all_files[@]}"
 
         if [ ${#all_files[@]} -eq 0 ]; then
           echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/trivy_images.yaml
+++ b/.github/workflows/trivy_images.yaml
@@ -63,6 +63,7 @@ jobs:
 
         # Ignore images whose basename is "/${{ matrix.artifact }}" to avoid scanning the bazel built images (e.g. /vizier-, /cloud-)
         deps_output_dir=sarif/${{ matrix.artifact }}_deps
+        mkdir -p ${deps_output_dir}
         cat ./bazel-bin/k8s/${{ matrix.artifact }}/${{ matrix.artifact }}_image_list.txt | grep -v "\/${{ matrix.artifact }}" | xargs -I{} sh -c 'trivy image {} --format=sarif --output=${deps_output_dir}/$(basename {} | cut -d":" -f1).sarif'
       # yamllint enable rule:line-length
     - run: |

--- a/k8s/cloud/BUILD.bazel
+++ b/k8s/cloud/BUILD.bazel
@@ -79,6 +79,26 @@ kustomize_build(
     ],
 )
 
+kustomize_build(
+    name = "pixie_oss_cloud",
+    srcs = glob(
+        [
+            "base/**/*.yaml",
+            "overlays/**/*.yaml",
+            "public/**/*.yaml",
+        ],
+        exclude = ["public/kustomization.yaml"],
+    ),
+    kustomization = "public/kustomization.yaml",
+    replacements = image_replacements(
+        image_map = CLOUD_IMAGE_TO_LABEL,
+    ),
+    toolchains = [
+        "//k8s:image_prefix",
+        "//k8s:bundle_version",
+    ],
+)
+
 container_bundle(
     name = "image_bundle",
     images = CLOUD_IMAGE_TO_LABEL,
@@ -101,4 +121,17 @@ container_push(
     name = "cloud_images_push",
     bundle = ":image_bundle",
     format = "Docker",
+)
+
+genrule(
+    name = "cloud_image_list",
+    srcs = [
+        ":pixie_oss_cloud",
+        "//k8s/cloud_deps:public",
+    ],
+    outs = ["cloud_image_list.txt"],
+    cmd = """
+    $(location @com_github_mikefarah_yq_v4//:v4) '..|.image?|select(.|type == "!!str")' -o json $(SRCS) | sort | uniq > $@
+    """,
+    tools = ["@com_github_mikefarah_yq_v4//:v4"],
 )

--- a/k8s/cloud_deps/BUILD.bazel
+++ b/k8s/cloud_deps/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:kustomize.bzl", "kustomize_build")
+
+package(default_visibility = ["//visibility:public"])
+
+kustomize_build(
+    name = "public",
+    srcs = glob(
+    [
+        "base/**/*.yaml",
+        "dev/**/*.yaml",
+        "public/**/*.yaml",
+    ],
+        exclude = ["public/kustomization.yaml"],
+    ),
+    kustomization = "public/kustomization.yaml",
+)

--- a/k8s/cloud_deps/BUILD.bazel
+++ b/k8s/cloud_deps/BUILD.bazel
@@ -21,11 +21,11 @@ package(default_visibility = ["//visibility:public"])
 kustomize_build(
     name = "public",
     srcs = glob(
-    [
-        "base/**/*.yaml",
-        "dev/**/*.yaml",
-        "public/**/*.yaml",
-    ],
+        [
+            "base/**/*.yaml",
+            "dev/**/*.yaml",
+            "public/**/*.yaml",
+        ],
         exclude = ["public/kustomization.yaml"],
     ),
     kustomization = "public/kustomization.yaml",


### PR DESCRIPTION
Summary: [trivy] Include vizier and cloud dependency images in image scan

While are aware of CVEs and vulnerabilities with Pixie's code, our dependency images are a blind spot in our security scanning. This change updates the trivy-image GitHub action to include the cloud and vizier dependency images so we can address those vulnerabilities in a timely manner.

This change makes it possible to add the operator dependency images in the future, but for now I've omitted them (dealing with helm is a bit challenging without some additional work).

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Verified the following
- [x] Simulated test works
```
$ bazel build k8s/cloud:cloud_image_list
$ cat bazel-bin/k8s/cloud/cloud_image_list.txt | grep -v '\/cloud'  | xargs -I{} sh -c 'trivy image {}'

$ bazel build k8s/vizier:vizier_image_list
$ cat bazel-bin/k8s/vizier/vizier_image_list.txt | grep -v '\/vizier'  | xargs -I{} sh -c 'trivy image {}'
```
- [x] GitHub action completed successfully ([link](https://github.com/pixie-io/pixie/actions/runs/16327263639))

