### PR TITLE
Fix Envoy CORS preflight responses and accidental config whitespace

### DIFF
--- a/k8s/cloud/base/proxy_envoy.yaml
+++ b/k8s/cloud/base/proxy_envoy.yaml
@@ -42,10 +42,7 @@ data:
                     allow_origin_string_match:
                     - prefix: "*"
                     allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                    allow_headers: >
-                      keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,
-                      x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,
-                      x-grpc-web,authorization,grpc-timeout,grpc-status,grpc-message
+                    allow_headers: "content-type,x-grpc-web,x-user-agent"
                     max_age: "1728000"
                     expose_headers: grpc-status,grpc-message,grpc-timeout
                     allow_credentials: true

--- a/k8s/cloud/dev/proxy_envoy.yaml
+++ b/k8s/cloud/dev/proxy_envoy.yaml
@@ -21,7 +21,7 @@ data:
         - filters:
           - name: envoy.http_connection_manager
             typed_config:
-              "@type": >
+              "@type": >-
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
               - name: envoy.file_access_log
@@ -49,10 +49,7 @@ data:
                     allow_origin_string_match:
                     - suffix: "dev.withpixie.dev"
                     allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                    allow_headers: >
-                      keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,
-                      x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,
-                      x-grpc-web,authorization,grpc-timeout,grpc-status,grpc-message
+                    allow_headers: "content-type,x-grpc-web,x-user-agent"
                     max_age: "1728000"
                     expose_headers: grpc-status,grpc-message,grpc-timeout
                     allow_credentials: true

--- a/k8s/cloud/prod/proxy_envoy.yaml
+++ b/k8s/cloud/prod/proxy_envoy.yaml
@@ -16,7 +16,7 @@ data:
         - filters:
           - name: envoy.http_connection_manager
             typed_config:
-              "@type": >
+              "@type": >-
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
               - name: envoy.file_access_log
@@ -44,10 +44,7 @@ data:
                     allow_origin_string_match:
                     - suffix: "withpixie.ai"
                     allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                    allow_headers: >
-                      keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,
-                      x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,
-                      x-grpc-web,authorization,grpc-timeout,grpc-status,grpc-message
+                    allow_headers: "content-type,x-grpc-web,x-user-agent"
                     max_age: "1728000"
                     expose_headers: grpc-status,grpc-message,grpc-timeout
                     allow_credentials: true

--- a/k8s/cloud/public/base/proxy_envoy.yaml
+++ b/k8s/cloud/public/base/proxy_envoy.yaml
@@ -21,7 +21,7 @@ data:
         - filters:
           - name: envoy.http_connection_manager
             typed_config:
-              "@type": >
+              "@type": >-
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
               - name: envoy.file_access_log
@@ -48,11 +48,9 @@ data:
                   cors:
                     allow_origin_string_match:
                     - suffix: "dev.withpixie.dev"
+                    # - suffix: "work.dev.withpixie.dev"
                     allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                    allow_headers: >
-                      keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,
-                      x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,
-                      x-grpc-web,authorization,grpc-timeout,grpc-status,grpc-message
+                    allow_headers: "content-type,x-grpc-web,x-user-agent"
                     max_age: "1728000"
                     expose_headers: grpc-status,grpc-message,grpc-timeout
                     allow_credentials: true

--- a/k8s/cloud/staging/proxy_envoy.yaml
+++ b/k8s/cloud/staging/proxy_envoy.yaml
@@ -16,7 +16,7 @@ data:
         - filters:
           - name: envoy.http_connection_manager
             typed_config:
-              "@type": >
+              "@type": >-
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
               - name: envoy.file_access_log
@@ -44,10 +44,7 @@ data:
                     allow_origin_string_match:
                     - suffix: "staging.withpixie.dev"
                     allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                    allow_headers: >
-                      keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,
-                      x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,
-                      x-grpc-web,authorization,grpc-timeout,grpc-status,grpc-message
+                    allow_headers: "content-type,x-grpc-web,x-user-agent"
                     max_age: "1728000"
                     expose_headers: grpc-status,grpc-message,grpc-timeout
                     allow_credentials: true

--- a/k8s/cloud/testing/proxy_envoy.yaml
+++ b/k8s/cloud/testing/proxy_envoy.yaml
@@ -16,7 +16,7 @@ data:
         - filters:
           - name: envoy.http_connection_manager
             typed_config:
-              "@type": >
+              "@type": >-
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
               - name: envoy.file_access_log
@@ -42,12 +42,9 @@ data:
                       cluster: api_service
                   cors:
                     allow_origin_string_match:
-                            - suffix: "testing.withpixie.dev"
+                    - suffix: "testing.withpixie.dev"
                     allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                    allow_headers: >
-                      keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,
-                      x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,
-                      x-grpc-web,authorization,grpc-timeout,grpc-status,grpc-message
+                    allow_headers: "content-type,x-grpc-web,x-user-agent"
                     max_age: "1728000"
                     expose_headers: grpc-status,grpc-message,grpc-timeout
                     allow_credentials: true


### PR DESCRIPTION
Summary: Fix Envoy CORS preflight responses and accidental config whitespace

A public (self hosted) cloud without an Ingress load balancer cannot successfully serve vizier api (web grpc) traffic. This is due to the fact that envoy's CORS pre-flight responses are malformed and cause CORS to fail.

<img width="1470" height="87" alt="Screenshot 2025-07-23 at 7 31 31 AM" src="https://github.com/user-attachments/assets/cc156d7d-7e48-4336-856d-e74fc9e1e6af" />
<img width="544" height="507" alt="Screenshot 2025-07-23 at 7 31 38 AM" src="https://github.com/user-attachments/assets/5e873688-ebaf-47d2-bbca-784a8e8aa2c6" />

This change fixes the header size and strips the value to the ones used in the CORS pre-flight request (seen above). In addition to the CORS fix, this PR removes the accidental whitespace added in #2230.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Verified that grpc web traffic is successful with a public cloud
<details><summary>CORS requests before and after</summary>

```
# CORS request before the fix shows a max header size error

$ curl -XOPTIONS -k https://work.dev.withpixie.dev:4444/px.api.vizierpb.VizierService/ExecuteScript -H 'Origin: https://work.dev.withpixie.dev' -H 'access-control-request-method: POST'  -H 'access-control-request-headers: content-type,x-grpc-web,x-user-agent' -v
[ ... ]
* HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
* Connection #0 to host work.dev.withpixie.dev left intact
curl: (92) Invalid HTTP header field was received: frame type: 1, stream: 1, name: [access-control-allow-headers], value: [keep-alive,user-agent,cache-control,content-type,content-transfer-encoding, x-accept-content-transfer-encoding,x-accept-response-streaming,x-us

# Verify CORS preflight request after the fix

$ curl -XOPTIONS -k https://work.dev.withpixie.dev:4444/px.api.vizierpb.VizierService/ExecuteScript -H 'Origin: https://work.dev.withpixie.dev' -H 'access-control-request-method: POST'  -H 'access-control-request-headers: content-type,x-grpc-web,x-user-agent' -v
* Host work.dev.withpixie.dev:4444 was resolved.
* IPv6: (none)
* IPv4: 10.98.69.218
*   Trying 10.98.69.218:4444...
* Connected to work.dev.withpixie.dev (10.98.69.218) port 4444
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: O=mkcert development certificate; OU=ddelnano@dev-vm.us-west1-a.c.endless-datum-422018.internal
*  start date: Jul 22 22:45:20 2025 GMT
*  expire date: Oct 22 22:45:20 2027 GMT
*  issuer: O=mkcert development CA; OU=ddelnano@dev-vm.us-west1-a.c.endless-datum-422018.internal; CN=mkcert ddelnano@dev-vm.us-west1-a.c.endless-datum-422018.internal
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://work.dev.withpixie.dev:4444/px.api.vizierpb.VizierService/ExecuteScript
* [HTTP/2] [1] [:method: OPTIONS]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: work.dev.withpixie.dev:4444]
* [HTTP/2] [1] [:path: /px.api.vizierpb.VizierService/ExecuteScript]
* [HTTP/2] [1] [user-agent: curl/8.5.0]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [origin: https://work.dev.withpixie.dev]
* [HTTP/2] [1] [access-control-request-method: POST]
* [HTTP/2] [1] [access-control-request-headers: content-type,x-grpc-web,x-user-agent]
> OPTIONS /px.api.vizierpb.VizierService/ExecuteScript HTTP/2
> Host: work.dev.withpixie.dev:4444
> User-Agent: curl/8.5.0
> Accept: */*
> Origin: https://work.dev.withpixie.dev
> access-control-request-method: POST
> access-control-request-headers: content-type,x-grpc-web,x-user-agent
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< HTTP/2 200
< access-control-allow-origin: https://work.dev.withpixie.dev
< access-control-allow-credentials: true
< access-control-allow-methods: GET, PUT, DELETE, POST, OPTIONS
< access-control-allow-headers: content-type,x-grpc-web,x-user-agent
< access-control-max-age: 1728000
< access-control-expose-headers: grpc-status,grpc-message,grpc-timeout
< date: Wed, 23 Jul 2025 14:14:34 GMT
< server: envoy
<
* Connection #0 to host work.dev.withpixie.dev left intact
```

</details>

- [x] Verified that envoy config no longer has whitespace
<details><summary>output</summary>

```
# Verify that main has an extra whitespace in its envoy config file

(main) $ yq '.data."envoy.yaml"' k8s/cloud/public/base/proxy_envoy.yaml  | yq '.static_resources.listeners[0].filter_chains[0].filters[0].typed_config.@type'  | hd00000000  74 79 70 65 2e 67 6f 6f  67 6c 65 61 70 69 73 2e  |type.googleapis.|
00000010  63 6f 6d 2f 65 6e 76 6f  79 2e 65 78 74 65 6e 73  |com/envoy.extens|
00000020  69 6f 6e 73 2e 66 69 6c  74 65 72 73 2e 6e 65 74  |ions.filters.net|
00000030  77 6f 72 6b 2e 68 74 74  70 5f 63 6f 6e 6e 65 63  |work.http_connec|
00000040  74 69 6f 6e 5f 6d 61 6e  61 67 65 72 2e 76 33 2e  |tion_manager.v3.|
00000050  48 74 74 70 43 6f 6e 6e  65 63 74 69 6f 6e 4d 61  |HttpConnectionMa|
00000060  6e 61 67 65 72 0a 0a                              |nager..|
00000067

# Verify the excess new line is fixed

(ddelnano/fix-envoy-cors-preflight-responses-and-whitespace) $ yq '.data."envoy.yaml"' k8s/cloud/public/base/proxy_envoy.yaml  | yq '.static_resources.listeners[0].filter_chains[0].filters[0].typed_config.@type'  | hd
00000000  74 79 70 65 2e 67 6f 6f  67 6c 65 61 70 69 73 2e  |type.googleapis.|
00000010  63 6f 6d 2f 65 6e 76 6f  79 2e 65 78 74 65 6e 73  |com/envoy.extens|
00000020  69 6f 6e 73 2e 66 69 6c  74 65 72 73 2e 6e 65 74  |ions.filters.net|
00000030  77 6f 72 6b 2e 68 74 74  70 5f 63 6f 6e 6e 65 63  |work.http_connec|
00000040  74 69 6f 6e 5f 6d 61 6e  61 67 65 72 2e 76 33 2e  |tion_manager.v3.|
00000050  48 74 74 70 43 6f 6e 6e  65 63 74 69 6f 6e 4d 61  |HttpConnectionMa|
00000060  6e 61 67 65 72 0a                                 |nager.|
00000066
```

</details>