### PR TITLE
Upgrade NATS go version

### DIFF
--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
       containers:
       - name: pl-nats
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/nats:2.9.25-scratch@sha256:869605f46ad21b76be1998e89345640671dbe46714105cf67676ddb0b78d3b85
+        image: ghcr.io/pixie-io/nats:2.9.25-scratch-pl1@sha256:ac7228464fbc7154e91c9a00cba85b5da1df9a3ded6c784cdd6009cece85a1e3
         ports:
         - containerPort: 4222
           name: client

--- a/k8s/vizier_deps/base/nats/nats_statefulset.yaml
+++ b/k8s/vizier_deps/base/nats/nats_statefulset.yaml
@@ -111,7 +111,7 @@ spec:
       containers:
       - name: pl-nats
         # yamllint disable-line rule:line-length
-        image: ghcr.io/pixie-io/nats:2.9.25-scratch@sha256:869605f46ad21b76be1998e89345640671dbe46714105cf67676ddb0b78d3b85
+        image: ghcr.io/pixie-io/nats:2.9.25-scratch-pl1@sha256:ac7228464fbc7154e91c9a00cba85b5da1df9a3ded6c784cdd6009cece85a1e3
         ports:
         - containerPort: 4222
           name: client

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -116,7 +116,8 @@ LINUX_HEADERS_GS_PATH := gs://pixie-dev-public/linux-headers/$(LINUX_HEADERS_REV
 
 ## NATS image parameters.
 NATS_IMAGE_VERSION := 2.9.25
-nats_image_tag := "ghcr.io/pixie-io/nats:$(NATS_IMAGE_VERSION)-scratch"
+NATS_IMAGE_REV := pl1
+nats_image_tag := "ghcr.io/pixie-io/nats:$(NATS_IMAGE_VERSION)-scratch-$(NATS_IMAGE_REV)"
 
 ## Ory image parameters.
 KRATOS_IMAGE_VERSION := 1.3.1

--- a/tools/docker/nats_image/Dockerfile
+++ b/tools/docker/nats_image/Dockerfile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine@sha256:fd9d9d7194ec40a9a6ae89fcaef3e47c47de7746dd5848ab5343695dbbd09f8c AS build
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d AS build
 
 ARG TARGETOS TARGETARCH
 ARG NATS_VERSION


### PR DESCRIPTION
Summary: Upgrade NATS go version

Relevant Issues: N/A

Type of change: /kind dependency

Test Plan: Image builds successfully