### PR TITLE
Replace u8string method to keep return value consistent

### DIFF
--- a/src/carnot/funcs/os/filesystem.h
+++ b/src/carnot/funcs/os/filesystem.h
@@ -42,7 +42,7 @@ inline std::string GetSharedLibraries(md::UPID upid) {
   for (const auto& p : std::filesystem::directory_iterator(fpath)) {
     if (std::filesystem::is_symlink(p)) {
       auto symlink = std::filesystem::read_symlink(p);
-      libraries.push_back(symlink.u8string());
+      libraries.push_back(symlink.string());
     }
   }
 


### PR DESCRIPTION
Summary: Replace `u8string` method to keep return value consistent

In c++ 20, the `u8string` method uses a different return type. This PR removes the use of this function to keep the code compatible with c++17 and c++20 in preparation for the clang 21 upgrade.

Relevant Issues: #2298

Type of change: /kind cleanup

Test Plan: Build should succeed