### PR TITLE
Upgrade postgres to latest minor release to address vulnerabilities

### DIFF
--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -15,7 +15,10 @@ spec:
     spec:
       initContainers:
       - name: postgres-wait
-        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+        # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+        # to remediate a critical vulnerability. Switch back to upstream once fixed.
+        # yamllint disable-line rule:line-length
+        image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         command: ['sh', '-c',
                   'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do
                   echo "waiting for postgres";

--- a/k8s/cloud/public/base/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/base/plugin_db_updater_job.yaml
@@ -15,7 +15,10 @@ spec:
     spec:
       initContainers:
       - name: postgres-wait
-        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+        # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+        # to remediate a critical vulnerability. Switch back to upstream once fixed.
+        # yamllint disable-line rule:line-length
+        image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         command: ['sh', '-c',
                   'until pg_isready -h ${PL_POSTGRES_HOSTNAME} -p ${PL_POSTGRES_PORT}; do
                   echo "waiting for postgres";

--- a/k8s/cloud_deps/dev/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/dev/postgres/postgres_deployment.yaml
@@ -14,7 +14,10 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+        # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+        # to remediate a critical vulnerability. Switch back to upstream once fixed.
+        # yamllint disable-line rule:line-length
+        image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         ports:
         - containerPort: 5432
         env:

--- a/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
+++ b/k8s/cloud_deps/public/postgres/postgres_deployment.yaml
@@ -14,7 +14,10 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+        # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+        # to remediate a critical vulnerability. Switch back to upstream once fixed.
+        # yamllint disable-line rule:line-length
+        image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         ports:
         - containerPort: 5432
         env:

--- a/k8s/clusters/prod/db_reader.yaml
+++ b/k8s/clusters/prod/db_reader.yaml
@@ -14,7 +14,10 @@ spec:
         name: db-reader
     spec:
       containers:
-      - image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+      # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+      # to remediate a critical vulnerability. Switch back to upstream once fixed.
+      # yamllint disable-line rule:line-length
+      - image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         imagePullPolicy: IfNotPresent
         name: psql
         command: ["bash"]

--- a/k8s/clusters/staging/db_reader.yaml
+++ b/k8s/clusters/staging/db_reader.yaml
@@ -14,7 +14,10 @@ spec:
         name: db-reader
     spec:
       containers:
-      - image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+      # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+      # to remediate a critical vulnerability. Switch back to upstream once fixed.
+      # yamllint disable-line rule:line-length
+      - image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         imagePullPolicy: IfNotPresent
         name: psql
         command: ["bash"]

--- a/k8s/clusters/testing/db_reader.yaml
+++ b/k8s/clusters/testing/db_reader.yaml
@@ -14,7 +14,10 @@ spec:
         name: db-reader
     spec:
       containers:
-      - image: postgres:14-alpine@sha256:446abaf8831c54f57212c0ae52f5df84e69eeb2767e2376d07bed9c9742b1243
+      # TODO(ddelnano): This image was rebuilt from https://github.com/docker-library/postgres 14-alpine
+      # to remediate a critical vulnerability. Switch back to upstream once fixed.
+      # yamllint disable-line rule:line-length
+      - image: ghcr.io/pixie-io/postgres:14-alpine-pl1@sha256:237c5fcf79b230979e12fe02f46e0ad29565b4ecb7cb15047197cbb9a6549e8d
         imagePullPolicy: IfNotPresent
         name: psql
         command: ["bash"]


### PR DESCRIPTION
Summary: Upgrade postgres to latest minor release to address vulnerabilities

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Verified `trivy image` scan is clean for this rebuild unlike the latest `postgres:14-alpine` image