### PR TITLE
Upgrade Elasticsearch to latest LTS version (9.x)

### DIFF
--- a/k8s/cloud_deps/base/elastic/cluster/elastic_cluster.yaml
+++ b/k8s/cloud_deps/base/elastic/cluster/elastic_cluster.yaml
@@ -1,56 +1,66 @@
 ---
+# Note: The elastic-internal-suspend container is automatically injected by ECK.
+# To control its resources, you may need to use ECK-specific configuration or
+# modify the ECK operator deployment settings.
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: pl-elastic
 spec:
-  # yamllint disable-line rule:line-length
-  image: gcr.io/pixie-oss/pixie-dev-public/elasticsearch:7.6.0-patched1@sha256:f734909115be9dba66736c4b7356fd52da58b1ffdb895ba74cb5c2fca2b133dd
-  version: 7.6.0
+  version: 9.0.4
   nodeSets:
   - name: master
     count: 3
     config:
-      node.master: true
-      node.data: false
-      node.ingest: false
+      node.roles: ["master"]
       node.store.allow_mmap: true
     podTemplate:
+      metadata:
+        annotations:
+          co.elastic.logs/module: elasticsearch
       spec:
         containers:
         - name: elasticsearch
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
-              add:
-              - SYS_CHROOT
-              - SETUID
               drop:
               - ALL
-            runAsUser: 0
+            runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
         initContainers:
-        - name: install-plugins
-          command:
-          - sh
-          - -c
-          - |
-              bin/elasticsearch-plugin install --batch repository-gcs
         - name: sysctl
           securityContext:
             allowPrivilegeEscalation: true
             privileged: true
-            seccompProfile:
-              type: RuntimeDefault
-          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
-        - name: elastic-internal-init-filesystem
-          securityContext:
-            allowPrivilegeEscalation: false
             runAsUser: 0
             seccompProfile:
               type: RuntimeDefault
+          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
+          resources:
+            limits:
+              memory: 128Mi
+              cpu: 100m
+            requests:
+              memory: 64Mi
+              cpu: 50m
+        - name: elastic-internal-init-filesystem
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 200m
+            requests:
+              memory: 128Mi
+              cpu: 100m
         securityContext:
+          fsGroup: 1000
+          runAsUser: 1000
           seccompProfile:
             type: RuntimeDefault
     volumeClaimTemplates:
@@ -67,25 +77,23 @@ spec:
     # pods can be disrupted for nodepool upgrades.
     count: 5
     config:
-      node.master: false
-      node.data: true
-      node.ingest: true
+      node.roles: ["data", "ingest"]
       node.store.allow_mmap: true
       node.attr.data: hot
     podTemplate:
+      metadata:
+        annotations:
+          co.elastic.logs/module: elasticsearch
       spec:
         containers:
-        - env:
-          - name: ES_JAVA_OPTS
-            value: -Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=True
-          name: elasticsearch
+        - name: elasticsearch
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 2Gi
             requests:
               cpu: 0.5
-              memory: 4Gi
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -94,30 +102,41 @@ spec:
               - SETUID
               drop:
               - ALL
-            runAsUser: 0
+            runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
         initContainers:
-        - name: install-plugins
-          command:
-          - sh
-          - -c
-          - |
-              bin/elasticsearch-plugin install --batch repository-gcs
         - name: sysctl
           securityContext:
             allowPrivilegeEscalation: true
             privileged: true
-            seccompProfile:
-              type: RuntimeDefault
-          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
-        - name: elastic-internal-init-filesystem
-          securityContext:
-            allowPrivilegeEscalation: false
             runAsUser: 0
             seccompProfile:
               type: RuntimeDefault
+          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
+          resources:
+            limits:
+              memory: 128Mi
+              cpu: 100m
+            requests:
+              memory: 64Mi
+              cpu: 50m
+        - name: elastic-internal-init-filesystem
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 200m
+            requests:
+              memory: 128Mi
+              cpu: 100m
         securityContext:
+          fsGroup: 1000
+          runAsUser: 1000
           seccompProfile:
             type: RuntimeDefault
     volumeClaimTemplates:

--- a/k8s/cloud_deps/base/elastic/operator/just_crds.yaml
+++ b/k8s/cloud_deps/base/elastic/operator/just_crds.yaml
@@ -1,16 +1,8 @@
-# yamllint disable-file
----
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -70,7 +62,8 @@ spec:
             description: AgentSpec defines the desired state of the Agent
             properties:
               config:
-                description: Config holds the Agent configuration. At most one of [`Config`, `ConfigRef`] can be specified.
+                description: Config holds the Agent configuration. At most one of
+                  [`Config`, `ConfigRef`] can be specified.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               configRef:
@@ -89,14 +82,17 @@ spec:
                   Cannot be used along with `deployment` or `statefulSet`.
                 properties:
                   podTemplate:
-                    description: PodTemplateSpec describes the data a pod should have when created from a template
+                    description: PodTemplateSpec describes the data a pod should have
+                      when created from a template
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   updateStrategy:
-                    description: DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+                    description: DaemonSetUpdateStrategy is a struct used to control
+                      the update strategy for a DaemonSet.
                     properties:
                       rollingUpdate:
-                        description: Rolling update config params. Present only if type = "RollingUpdate".
+                        description: Rolling update config params. Present only if
+                          type = "RollingUpdate".
                         properties:
                           maxSurge:
                             anyOf:
@@ -144,7 +140,8 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+                        description: Type of daemon set update. Can be "RollingUpdate"
+                          or "OnDelete". Default is RollingUpdate.
                         type: string
                     type: object
                 type: object
@@ -154,14 +151,16 @@ spec:
                   Cannot be used along with `daemonSet` or `statefulSet`.
                 properties:
                   podTemplate:
-                    description: PodTemplateSpec describes the data a pod should have when created from a template
+                    description: PodTemplateSpec describes the data a pod should have
+                      when created from a template
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   replicas:
                     format: int32
                     type: integer
                   strategy:
-                    description: DeploymentStrategy describes how to replace existing pods with new ones.
+                    description: DeploymentStrategy describes how to replace existing
+                      pods with new ones.
                     properties:
                       rollingUpdate:
                         description: |-
@@ -203,7 +202,8 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
                         type: string
                     type: object
                 type: object
@@ -214,10 +214,12 @@ spec:
                 items:
                   properties:
                     name:
-                      description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                      description: Name of an existing Kubernetes object corresponding
+                        to an Elastic resource managed by ECK.
                       type: string
                     namespace:
-                      description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                      description: Namespace of the Kubernetes object. If empty, defaults
+                        to the current namespace.
                       type: string
                     outputName:
                       type: string
@@ -241,7 +243,8 @@ spec:
                   type: object
                 type: array
               fleetServerEnabled:
-                description: FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`.
+                description: FleetServerEnabled determines whether this Agent will
+                  launch Fleet Server. Don't set unless `mode` is set to `fleet`.
                 type: boolean
               fleetServerRef:
                 description: |-
@@ -249,10 +252,12 @@ spec:
                   Don't set unless `mode` is set to `fleet`.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -273,10 +278,12 @@ spec:
                     type: string
                 type: object
               http:
-                description: HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled.
+                description: HTTP holds the HTTP layer configuration for the Agent
+                  in Fleet mode with Fleet Server enabled.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -491,7 +498,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -533,7 +541,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -596,10 +605,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -612,13 +623,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -658,15 +668,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -680,7 +694,8 @@ spec:
                     type: object
                 type: object
               image:
-                description: Image is the Agent Docker image to deploy. Version has to match the Agent in the image.
+                description: Image is the Agent Docker image to deploy. Version has
+                  to match the Agent in the image.
                 type: string
               kibanaRef:
                 description: |-
@@ -688,10 +703,12 @@ spec:
                   unless `mode` is set to `fleet`.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -713,8 +730,10 @@ spec:
                 type: object
               mode:
                 description: |-
-                  Mode specifies the source of configuration for the Agent. The configuration can be specified locally through
-                  `config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode).
+                  Mode specifies the runtime mode for the Agent. The configuration can be specified locally through
+                  `config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with
+                  version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.
+                  See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet
                   Defaults to `standalone` mode.
                 enum:
                 - standalone
@@ -726,7 +745,8 @@ spec:
                   This field will become mandatory in a future release, default policies are deprecated since 8.1.0.
                 type: string
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying DaemonSet or Deployment or StatefulSet.
                 format: int32
                 type: integer
               secureSettings:
@@ -735,7 +755,8 @@ spec:
                   Secrets data can be then referenced in the Agent config using the Secret's keys or as specified in `Entries` field of
                   each SecureSetting.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -743,7 +764,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -790,7 +812,8 @@ spec:
                     - Parallel
                     type: string
                   podTemplate:
-                    description: PodTemplateSpec describes the data a pod should have when created from a template
+                    description: PodTemplateSpec describes the data a pod should have
+                      when created from a template
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   replicas:
@@ -804,7 +827,8 @@ spec:
                       Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
                       Items defined here take precedence over any default claims added by the operator with the same name.
                     items:
-                      description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                      description: PersistentVolumeClaim is a user's request for and
+                        claim to a persistent volume
                       properties:
                         apiVersion:
                           description: |-
@@ -874,10 +898,12 @@ spec:
                                     For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
+                                  description: Kind is the type of resource being
+                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
+                                  description: Name is the name of resource being
+                                    referenced
                                   type: string
                               required:
                               - kind
@@ -917,10 +943,12 @@ spec:
                                     For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
+                                  description: Kind is the type of resource being
+                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
+                                  description: Name is the name of resource being
+                                    referenced
                                   type: string
                                 namespace:
                                   description: |-
@@ -966,17 +994,20 @@ spec:
                                   type: object
                               type: object
                             selector:
-                              description: selector is a label query over volumes to consider for binding.
+                              description: selector is a label query over volumes
+                                to consider for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -1035,7 +1066,8 @@ spec:
                                 Value of Filesystem is implied when not included in claim spec.
                               type: string
                             volumeName:
-                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
                               type: string
                           type: object
                       type: object
@@ -1092,17 +1124,11 @@ spec:
     subresources:
       status: {}
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -1166,13 +1192,16 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to the output Elasticsearch
+                  cluster running in the same Kubernetes cluster.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -1193,10 +1222,12 @@ spec:
                     type: string
                 type: object
               http:
-                description: HTTP holds the HTTP layer configuration for the APM Server resource.
+                description: HTTP holds the HTTP layer configuration for the APM Server
+                  resource.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -1411,7 +1442,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -1453,7 +1485,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -1516,10 +1549,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -1532,13 +1567,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -1578,15 +1612,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -1608,10 +1646,12 @@ spec:
                   It allows APM agent central configuration management in Kibana.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -1632,17 +1672,22 @@ spec:
                     type: string
                 type: object
               podTemplate:
-                description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
+                description: PodTemplate provides customisation options (labels, annotations,
+                  affinity rules, resource requests, and so on) for the APM Server
+                  pods.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying Deployment.
                 format: int32
                 type: integer
               secureSettings:
-                description: SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for APM Server.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -1650,7 +1695,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -1686,21 +1732,25 @@ spec:
             description: ApmServerStatus defines the observed state of ApmServer
             properties:
               availableNodes:
-                description: AvailableNodes is the number of available replicas in the deployment.
+                description: AvailableNodes is the number of available replicas in
+                  the deployment.
                 format: int32
                 type: integer
               count:
-                description: Count corresponds to Scale.Status.Replicas, which is the actual number of observed instances of the scaled object.
+                description: Count corresponds to Scale.Status.Replicas, which is
+                  the actual number of observed instances of the scaled object.
                 format: int32
                 type: integer
               elasticsearchAssociationStatus:
-                description: ElasticsearchAssociationStatus is the status of any auto-linking to Elasticsearch clusters.
+                description: ElasticsearchAssociationStatus is the status of any auto-linking
+                  to Elasticsearch clusters.
                 type: string
               health:
                 description: Health of the deployment.
                 type: string
               kibanaAssociationStatus:
-                description: KibanaAssociationStatus is the status of any auto-linking to Kibana.
+                description: KibanaAssociationStatus is the status of any auto-linking
+                  to Kibana.
                 type: string
               observedGeneration:
                 description: |-
@@ -1711,13 +1761,15 @@ spec:
                 format: int64
                 type: integer
               secretTokenSecret:
-                description: SecretTokenSecretName is the name of the Secret that contains the secret token
+                description: SecretTokenSecretName is the name of the Secret that
+                  contains the secret token
                 type: string
               selector:
                 description: Selector is the label selector used to find all pods.
                 type: string
               service:
-                description: ExternalService is the name of the service the agents should connect to.
+                description: ExternalService is the name of the service the agents
+                  should connect to.
                 type: string
               version:
                 description: |-
@@ -1783,22 +1835,26 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to the output Elasticsearch
+                  cluster running in the same Kubernetes cluster.
                 properties:
                   name:
                     description: Name of the Kubernetes object.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                 required:
                 - name
                 type: object
               http:
-                description: HTTP holds the HTTP layer configuration for the APM Server resource.
+                description: HTTP holds the HTTP layer configuration for the APM Server
+                  resource.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -2013,7 +2069,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -2055,7 +2112,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -2118,10 +2176,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -2134,13 +2194,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -2180,15 +2239,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -2205,13 +2268,17 @@ spec:
                 description: Image is the APM Server Docker image to deploy.
                 type: string
               podTemplate:
-                description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
+                description: PodTemplate provides customisation options (labels, annotations,
+                  affinity rules, resource requests, and so on) for the APM Server
+                  pods.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               secureSettings:
-                description: SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for APM Server.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -2219,7 +2286,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -2248,19 +2316,23 @@ spec:
             description: ApmServerStatus defines the observed state of ApmServer
             properties:
               associationStatus:
-                description: Association is the status of any auto-linking to Elasticsearch clusters.
+                description: Association is the status of any auto-linking to Elasticsearch
+                  clusters.
                 type: string
               availableNodes:
                 format: int32
                 type: integer
               health:
-                description: ApmServerHealth expresses the status of the Apm Server instances.
+                description: ApmServerHealth expresses the status of the Apm Server
+                  instances.
                 type: string
               secretTokenSecret:
-                description: SecretTokenSecretName is the name of the Secret that contains the secret token
+                description: SecretTokenSecretName is the name of the Secret that
+                  contains the secret token
                 type: string
               service:
-                description: ExternalService is the name of the service the agents should connect to.
+                description: ExternalService is the name of the service the agents
+                  should connect to.
                 type: string
             type: object
         type: object
@@ -2271,22 +2343,17 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: to not break compatibility when upgrading from previous versions of the CRD
+        description: to not break compatibility when upgrading from previous versions
+          of the CRD
         type: object
     served: false
     storage: false
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -2350,7 +2417,8 @@ spec:
             description: BeatSpec defines the desired state of a Beat.
             properties:
               config:
-                description: Config holds the Beat configuration. At most one of [`Config`, `ConfigRef`] can be specified.
+                description: Config holds the Beat configuration. At most one of [`Config`,
+                  `ConfigRef`] can be specified.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               configRef:
@@ -2369,14 +2437,17 @@ spec:
                   Cannot be used along with `deployment`. If both are absent a default for the Type is used.
                 properties:
                   podTemplate:
-                    description: PodTemplateSpec describes the data a pod should have when created from a template
+                    description: PodTemplateSpec describes the data a pod should have
+                      when created from a template
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   updateStrategy:
-                    description: DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+                    description: DaemonSetUpdateStrategy is a struct used to control
+                      the update strategy for a DaemonSet.
                     properties:
                       rollingUpdate:
-                        description: Rolling update config params. Present only if type = "RollingUpdate".
+                        description: Rolling update config params. Present only if
+                          type = "RollingUpdate".
                         properties:
                           maxSurge:
                             anyOf:
@@ -2424,7 +2495,8 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+                        description: Type of daemon set update. Can be "RollingUpdate"
+                          or "OnDelete". Default is RollingUpdate.
                         type: string
                     type: object
                 type: object
@@ -2434,14 +2506,16 @@ spec:
                   Cannot be used along with `daemonSet`. If both are absent a default for the Type is used.
                 properties:
                   podTemplate:
-                    description: PodTemplateSpec describes the data a pod should have when created from a template
+                    description: PodTemplateSpec describes the data a pod should have
+                      when created from a template
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   replicas:
                     format: int32
                     type: integer
                   strategy:
-                    description: DeploymentStrategy describes how to replace existing pods with new ones.
+                    description: DeploymentStrategy describes how to replace existing
+                      pods with new ones.
                     properties:
                       rollingUpdate:
                         description: |-
@@ -2483,18 +2557,22 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
                         type: string
                     type: object
                 type: object
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                  running in the same Kubernetes cluster.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -2515,7 +2593,8 @@ spec:
                     type: string
                 type: object
               image:
-                description: Image is the Beat Docker image to deploy. Version and Type have to match the Beat in the image.
+                description: Image is the Beat Docker image to deploy. Version and
+                  Type have to match the Beat in the image.
                 type: string
               kibanaRef:
                 description: |-
@@ -2523,10 +2602,12 @@ spec:
                   It allows automatic setup of dashboards and visualizations.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -2553,7 +2634,8 @@ spec:
                   Elasticsearch monitoring cluster running in the same Kubernetes cluster.
                 properties:
                   logs:
-                    description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
+                    description: Logs holds references to Elasticsearch clusters which
+                      receive log data from an associated resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -2565,10 +2647,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -2591,7 +2675,8 @@ spec:
                         type: array
                     type: object
                   metrics:
-                    description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
+                    description: Metrics holds references to Elasticsearch clusters
+                      which receive monitoring data from this resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -2603,10 +2688,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -2630,7 +2717,8 @@ spec:
                     type: object
                 type: object
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying DaemonSet or Deployment.
                 format: int32
                 type: integer
               secureSettings:
@@ -2639,7 +2727,8 @@ spec:
                   Secrets data can be then referenced in the Beat config using the Secret's keys or as specified in `Entries` field of
                   each SecureSetting.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -2647,7 +2736,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -2733,17 +2823,11 @@ spec:
     subresources:
       status: {}
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -2776,7 +2860,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ElasticMapsServer represents an Elastic Map Server resource in a Kubernetes cluster.
+        description: ElasticMapsServer represents an Elastic Map Server resource in
+          a Kubernetes cluster.
         properties:
           apiVersion:
             description: |-
@@ -2796,10 +2881,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: MapsSpec holds the specification of an Elastic Maps Server instance.
+            description: MapsSpec holds the specification of an Elastic Maps Server
+              instance.
             properties:
               config:
-                description: 'Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration'
+                description: 'Config holds the ElasticMapsServer configuration. See:
+                  https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               configRef:
@@ -2816,13 +2903,16 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                  running in the same Kubernetes cluster.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -2843,10 +2933,12 @@ spec:
                     type: string
                 type: object
               http:
-                description: HTTP holds the HTTP layer configuration for Elastic Maps Server.
+                description: HTTP holds the HTTP layer configuration for Elastic Maps
+                  Server.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -3061,7 +3153,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -3103,7 +3196,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -3166,10 +3260,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -3182,13 +3278,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -3228,15 +3323,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -3253,11 +3352,14 @@ spec:
                 description: Image is the Elastic Maps Server Docker image to deploy.
                 type: string
               podTemplate:
-                description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods
+                description: PodTemplate provides customisation options (labels, annotations,
+                  affinity rules, resource requests, and so on) for the Elastic Maps
+                  Server pods
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying Deployment.
                 format: int32
                 type: integer
               serviceAccountName:
@@ -3278,11 +3380,13 @@ spec:
                 description: AssociationStatus is the status of an association resource.
                 type: string
               availableNodes:
-                description: AvailableNodes is the number of available replicas in the deployment.
+                description: AvailableNodes is the number of available replicas in
+                  the deployment.
                 format: int32
                 type: integer
               count:
-                description: Count corresponds to Scale.Status.Replicas, which is the actual number of observed instances of the scaled object.
+                description: Count corresponds to Scale.Status.Replicas, which is
+                  the actual number of observed instances of the scaled object.
                 format: int32
                 type: integer
               health:
@@ -3315,17 +3419,11 @@ spec:
         statusReplicasPath: .status.count
       status: {}
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -3356,7 +3454,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ElasticsearchAutoscaler represents an ElasticsearchAutoscaler resource in a Kubernetes cluster.
+        description: ElasticsearchAutoscaler represents an ElasticsearchAutoscaler
+          resource in a Kubernetes cluster.
         properties:
           apiVersion:
             description: |-
@@ -3376,19 +3475,23 @@ spec:
           metadata:
             type: object
           spec:
-            description: ElasticsearchAutoscalerSpec holds the specification of an Elasticsearch autoscaler resource.
+            description: ElasticsearchAutoscalerSpec holds the specification of an
+              Elasticsearch autoscaler resource.
             properties:
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to an Elasticsearch cluster that exists in the same namespace.
+                description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                  that exists in the same namespace.
                 properties:
                   name:
-                    description: Name is the name of the Elasticsearch resource to scale automatically.
+                    description: Name is the name of the Elasticsearch resource to
+                      scale automatically.
                     minLength: 1
                     type: string
                 type: object
               policies:
                 items:
-                  description: AutoscalingPolicySpec holds a named autoscaling policy and the associated resources limits (cpu, memory, storage).
+                  description: AutoscalingPolicySpec holds a named autoscaling policy
+                    and the associated resources limits (cpu, memory, storage).
                   properties:
                     deciders:
                       additionalProperties:
@@ -3398,10 +3501,12 @@ spec:
                           DeciderSettings allow the user to tweak autoscaling deciders.
                           The map data structure complies with the <key,value> format expected by Elasticsearch.
                         type: object
-                      description: Deciders allow the user to override default settings for autoscaling deciders.
+                      description: Deciders allow the user to override default settings
+                        for autoscaling deciders.
                       type: object
                     name:
-                      description: Name identifies the autoscaling policy in the autoscaling specification.
+                      description: Name identifies the autoscaling policy in the autoscaling
+                        specification.
                       type: string
                     resources:
                       description: |-
@@ -3413,27 +3518,31 @@ spec:
                         managed by the autoscaling policy are left untouched.
                       properties:
                         cpu:
-                          description: QuantityRange models a resource limit range for resources which can be expressed with resource.Quantity.
+                          description: QuantityRange models a resource limit range
+                            for resources which can be expressed with resource.Quantity.
                           properties:
                             max:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Max represents the upper limit for the resources managed by the autoscaler.
+                              description: Max represents the upper limit for the
+                                resources managed by the autoscaler.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             min:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Min represents the lower limit for the resources managed by the autoscaler.
+                              description: Min represents the lower limit for the
+                                resources managed by the autoscaler.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             requestsToLimitsRatio:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: RequestsToLimitsRatio allows to customize Kubernetes resource Limit based on the Request.
+                              description: RequestsToLimitsRatio allows to customize
+                                Kubernetes resource Limit based on the Request.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           required:
@@ -3441,27 +3550,31 @@ spec:
                           - min
                           type: object
                         memory:
-                          description: QuantityRange models a resource limit range for resources which can be expressed with resource.Quantity.
+                          description: QuantityRange models a resource limit range
+                            for resources which can be expressed with resource.Quantity.
                           properties:
                             max:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Max represents the upper limit for the resources managed by the autoscaler.
+                              description: Max represents the upper limit for the
+                                resources managed by the autoscaler.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             min:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Min represents the lower limit for the resources managed by the autoscaler.
+                              description: Min represents the lower limit for the
+                                resources managed by the autoscaler.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             requestsToLimitsRatio:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: RequestsToLimitsRatio allows to customize Kubernetes resource Limit based on the Request.
+                              description: RequestsToLimitsRatio allows to customize
+                                Kubernetes resource Limit based on the Request.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           required:
@@ -3469,14 +3582,18 @@ spec:
                           - min
                           type: object
                         nodeCount:
-                          description: NodeCountRange is used to model the minimum and the maximum number of nodes over all the NodeSets managed by the same autoscaling policy.
+                          description: NodeCountRange is used to model the minimum
+                            and the maximum number of nodes over all the NodeSets
+                            managed by the same autoscaling policy.
                           properties:
                             max:
-                              description: Max represents the maximum number of nodes in a tier.
+                              description: Max represents the maximum number of nodes
+                                in a tier.
                               format: int32
                               type: integer
                             min:
-                              description: Min represents the minimum number of nodes in a tier.
+                              description: Min represents the minimum number of nodes
+                                in a tier.
                               format: int32
                               type: integer
                           required:
@@ -3484,27 +3601,31 @@ spec:
                           - min
                           type: object
                         storage:
-                          description: QuantityRange models a resource limit range for resources which can be expressed with resource.Quantity.
+                          description: QuantityRange models a resource limit range
+                            for resources which can be expressed with resource.Quantity.
                           properties:
                             max:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Max represents the upper limit for the resources managed by the autoscaler.
+                              description: Max represents the upper limit for the
+                                resources managed by the autoscaler.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             min:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Min represents the lower limit for the resources managed by the autoscaler.
+                              description: Min represents the lower limit for the
+                                resources managed by the autoscaler.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             requestsToLimitsRatio:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: RequestsToLimitsRatio allows to customize Kubernetes resource Limit based on the Request.
+                              description: RequestsToLimitsRatio allows to customize
+                                Kubernetes resource Limit based on the Request.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           required:
@@ -3515,7 +3636,8 @@ spec:
                       - nodeCount
                       type: object
                     roles:
-                      description: An autoscaling policy must target a unique set of roles.
+                      description: An autoscaling policy must target a unique set
+                        of roles.
                       items:
                         type: string
                       type: array
@@ -3524,7 +3646,8 @@ spec:
                   type: object
                 type: array
               pollingPeriod:
-                description: PollingPeriod is the period at which to synchronize with the Elasticsearch autoscaling API.
+                description: PollingPeriod is the period at which to synchronize with
+                  the Elasticsearch autoscaling API.
                 type: string
             required:
             - elasticsearchRef
@@ -3533,7 +3656,8 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions holds the current service state of the autoscaling controller.
+                description: Conditions holds the current service state of the autoscaling
+                  controller.
                 items:
                   description: |-
                     Condition represents Elasticsearch resource's condition.
@@ -3547,7 +3671,8 @@ spec:
                     status:
                       type: string
                     type:
-                      description: ConditionType defines the condition of an Elasticsearch resource.
+                      description: ConditionType defines the condition of an Elasticsearch
+                        resource.
                       type: string
                   required:
                   - status
@@ -3555,30 +3680,36 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: ObservedGeneration is the last observed generation by the controller.
+                description: ObservedGeneration is the last observed generation by
+                  the controller.
                 format: int64
                 type: integer
               policies:
-                description: AutoscalingPolicyStatuses is used to expose state messages to user or external system.
+                description: AutoscalingPolicyStatuses is used to expose state messages
+                  to user or external system.
                 items:
                   properties:
                     lastModificationTime:
-                      description: LastModificationTime is the last time the resources have been updated, used by the cooldown algorithm.
+                      description: LastModificationTime is the last time the resources
+                        have been updated, used by the cooldown algorithm.
                       format: date-time
                       type: string
                     name:
                       description: Name is the name of the autoscaling policy
                       type: string
                     nodeSets:
-                      description: NodeSetNodeCount holds the number of nodes for each nodeSet.
+                      description: NodeSetNodeCount holds the number of nodes for
+                        each nodeSet.
                       items:
-                        description: NodeSetNodeCount models the number of nodes expected in a given NodeSet.
+                        description: NodeSetNodeCount models the number of nodes expected
+                          in a given NodeSet.
                         properties:
                           name:
                             description: Name of the Nodeset.
                             type: string
                           nodeCount:
-                            description: NodeCount is the number of nodes, as computed by the autoscaler, expected in this NodeSet.
+                            description: NodeCount is the number of nodes, as computed
+                              by the autoscaler, expected in this NodeSet.
                             format: int32
                             type: integer
                         required:
@@ -3598,7 +3729,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: ResourceList is a set of (resource name, quantity) pairs.
+                          description: ResourceList is a set of (resource name, quantity)
+                            pairs.
                           type: object
                         requests:
                           additionalProperties:
@@ -3607,11 +3739,13 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: ResourceList is a set of (resource name, quantity) pairs.
+                          description: ResourceList is a set of (resource name, quantity)
+                            pairs.
                           type: object
                       type: object
                     state:
-                      description: PolicyStates may contain various messages regarding the current state of this autoscaling policy.
+                      description: PolicyStates may contain various messages regarding
+                        the current state of this autoscaling policy.
                       items:
                         properties:
                           messages:
@@ -3636,17 +3770,11 @@ spec:
     subresources:
       status: {}
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -3682,7 +3810,8 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.
+        description: Elasticsearch represents an Elasticsearch resource in a Kubernetes
+          cluster.
         properties:
           apiVersion:
             description: |-
@@ -3702,18 +3831,22 @@ spec:
           metadata:
             type: object
           spec:
-            description: ElasticsearchSpec holds the specification of an Elasticsearch cluster.
+            description: ElasticsearchSpec holds the specification of an Elasticsearch
+              cluster.
             properties:
               auth:
-                description: Auth contains user authentication and authorization security settings for Elasticsearch.
+                description: Auth contains user authentication and authorization security
+                  settings for Elasticsearch.
                 properties:
                   disableElasticUser:
-                    description: DisableElasticUser disables the default elastic user that is created by ECK.
+                    description: DisableElasticUser disables the default elastic user
+                      that is created by ECK.
                     type: boolean
                   fileRealm:
                     description: FileRealm to propagate to the Elasticsearch cluster.
                     items:
-                      description: FileRealmSource references users to create in the Elasticsearch cluster.
+                      description: FileRealmSource references users to create in the
+                        Elasticsearch cluster.
                       properties:
                         secretName:
                           description: SecretName is the name of the secret.
@@ -3723,7 +3856,8 @@ spec:
                   roles:
                     description: Roles to propagate to the Elasticsearch cluster.
                     items:
-                      description: RoleSource references roles to create in the Elasticsearch cluster.
+                      description: RoleSource references roles to create in the Elasticsearch
+                        cluster.
                       properties:
                         secretName:
                           description: SecretName is the name of the secret.
@@ -3735,7 +3869,8 @@ spec:
                 description: HTTP holds HTTP layer settings for Elasticsearch.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -3950,7 +4085,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -3992,7 +4128,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -4055,10 +4192,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -4071,13 +4210,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -4117,15 +4255,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -4149,7 +4291,8 @@ spec:
                   Elasticsearch monitoring clusters running in the same Kubernetes cluster.
                 properties:
                   logs:
-                    description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
+                    description: Logs holds references to Elasticsearch clusters which
+                      receive log data from an associated resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -4161,10 +4304,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -4187,7 +4332,8 @@ spec:
                         type: array
                     type: object
                   metrics:
-                    description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
+                    description: Metrics holds references to Elasticsearch clusters
+                      which receive monitoring data from this resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -4199,10 +4345,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -4226,9 +4374,11 @@ spec:
                     type: object
                 type: object
               nodeSets:
-                description: NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates.
+                description: NodeSets allow specifying groups of Elasticsearch nodes
+                  sharing the same configuration and Pod templates.
                 items:
-                  description: NodeSet is the specification for a group of Elasticsearch nodes sharing the same configuration and a Pod template.
+                  description: NodeSet is the specification for a group of Elasticsearch
+                    nodes sharing the same configuration and a Pod template.
                   properties:
                     config:
                       description: Config holds the Elasticsearch configuration.
@@ -4241,12 +4391,15 @@ spec:
                       format: int32
                       type: integer
                     name:
-                      description: Name of this set of nodes. Becomes a part of the Elasticsearch node.name setting.
+                      description: Name of this set of nodes. Becomes a part of the
+                        Elasticsearch node.name setting.
                       maxLength: 23
                       pattern: '[a-zA-Z0-9-]+'
                       type: string
                     podTemplate:
-                      description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
+                      description: PodTemplate provides customisation options (labels,
+                        annotations, affinity rules, resource requests, and so on)
+                        for the Pods belonging to this NodeSet.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     volumeClaimTemplates:
@@ -4255,7 +4408,8 @@ spec:
                         Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
                         Items defined here take precedence over any default claims added by the operator with the same name.
                       items:
-                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                        description: PersistentVolumeClaim is a user's request for
+                          and claim to a persistent volume
                         properties:
                           apiVersion:
                             description: |-
@@ -4325,10 +4479,12 @@ spec:
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                 required:
                                 - kind
@@ -4368,10 +4524,12 @@ spec:
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                   namespace:
                                     description: |-
@@ -4417,17 +4575,21 @@ spec:
                                     type: object
                                 type: object
                               selector:
-                                description: selector is a label query over volumes to consider for binding.
+                                description: selector is a label query over volumes
+                                  to consider for binding.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
                                     items:
                                       description: |-
                                         A label selector requirement is a selector that contains values, a key, and an operator that
                                         relates the key and values.
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
+                                          description: key is the label key that the
+                                            selector applies to.
                                           type: string
                                         operator:
                                           description: |-
@@ -4486,7 +4648,8 @@ spec:
                                   Value of Filesystem is implied when not included in claim spec.
                                 type: string
                               volumeName:
-                                description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                description: volumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
                                 type: string
                             type: object
                         type: object
@@ -4556,14 +4719,16 @@ spec:
                           all pods within the namespace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
                               description: |-
                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector applies to.
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
                                   description: |-
@@ -4620,9 +4785,6 @@ spec:
                           Additional policies may be added in the future.
                           Clients making eviction decisions should disallow eviction of unhealthy pods
                           if they encounter an unrecognized policy in this field.
-
-                          This field is beta-level. The eviction API uses this field when
-                          the feature gate PDBUnhealthyPodEvictionPolicy is enabled (enabled by default).
                         type: string
                     type: object
                 type: object
@@ -4635,15 +4797,19 @@ spec:
                     type: boolean
                 type: object
               remoteClusters:
-                description: RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster.
+                description: RemoteClusters enables you to establish uni-directional
+                  connections to a remote Elasticsearch cluster.
                 items:
-                  description: RemoteCluster declares a remote Elasticsearch cluster connection.
+                  description: RemoteCluster declares a remote Elasticsearch cluster
+                    connection.
                   properties:
                     apiKey:
-                      description: 'APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html'
+                      description: 'APIKey can be used to enable remote cluster access
+                        using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html'
                       properties:
                         access:
-                          description: Access is the name of the API Key. It is automatically generated if not set or empty.
+                          description: Access is the name of the API Key. It is automatically
+                            generated if not set or empty.
                           properties:
                             replication:
                               properties:
@@ -4687,13 +4853,16 @@ spec:
                       - access
                       type: object
                     elasticsearchRef:
-                      description: ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster.
+                      description: ElasticsearchRef is a reference to an Elasticsearch
+                        cluster running within the same k8s cluster.
                       properties:
                         name:
-                          description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                          description: Name of an existing Kubernetes object corresponding
+                            to an Elastic resource managed by ECK.
                           type: string
                         namespace:
-                          description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                          description: Namespace of the Kubernetes object. If empty,
+                            defaults to the current namespace.
                           type: string
                         serviceName:
                           description: |-
@@ -4713,13 +4882,16 @@ spec:
                   type: object
                 type: array
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying StatefulSets.
                 format: int32
                 type: integer
               secureSettings:
-                description: SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for Elasticsearch.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -4727,7 +4899,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -4757,7 +4930,8 @@ spec:
                 description: Transport holds transport layer settings for Elasticsearch.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -4972,7 +5146,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -5014,7 +5189,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -5077,10 +5253,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -5093,13 +5271,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -5123,7 +5300,8 @@ spec:
                         type: object
                     type: object
                   tls:
-                    description: TLS defines options for configuring TLS on the transport layer.
+                    description: TLS defines options for configuring TLS on the transport
+                      layer.
                     properties:
                       certificate:
                         description: |-
@@ -5154,16 +5332,20 @@ spec:
                           Example: if set to "node.cluster.local", the generated certificate will have its otherName set to "<pod_name>.node.cluster.local".
                         type: string
                       selfSignedCertificates:
-                        description: SelfSignedCertificates allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificates allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that provisioning of the self-signed certificates should be disabled.
+                            description: Disabled indicates that provisioning of the
+                              self-signed certificates should be disabled.
                             type: boolean
                         type: object
                       subjectAltNames:
-                        description: SubjectAlternativeNames is a list of SANs to include in the generated node transport TLS certificates.
+                        description: SubjectAlternativeNames is a list of SANs to
+                          include in the generated node transport TLS certificates.
                         items:
-                          description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                          description: SubjectAlternativeName represents a SAN entry
+                            in a x509 certificate.
                           properties:
                             dns:
                               description: DNS is the DNS name of the subject.
@@ -5176,10 +5358,12 @@ spec:
                     type: object
                 type: object
               updateStrategy:
-                description: UpdateStrategy specifies how updates to the cluster should be performed.
+                description: UpdateStrategy specifies how updates to the cluster should
+                  be performed.
                 properties:
                   changeBudget:
-                    description: ChangeBudget defines the constraints to consider when applying changes to the Elasticsearch cluster.
+                    description: ChangeBudget defines the constraints to consider
+                      when applying changes to the Elasticsearch cluster.
                     properties:
                       maxSurge:
                         description: |-
@@ -5236,7 +5420,8 @@ spec:
                     status:
                       type: string
                     type:
-                      description: ConditionType defines the condition of an Elasticsearch resource.
+                      description: ConditionType defines the condition of an Elasticsearch
+                        resource.
                       type: string
                   required:
                   - status
@@ -5244,7 +5429,8 @@ spec:
                   type: object
                 type: array
               health:
-                description: ElasticsearchHealth is the health of the cluster as returned by the health API.
+                description: ElasticsearchHealth is the health of the cluster as returned
+                  by the health API.
                 type: string
               inProgressOperations:
                 description: |-
@@ -5260,7 +5446,8 @@ spec:
                         format: date-time
                         type: string
                       nodes:
-                        description: Nodes which are scheduled to be removed from the cluster.
+                        description: Nodes which are scheduled to be removed from
+                          the cluster.
                         items:
                           description: |-
                             DownscaledNode provides an overview of in progress changes applied by the operator to remove Elasticsearch nodes from the cluster.
@@ -5272,7 +5459,8 @@ spec:
                                 Elasticsearch shutdown API.
                               type: string
                             name:
-                              description: Name of the Elasticsearch node that should be removed.
+                              description: Name of the Elasticsearch node that should
+                                be removed.
                               type: string
                             shutdownStatus:
                               description: |-
@@ -5307,13 +5495,17 @@ spec:
                             **This API is in technical preview and may be changed or removed in a future release.**
                           properties:
                             message:
-                              description: Optional message to explain why a node may not be immediately restarted for upgrade.
+                              description: Optional message to explain why a node
+                                may not be immediately restarted for upgrade.
                               type: string
                             name:
-                              description: Name of the Elasticsearch node that should be upgraded.
+                              description: Name of the Elasticsearch node that should
+                                be upgraded.
                               type: string
                             predicate:
-                              description: Predicate is the name of the predicate currently preventing this node from being deleted for an upgrade.
+                              description: Predicate is the name of the predicate
+                                currently preventing this node from being deleted
+                                for an upgrade.
                               type: string
                             status:
                               description: |-
@@ -5339,13 +5531,16 @@ spec:
                         items:
                           properties:
                             message:
-                              description: Optional message to explain why a node may not be immediately added.
+                              description: Optional message to explain why a node
+                                may not be immediately added.
                               type: string
                             name:
-                              description: Name of the Elasticsearch node that should be added to the cluster.
+                              description: Name of the Elasticsearch node that should
+                                be added to the cluster.
                               type: string
                             status:
-                              description: NewNodeStatus states if a new node is being created, or if the upscale is delayed.
+                              description: NewNodeStatus states if a new node is being
+                                created, or if the upscale is delayed.
                               type: string
                           required:
                           - name
@@ -5375,7 +5570,8 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: ElasticsearchOrchestrationPhase is the phase Elasticsearch is in from the controller point of view.
+                description: ElasticsearchOrchestrationPhase is the phase Elasticsearch
+                  is in from the controller point of view.
                 type: string
               version:
                 description: |-
@@ -5409,7 +5605,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.
+        description: Elasticsearch represents an Elasticsearch resource in a Kubernetes
+          cluster.
         properties:
           apiVersion:
             description: |-
@@ -5429,13 +5626,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: ElasticsearchSpec holds the specification of an Elasticsearch cluster.
+            description: ElasticsearchSpec holds the specification of an Elasticsearch
+              cluster.
             properties:
               http:
                 description: HTTP holds HTTP layer settings for Elasticsearch.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -5650,7 +5849,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -5692,7 +5892,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -5755,10 +5956,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -5771,13 +5974,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -5817,15 +6019,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -5842,9 +6048,11 @@ spec:
                 description: Image is the Elasticsearch Docker image to deploy.
                 type: string
               nodeSets:
-                description: NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates.
+                description: NodeSets allow specifying groups of Elasticsearch nodes
+                  sharing the same configuration and Pod templates.
                 items:
-                  description: NodeSet is the specification for a group of Elasticsearch nodes sharing the same configuration and a Pod template.
+                  description: NodeSet is the specification for a group of Elasticsearch
+                    nodes sharing the same configuration and a Pod template.
                   properties:
                     config:
                       description: Config holds the Elasticsearch configuration.
@@ -5855,12 +6063,15 @@ spec:
                       minimum: 1
                       type: integer
                     name:
-                      description: Name of this set of nodes. Becomes a part of the Elasticsearch node.name setting.
+                      description: Name of this set of nodes. Becomes a part of the
+                        Elasticsearch node.name setting.
                       maxLength: 23
                       pattern: '[a-zA-Z0-9-]+'
                       type: string
                     podTemplate:
-                      description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
+                      description: PodTemplate provides customisation options (labels,
+                        annotations, affinity rules, resource requests, and so on)
+                        for the Pods belonging to this NodeSet.
                       type: object
                     volumeClaimTemplates:
                       description: |-
@@ -5868,7 +6079,8 @@ spec:
                         Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
                         Items defined here take precedence over any default claims added by the operator with the same name.
                       items:
-                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                        description: PersistentVolumeClaim is a user's request for
+                          and claim to a persistent volume
                         properties:
                           apiVersion:
                             description: |-
@@ -5938,10 +6150,12 @@ spec:
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                 required:
                                 - kind
@@ -5981,10 +6195,12 @@ spec:
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                   namespace:
                                     description: |-
@@ -6030,17 +6246,21 @@ spec:
                                     type: object
                                 type: object
                               selector:
-                                description: selector is a label query over volumes to consider for binding.
+                                description: selector is a label query over volumes
+                                  to consider for binding.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
                                     items:
                                       description: |-
                                         A label selector requirement is a selector that contains values, a key, and an operator that
                                         relates the key and values.
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
+                                          description: key is the label key that the
+                                            selector applies to.
                                           type: string
                                         operator:
                                           description: |-
@@ -6099,7 +6319,8 @@ spec:
                                   Value of Filesystem is implied when not included in claim spec.
                                 type: string
                               volumeName:
-                                description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                description: volumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
                                 type: string
                             type: object
                         type: object
@@ -6170,14 +6391,16 @@ spec:
                           In policy/v1, an empty selector will select all pods in the namespace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
                               description: |-
                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector applies to.
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
                                   description: |-
@@ -6234,16 +6457,15 @@ spec:
                           Additional policies may be added in the future.
                           Clients making eviction decisions should disallow eviction of unhealthy pods
                           if they encounter an unrecognized policy in this field.
-
-                          This field is beta-level. The eviction API uses this field when
-                          the feature gate PDBUnhealthyPodEvictionPolicy is enabled (enabled by default).
                         type: string
                     type: object
                 type: object
               secureSettings:
-                description: SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for Elasticsearch.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -6251,7 +6473,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -6273,10 +6496,12 @@ spec:
                   type: object
                 type: array
               updateStrategy:
-                description: UpdateStrategy specifies how updates to the cluster should be performed.
+                description: UpdateStrategy specifies how updates to the cluster should
+                  be performed.
                 properties:
                   changeBudget:
-                    description: ChangeBudget defines the constraints to consider when applying changes to the Elasticsearch cluster.
+                    description: ChangeBudget defines the constraints to consider
+                      when applying changes to the Elasticsearch cluster.
                     properties:
                       maxSurge:
                         description: |-
@@ -6307,10 +6532,12 @@ spec:
                 format: int32
                 type: integer
               health:
-                description: ElasticsearchHealth is the health of the cluster as returned by the health API.
+                description: ElasticsearchHealth is the health of the cluster as returned
+                  by the health API.
                 type: string
               phase:
-                description: ElasticsearchOrchestrationPhase is the phase Elasticsearch is in from the controller point of view.
+                description: ElasticsearchOrchestrationPhase is the phase Elasticsearch
+                  is in from the controller point of view.
                 type: string
             type: object
         type: object
@@ -6321,22 +6548,17 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: to not break compatibility when upgrading from previous versions of the CRD
+        description: to not break compatibility when upgrading from previous versions
+          of the CRD
         type: object
     served: false
     storage: false
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -6369,7 +6591,8 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
+        description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise
+          Search.
         properties:
           apiVersion:
             description: |-
@@ -6389,7 +6612,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
+            description: EnterpriseSearchSpec holds the specification of an Enterprise
+              Search resource.
             properties:
               config:
                 description: Config holds the Enterprise Search configuration.
@@ -6409,13 +6633,16 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to the Elasticsearch
+                  cluster running in the same Kubernetes cluster.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -6436,10 +6663,12 @@ spec:
                     type: string
                 type: object
               http:
-                description: HTTP holds the HTTP layer configuration for Enterprise Search resource.
+                description: HTTP holds the HTTP layer configuration for Enterprise
+                  Search resource.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -6654,7 +6883,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -6696,7 +6926,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -6759,10 +6990,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -6775,13 +7008,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -6821,15 +7053,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -6852,7 +7088,8 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying Deployment.
                 format: int32
                 type: integer
               serviceAccountName:
@@ -6868,14 +7105,17 @@ spec:
             description: EnterpriseSearchStatus defines the observed state of EnterpriseSearch
             properties:
               associationStatus:
-                description: Association is the status of any auto-linking to Elasticsearch clusters.
+                description: Association is the status of any auto-linking to Elasticsearch
+                  clusters.
                 type: string
               availableNodes:
-                description: AvailableNodes is the number of available replicas in the deployment.
+                description: AvailableNodes is the number of available replicas in
+                  the deployment.
                 format: int32
                 type: integer
               count:
-                description: Count corresponds to Scale.Status.Replicas, which is the actual number of observed instances of the scaled object.
+                description: Count corresponds to Scale.Status.Replicas, which is
+                  the actual number of observed instances of the scaled object.
                 format: int32
                 type: integer
               health:
@@ -6893,7 +7133,8 @@ spec:
                 description: Selector is the label selector used to find all pods.
                 type: string
               service:
-                description: ExternalService is the name of the service associated to the Enterprise Search Pods.
+                description: ExternalService is the name of the service associated
+                  to the Enterprise Search Pods.
                 type: string
               version:
                 description: |-
@@ -6928,7 +7169,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
+        description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise
+          Search.
         properties:
           apiVersion:
             description: |-
@@ -6948,7 +7190,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
+            description: EnterpriseSearchSpec holds the specification of an Enterprise
+              Search resource.
             properties:
               config:
                 description: Config holds the Enterprise Search configuration.
@@ -6968,13 +7211,16 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to the Elasticsearch
+                  cluster running in the same Kubernetes cluster.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -6995,10 +7241,12 @@ spec:
                     type: string
                 type: object
               http:
-                description: HTTP holds the HTTP layer configuration for Enterprise Search resource.
+                description: HTTP holds the HTTP layer configuration for Enterprise
+                  Search resource.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -7213,7 +7461,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -7255,7 +7504,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -7318,10 +7568,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -7334,13 +7586,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -7380,15 +7631,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -7423,14 +7678,17 @@ spec:
             description: EnterpriseSearchStatus defines the observed state of EnterpriseSearch
             properties:
               associationStatus:
-                description: Association is the status of any auto-linking to Elasticsearch clusters.
+                description: Association is the status of any auto-linking to Elasticsearch
+                  clusters.
                 type: string
               availableNodes:
-                description: AvailableNodes is the number of available replicas in the deployment.
+                description: AvailableNodes is the number of available replicas in
+                  the deployment.
                 format: int32
                 type: integer
               count:
-                description: Count corresponds to Scale.Status.Replicas, which is the actual number of observed instances of the scaled object.
+                description: Count corresponds to Scale.Status.Replicas, which is
+                  the actual number of observed instances of the scaled object.
                 format: int32
                 type: integer
               health:
@@ -7440,7 +7698,8 @@ spec:
                 description: Selector is the label selector used to find all pods.
                 type: string
               service:
-                description: ExternalService is the name of the service associated to the Enterprise Search Pods.
+                description: ExternalService is the name of the service associated
+                  to the Enterprise Search Pods.
                 type: string
               version:
                 description: |-
@@ -7454,17 +7713,11 @@ spec:
     subresources:
       status: {}
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -7528,13 +7781,16 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                  running in the same Kubernetes cluster.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -7560,10 +7816,12 @@ spec:
                   Kibana provides the default Enterprise Search UI starting version 7.14.
                 properties:
                   name:
-                    description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                    description: Name of an existing Kubernetes object corresponding
+                      to an Elastic resource managed by ECK.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                   secretName:
                     description: |-
@@ -7587,7 +7845,8 @@ spec:
                 description: HTTP holds the HTTP layer configuration for Kibana.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -7802,7 +8061,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -7844,7 +8104,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -7907,10 +8168,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -7923,13 +8186,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -7969,15 +8231,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -8001,7 +8267,8 @@ spec:
                   Elasticsearch monitoring clusters running in the same Kubernetes cluster.
                 properties:
                   logs:
-                    description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
+                    description: Logs holds references to Elasticsearch clusters which
+                      receive log data from an associated resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -8013,10 +8280,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -8039,7 +8308,8 @@ spec:
                         type: array
                     type: object
                   metrics:
-                    description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
+                    description: Metrics holds references to Elasticsearch clusters
+                      which receive monitoring data from this resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -8051,10 +8321,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -8078,17 +8350,21 @@ spec:
                     type: object
                 type: object
               podTemplate:
-                description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods
+                description: PodTemplate provides customisation options (labels, annotations,
+                  affinity rules, resource requests, and so on) for the Kibana pods
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying Deployment.
                 format: int32
                 type: integer
               secureSettings:
-                description: SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for Kibana.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -8096,7 +8372,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -8137,18 +8414,22 @@ spec:
                   This field is deprecated and will be removed in a future release. Use ElasticsearchAssociationStatus instead.
                 type: string
               availableNodes:
-                description: AvailableNodes is the number of available replicas in the deployment.
+                description: AvailableNodes is the number of available replicas in
+                  the deployment.
                 format: int32
                 type: integer
               count:
-                description: Count corresponds to Scale.Status.Replicas, which is the actual number of observed instances of the scaled object.
+                description: Count corresponds to Scale.Status.Replicas, which is
+                  the actual number of observed instances of the scaled object.
                 format: int32
                 type: integer
               elasticsearchAssociationStatus:
-                description: ElasticsearchAssociationStatus is the status of any auto-linking to Elasticsearch clusters.
+                description: ElasticsearchAssociationStatus is the status of any auto-linking
+                  to Elasticsearch clusters.
                 type: string
               enterpriseSearchAssociationStatus:
-                description: EnterpriseSearchAssociationStatus is the status of any auto-linking to Enterprise Search.
+                description: EnterpriseSearchAssociationStatus is the status of any
+                  auto-linking to Enterprise Search.
                 type: string
               health:
                 description: Health of the deployment.
@@ -8157,7 +8438,8 @@ spec:
                 additionalProperties:
                   description: AssociationStatus is the status of an association resource.
                   type: string
-                description: MonitoringAssociationStatus is the status of any auto-linking to monitoring Elasticsearch clusters.
+                description: MonitoringAssociationStatus is the status of any auto-linking
+                  to monitoring Elasticsearch clusters.
                 type: object
               observedGeneration:
                 description: |-
@@ -8234,13 +8516,15 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRef:
-                description: ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
+                description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                  running in the same Kubernetes cluster.
                 properties:
                   name:
                     description: Name of the Kubernetes object.
                     type: string
                   namespace:
-                    description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    description: Namespace of the Kubernetes object. If empty, defaults
+                      to the current namespace.
                     type: string
                 required:
                 - name
@@ -8249,7 +8533,8 @@ spec:
                 description: HTTP holds the HTTP layer configuration for Kibana.
                 properties:
                   service:
-                    description: Service defines the template for the associated Kubernetes Service object.
+                    description: Service defines the template for the associated Kubernetes
+                      Service object.
                     properties:
                       metadata:
                         description: |-
@@ -8464,7 +8749,8 @@ spec:
                               The list of ports that are exposed by this service.
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
-                              description: ServicePort contains information on service's port.
+                              description: ServicePort contains information on service's
+                                port.
                               properties:
                                 appProtocol:
                                   description: |-
@@ -8506,7 +8792,8 @@ spec:
                                   format: int32
                                   type: integer
                                 port:
-                                  description: The port that will be exposed by this service.
+                                  description: The port that will be exposed by this
+                                    service.
                                   format: int32
                                   type: integer
                                 protocol:
@@ -8569,10 +8856,12 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             type: string
                           sessionAffinityConfig:
-                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
                             properties:
                               clientIP:
-                                description: clientIP contains the configurations of Client IP based session affinity.
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
                                 properties:
                                   timeoutSeconds:
                                     description: |-
@@ -8585,13 +8874,12 @@ spec:
                             type: object
                           trafficDistribution:
                             description: |-
-                              TrafficDistribution offers a way to express preferences for how traffic is
-                              distributed to Service endpoints. Implementations can use this field as a
-                              hint, but are not required to guarantee strict adherence. If the field is
-                              not set, the implementation will apply its default routing strategy. If set
-                              to "PreferClose", implementations should prioritize endpoints that are
-                              topologically close (e.g., same zone).
-                              This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                              TrafficDistribution offers a way to express preferences for how traffic
+                              is distributed to Service endpoints. Implementations can use this field
+                              as a hint, but are not required to guarantee strict adherence. If the
+                              field is not set, the implementation will apply its default routing
+                              strategy. If set to "PreferClose", implementations should prioritize
+                              endpoints that are in the same zone.
                             type: string
                           type:
                             description: |-
@@ -8631,15 +8919,19 @@ spec:
                             type: string
                         type: object
                       selfSignedCertificate:
-                        description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                        description: SelfSignedCertificate allows configuring the
+                          self-signed certificate generated by the operator.
                         properties:
                           disabled:
-                            description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                            description: Disabled indicates that the provisioning
+                              of the self-signed certifcate should be disabled.
                             type: boolean
                           subjectAltNames:
-                            description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                            description: SubjectAlternativeNames is a list of SANs
+                              to include in the generated HTTP TLS certificate.
                             items:
-                              description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                              description: SubjectAlternativeName represents a SAN
+                                entry in a x509 certificate.
                               properties:
                                 dns:
                                   description: DNS is the DNS name of the subject.
@@ -8656,13 +8948,16 @@ spec:
                 description: Image is the Kibana Docker image to deploy.
                 type: string
               podTemplate:
-                description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods
+                description: PodTemplate provides customisation options (labels, annotations,
+                  affinity rules, resource requests, and so on) for the Kibana pods
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               secureSettings:
-                description: SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for Kibana.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -8670,7 +8965,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -8716,22 +9012,17 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: to not break compatibility when upgrading from previous versions of the CRD
+        description: to not break compatibility when upgrading from previous versions
+          of the CRD
         type: object
     served: false
     storage: false
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -8792,7 +9083,8 @@ spec:
             description: LogstashSpec defines the desired state of Logstash
             properties:
               config:
-                description: Config holds the Logstash configuration. At most one of [`Config`, `ConfigRef`] can be specified.
+                description: Config holds the Logstash configuration. At most one
+                  of [`Config`, `ConfigRef`] can be specified.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               configRef:
@@ -8809,9 +9101,11 @@ spec:
                 format: int32
                 type: integer
               elasticsearchRefs:
-                description: ElasticsearchRefs are references to Elasticsearch clusters running in the same Kubernetes cluster.
+                description: ElasticsearchRefs are references to Elasticsearch clusters
+                  running in the same Kubernetes cluster.
                 items:
-                  description: ElasticsearchCluster is a named reference to an Elasticsearch cluster which can be used in a Logstash pipeline.
+                  description: ElasticsearchCluster is a named reference to an Elasticsearch
+                    cluster which can be used in a Logstash pipeline.
                   properties:
                     clusterName:
                       description: |-
@@ -8820,10 +9114,12 @@ spec:
                       minLength: 1
                       type: string
                     name:
-                      description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                      description: Name of an existing Kubernetes object corresponding
+                        to an Elastic resource managed by ECK.
                       type: string
                     namespace:
-                      description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                      description: Namespace of the Kubernetes object. If empty, defaults
+                        to the current namespace.
                       type: string
                     secretName:
                       description: |-
@@ -8847,7 +9143,8 @@ spec:
                   type: object
                 type: array
               image:
-                description: Image is the Logstash Docker image to deploy. Version and Type have to match the Logstash in the image.
+                description: Image is the Logstash Docker image to deploy. Version
+                  and Type have to match the Logstash in the image.
                 type: string
               monitoring:
                 description: |-
@@ -8856,7 +9153,8 @@ spec:
                   Elasticsearch monitoring clusters running in the same Kubernetes cluster.
                 properties:
                   logs:
-                    description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
+                    description: Logs holds references to Elasticsearch clusters which
+                      receive log data from an associated resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -8868,10 +9166,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -8894,7 +9194,8 @@ spec:
                         type: array
                     type: object
                   metrics:
-                    description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
+                    description: Metrics holds references to Elasticsearch clusters
+                      which receive monitoring data from this resource.
                     properties:
                       elasticsearchRefs:
                         description: |-
@@ -8906,10 +9207,12 @@ spec:
                             or a Secret describing an external Elastic resource not managed by the operator.
                           properties:
                             name:
-                              description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                              description: Name of an existing Kubernetes object corresponding
+                                to an Elastic resource managed by ECK.
                               type: string
                             namespace:
-                              description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                              description: Namespace of the Kubernetes object. If
+                                empty, defaults to the current namespace.
                               type: string
                             secretName:
                               description: |-
@@ -8933,7 +9236,8 @@ spec:
                     type: object
                 type: object
               pipelines:
-                description: Pipelines holds the Logstash Pipelines. At most one of [`Pipelines`, `PipelinesRef`] can be specified.
+                description: Pipelines holds the Logstash Pipelines. At most one of
+                  [`Pipelines`, `PipelinesRef`] can be specified.
                 items:
                   type: object
                 type: array
@@ -8949,11 +9253,13 @@ spec:
                     type: string
                 type: object
               podTemplate:
-                description: PodTemplate provides customisation options for the Logstash pods.
+                description: PodTemplate provides customisation options for the Logstash
+                  pods.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSet.
+                description: RevisionHistoryLimit is the number of revisions to retain
+                  to allow rollback in the underlying StatefulSet.
                 format: int32
                 type: integer
               secureSettings:
@@ -8962,7 +9268,8 @@ spec:
                   Secrets data can be then referenced in the Logstash config using the Secret's keys or as specified in `Entries` field of
                   each SecureSetting.
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -8970,7 +9277,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -9006,7 +9314,8 @@ spec:
                     name:
                       type: string
                     service:
-                      description: Service defines the template for the associated Kubernetes Service object.
+                      description: Service defines the template for the associated
+                        Kubernetes Service object.
                       properties:
                         metadata:
                           description: |-
@@ -9221,7 +9530,8 @@ spec:
                                 The list of ports that are exposed by this service.
                                 More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
-                                description: ServicePort contains information on service's port.
+                                description: ServicePort contains information on service's
+                                  port.
                                 properties:
                                   appProtocol:
                                     description: |-
@@ -9263,7 +9573,8 @@ spec:
                                     format: int32
                                     type: integer
                                   port:
-                                    description: The port that will be exposed by this service.
+                                    description: The port that will be exposed by
+                                      this service.
                                     format: int32
                                     type: integer
                                   protocol:
@@ -9326,10 +9637,12 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
-                              description: sessionAffinityConfig contains the configurations of session affinity.
+                              description: sessionAffinityConfig contains the configurations
+                                of session affinity.
                               properties:
                                 clientIP:
-                                  description: clientIP contains the configurations of Client IP based session affinity.
+                                  description: clientIP contains the configurations
+                                    of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
                                       description: |-
@@ -9342,13 +9655,12 @@ spec:
                               type: object
                             trafficDistribution:
                               description: |-
-                                TrafficDistribution offers a way to express preferences for how traffic is
-                                distributed to Service endpoints. Implementations can use this field as a
-                                hint, but are not required to guarantee strict adherence. If the field is
-                                not set, the implementation will apply its default routing strategy. If set
-                                to "PreferClose", implementations should prioritize endpoints that are
-                                topologically close (e.g., same zone).
-                                This is a beta field and requires enabling ServiceTrafficDistribution feature.
+                                TrafficDistribution offers a way to express preferences for how traffic
+                                is distributed to Service endpoints. Implementations can use this field
+                                as a hint, but are not required to guarantee strict adherence. If the
+                                field is not set, the implementation will apply its default routing
+                                strategy. If set to "PreferClose", implementations should prioritize
+                                endpoints that are in the same zone.
                               type: string
                             type:
                               description: |-
@@ -9388,15 +9700,19 @@ spec:
                               type: string
                           type: object
                         selfSignedCertificate:
-                          description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                          description: SelfSignedCertificate allows configuring the
+                            self-signed certificate generated by the operator.
                           properties:
                             disabled:
-                              description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                              description: Disabled indicates that the provisioning
+                                of the self-signed certifcate should be disabled.
                               type: boolean
                             subjectAltNames:
-                              description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                              description: SubjectAlternativeNames is a list of SANs
+                                to include in the generated HTTP TLS certificate.
                               items:
-                                description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                                description: SubjectAlternativeName represents a SAN
+                                  entry in a x509 certificate.
                                 properties:
                                   dns:
                                     description: DNS is the DNS name of the subject.
@@ -9411,10 +9727,12 @@ spec:
                   type: object
                 type: array
               updateStrategy:
-                description: UpdateStrategy is a StatefulSetUpdateStrategy. The default type is "RollingUpdate".
+                description: UpdateStrategy is a StatefulSetUpdateStrategy. The default
+                  type is "RollingUpdate".
                 properties:
                   rollingUpdate:
-                    description: RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+                    description: RollingUpdate is used to communicate parameters when
+                      Type is RollingUpdateStatefulSetStrategyType.
                     properties:
                       maxUnavailable:
                         anyOf:
@@ -9453,7 +9771,8 @@ spec:
                   Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
                   Items defined here take precedence over any default claims added by the operator with the same name.
                 items:
-                  description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
                   properties:
                     apiVersion:
                       description: |-
@@ -9615,17 +9934,20 @@ spec:
                               type: object
                           type: object
                         selector:
-                          description: selector is a label query over volumes to consider for binding.
+                          description: selector is a label query over volumes to consider
+                            for binding.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
                                 description: |-
                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector applies to.
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
                                     description: |-
@@ -9684,7 +10006,8 @@ spec:
                             Value of Filesystem is implied when not included in claim spec.
                           type: string
                         volumeName:
-                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                          description: volumeName is the binding reference to the
+                            PersistentVolume backing this claim.
                           type: string
                       type: object
                     status:
@@ -9708,7 +10031,41 @@ spec:
                               that it does not recognizes, then it should ignore that update and let other controllers
                               handle it.
                             type: string
-                          description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                          description: "allocatedResourceStatuses stores status of
+                            resource being resized for the given PVC.\nKey names follow
+                            standard Kubernetes label syntax. Valid values are either:\n\t*
+                            Un-prefixed keys:\n\t\t- storage - the capacity of the
+                            volume.\n\t* Custom resources must use implementation-defined
+                            prefixed names such as \"example.com/my-custom-resource\"\nApart
+                            from above values - keys that are unprefixed or have kubernetes.io
+                            prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus
+                            can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState
+                            set when resize controller starts resizing the volume
+                            in control-plane.\n\t- ControllerResizeFailed:\n\t\tState
+                            set when resize has failed in resize controller with a
+                            terminal error.\n\t- NodeResizePending:\n\t\tState set
+                            when resize controller has finished resizing the volume
+                            but further resizing of\n\t\tvolume is needed on the node.\n\t-
+                            NodeResizeInProgress:\n\t\tState set when kubelet starts
+                            resizing the volume.\n\t- NodeResizeFailed:\n\t\tState
+                            set when resizing has failed in kubelet with a terminal
+                            error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor
+                            example: if expanding a PVC for more capacity - this field
+                            can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeFailed\"\nWhen this field is not set, it
+                            means that no resize operation is in progress for the
+                            given PVC.\n\nA controller that receives PVC update with
+                            previously unknown resourceName or ClaimResourceStatus\nshould
+                            ignore the update for the purpose it was designed. For
+                            example - a controller that\nonly is responsible for resizing
+                            capacity of the volume, should ignore PVC updates that
+                            change other valid\nresources associated with PVC.\n\nThis
+                            is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            feature."
                           type: object
                           x-kubernetes-map-type: granular
                         allocatedResources:
@@ -9718,7 +10075,30 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                          description: "allocatedResources tracks the resources allocated
+                            to a PVC including its capacity.\nKey names follow standard
+                            Kubernetes label syntax. Valid values are either:\n\t*
+                            Un-prefixed keys:\n\t\t- storage - the capacity of the
+                            volume.\n\t* Custom resources must use implementation-defined
+                            prefixed names such as \"example.com/my-custom-resource\"\nApart
+                            from above values - keys that are unprefixed or have kubernetes.io
+                            prefix are considered\nreserved and hence may not be used.\n\nCapacity
+                            reported here may be larger than the actual capacity when
+                            a volume expansion operation\nis requested.\nFor storage
+                            quota, the larger value from allocatedResources and PVC.spec.resources
+                            is used.\nIf allocatedResources is not set, PVC.spec.resources
+                            alone is used for quota calculation.\nIf a volume expansion
+                            capacity request is lowered, allocatedResources is only\nlowered
+                            if there are no expansion operations in progress and if
+                            the actual volume capacity\nis equal or lower than the
+                            requested capacity.\n\nA controller that receives PVC
+                            update with previously unknown resourceName\nshould ignore
+                            the update for the purpose it was designed. For example
+                            - a controller that\nonly is responsible for resizing
+                            capacity of the volume, should ignore PVC updates that
+                            change other valid\nresources associated with PVC.\n\nThis
+                            is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            feature."
                           type: object
                         capacity:
                           additionalProperties:
@@ -9727,25 +10107,30 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: capacity represents the actual resources of the underlying volume.
+                          description: capacity represents the actual resources of
+                            the underlying volume.
                           type: object
                         conditions:
                           description: |-
                             conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
                             resized then the Condition will be set to 'Resizing'.
                           items:
-                            description: PersistentVolumeClaimCondition contains details about state of pvc
+                            description: PersistentVolumeClaimCondition contains details
+                              about state of pvc
                             properties:
                               lastProbeTime:
-                                description: lastProbeTime is the time we probed the condition.
+                                description: lastProbeTime is the time we probed the
+                                  condition.
                                 format: date-time
                                 type: string
                               lastTransitionTime:
-                                description: lastTransitionTime is the time the condition transitioned from one status to another.
+                                description: lastTransitionTime is the time the condition
+                                  transitioned from one status to another.
                                 format: date-time
                                 type: string
                               message:
-                                description: message is the human-readable message indicating details about last transition.
+                                description: message is the human-readable message
+                                  indicating details about last transition.
                                 type: string
                               reason:
                                 description: |-
@@ -9785,10 +10170,23 @@ spec:
                             This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                           properties:
                             status:
-                              description: "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately."
+                              description: "status is the status of the ControllerModifyVolume
+                                operation. It can be in any of following states:\n
+                                - Pending\n   Pending indicates that the PersistentVolumeClaim
+                                cannot be modified due to unmet requirements, such
+                                as\n   the specified VolumeAttributesClass not existing.\n
+                                - InProgress\n   InProgress indicates that the volume
+                                is being modified.\n - Infeasible\n  Infeasible indicates
+                                that the request has been rejected as invalid by the
+                                CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass
+                                needs to be specified.\nNote: New statuses can be
+                                added in the future. Consumers should check for unknown
+                                statuses and fail appropriately."
                               type: string
                             targetVolumeAttributesClassName:
-                              description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled
+                              description: targetVolumeAttributesClassName is the
+                                name of the VolumeAttributesClass the PVC currently
+                                being reconciled
                               type: string
                           required:
                           - status
@@ -9812,7 +10210,8 @@ spec:
                 additionalProperties:
                   description: AssociationStatus is the status of an association resource.
                   type: string
-                description: ElasticsearchAssociationStatus is the status of any auto-linking to Elasticsearch clusters.
+                description: ElasticsearchAssociationStatus is the status of any auto-linking
+                  to Elasticsearch clusters.
                 type: object
               expectedNodes:
                 format: int32
@@ -9823,7 +10222,8 @@ spec:
                 additionalProperties:
                   description: AssociationStatus is the status of an association resource.
                   type: string
-                description: MonitoringAssociationStatus is the status of any auto-linking to monitoring Elasticsearch clusters.
+                description: MonitoringAssociationStatus is the status of any auto-linking
+                  to monitoring Elasticsearch clusters.
                 type: object
               observedGeneration:
                 description: |-
@@ -9853,17 +10253,11 @@ spec:
         statusReplicasPath: .status.expectedNodes
       status: {}
 ---
-# Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: 'elastic-operator'
-    app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.0.0'
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co
@@ -9892,7 +10286,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: StackConfigPolicy represents a StackConfigPolicy resource in a Kubernetes cluster.
+        description: StackConfigPolicy represents a StackConfigPolicy resource in
+          a Kubernetes cluster.
         properties:
           apiVersion:
             description: |-
@@ -9916,7 +10311,8 @@ spec:
               elasticsearch:
                 properties:
                   clusterSettings:
-                    description: ClusterSettings holds the Elasticsearch cluster settings (/_cluster/settings)
+                    description: ClusterSettings holds the Elasticsearch cluster settings
+                      (/_cluster/settings)
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   config:
@@ -9924,44 +10320,55 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   indexLifecyclePolicies:
-                    description: IndexLifecyclePolicies holds the Index Lifecycle policies settings (/_ilm/policy)
+                    description: IndexLifecyclePolicies holds the Index Lifecycle
+                      policies settings (/_ilm/policy)
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   indexTemplates:
-                    description: IndexTemplates holds the Index and Component Templates settings
+                    description: IndexTemplates holds the Index and Component Templates
+                      settings
                     properties:
                       componentTemplates:
-                        description: ComponentTemplates holds the Component Templates settings (/_component_template)
+                        description: ComponentTemplates holds the Component Templates
+                          settings (/_component_template)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       composableIndexTemplates:
-                        description: ComposableIndexTemplates holds the Index Templates settings (/_index_template)
+                        description: ComposableIndexTemplates holds the Index Templates
+                          settings (/_index_template)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   ingestPipelines:
-                    description: IngestPipelines holds the Ingest Pipelines settings (/_ingest/pipeline)
+                    description: IngestPipelines holds the Ingest Pipelines settings
+                      (/_ingest/pipeline)
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   secretMounts:
-                    description: SecretMounts are additional Secrets that need to be mounted into the Elasticsearch pods.
+                    description: SecretMounts are additional Secrets that need to
+                      be mounted into the Elasticsearch pods.
                     items:
-                      description: SecretMount contains information about additional secrets to be mounted to the elasticsearch pods
+                      description: SecretMount contains information about additional
+                        secrets to be mounted to the elasticsearch pods
                       properties:
                         mountPath:
-                          description: MountPath denotes the path to which the secret should be mounted to inside the elasticsearch pod
+                          description: MountPath denotes the path to which the secret
+                            should be mounted to inside the elasticsearch pod
                           type: string
                         secretName:
-                          description: SecretName denotes the name of the secret that needs to be mounted to the elasticsearch pod
+                          description: SecretName denotes the name of the secret that
+                            needs to be mounted to the elasticsearch pod
                           type: string
                       type: object
                     type: array
                     x-kubernetes-preserve-unknown-fields: true
                   secureSettings:
-                    description: SecureSettings are additional Secrets that contain data to be configured to Elasticsearch's keystore.
+                    description: SecureSettings are additional Secrets that contain
+                      data to be configured to Elasticsearch's keystore.
                     items:
-                      description: SecretSource defines a data source based on a Kubernetes Secret.
+                      description: SecretSource defines a data source based on a Kubernetes
+                        Secret.
                       properties:
                         entries:
                           description: |-
@@ -9969,7 +10376,8 @@ spec:
                             If not defined, all keys will be projected to similarly named paths in the filesystem.
                             If defined, only the specified keys will be projected to the corresponding paths.
                           items:
-                            description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                            description: KeyToPath defines how to map a key in a Secret
+                              object to a filesystem path.
                             properties:
                               key:
                                 description: Key is the key contained in the secret.
@@ -9992,15 +10400,18 @@ spec:
                     type: array
                     x-kubernetes-preserve-unknown-fields: true
                   securityRoleMappings:
-                    description: SecurityRoleMappings holds the Role Mappings settings (/_security/role_mapping)
+                    description: SecurityRoleMappings holds the Role Mappings settings
+                      (/_security/role_mapping)
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   snapshotLifecyclePolicies:
-                    description: SnapshotLifecyclePolicies holds the Snapshot Lifecycle Policies settings (/_slm/policy)
+                    description: SnapshotLifecyclePolicies holds the Snapshot Lifecycle
+                      Policies settings (/_slm/policy)
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   snapshotRepositories:
-                    description: SnapshotRepositories holds the Snapshot Repositories settings (/_snapshot)
+                    description: SnapshotRepositories holds the Snapshot Repositories
+                      settings (/_snapshot)
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -10011,9 +10422,11 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   secureSettings:
-                    description: SecureSettings are additional Secrets that contain data to be configured to Kibana's keystore.
+                    description: SecureSettings are additional Secrets that contain
+                      data to be configured to Kibana's keystore.
                     items:
-                      description: SecretSource defines a data source based on a Kubernetes Secret.
+                      description: SecretSource defines a data source based on a Kubernetes
+                        Secret.
                       properties:
                         entries:
                           description: |-
@@ -10021,7 +10434,8 @@ spec:
                             If not defined, all keys will be projected to similarly named paths in the filesystem.
                             If defined, only the specified keys will be projected to the corresponding paths.
                           items:
-                            description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                            description: KeyToPath defines how to map a key in a Secret
+                              object to a filesystem path.
                             properties:
                               key:
                                 description: Key is the key contained in the secret.
@@ -10051,14 +10465,16 @@ spec:
                   label selector matches no objects.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
                       description: |-
                         A label selector requirement is a selector that contains values, a key, and an operator that
                         relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
                           description: |-
@@ -10092,9 +10508,11 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               secureSettings:
-                description: 'Deprecated: SecureSettings only applies to Elasticsearch and is deprecated. It must be set per application instead.'
+                description: 'Deprecated: SecureSettings only applies to Elasticsearch
+                  and is deprecated. It must be set per application instead.'
                 items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+                  description: SecretSource defines a data source based on a Kubernetes
+                    Secret.
                   properties:
                     entries:
                       description: |-
@@ -10102,7 +10520,8 @@ spec:
                         If not defined, all keys will be projected to similarly named paths in the filesystem.
                         If defined, only the specified keys will be projected to the corresponding paths.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: KeyToPath defines how to map a key in a Secret
+                          object to a filesystem path.
                         properties:
                           key:
                             description: Key is the key contained in the secret.
@@ -10129,7 +10548,8 @@ spec:
               details:
                 additionalProperties:
                   additionalProperties:
-                    description: ResourcePolicyStatus models the status of the policy for one resource to be configured.
+                    description: ResourcePolicyStatus models the status of the policy
+                      for one resource to be configured.
                     properties:
                       currentVersion:
                         description: |-
@@ -10155,13 +10575,16 @@ spec:
                         type: string
                     type: object
                   type: object
-                description: Details holds the status details for each resource to be configured.
+                description: Details holds the status details for each resource to
+                  be configured.
                 type: object
               errors:
-                description: Errors is the number of resources which have an incorrect configuration
+                description: Errors is the number of resources which have an incorrect
+                  configuration
                 type: integer
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed for this StackConfigPolicy.
+                description: ObservedGeneration is the most recent generation observed
+                  for this StackConfigPolicy.
                 format: int64
                 type: integer
               phase:
@@ -10171,14 +10594,16 @@ spec:
                 description: Ready is the number of resources successfully configured.
                 type: integer
               readyCount:
-                description: ReadyCount is a human representation of the number of resources successfully configured.
+                description: ReadyCount is a human representation of the number of
+                  resources successfully configured.
                 type: string
               resources:
                 description: Resources is the number of resources to be configured.
                 type: integer
               resourcesStatuses:
                 additionalProperties:
-                  description: ResourcePolicyStatus models the status of the policy for one resource to be configured.
+                  description: ResourcePolicyStatus models the status of the policy
+                    for one resource to be configured.
                   properties:
                     currentVersion:
                       description: |-
@@ -10213,802 +10638,3 @@ spec:
     storage: true
     subresources:
       status: {}
-
----
-# Source: eck-operator/templates/operator-namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: elastic-system
-  labels:
-    name: elastic-system
----
-# Source: eck-operator/templates/service-account.yaml
-apiVersion: v1
-kind: ServiceAccount
-automountServiceAccountToken: true
-metadata:
-  name: elastic-operator
-  namespace: elastic-system
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
----
-# Source: eck-operator/templates/webhook.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: elastic-webhook-server-cert
-  namespace: elastic-system
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
----
-# Source: eck-operator/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: elastic-operator
-  namespace: elastic-system
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-data:
-  eck.yaml: |-
-    log-verbosity: 0
-    metrics-port: 0
-    metrics-secure: false
-    container-registry: docker.elastic.co
-    max-concurrent-reconciles: 3
-    ca-cert-validity: 8760h
-    ca-cert-rotate-before: 24h
-    cert-validity: 8760h
-    cert-rotate-before: 24h
-    disable-config-watch: false
-    exposed-node-labels: [topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.*]
-    set-default-security-context: auto-detect
-    kube-client-timeout: 60s
-    elasticsearch-client-timeout: 180s
-    disable-telemetry: false
-    distribution-channel: all-in-one
-    validate-storage-class: true
-    enable-webhook: true
-    webhook-name: elastic-webhook.k8s.elastic.co
-    webhook-port: 9443
-    operator-namespace: elastic-system
-    enable-leader-election: true
-    elasticsearch-observation-interval: 10s
-    ubi-only: false
----
-# Source: eck-operator/templates/cluster-roles.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: elastic-operator
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-rules:
-- apiGroups:
-  - "authorization.k8s.io"
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  resourceNames:
-  - elastic-operator-leader
-  verbs:
-  - get
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - events
-  - persistentvolumeclaims
-  - secrets
-  - services
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  - daemonsets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - elasticsearch.k8s.elastic.co
-  resources:
-  - elasticsearches
-  - elasticsearches/status
-  - elasticsearches/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - autoscaling.k8s.elastic.co
-  resources:
-  - elasticsearchautoscalers
-  - elasticsearchautoscalers/status
-  - elasticsearchautoscalers/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - kibana.k8s.elastic.co
-  resources:
-  - kibanas
-  - kibanas/status
-  - kibanas/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - apm.k8s.elastic.co
-  resources:
-  - apmservers
-  - apmservers/status
-  - apmservers/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - enterprisesearch.k8s.elastic.co
-  resources:
-  - enterprisesearches
-  - enterprisesearches/status
-  - enterprisesearches/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - beat.k8s.elastic.co
-  resources:
-  - beats
-  - beats/status
-  - beats/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - agent.k8s.elastic.co
-  resources:
-  - agents
-  - agents/status
-  - agents/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - maps.k8s.elastic.co
-  resources:
-  - elasticmapsservers
-  - elasticmapsservers/status
-  - elasticmapsservers/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - stackconfigpolicy.k8s.elastic.co
-  resources:
-  - stackconfigpolicies
-  - stackconfigpolicies/status
-  - stackconfigpolicies/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - logstash.k8s.elastic.co
-  resources:
-  - logstashes
-  - logstashes/status
-  - logstashes/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
----
-# Source: eck-operator/templates/cluster-roles.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "elastic-operator-view"
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-rules:
-- apiGroups: ["elasticsearch.k8s.elastic.co"]
-  resources: ["elasticsearches"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["autoscaling.k8s.elastic.co"]
-  resources: ["elasticsearchautoscalers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apm.k8s.elastic.co"]
-  resources: ["apmservers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["kibana.k8s.elastic.co"]
-  resources: ["kibanas"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["enterprisesearch.k8s.elastic.co"]
-  resources: ["enterprisesearches"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["beat.k8s.elastic.co"]
-  resources: ["beats"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["agent.k8s.elastic.co"]
-  resources: ["agents"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["maps.k8s.elastic.co"]
-  resources: ["elasticmapsservers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["stackconfigpolicy.k8s.elastic.co"]
-  resources: ["stackconfigpolicies"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["logstash.k8s.elastic.co"]
-  resources: ["logstashes"]
-  verbs: ["get", "list", "watch"]
----
-# Source: eck-operator/templates/cluster-roles.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "elastic-operator-edit"
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-rules:
-- apiGroups: ["elasticsearch.k8s.elastic.co"]
-  resources: ["elasticsearches"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["autoscaling.k8s.elastic.co"]
-  resources: ["elasticsearchautoscalers"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["apm.k8s.elastic.co"]
-  resources: ["apmservers"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["kibana.k8s.elastic.co"]
-  resources: ["kibanas"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["enterprisesearch.k8s.elastic.co"]
-  resources: ["enterprisesearches"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["beat.k8s.elastic.co"]
-  resources: ["beats"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["agent.k8s.elastic.co"]
-  resources: ["agents"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["maps.k8s.elastic.co"]
-  resources: ["elasticmapsservers"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["stackconfigpolicy.k8s.elastic.co"]
-  resources: ["stackconfigpolicies"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
-- apiGroups: ["logstash.k8s.elastic.co"]
-  resources: ["logstashes"]
-  verbs: ["create", "delete", "deletecollection", "patch", "update"]
----
-# Source: eck-operator/templates/role-bindings.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: elastic-operator
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: elastic-operator
-subjects:
-- kind: ServiceAccount
-  name: elastic-operator
-  namespace: elastic-system
----
-# Source: eck-operator/templates/webhook.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: elastic-webhook-server
-  namespace: elastic-system
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-spec:
-  ports:
-  - name: https
-    port: 443
-    targetPort: 9443
-  selector:
-    control-plane: elastic-operator
----
-# Source: eck-operator/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: elastic-operator
-  namespace: elastic-system
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-spec:
-  selector:
-    matchLabels:
-      control-plane: elastic-operator
-  serviceName: elastic-operator
-  replicas: 1
-  template:
-    metadata:
-      annotations:
-        # Rename the fields "error" to "error.message" and "source" to "event.source"
-        # This is to avoid a conflict with the ECS "error" and "source" documents.
-        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
-        "checksum/config": 3fdaff4a979089797cb469806c19162f44297428bf811896931864c528196029
-      labels:
-        control-plane: elastic-operator
-    spec:
-      terminationGracePeriodSeconds: 10
-      serviceAccountName: elastic-operator
-      automountServiceAccountToken: true
-      securityContext:
-        runAsNonRoot: true
-      containers:
-      - image: "docker.elastic.co/eck/eck-operator:3.0.0"
-        imagePullPolicy: IfNotPresent
-        name: manager
-        args:
-        - "manager"
-        - "--config=/conf/eck.yaml"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-        env:
-        - name: OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: WEBHOOK_SECRET
-          value: elastic-webhook-server-cert
-        resources:
-          limits:
-            cpu: 1
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 150Mi
-        ports:
-        - containerPort: 9443
-          name: https-webhook
-          protocol: TCP
-        volumeMounts:
-        - mountPath: "/conf"
-          name: conf
-          readOnly: true
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: conf
-        configMap:
-          name: elastic-operator
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: elastic-webhook-server-cert
----
-# Source: eck-operator/templates/webhook.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: elastic-webhook.k8s.elastic.co
-  labels:
-    control-plane: elastic-operator
-    app.kubernetes.io/version: "3.0.0"
-webhooks:
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-agent-k8s-elastic-co-v1alpha1-agent
-  failurePolicy: Ignore
-  name: elastic-agent-validation-v1alpha1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - agent.k8s.elastic.co
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - agents
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-apm-k8s-elastic-co-v1-apmserver
-  failurePolicy: Ignore
-  name: elastic-apm-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - apm.k8s.elastic.co
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - apmservers
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
-  failurePolicy: Ignore
-  name: elastic-apm-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - apm.k8s.elastic.co
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - apmservers
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-beat-k8s-elastic-co-v1beta1-beat
-  failurePolicy: Ignore
-  name: elastic-beat-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - beat.k8s.elastic.co
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - beats
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-enterprisesearch-k8s-elastic-co-v1-enterprisesearch
-  failurePolicy: Ignore
-  name: elastic-ent-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - enterprisesearch.k8s.elastic.co
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - enterprisesearches
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
-  failurePolicy: Ignore
-  name: elastic-ent-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - enterprisesearch.k8s.elastic.co
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - enterprisesearches
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
-  failurePolicy: Ignore
-  name: elastic-es-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - elasticsearch.k8s.elastic.co
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - elasticsearches
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
-  failurePolicy: Ignore
-  name: elastic-es-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - elasticsearch.k8s.elastic.co
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - elasticsearches
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-ems-k8s-elastic-co-v1alpha1-mapsservers
-  failurePolicy: Ignore
-  name: elastic-ems-validation-v1alpha1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - maps.k8s.elastic.co
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - mapsservers
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-kibana-k8s-elastic-co-v1-kibana
-  failurePolicy: Ignore
-  name: elastic-kb-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - kibana.k8s.elastic.co
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kibanas
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
-  failurePolicy: Ignore
-  name: elastic-kb-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - kibana.k8s.elastic.co
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kibanas
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-autoscaling-k8s-elastic-co-v1alpha1-elasticsearchautoscaler
-  failurePolicy: Ignore
-  name: elastic-esa-validation-v1alpha1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - autoscaling.k8s.elastic.co
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - elasticsearchautoscalers
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-scp-k8s-elastic-co-v1alpha1-stackconfigpolicies
-  failurePolicy: Ignore
-  name: elastic-scp-validation-v1alpha1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - stackconfigpolicy.k8s.elastic.co
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - stackconfigpolicies
-- clientConfig:
-    service:
-      name: elastic-webhook-server
-      namespace: elastic-system
-      path: /validate-logstash-k8s-elastic-co-v1alpha1-logstash
-  failurePolicy: Ignore
-  name: elastic-logstash-validation-v1alpha1.k8s.elastic.co
-  matchPolicy: Exact
-  admissionReviewVersions: [v1, v1beta1]
-  sideEffects: None
-  rules:
-  - apiGroups:
-    - logstash.k8s.elastic.co
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - logstashes
-

--- a/k8s/cloud_deps/dev/elastic/elastic_replica_patch.yaml
+++ b/k8s/cloud_deps/dev/elastic/elastic_replica_patch.yaml
@@ -5,12 +5,8 @@
   value: 2
 
 - op: replace
-  path: /spec/nodeSets/0/config/node.data
-  value: true
-
-- op: replace
-  path: /spec/nodeSets/0/config/node.ingest
-  value: true
+  path: /spec/nodeSets/0/config/node.roles
+  value: ["master", "data", "ingest"]
 
 # Data node.
 - op: replace

--- a/k8s/cloud_deps/public/elastic/elastic_gcs_plugin.yaml
+++ b/k8s/cloud_deps/public/elastic/elastic_gcs_plugin.yaml
@@ -1,5 +1,0 @@
----
-- op: remove
-  path: /spec/nodeSets/0/podTemplate/spec/initContainers/0
-- op: remove
-  path: /spec/nodeSets/1/podTemplate/spec/initContainers/0

--- a/k8s/cloud_deps/public/elastic/elastic_replica_patch.yaml
+++ b/k8s/cloud_deps/public/elastic/elastic_replica_patch.yaml
@@ -5,12 +5,8 @@
   value: 2
 
 - op: replace
-  path: /spec/nodeSets/0/config/node.data
-  value: true
-
-- op: replace
-  path: /spec/nodeSets/0/config/node.ingest
-  value: true
+  path: /spec/nodeSets/0/config/node.roles
+  value: ["master", "data", "ingest"]
 
 # Data node.
 - op: replace

--- a/k8s/cloud_deps/public/elastic/kustomization.yaml
+++ b/k8s/cloud_deps/public/elastic/kustomization.yaml
@@ -21,9 +21,3 @@ patches:
     kind: Elasticsearch
     name: pl-elastic
     version: v1
-- path: elastic_gcs_plugin.yaml
-  target:
-    group: elasticsearch.k8s.elastic.co
-    kind: Elasticsearch
-    name: pl-elastic
-    version: v1

--- a/src/cloud/indexer/md/mapping.o.go
+++ b/src/cloud/indexer/md/mapping.o.go
@@ -106,7 +106,7 @@ const IndexMapping = `
         },
         "tokenizer": {
           "ngram_tokenizer": {
-            "type": "nGram",
+            "type": "ngram",
             "min_gram": "1",
             "max_gram": "10",
             "token_chars": [


### PR DESCRIPTION
Summary: Upgrade Elasticsearch to latest LTS version (9.x)

TBD

Relevant Issues: N/A

Type of change: /kind dependencies

Test Plan: Deployed a fresh cloud and verified indexer service is functional and pxl argument autocomplete works

Changelog Message: Upgrade Pixie cloud's Elasticsearch from 7.6.0 to the latest LTS release (9.x).

⚠️ This upgrade involves two major version changes and care must be taken to seamlessly upgrade an existing cluster. The two strategies for migrating to the new version include upgrading one major version at a time (as detailed [here](https://www.elastic.co/guide/en/elastic-stack/8.18/upgrading-elastic-stack.html#prepare-to-upgrade)) or reindexing your data to a [new deployment](https://www.elastic.co/guide/en/elastic-stack/8.18/upgrade-elastic-stack-for-elastic-cloud.html#upgrading-reindex). Please consult the official Elasticsearch docs for more details.