### PR TITLE
Update handling of missing kernel headers to better reflect warning status

### DIFF
--- a/src/pixie_cli/pkg/components/spinner.go
+++ b/src/pixie_cli/pkg/components/spinner.go
@@ -108,6 +108,9 @@ func (d *statusDecorator) Decor(stat *decor.Statistics) string {
 		return ""
 	}
 	if d.err != nil {
+		if _, ok := d.err.(*UIWarning); ok {
+			return StatusWarn(d.width)
+		}
 		return StatusErr(d.width)
 	}
 	return StatusOK(d.width)
@@ -135,6 +138,9 @@ func (d *errorViewDecorator) Decor(stat *decor.Statistics) string {
 	}
 	if d.err == nil {
 		return ""
+	}
+	if _, ok := d.err.(*UIWarning); ok {
+		return color.YellowString(fmt.Sprintf(" WARN: %s", d.err.Error()))
 	}
 	return color.RedString(fmt.Sprintf(" ERR: %s", d.err.Error()))
 }

--- a/src/pixie_cli/pkg/components/status.go
+++ b/src/pixie_cli/pkg/components/status.go
@@ -25,9 +25,25 @@ import (
 )
 
 var (
-	statusOK  = "\u2714"
-	statusErr = "\u2715"
+	statusOK   = "\u2714"
+	statusErr  = "\u2715"
+	statusWarn = "\u26a0"
 )
+
+// UIWarning is a wrapper type that marks errors as warnings for UI display.
+// Errors wrapped in UIWarning will be displayed with yellow warning colors
+// instead of red error colors in the spinner table.
+type UIWarning struct {
+	Err error
+}
+
+func (w UIWarning) Error() string {
+	return w.Err.Error()
+}
+
+func (w UIWarning) Unwrap() error {
+	return w.Err
+}
 
 func computePadding(s string, pad int) (int, int) {
 	var padS, padE int
@@ -54,4 +70,10 @@ func StatusOK(pad int) string {
 func StatusErr(pad int) string {
 	padS, padE := computePadding(statusErr, pad)
 	return strings.Repeat(" ", padS) + color.RedString(statusErr) + strings.Repeat(" ", padE)
+}
+
+// StatusWarn prints out the default Warn symbol, center padded to the size specified.
+func StatusWarn(pad int) string {
+	padS, padE := computePadding(statusWarn, pad)
+	return strings.Repeat(" ", padS) + color.YellowString(statusWarn) + strings.Repeat(" ", padE)
 }

--- a/src/pixie_cli/pkg/vizier/logs.go
+++ b/src/pixie_cli/pkg/vizier/logs.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"px.dev/pixie/src/pixie_cli/pkg/components"
 	"px.dev/pixie/src/utils/script"
 	"px.dev/pixie/src/utils/shared/k8s"
 )
@@ -132,7 +133,7 @@ func (c *LogCollector) CollectPixieLogs(fName string) error {
 	outputCh, err := RunSimpleHealthCheckScript(c.br, c.cloudAddr, clusterID)
 	if err != nil {
 		entry := log.WithError(err)
-		if _, ok := err.(*HealthCheckWarning); ok {
+		if _, ok := err.(*components.UIWarning); ok {
 			entry.Warn("healthcheck script detected the following warnings:")
 		} else {
 			entry.Warn("failed to run healthcheck script")

--- a/src/pixie_cli/pkg/vizier/script.go
+++ b/src/pixie_cli/pkg/vizier/script.go
@@ -44,8 +44,10 @@ import (
 )
 
 const (
-	equalityThreshold          = 0.01
-	headersInstalledPercColumn = "headers_installed_percent" // must match the column in px/agent_status_diagnostics
+	equalityThreshold                = 0.01
+	headersInstalledPercColumn       = "headers_installed_percent" // must match the column in px/agent_status_diagnostics
+	missingKernelHeadersMsg          = "Detected missing kernel headers on your cluster's nodes. This may cause issues with the Pixie agent. Please see https://px.dev/kernel-headers for more details."
+	missingKernelHeadersSuspectedMsg = "Detected missing kernel headers on your cluster's nodes. This may cause issues with the Pixie agent. Please see https://px.dev/kernel-headers for more details. If you are using a distro kernel, this is expected and can be ignored."
 )
 
 type taskWrapper struct {
@@ -266,16 +268,8 @@ func RunScript(ctx context.Context, conns []*Connector, execScript *script.Execu
 	return mergedResponses, nil
 }
 
-type HealthCheckWarning struct {
-	message string
-}
-
-func (h *HealthCheckWarning) Error() string {
-	return h.message
-}
-
 func newHealthCheckWarning(message string) error {
-	return &HealthCheckWarning{message}
+	return &components.UIWarning{Err: fmt.Errorf("%s", message)}
 }
 
 func evaluateHealthCheckResult(output string) error {
@@ -289,12 +283,11 @@ func evaluateHealthCheckResult(output string) error {
 		switch t := v.(type) {
 		case float64:
 			if math.Abs(1.0-t) > equalityThreshold {
-				msg := "Detected missing kernel headers on your cluster's nodes. This may cause issues with the Pixie agent. Please install kernel headers on all nodes."
-				return newHealthCheckWarning(msg)
+				return &components.UIWarning{Err: fmt.Errorf("%s", missingKernelHeadersMsg)}
 			}
 		}
 	} else {
-		return newHealthCheckWarning("Unable to detect if the cluster's nodes have the distro kernel headers installed (vizier too old to perform this check). Please ensure that the kernel headers are installed on all nodes.")
+		return &components.UIWarning{Err: fmt.Errorf("%s", missingKernelHeadersSuspectedMsg)}
 	}
 	return nil
 }


### PR DESCRIPTION
Summary: Update handling of missing kernel headers to better reflect warning status

The `px` cli was updated to include a warning when it detected that a cluster didn't have kernel headers installed. The initial implementation reused the same UI elements that the cli included and therefore the "warning" was printed with red text prefixed with `ERR:` (as seen below).

<img width="1579" height="49" alt="error" src="https://github.com/user-attachments/assets/6b198524-9e90-432f-8692-a2e723372c4b" />

This was harsher than intended and could cause confusion for users that otherwise have a working cluster. This PR updates the warning with yellow text and a more appropriate prefix (`WARN: `) and links to documentation (added in XXX) that provides more detail.

Relevant Issues: #2051

Type of change: /kind bugfix

Test Plan: Deployed a new vizier that failed the check and verified the text is no longer red and links to documentation

<img width="1512" height="436" alt="Screenshot 2025-07-28 at 8 42 33 AM" src="https://github.com/user-attachments/assets/6b374ac9-198e-4140-87f7-824f39958adc" />