### PR TITLE
Upgrade magic_enum to fix builds for clang v16 and later

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -168,9 +168,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/nats-io/nats.c/archive/refs/tags/v3.3.0.tar.gz"],
     ),
     com_github_neargye_magic_enum = dict(
-        sha256 = "4fe6627407a656d0d73879c0346b251ccdcfb718c37bef5410ba172c7c7d5f9a",
-        strip_prefix = "magic_enum-0.7.0",
-        urls = ["https://github.com/Neargye/magic_enum/archive/refs/tags/v0.7.0.tar.gz"],
+        sha256 = "b403d3dad4ef542fdc3024fa37d3a6cedb4ad33c72e31b6d9bab89dcaf69edf7",
+        strip_prefix = "magic_enum-0.9.7",
+        urls = ["https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.7.tar.gz"],
     ),
     com_github_nlohmann_json = dict(
         sha256 = "87b5884741427220d3a33df1363ae0e8b898099fbc59f1c451113f6732891014",

--- a/src/carnot/exec/agg_node.cc
+++ b/src/carnot/exec/agg_node.cc
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <cstdint>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/carnot/exec/expression_evaluator.h"
 #include "src/carnot/plan/scalar_expression.h"

--- a/src/carnot/exec/udtf_source_node.cc
+++ b/src/carnot/exec/udtf_source_node.cc
@@ -25,7 +25,7 @@
 #include <string_view>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/carnot/plan/scalar_expression.h"
 #include "src/carnot/udf/registry.h"

--- a/src/carnot/plan/operators.cc
+++ b/src/carnot/plan/operators.cc
@@ -29,7 +29,7 @@
 #include <absl/strings/str_join.h>
 #include <absl/strings/substitute.h>
 #include <google/protobuf/text_format.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/carnot/plan/scalar_expression.h"
 #include "src/carnot/planpb/plan.pb.h"

--- a/src/carnot/plan/plan_fragment.cc
+++ b/src/carnot/plan/plan_fragment.cc
@@ -26,7 +26,7 @@
 
 #include <absl/strings/str_cat.h>
 #include <absl/strings/substitute.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/carnot/dag/dag.h"
 #include "src/carnot/planpb/plan.pb.h"

--- a/src/carnot/planner/parser/parser.cc
+++ b/src/carnot/planner/parser/parser.cc
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <pypa/ast/ast.hh>
 #include <pypa/ast/tree_walker.hh>
 #include <pypa/parser/parser.hh>

--- a/src/common/base/enum_utils.h
+++ b/src/common/base/enum_utils.h
@@ -21,7 +21,7 @@
 #include <map>
 #include <utility>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 namespace px {
 

--- a/src/common/base/error.h
+++ b/src/common/base/error.h
@@ -21,7 +21,7 @@
 #include <string>
 
 #include <absl/strings/substitute.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/status.h"
 #include "src/common/base/statuspb/status.pb.h"

--- a/src/common/base/magic_enum_test.cc
+++ b/src/common/base/magic_enum_test.cc
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum_all.hpp>
 #include "src/common/testing/testing.h"
 
 // The following test cases are mostly from MagicEnum docs: https://github.com/Neargye/magic_enum.

--- a/src/common/base/utils.h
+++ b/src/common/base/utils.h
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include <absl/strings/str_format.h>
 #include "src/common/base/error.h"

--- a/src/integrations/grpc_clocksync/grpc_clock_converter.h
+++ b/src/integrations/grpc_clocksync/grpc_clock_converter.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "src/common/clock/clock_conversion.h"
 #include "src/integrations/grpc_clocksync/proto/clocksync.grpc.pb.h"
 

--- a/src/shared/types/typespb/wrapper/types_pb_wrapper.h
+++ b/src/shared/types/typespb/wrapper/types_pb_wrapper.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/shared/types/typespb/types.pb.h"
 

--- a/src/stirling/bpf_tools/bcc_wrapper.cc
+++ b/src/stirling/bpf_tools/bcc_wrapper.cc
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <string>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/common/fs/fs_wrapper.h"

--- a/src/stirling/bpf_tools/probe_specs/probe_specs.h
+++ b/src/stirling/bpf_tools/probe_specs/probe_specs.h
@@ -36,7 +36,7 @@
 #include <memory>
 #include <string>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/common/json/json.h"

--- a/src/stirling/core/source_connector.cc
+++ b/src/stirling/core/source_connector.cc
@@ -20,7 +20,7 @@
 #include <ctime>
 #include <memory>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/core/source_connector.h"
 

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.hpp
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.hpp
@@ -25,7 +25,7 @@
 #include <string>
 
 #include <absl/strings/substitute.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/enum_utils.h"
 #include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.h"

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/go_grpc_types.hpp
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/go_grpc_types.hpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <string>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/common.hpp"

--- a/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/protocols_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/bcc_bpf_intf/protocols_test.cc
@@ -18,7 +18,7 @@
 
 #include <absl/strings/str_replace.h>
 #include <gtest/gtest.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.cc
@@ -30,7 +30,7 @@
 #include <vector>
 
 #include <absl/strings/numbers.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/inet_utils.h"
 #include "src/common/system/proc_pid_path.h"

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker.h
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker.h
@@ -29,7 +29,7 @@
 #include <variant>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/system/proc_parser.h"
 #include "src/common/system/socket_info.h"

--- a/src/stirling/source_connectors/socket_tracer/conn_tracker_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/conn_tracker_test.cc
@@ -25,7 +25,7 @@
 #include <gtest/gtest.h>
 #include <sys/socket.h>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "protocols/http/types.h"
 #include "src/common/testing/testing.h"

--- a/src/stirling/source_connectors/socket_tracer/metrics.cc
+++ b/src/stirling/source_connectors/socket_tracer/metrics.cc
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/source_connectors/socket_tracer/metrics.h"
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/cql/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/cql/types.h
@@ -22,7 +22,7 @@
 #include <optional>
 #include <string>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"  // For FrameBase.
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/dns/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/dns/types.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"  // For FrameBase.
 

--- a/src/stirling/source_connectors/socket_tracer/protocols/kafka/common/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/kafka/common/types.h
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"  // For FrameBase

--- a/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mux/types.h
@@ -23,7 +23,7 @@
 #include <utility>
 
 #include <absl/container/flat_hash_map.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"
 #include "src/stirling/utils/utils.h"

--- a/src/stirling/source_connectors/socket_tracer/protocols/mysql/types.h
+++ b/src/stirling/source_connectors/socket_tracer/protocols/mysql/types.h
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/stirling/source_connectors/socket_tracer/protocols/common/event_parser.h"  // For FrameBase

--- a/src/stirling/source_connectors/socket_tracer/protocols/pgsql/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/pgsql/parse.cc
@@ -25,7 +25,7 @@
 #include <utility>
 
 #include <absl/strings/ascii.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/stirling/utils/binary_decoder.h"

--- a/src/stirling/source_connectors/socket_tracer/protocols/tls/parse.cc
+++ b/src/stirling/source_connectors/socket_tracer/protocols/tls/parse.cc
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/utils/binary_decoder.h"
 

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_bpf_test.cc
@@ -24,7 +24,7 @@
 #include <string_view>
 #include <thread>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/fs/temp_file.h"
 #include "src/common/system/clock.h"

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector.cc
@@ -30,7 +30,7 @@
 #include <absl/strings/match.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/delimited_message_util.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "src/common/system/kernel_version.h"
 
 #include "src/common/base/base.h"

--- a/src/stirling/source_connectors/socket_tracer/socket_trace_connector_benchmark.cc
+++ b/src/stirling/source_connectors/socket_tracer/socket_trace_connector_benchmark.cc
@@ -21,7 +21,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/str_split.h>
 #include <benchmark/benchmark.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/perf/memory_tracker.h"
 #include "src/common/perf/tcmalloc.h"
@@ -91,8 +91,7 @@ px::StatusOr<absl::flat_hash_set<DisplayStatCategory>> GetDisplayStatCategories(
   absl::flat_hash_set<DisplayStatCategory> categories;
   auto case_insensitive_cmp = [](char a, char b) { return tolower(a) == tolower(b); };
   for (std::string_view category_str : absl::StrSplit(FLAGS_display, ",")) {
-    auto cast_opt = magic_enum::enum_cast<DisplayStatCategory, decltype(case_insensitive_cmp)>(
-        category_str, case_insensitive_cmp);
+    auto cast_opt = magic_enum::enum_cast<DisplayStatCategory>(category_str, case_insensitive_cmp);
     if (!cast_opt.has_value()) {
       return px::error::InvalidArgument("Invalid DisplayStatCategory: ", category_str);
     }

--- a/src/stirling/source_connectors/stirling_error/stirling_error_connector.cc
+++ b/src/stirling/source_connectors/stirling_error/stirling_error_connector.cc
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 #include "src/common/system/proc_parser.h"

--- a/src/stirling/testing/overloads.h
+++ b/src/stirling/testing/overloads.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <absl/strings/substitute.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/stirling/utils/monitor.h"
 #include "src/stirling/utils/tcp_stats.h"

--- a/src/stirling/utils/enum_map.h
+++ b/src/stirling/utils/enum_map.h
@@ -22,13 +22,15 @@
 #include <vector>
 
 #include <absl/container/flat_hash_set.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/common/base/base.h"
 
 namespace px {
 namespace stirling {
 namespace utils {
+
+using magic_enum::as_common;
 
 /**
  * A map-like data structure backed by vector. The key type must be enum type.
@@ -38,7 +40,7 @@ namespace utils {
 template <typename TEnumKeyType, typename TValueType>
 class EnumMap {
  public:
-  EnumMap() : values_(magic_enum::detail::reflected_max_v<TEnumKeyType>) {}
+  EnumMap() : values_(magic_enum::detail::reflected_max<TEnumKeyType, as_common<>>()) {}
 
   bool Set(TEnumKeyType key, TValueType value) {
     if (set_keys_.contains(key)) {

--- a/src/stirling/utils/stat_counter.h
+++ b/src/stirling/utils/stat_counter.h
@@ -25,7 +25,7 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/substitute.h>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 namespace px {
 namespace stirling {

--- a/src/vizier/funcs/md_udtfs/md_udtfs_impl.h
+++ b/src/vizier/funcs/md_udtfs/md_udtfs_impl.h
@@ -29,7 +29,7 @@
 
 #include <absl/numeric/int128.h>
 #include <grpcpp/grpcpp.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "src/carnot/udf/registry.h"
 #include "src/carnot/udf/udf.h"


### PR DESCRIPTION
Summary: Upgrade magic_enum to fix builds for clang v16 and later

This upgrades to a magic_enum version that includes this fix (https://github.com/Neargye/magic_enum/issues/204).

Relevant Issues: #2298

Type of change: /kind cleanup

Test Plan: Build succeeds