### PR TITLE
Add Pixie hydra and kratos images to fix security vulns (upgrade Go and vuln deps)

### DIFF
--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -119,6 +119,12 @@ LINUX_HEADERS_GS_PATH := gs://pixie-dev-public/linux-headers/$(LINUX_HEADERS_REV
 NATS_IMAGE_VERSION := 2.9.25
 nats_image_tag := "ghcr.io/pixie-io/nats:$(NATS_IMAGE_VERSION)-scratch"
 
+## Ory image parameters.
+KRATOS_IMAGE_VERSION := 1.3.1
+kratos_image_tag := "ghcr.io/pixie-io/kratos:$(KRATOS_IMAGE_VERSION)-scratch"
+HYDRA_IMAGE_VERSION := 2.3.0
+hydra_image_tag := "ghcr.io/pixie-io/hydra:$(HYDRA_IMAGE_VERSION)-scratch"
+
 ## Copybara image parameters.
 COPYBARA_IMAGE_VERSION := 20210420
 copybara_image_tag := "gcr.io/pixie-oss/pixie-dev-public/copybara:$(COPYBARA_IMAGE_VERSION)"
@@ -274,6 +280,24 @@ build_and_upload_nats_image:
 		--platform linux/amd64,linux/arm64 \
 		--build-arg=NATS_VERSION="v$(NATS_IMAGE_VERSION)" \
 		-t $(nats_image_tag) \
+		--push
+
+.PHONY: build_and_upload_kratos_image
+build_and_upload_kratos_image:
+	$(DOCKER) buildx build kratos_image \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg=KRATOS_VERSION="v$(KRATOS_IMAGE_VERSION)" \
+		--build-arg=BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+		-t $(kratos_image_tag) \
+		--push
+
+.PHONY: build_and_upload_hydra_image
+build_and_upload_hydra_image:
+	$(DOCKER) buildx build hydra_image \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg=HYDRA_VERSION="v$(HYDRA_IMAGE_VERSION)" \
+		--build-arg=BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+		-t $(hydra_image_tag) \
 		--push
 
 .PHONY: build_and_upload_copybara_image

--- a/tools/docker/hydra_image/Dockerfile
+++ b/tools/docker/hydra_image/Dockerfile
@@ -1,0 +1,38 @@
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine@sha256:9fadeb603e14f1f3e08bdbec6681fa14446053c498a554f3e57260bf892c487e AS build
+
+ARG TARGETOS TARGETARCH
+ARG HYDRA_VERSION
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+RUN apk update
+RUN apk add git
+
+RUN git clone --depth 1 https://github.com/ory/hydra.git
+WORKDIR /src/hydra
+RUN git fetch --tags && git checkout $HYDRA_VERSION
+
+ENV GO111MODULE=on
+# kratos and hydra require CGO if sqlite is used, but we exclusively use postgres
+ENV CGO_ENABLED=0
+
+RUN go mod download
+
+# TODO(ddelnano): Remove once hydra upstream has updated dependencies
+RUN go get github.com/golang-jwt/jwt/v5@v5.2.2
+RUN go get golang.org/x/oauth2@v0.27.0
+RUN go get golang.org/x/crypto@v0.38.0
+
+RUN go build -ldflags="-extldflags=-static" -tags sqlite_omit_load_extension -o /usr/bin/hydra
+
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:627d6c5a23ad24e6bdff827f16c7b60e0289029b0c79e9f7ccd54ae3279fb45f
+
+COPY --from=build /usr/bin/hydra /usr/bin/hydra
+
+EXPOSE 4444 4445
+
+ENTRYPOINT ["hydra"]
+CMD ["serve", "all"]

--- a/tools/docker/hydra_image/Dockerfile
+++ b/tools/docker/hydra_image/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine@sha256:9fadeb603e14f1f3e08bdbec6681fa14446053c498a554f3e57260bf892c487e AS build
 
 ARG TARGETOS TARGETARCH

--- a/tools/docker/kratos_image/Dockerfile
+++ b/tools/docker/kratos_image/Dockerfile
@@ -1,0 +1,49 @@
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine@sha256:9fadeb603e14f1f3e08bdbec6681fa14446053c498a554f3e57260bf892c487e AS build
+
+ARG TARGETOS TARGETARCH
+ARG KRATOS_VERSION
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+RUN apk update
+RUN apk add git
+
+RUN git clone --depth 1 https://github.com/ory/kratos.git
+WORKDIR /src/kratos
+RUN git fetch --tags && git checkout $KRATOS_VERSION
+
+# The hydra and kratos migrations attempt to create the same table.
+# Kratos's migration only creates the table while hydra's migration creates the table
+# and inserts a row. Therefore, we replace kratos's problematic version with empty placeholders
+# to avoid a conflict. Removing the problematic migration file prior to module initialization and
+# compilation did not work.
+RUN for file in persistence/sql/migrations/sql/20150100000001000000_networks.*.sql; do echo "-- Migration disabled to avoid conflict with hydra" > "$file"; done
+
+ENV GO111MODULE=on
+# kratos and hydra require CGO if sqlite is used, but we exclusively use postgres
+ENV CGO_ENABLED=0
+
+RUN go mod download
+
+# TODO(ddelnano): Remove once kratos upstream has updated dependencies
+RUN go get github.com/golang-jwt/jwt/v4@v4.5.2
+RUN go get github.com/golang-jwt/jwt/v5@v5.2.2
+RUN go get golang.org/x/crypto@v0.35.0
+RUN go get golang.org/x/oauth2@v0.27.0
+
+ARG BUILD_DATE
+
+RUN go build \
+  -ldflags="-X 'github.com/ory/kratos/driver/config.Version=${KRATOS_VERSION}' -X 'github.com/ory/kratos/driver/config.Date=${BUILD_DATE}' -X 'github.com/ory/kratos/driver/config.Commit=$(git rev-parse HEAD)'" \
+  -o /usr/bin/kratos
+
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:627d6c5a23ad24e6bdff827f16c7b60e0289029b0c79e9f7ccd54ae3279fb45f
+
+COPY --from=build /usr/bin/kratos /usr/bin/kratos
+EXPOSE 4433 4434
+
+ENTRYPOINT ["kratos"]
+CMD ["serve"]

--- a/tools/docker/kratos_image/Dockerfile
+++ b/tools/docker/kratos_image/Dockerfile
@@ -31,13 +31,6 @@ RUN git clone --depth 1 https://github.com/ory/kratos.git
 WORKDIR /src/kratos
 RUN git fetch --tags && git checkout $KRATOS_VERSION
 
-# The hydra and kratos migrations attempt to create the same table.
-# Kratos's migration only creates the table while hydra's migration creates the table
-# and inserts a row. Therefore, we replace kratos's problematic version with empty placeholders
-# to avoid a conflict. Removing the problematic migration file prior to module initialization and
-# compilation did not work.
-RUN for file in persistence/sql/migrations/sql/20150100000001000000_networks.*.sql; do echo "-- Migration disabled to avoid conflict with hydra" > "$file"; done
-
 ENV GO111MODULE=on
 # kratos and hydra require CGO if sqlite is used, but we exclusively use postgres
 ENV CGO_ENABLED=0

--- a/tools/docker/kratos_image/Dockerfile
+++ b/tools/docker/kratos_image/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine@sha256:9fadeb603e14f1f3e08bdbec6681fa14446053c498a554f3e57260bf892c487e AS build
 
 ARG TARGETOS TARGETARCH


### PR DESCRIPTION
Summary: Add Pixie hydra and kratos images to fix security vulns (upgrade Go and vuln deps)

Ory's OSS projects are released every ~6 months. This means non Enterprise customers are stuck running images built with old go versions and out of date dependencies.

I've split out adding these images with the change to use them since the upgrade itself requires quite a few changes.

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Skaffold'ed a cloud running these versions and verified auth functionality works e2e
- [x] Verified images have the critical and high vulnerabilities addressed
<details><summary>trivy scan</summary>

```
$ trivy image --scanners vuln ghcr.io/pixie-io/hydra:2.3.0-scratch@sha256:cc4503bc8d0f97624e3d6fa004ebda13ef26407b5cc1284191f2958fa93d312c
2025-07-24T18:40:46.806Z        INFO    Vulnerability scanning is enabled
2025-07-24T18:40:48.552Z        INFO    Detected OS: debian
2025-07-24T18:40:48.552Z        INFO    Detecting Debian vulnerabilities...
2025-07-24T18:40:48.552Z        INFO    Number of language-specific files: 1
2025-07-24T18:40:48.552Z        INFO    Detecting gobinary vulnerabilities...

ghcr.io/pixie-io/hydra:2.3.0-scratch@sha256:cc4503bc8d0f97624e3d6fa004ebda13ef26407b5cc1284191f2958fa93d312c (debian 12.11)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/bin/hydra (gobinary)

Total: 4 (UNKNOWN: 0, LOW: 1, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌───────────────────────────────┬─────────────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│            Library            │    Vulnerability    │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────────┼─────────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/cloudflare/circl   │ GHSA-2x5j-vhc8-9cwm │ LOW      │ v1.3.7            │ 1.6.1         │ CIRCL-Fourq: Missing and wrong validation can lead to      │
│                               │                     │          │                   │               │ incorrect results                                          │
│                               │                     │          │                   │               │ https://github.com/advisories/GHSA-2x5j-vhc8-9cwm          │
├───────────────────────────────┼─────────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/go-jose/go-jose/v3 │ CVE-2025-27144      │ MEDIUM   │ v3.0.3            │ 3.0.4         │ go-jose: Go JOSE's Parsing Vulnerable to Denial of Service │
│                               │                     │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-27144                 │
├───────────────────────────────┼─────────────────────┤          ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/net              │ CVE-2025-22870      │          │ v0.33.0           │ 0.36.0        │ golang.org/x/net/proxy: golang.org/x/net/http/httpproxy:   │
│                               │                     │          │                   │               │ HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net  │
│                               │                     │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22870                 │
│                               ├─────────────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                               │ CVE-2025-22872      │          │                   │ 0.38.0        │ golang.org/x/net/html: Incorrect Neutralization of Input   │
│                               │                     │          │                   │               │ During Web Page Generation in x/net in...                  │
│                               │                     │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22872                 │
└───────────────────────────────┴─────────────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

$ trivy image --scanners vuln ghcr.io/pixie-io/kratos:1.3.1-scratch@sha256:af0776882c10c3e9137006511c3d4a7aaab2598e75bd86f5692a4a9759da5054
2025-07-24T18:38:18.138Z        INFO    Vulnerability scanning is enabled
2025-07-24T18:38:20.123Z        INFO    Detected OS: debian
2025-07-24T18:38:20.123Z        INFO    Detecting Debian vulnerabilities...
2025-07-24T18:38:20.123Z        INFO    Number of language-specific files: 1
2025-07-24T18:38:20.123Z        INFO    Detecting gobinary vulnerabilities...

ghcr.io/pixie-io/kratos:1.3.1-scratch@sha256:af0776882c10c3e9137006511c3d4a7aaab2598e75bd86f5692a4a9759da5054 (debian 12.11)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/bin/kratos (gobinary)

Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 0, CRITICAL: 0)

┌───────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│            Library            │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/go-jose/go-jose/v3 │ CVE-2025-27144 │ MEDIUM   │ v3.0.3            │ 3.0.4         │ go-jose: Go JOSE's Parsing Vulnerable to Denial of Service │
│                               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-27144                 │
├───────────────────────────────┤                │          ├───────────────────┼───────────────┤                                                            │
│ github.com/go-jose/go-jose/v4 │                │          │ v4.0.2            │ 4.0.5         │                                                            │
│                               │                │          │                   │               │                                                            │
├───────────────────────────────┼────────────────┤          ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/golang/glog        │ CVE-2024-45339 │          │ v1.2.1            │ 1.2.4         │ github.com/golang/glog: Vulnerability when creating log    │
│                               │                │          │                   │               │ files in github.com/golang/glog                            │
│                               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-45339                 │
├───────────────────────────────┼────────────────┤          ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/net              │ CVE-2025-22870 │          │ v0.27.0           │ 0.36.0        │ golang.org/x/net/proxy: golang.org/x/net/http/httpproxy:   │
│                               │                │          │                   │               │ HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net  │
│                               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22870                 │
│                               ├────────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                               │ CVE-2025-22872 │          │                   │ 0.38.0        │ golang.org/x/net/html: Incorrect Neutralization of Input   │
│                               │                │          │                   │               │ During Web Page Generation in x/net in...                  │
│                               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22872                 │
└───────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```

</details>