### PR TITLE
Upgrade curl to latest version

### DIFF
--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -28,7 +28,7 @@ spec:
 
       initContainers:
       - name: wait-sock-shop
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do
             echo "waiting for ${SOCK_SHOP_HEALTH_ADDR}";

--- a/demos/sock-shop/sock-shop-loadgen.yaml
+++ b/demos/sock-shop/sock-shop-loadgen.yaml
@@ -28,7 +28,7 @@ spec:
 
       initContainers:
       - name: wait-sock-shop
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           until timeout 2 curl -f "${SOCK_SHOP_HEALTH_ADDR}"; do
             echo "waiting for ${SOCK_SHOP_HEALTH_ADDR}";

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -157,7 +157,7 @@ spec:
       - name: admin-create-if-not-exists
         imagePullPolicy: IfNotPresent
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           URL="${ADMIN_URL}/admin/health/ready";
           until [ $(curl -k -m 0.5 -s -o /dev/null -w "%{http_code}" ${URL}) -eq 200 ]; do

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -157,7 +157,7 @@ spec:
       - name: admin-create-if-not-exists
         imagePullPolicy: IfNotPresent
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           URL="${ADMIN_URL}/admin/health/ready";
           until [ $(curl -k -m 0.5 -s -o /dev/null -w "%{http_code}" ${URL}) -eq 200 ]; do

--- a/k8s/devinfra/buildbuddy-executor/values.yaml
+++ b/k8s/devinfra/buildbuddy-executor/values.yaml
@@ -37,7 +37,7 @@ config:
 extraInitContainers:
 - name: download-executor
   # yamllint disable-line rule:line-length
-  image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+  image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
   # yamllint disable rule:line-length
   command: ['sh', '-c', 'set -e;
     curl -fsSL https://github.com/buildbuddy-io/buildbuddy/releases/download/v2.154.0/executor-enterprise-linux-amd64 > /bb-executor/executor;

--- a/k8s/devinfra/buildbuddy-executor/values.yaml
+++ b/k8s/devinfra/buildbuddy-executor/values.yaml
@@ -37,7 +37,7 @@ config:
 extraInitContainers:
 - name: download-executor
   # yamllint disable-line rule:line-length
-  image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+  image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
   # yamllint disable rule:line-length
   command: ['sh', '-c', 'set -e;
     curl -fsSL https://github.com/buildbuddy-io/buildbuddy/releases/download/v2.154.0/executor-enterprise-linux-amd64 > /bb-executor/executor;

--- a/k8s/operator/helm/templates/csv-deleter.yaml
+++ b/k8s/operator/helm/templates/csv-deleter.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: olm-operator-serviceaccount
       containers:
         - name: trigger-csv-finalizer
-          image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+          image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
           command:
             - /bin/sh
             - -c

--- a/k8s/operator/helm/templates/csv-deleter.yaml
+++ b/k8s/operator/helm/templates/csv-deleter.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: olm-operator-serviceaccount
       containers:
         - name: trigger-csv-finalizer
-          image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+          image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
           command:
             - /bin/sh
             - -c

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/kelvin_deployment.yaml
+++ b/k8s/vizier/base/kelvin_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/patch_sentry.yaml
+++ b/k8s/vizier/base/patch_sentry.yaml
@@ -9,7 +9,7 @@ spec:
       initContainers:
       - name: cc-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/readyz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/patch_sentry.yaml
+++ b/k8s/vizier/base/patch_sentry.yaml
@@ -9,7 +9,7 @@ spec:
       initContainers:
       - name: cc-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/readyz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
       - name: mds-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
       - name: mds-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
+++ b/k8s/vizier/bootstrap/cloud_connector_deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -57,7 +57,7 @@ spec:
           value: "http"
       - name: etcd-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           ETCD_PATH="${PL_MD_ETCD_SERVER}";

--- a/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
+++ b/k8s/vizier/etcd_metadata/base/metadata_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do
@@ -57,7 +57,7 @@ spec:
           value: "http"
       - name: etcd-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           ETCD_PATH="${PL_MD_ETCD_SERVER}";

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/pem/base/pem_daemonset.yaml
+++ b/k8s/vizier/pem/base/pem_daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
+++ b/k8s/vizier/persistent_metadata/base/metadata_statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       initContainers:
       - name: nats-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/k8s/vizier/sanitizer/kelvin_deployment.yaml
+++ b/k8s/vizier/sanitizer/kelvin_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       - name: qb-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         command: ['sh', '-c', 'set -x;
           URL="https://${SERVICE_NAME}:${SERVICE_PORT}/healthz";
           until [ $(curl -m 0.5 -s -o /dev/null -w "%{http_code}" -k ${URL}) -eq 200 ]; do

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       initContainers:
       - name: wait-for-publisher
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://jetstream-publisher.${NS}.svc.cluster.local:8080/metrics";

--- a/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
+++ b/src/e2e_test/jetstream_loadtest/k8s/subscriber_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       initContainers:
       - name: wait-for-publisher
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://jetstream-publisher.${NS}.svc.cluster.local:8080/metrics";

--- a/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
       - name: server-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/http/wrk/k8s/client_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
       - name: server-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="${PROTOCOL}://${SERVICE_NAME}:${SERVICE_PORT}${HEALTH_PATH}";

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: server-wait
         # yamllint disable-line rule:line-length
-        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
+        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://${SERVICE_NAME}:${SERVICE_PORT}/";

--- a/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
+++ b/src/e2e_test/protocol_loadtest/k8s/client/client_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: server-wait
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd
+        image: alpine/curl:8.14.1@sha256:fe395e422d73daaf0ea6cf39b1ea50c999255b38d719856322cd11806c6b7286
         # yamllint disable rule:line-length
         command: ['sh', '-c', 'set -xe;
           URL="http://${SERVICE_NAME}:${SERVICE_PORT}/";


### PR DESCRIPTION
Summary: Upgrade curl to latest version

This image was copied from the upstream `curlimages/curl` image:

```
$ crane copy curlimages/curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922 ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0
```

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Skaffold'ed a cloud and vizier with the new image
- [x] Verified this image has a clean trivy scan
- [x] Verified the image is multiarch
```
$ crane manifest ghcr.io/pixie-io/pixie-oss-pixie-dev-public-curl:8.15.0@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922 | jq '.manifests[].platform.architecture'
"386"
"arm"
"amd64"
"arm64"
"ppc64le"
```