### PR TITLE
Fix script bundle creation and improve PEM/Kelvin heap dump collection for large clusters

### DIFF
--- a/src/pxl_scripts/px/collect_agent_heaps/collect_agent_heaps.pxl
+++ b/src/pxl_scripts/px/collect_agent_heaps/collect_agent_heaps.pxl
@@ -16,13 +16,15 @@
 
 import px
 
-df = px.GetAgentStatus()
-df.ip_address = px.pluck_array(px.split(df.ip_address, ":"), 0)
-df.hostname_by_ip = px.pod_id_to_node_name(px.ip_to_pod_id(df.ip_address))
-df.hostname = px.select(df.hostname_by_ip == "", df.hostname, df.hostname_by_ip)
-df = df[['asid', 'hostname']]
-heap_stats = px._HeapGrowthStacks()
-df = df.merge(heap_stats, how='inner', left_on='asid', right_on='asid')
-df.asid = df.asid_x
-df = df[['asid', 'hostname', 'heap']]
-px.display(df)
+
+# TODO(ddelnano): asid is unused until gh#2245 is addressed.
+def collect_pprofs(asid: int):
+    df = px.GetAgentStatus()
+    df.ip_address = px.pluck_array(px.split(df.ip_address, ":"), 0)
+    df.hostname_by_ip = px.pod_id_to_node_name(px.ip_to_pod_id(df.ip_address))
+    df.hostname = px.select(df.hostname_by_ip == "", df.hostname, df.hostname_by_ip)
+    df = df[['asid', 'hostname']]
+    heap_stats = px._HeapGrowthStacks()
+    df = df.merge(heap_stats, how='inner', left_on='asid', right_on='asid')
+    df.asid = df.asid_x
+    return df[['asid', 'hostname', 'heap']]

--- a/src/pxl_scripts/px/collect_agent_heaps/manifest.yaml
+++ b/src/pxl_scripts/px/collect_agent_heaps/manifest.yaml
@@ -1,0 +1,3 @@
+---
+short: Collect Agent Heap Dumps
+long: Script useful for debugging kelvin and PEM memory footprint.

--- a/src/pxl_scripts/px/collect_agent_heaps/vis.json
+++ b/src/pxl_scripts/px/collect_agent_heaps/vis.json
@@ -1,0 +1,39 @@
+{
+    "variables": [
+        {
+            "name": "asid",
+            "type": "PX_INT64",
+            "description": "Whether to filter the results to a particular ASID",
+            "defaultValue": "-1"
+        }
+    ],
+    "globalFuncs": [
+        {
+            "outputName": "collect_pprofs",
+            "func": {
+                "name": "collect_pprofs",
+                "args": [
+                    {
+                        "name": "asid",
+                        "variable": "asid"
+                    }
+                ]
+            }
+        }
+    ],
+    "widgets": [
+        {
+            "name": "Table",
+            "position": {
+                "x": 0,
+                "y": 0,
+                "w": 12,
+                "h": 4
+            },
+            "globalFuncOutputName": "collect_pprofs",
+            "displaySpec": {
+                "@type": "types.px.dev/px.vispb.Table"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Summary: Fix script bundle creation and improve PEM/Kelvin heap dump collection for large clusters

The `src/pxl_scripts/px/collect_heap_dumps.pxl` was added at the root of a top level script directory. Since this script is largely used adhoc, this went unnoticed until I worked on #2245 and #2246. This moves the script into a proper directory structure and updates it to accommodate very large clusters (see relevant issue for more details).

Relevant Issues: https://github.com/pixie-io/pixie/issues/2245

Type of change: /kind bug

Test Plan: Verified pxl script runs in the UI and that bundle creation works again
```
# Fails on main

(main) $ make bundle-oss.json
px create-bundle --search_path /home/ddelnano/code/pixie-extra/src/pxl_scripts --base bpftrace --base px --base pxbeta --base sotw -o /home/ddelnano/code/pixie-extra/src/pxl_scripts/bundle-oss.json
Pixie CLI
FATA[0000] Failed to create bundle                       error="open /home/ddelnano/code/pixie-extra/src/pxl_scripts/px/manifest.yaml: no such file or directory"
make: *** [Makefile:28: bundle-oss.json] Error 1

# Succeeds with this change

(ddelnano/fix-script-bundle-improve-heap-dump-scripts) $ make bundle-oss.json
px create-bundle --search_path /home/ddelnano/code/pixie-extra/src/pxl_scripts --base bpftrace --base px --base pxbeta --base sotw -o /home/ddelnano/code/pixie-extra/src/pxl_scripts/bundle-oss.json
Pixie CLI
```