### PR TITLE
Upgrade bcc to version that's clang 21 compatible

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -130,10 +130,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/h2o/picohttpparser/archive/1d2b8a184e7ebe6651c30dcede37ba1d89691351.tar.gz"],
     ),
     com_github_iovisor_bcc = dict(
-        sha256 = "416426fbe22d617d8aed088062f4489e69176136e99dc0b933df58e83d9175da",
-        strip_prefix = "bcc-e57be8465b9cf238f1c04b1c7e154fd1db85326d",
+        sha256 = "a5634e161436058f396bba0e0219379de4f4cd2b95ecc6186eca5f6042a828e0",
+        strip_prefix = "bcc-6653dcb43b3be2e0c5a8e75fce7e0ed9b055e8eb",
         urls = [
-            "https://github.com/pixie-io/bcc/archive/e57be8465b9cf238f1c04b1c7e154fd1db85326d.tar.gz",
+            "https://github.com/pixie-io/bcc/archive/6653dcb43b3be2e0c5a8e75fce7e0ed9b055e8eb.tar.gz",
         ],
     ),
     com_github_iovisor_bpftrace = dict(


### PR DESCRIPTION
Summary: Upgrade bcc to version that's clang 21 compatible

This upgrades bcc to a commit from the [pixie10 branch](https://github.com/pixie-io/bcc/commits/pixie10). This most recent rebase includes the following changes:
* Rebased the 9 Pixie-specific commits on top of [v0.35.0](https://github.com/iovisor/bcc/tree/v0.35.0) plus 31 additional upstream commits through 8c5c96ad (commit log seen below)
* Removes https://github.com/pixie-io/bcc/commit/41b2fbe0fc992287c44b1b0e60e45fc8f1ff6a13 from our fork as it's available upstream (https://github.com/iovisor/bcc/pull/4442)
<details><summary>Commits included on top of v0.35.0</summary>

```
git log v0.35.0...8c5c96ad3beeed2fa827017f451a952306826974 --oneline
8c5c96ad Fix a build failure with clang21 (#5369)
b8b76e9a add descriptions for using pid in attach_uprobe and attach_uretprobe. (#5367)
36305815 tools/{biolatency,biosnoop,biotop}: use TRACEPOINT_PROBE() for tracepoints (#5366)
c8ad35aa Cleanup CODEOWNERS file (#5368)
78423e16 Add support for executing a program and tracing it (#5362)
21143df6 libbpf-tools/ksnoop: Remove useless and white lines (#5365)
a9c6650e syscall_helpers.c / syscall.py: update syscall list (#5363)
56409526 Fix potential verification failure for opensnoop.py (#5364)
0ae562c8 libbpf-tools: ksnoop: Fix two invalid access to map value (#5361)
789e923f libbpf-tools/klockstat: Allows kprobe fallback to work with lock debugging (#5359)
5f7bcb36 libbpf-tools/memleak: fix typo (#5358)
6bd2760a bcc:  Fix for test tools_memleak.py (#5355)
af21da6f libbpf-tools/filelife: Fix wrong full-path (#5347)
ac3eda96 net_monitor: fix typos in comments (#5360)
673911cf libbpf-tools: runqslower: add -c option to filter by process name prefix
2f3361c6 libbpf-tools: Fix the license for newly added path* files (#5346)
137bd5fb tools/filetop: Add directory filter (#5300)
9adce7ad libbpf-tools/syscall_helpers: Modify syscall_name to return error code (#5314)
939828c4 tools/runqlat: Dynamically size pid/pidns histogram map (#5342)
74bddcbe libbpf-tools/filelife: support full-path
ab8e0616 libbpf-tools: Introduce path helpers
d1faaf3d tools/opensnoop: support mount full-path (#5339)
8e3a1d33 tools/opensnoop: one event is enough for full-path (#5334)
7c4cf388 Bcc: mptcpify: add the NULL check for variable 'mode' (#5336)
6291ff52 libbpf-tools/opensnoop: support mount full-path (#5333)
2f77081d fix typo in README.md (#5335)
ee3ba780 libbpf-tools/offcputime: fix min or max_block_ns unit (#5327)
26eaf13b removing luajit options to ensure no errors will be thrown when running (#5326)
b1c5548d libbpf-tools: opensnoop: add full-path argument -F (#5323)
bbb8df98 Added functionality to detach all uprobes for a binary (#5325)
4bc48581 Doc/dead links (#5322)
```

</details>

Relevant Issues: #2298

Type of change: /kind cleanup

Test Plan: `#ci:bpf-build-all-kernels` build should pass
- [x] Socket tracer is functional on COS GKE cluster
- [x] Socket tracer is functional on Amazon Linux 2023 EKS cluster
- [x] Socket tracer is functional on Bottlerocket EKS cluster