### PR TITLE
Remove use of protobuf debug APIs in test assertions to fix breaking change

### DIFF
--- a/src/carnot/planner/compiler_error_context/compiler_error_context_test.cc
+++ b/src/carnot/planner/compiler_error_context/compiler_error_context_test.cc
@@ -51,7 +51,7 @@ TEST(CompilerErrorContextStatus, Default) {
   ASSERT_TRUE(status_pb.context().Is<compilerpb::CompilerErrorGroup>());
 
   status_pb.context().UnpackTo(&errorgroup_out);
-  EXPECT_EQ(errorgroup_in.DebugString(), errorgroup_out.DebugString());
+  EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(errorgroup_in, errorgroup_out));
   for (int64_t i = 0; i < errorgroup_in.errors_size(); i++) {
     auto error_parent_out = errorgroup_in.errors(i);
     auto error_out = error_parent_out.line_col_error();

--- a/src/carnot/planner/distributed/distributed_plan/distributed_plan_test.cc
+++ b/src/carnot/planner/distributed/distributed_plan/distributed_plan_test.cc
@@ -18,6 +18,7 @@
 
 #include <gmock/gmock.h>
 #include <google/protobuf/text_format.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 
 #include <unordered_map>
@@ -208,7 +209,8 @@ TEST_F(DistributedPlanTest, construction_test) {
 
   for (const auto& [carnot_id, carnot_info] : carnot_id_to_carnot_info_map) {
     CarnotInstance* carnot_instance = physical_plan->Get(carnot_id);
-    EXPECT_THAT(carnot_instance->carnot_info(), EqualsProto(carnot_info.DebugString()));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(carnot_instance->carnot_info(),
+                                                                   carnot_info));
     EXPECT_THAT(carnot_instance->QueryBrokerAddress(), carnot_info.query_broker_address());
     auto new_graph = std::make_shared<IR>();
     SwapGraphBeingBuilt(new_graph);

--- a/src/carnot/planner/docs/doc_extractor_main.cc
+++ b/src/carnot/planner/docs/doc_extractor_main.cc
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <fstream>
+#include <string>
+
+#include <google/protobuf/text_format.h>
+
 #include "src/carnot/planner/docs/doc_extractor.h"
 #include "src/carnot/udf_exporter/udf_exporter.h"
-
-#include <fstream>
 
 namespace px {
 namespace carnot {
@@ -79,8 +82,11 @@ int main(int argc, char** argv) {
   }
   auto docs = docs_or_s.ConsumeValueOrDie();
 
+  std::string text_output;
+  google::protobuf::TextFormat::PrintToString(docs, &text_output);
+
   std::ofstream output_file;
   output_file.open(FLAGS_output_file);
-  output_file << docs.DebugString();
+  output_file << text_output;
   output_file.close();
 }

--- a/src/common/base/status_test.cc
+++ b/src/common/base/status_test.cc
@@ -111,7 +111,7 @@ TEST(Status, context_copy_tests) {
   Status s2 = s1;
   EXPECT_TRUE(s2.has_context());
   EXPECT_EQ(s1, s2);
-  EXPECT_EQ(s1.context()->DebugString(), s2.context()->DebugString());
+  EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(*s1.context(), *s2.context()));
 }
 
 TEST(Status, context_vs_no_context_status) {
@@ -120,7 +120,7 @@ TEST(Status, context_vs_no_context_status) {
   EXPECT_NE(s1, s2);
   EXPECT_FALSE(s2.has_context());
   EXPECT_EQ(s2.context(), nullptr);
-  EXPECT_NE(s1.ToProto().DebugString(), s2.ToProto().DebugString());
+  EXPECT_FALSE(google::protobuf::util::MessageDifferencer::Equals(s1.ToProto(), s2.ToProto()));
 }
 
 TEST(StatusAdapter, proto_with_context_test) {

--- a/src/vizier/services/agent/pem/tracepoint_manager_test.cc
+++ b/src/vizier/services/agent/pem/tracepoint_manager_test.cc
@@ -115,8 +115,8 @@ TEST_F(TracepointManagerTest, CreateTracepoint) {
   tracepoint->set_name("test_tracepoint");
 
   EXPECT_CALL(stirling_,
-              RegisterTracepoint(tracepoint_id, ::testing::Pointee(testing::proto::EqualsProto(
-                                                    tracepoint->DebugString()))));
+              RegisterTracepoint(tracepoint_id,
+                                 ::testing::Pointee(testing::proto::EqualsProto(*tracepoint))));
   EXPECT_OK(tracepoint_manager_->HandleMessage(std::move(msg)));
 
   EXPECT_CALL(stirling_, GetTracepointInfo(tracepoint_id))
@@ -152,8 +152,8 @@ TEST_F(TracepointManagerTest, CreateTracepointFailed) {
   tracepoint->set_name("test_tracepoint");
 
   EXPECT_CALL(stirling_,
-              RegisterTracepoint(tracepoint_id, ::testing::Pointee(testing::proto::EqualsProto(
-                                                    tracepoint->DebugString()))));
+              RegisterTracepoint(tracepoint_id,
+                                 ::testing::Pointee(testing::proto::EqualsProto(*tracepoint))));
   EXPECT_OK(tracepoint_manager_->HandleMessage(std::move(msg)));
 
   EXPECT_CALL(stirling_, GetTracepointInfo(tracepoint_id))
@@ -185,8 +185,8 @@ TEST_F(TracepointManagerTest, CreateTracepointPreconditionFailed) {
   tracepoint->set_name("test_tracepoint");
 
   EXPECT_CALL(stirling_,
-              RegisterTracepoint(tracepoint_id, ::testing::Pointee(testing::proto::EqualsProto(
-                                                    tracepoint->DebugString()))));
+              RegisterTracepoint(tracepoint_id,
+                                 ::testing::Pointee(testing::proto::EqualsProto(*tracepoint))));
   EXPECT_OK(tracepoint_manager_->HandleMessage(std::move(msg)));
 
   EXPECT_CALL(stirling_, GetTracepointInfo(tracepoint_id))


### PR DESCRIPTION
Summary: Remove use of protobuf debug APIs in test assertions to fix breaking change

Protobuf v30 and later intentionally malform the `DebugString` string output to prevent it from being parsed as a protobuf message ([announcement details](https://protobuf.dev/news/2024-12-04/)). This breaks our protobuf test assertions and is something we need to fix ahead of migrating to bazel 7.

Relevant Issues: https://github.com/pixie-io/pixie/issues/2282

Type of change: /kind cleanup

Test Plan: Build should pass