### PR TITLE
Upgrade nats to 2.9.x version with new on-disk storage and patch security vulnerabilties

### DIFF
--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
       containers:
       - name: pl-nats
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:2.9.19-scratch@sha256:5de59286eb54ead4d4a9279846098d4097b9c17a3c0588182398a7250cde1af9
+        image: ghcr.io/pixie-io/nats:2.9.25-scratch@sha256:869605f46ad21b76be1998e89345640671dbe46714105cf67676ddb0b78d3b85
         ports:
         - containerPort: 4222
           name: client

--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -111,7 +111,7 @@ spec:
       containers:
       - name: pl-nats
         # yamllint disable-line rule:line-length
-        image: gcr.io/pixie-oss/pixie-prod/vizier-deps/nats:2.9.19-scratch@sha256:5de59286eb54ead4d4a9279846098d4097b9c17a3c0588182398a7250cde1af9
+        image: ghcr.io/pixie-io/nats:2.9.25-scratch@sha256:869605f46ad21b76be1998e89345640671dbe46714105cf67676ddb0b78d3b85
         ports:
         - containerPort: 4222
           name: client

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -116,7 +116,7 @@ LINUX_HEADERS_ARM64_MERGED_FILE := $(LINUX_HEADER_BUILD_DIR)/linux-headers-merge
 LINUX_HEADERS_GS_PATH := gs://pixie-dev-public/linux-headers/$(LINUX_HEADERS_REV)
 
 ## NATS image parameters.
-NATS_IMAGE_VERSION := 2.9.19
+NATS_IMAGE_VERSION := 2.9.25
 nats_image_tag := "ghcr.io/pixie-io/nats:$(NATS_IMAGE_VERSION)-scratch"
 
 ## Copybara image parameters.

--- a/tools/docker/nats_image/Dockerfile
+++ b/tools/docker/nats_image/Dockerfile
@@ -29,12 +29,16 @@ RUN apk add git
 
 RUN git clone --depth 1 https://github.com/nats-io/nats-server.git
 WORKDIR /src/nats-server
-RUN git checkout $NATS_VERSION
+RUN git fetch --tags && git checkout $NATS_VERSION
 
 ARG GO111MODULE=on
 ARG CGO_ENABLED=0
 
 RUN go mod download
+# TODO(ddelnano): Remove once NATS server is updated to have
+# vulnerability free upstream deps
+RUN go get golang.org/x/crypto@v0.35.0
+RUN go get github.com/nats-io/nkeys@v0.4.6
 RUN go build -trimpath -ldflags "-X github.com/nats-io/nats-server/v2/server.gitCommit=$(git rev-parse --short HEAD)" -o ./nats-server
 
 FROM scratch


### PR DESCRIPTION
Summary: Upgrade nats to 2.9.x version with new on-disk storage and patch security vulnerabilities.

This change aims to prepare for a seamless upgrade to a more recent NATS version while addressing some security vulnerabilities. As mentioned in the [NATS release notes](https://nats.io/blog/nats-server-2.9.22-release/), the v2.9.22+ release is aware of the on-disk storage changes introduced in v2.10.x. This makes it possible to downgrade from v2.10.x safely should the next, more ambitious upgrade result in issues.

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Skaffold'ed a cloud and vizier and acceptance tested common flows end to end
- [x] `trivy scan` for this image is clean
```
trivy image --scanners vuln ghcr.io/pixie-io/nats:2.9.25-scratch@sha256:869605f46ad21b76be1998e89345640671dbe46714105cf67676ddb0b78d3b85 -v
2025-07-23T05:25:23.173Z        INFO    Vulnerability scanning is enabled
2025-07-23T05:25:23.177Z        INFO    Number of language-specific files: 1
2025-07-23T05:25:23.177Z        INFO    Detecting gobinary vulnerabilities...
```

Changelog Message: Upgrade Cloud and Vizier NATS to v2.9.25. This upgrades NATS on-disk format to the one introduced in the v2.10.x series. Please see the [NATS release notes](https://nats.io/blog/nats-server-2.9.22-release/) for more details on this upgrade.