### PR TITLE
Bump pxapi to 0.9.1 after Authlib upgrade

### DIFF
--- a/src/api/python/BUILD.bazel
+++ b/src/api/python/BUILD.bazel
@@ -43,7 +43,7 @@ py_wheel(
         "protobuf==6.33.1",
     ],
     strip_path_prefixes = ["src/api/python/"],
-    version = "0.9.0",
+    version = "0.9.1",
     deps = [
         "//src/api/python/pxapi:pxapi_library",
         "//src/api/python/pxapi/proto:pxapi_py_proto_library",


### PR DESCRIPTION
Summary: TSIA

Relevant Issues: N/A

Type of change: /kind dependency

Test Plan: Previous testing in #2346

Changelog Message: Release 0.9.1 pxapi python pip package
