### PR TITLE
Increase ASAN short test timeout to address flaky tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -143,7 +143,8 @@ test:gcc --config=tmp-sandbox
 build:asan --config=clang
 build:asan --//bazel:sanitizer=asan
 build:asan --features=asan
-build:asan --test_timeout="120,600,1800,3600"
+# TODO(#2295): Revert to lower timeouts once ASAN performance is improved.
+build:asan --test_timeout="180,600,1800,3600"
 build:asan --define PL_CONFIG_ASAN=1
 build:asan --define tcmalloc=disabled
 build:asan --build_tag_filters=-no_asan

--- a/src/vizier/services/agent/shared/manager/BUILD.bazel
+++ b/src/vizier/services/agent/shared/manager/BUILD.bazel
@@ -86,8 +86,6 @@ pl_cc_test(
 
 pl_cc_test(
     name = "heartbeat_test",
-    # TODO(ddelnano): Remove the moderate timeout once flakiness is resolved (gh#2295)
-    timeout = "moderate",
     srcs = ["heartbeat_test.cc"],
     deps = [
         ":cc_library",
@@ -120,8 +118,6 @@ pl_cc_test(
 
 pl_cc_test(
     name = "registration_test",
-    # TODO(ddelnano): Remove the moderate timeout once flakiness is resolved (gh#2295)
-    timeout = "moderate",
     srcs = ["registration_test.cc"],
     deps = [
         ":cc_library",


### PR DESCRIPTION
Summary: Increase ASAN short test timeout to address flaky tests

The following tests are frequently hitting the 2-minute Bazel timeout on ASAN builds:
- `//src/vizier/services/agent/shared/manager:heartbeat_test`
- `//src/vizier/services/agent/shared/manager:registration_test`
- `//src/carnot/builtins:collections_test`

BuildBuddy history from the main branch shows these tests are running up against the timeout threshold (see screenshot below). I believe BuildBuddy is under reporting the issues seen since builds are also seeing BEP API timeouts.

<img width="912" height="512" alt="Screenshot 2025-12-10 at 12 05 55 PM" src="https://github.com/user-attachments/assets/3a7632b9-ef1d-407b-81aa-1f9babdbaea3" />

```
//src/vizier/services/agent/shared/manager:heartbeat_test               TIMEOUT in 120.5s
  /github/home/.cache/bazel/_bazel_root/56ec069a32c4abebc78228236a835895/execroot/px/bazel-out/k8-dbg/testlogs/src/vizier/services/agent/shared/manager/heartbeat_test/test.log
//src/vizier/services/agent/shared/manager:registration_test            TIMEOUT in 120.5s
  /github/home/.cache/bazel/_bazel_root/56ec069a32c4abebc78228236a835895/execroot/px/bazel-out/k8-dbg/testlogs/src/vizier/services/agent/shared/manager/registration_test/test.log

[ ... ]
ERROR: The Build Event Protocol upload timed out. com.google.common.util.concurrent.TimeoutFuture$TimeoutFutureException: Timed out: NonCancellationPropagatingFuture@6ce6bba6[status=PENDING, info=[delegate=[SettableFuture@29e4285e[status=PENDING]]]]
Bazel returned code 38, ignoring...
```

This PR increases the short test timeout to unblock ongoing Bazel 7 upgrade work and prevent unrelated PRs from failing due to these timeouts.

Relevant Issues: #2295

Type of change: /kind bugfix

Test Plan: Build succeeds