### PR TITLE
Trim linux headers to LTS kernel versions for 4.x and 5.x and include new LTS versions for 6.x kernels.

### DIFF
--- a/bazel/linux_headers.bzl
+++ b/bazel/linux_headers.bzl
@@ -28,19 +28,17 @@ def linux_headers():
     http_file(
         name = "linux_headers_merged_x86_64_tar_gz",
         urls = [
-            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl7/linux-headers-merged-x86_64-pl7.tar.gz",
-            "https://storage.googleapis.com/pixie-dev-public/linux-headers/pl7/linux-headers-merged-x86_64-pl7.tar.gz",
+            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl8/linux-headers-merged-x86_64-pl8.tar.gz",
         ],
-        sha256 = "e4635db60d7f4139a8fea1b0490a0d0159e1edb9f3272ba2bcf40f8ea933bf93",
+        sha256 = "07d0393aca727faadd41146585f92e3d9df239d91e2fa985ec55e50dc8526594",
         downloaded_file_path = "linux-headers-merged-x86_64.tar.gz",
     )
     http_file(
         name = "linux_headers_merged_arm64_tar_gz",
         urls = [
-            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl7/linux-headers-merged-arm64-pl7.tar.gz",
-            "https://storage.googleapis.com/pixie-dev-public/linux-headers/pl7/linux-headers-merged-arm64-pl7.tar.gz",
+            "https://github.com/pixie-io/dev-artifacts/releases/download/linux-headers%2Fpl8/linux-headers-merged-arm64-pl8.tar.gz",
         ],
-        sha256 = "c2a99ad6462dd1211c4e2f54f7279b7cf526e73918148350ccba988b95ca6115",
+        sha256 = "75a05de508a7e83204e023ecdbdc2322b42fc812037a253de29c178871db7012",
         downloaded_file_path = "linux-headers-merged-arm64.tar.gz",
     )
 

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -74,12 +74,12 @@ LINUX_HEADER_BUILD_DIR := $(BUILD_DIR)/linux_headers
 LINUX_HEADER_ASSETS_BUILD_DIR := $(LINUX_HEADER_BUILD_DIR)/assets
 LINUX_KERNEL_VERSIONS := 4.18.20 \
         5.10.252 \
-	5.14.21 \
-	6.1.167 \
-	6.6.132 \
-	6.12.80 \
-	6.18.21 \
-	6.19.10
+        5.14.21 \
+        6.1.167 \
+        6.6.132 \
+        6.12.80 \
+        6.18.21 \
+        6.19.10
 
 
 LINUX_HEADER_TEMPLATE := linux-headers-%.tar.gz
@@ -114,7 +114,8 @@ elasticsearch_image_tag := "gcr.io/pixie-oss/pixie-dev-public/elasticsearch:$(EL
 
 ## Linux kernel for qemu/BPF tests.
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel_build
-KERNEL_BUILD_VERSIONS := 5.10.252 \
+KERNEL_BUILD_VERSIONS := 4.14.309 \
+        5.10.252 \
 	5.14.21 \
 	6.1.167 \
 	6.6.132 \

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -72,36 +72,15 @@ SYSROOT_CREATOR_IMAGE_TAG := sysroot-creator-$(SYSROOT_REV)
 ## Linux image parameters
 LINUX_HEADER_BUILD_DIR := $(BUILD_DIR)/linux_headers
 LINUX_HEADER_ASSETS_BUILD_DIR := $(LINUX_HEADER_BUILD_DIR)/assets
-LINUX_KERNEL_VERSIONS := 4.14.309 \
-	4.15.18 \
-	4.16.18 \
-	4.17.19 \
-	4.18.20 \
-	4.19.325 \
-	4.20.17 \
-	5.0.21 \
-	5.1.21 \
-	5.2.21 \
-	5.3.18 \
-	5.4.293 \
-	5.5.19 \
-	5.6.19 \
-	5.7.19 \
-	5.8.18 \
-	5.9.16 \
-	5.10.237 \
-	5.11.22 \
-	5.12.19 \
-	5.13.19 \
+LINUX_KERNEL_VERSIONS := 4.18.20 \
+        5.10.252 \
 	5.14.21 \
-	5.15.181 \
-	5.16.20 \
-	5.17.15 \
-	5.18.19 \
-	5.19.17 \
-	6.0.19 \
-	6.1.137 \
-	6.6.89
+	6.1.167 \
+	6.6.132 \
+	6.12.80 \
+	6.18.21 \
+	6.19.10
+
 
 LINUX_HEADER_TEMPLATE := linux-headers-%.tar.gz
 LINUX_HEADER_X86_64_TARGETS = $(addprefix $(LINUX_HEADER_ASSETS_BUILD_DIR)/, \
@@ -135,14 +114,12 @@ elasticsearch_image_tag := "gcr.io/pixie-oss/pixie-dev-public/elasticsearch:$(EL
 
 ## Linux kernel for qemu/BPF tests.
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel_build
-# 4.19.276, 4.14.304 are the correct versions here, but there is a bug with patch > 255.
-KERNEL_BUILD_VERSIONS := 4.14.254 \
-	4.19.254 \
-	5.4.254 \
-	5.10.224 \
-	5.15.165 \
-	6.1.106 \
-	6.8.12
+KERNEL_BUILD_VERSIONS := 5.10.252 \
+	5.14.21 \
+	6.1.167 \
+	6.6.132 \
+	6.12.80 \
+	6.18.21
 
 KERNEL_BUILD_TEMPLATE := linux-build-%.tar.gz
 KERNEL_BUILD_TARGETS = $(addprefix $(KERNEL_BUILD_DIR)/, $(patsubst %,$(KERNEL_BUILD_TEMPLATE), $(KERNEL_BUILD_VERSIONS)))
@@ -251,7 +228,7 @@ $(LINUX_HEADERS_ARM64_MERGED_FILE): $(LINUX_HEADER_ARM64_TARGETS)
 
 .PHONY: upload_linux_headers
 upload_linux_headers:  $(LINUX_HEADERS_X86_64_MERGED_FILE) $(LINUX_HEADERS_ARM64_MERGED_FILE) ## Target to build and upload linux headers image
-	gsutil cp $^ $(LINUX_HEADERS_GS_PATH)
+	# gsutil cp $^ $(LINUX_HEADERS_GS_PATH)
 	$(GH_RELEASE_UPLOAD) linux-headers $(LINUX_HEADERS_REV) $^
 	sha256sum $^
 

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -125,12 +125,12 @@ elasticsearch_image_tag := "gcr.io/pixie-oss/pixie-dev-public/elasticsearch:$(EL
 ## Linux kernel for qemu/BPF tests.
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel_build
 KERNEL_BUILD_VERSIONS := 4.18.20 \
-        5.10.252 \
-        5.14.21 \
-        6.1.167 \
-        6.6.132 \
-        6.12.80 \
-        6.18.21
+       5.10.252 \
+       5.14.21 \
+       6.1.167 \
+       6.6.132 \
+       6.12.80 \
+       6.18.21
 
 KERNEL_BUILD_TEMPLATE := linux-build-%.tar.gz
 KERNEL_BUILD_TARGETS = $(addprefix $(KERNEL_BUILD_DIR)/, $(patsubst %,$(KERNEL_BUILD_TEMPLATE), $(KERNEL_BUILD_VERSIONS)))

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -72,14 +72,25 @@ SYSROOT_CREATOR_IMAGE_TAG := sysroot-creator-$(SYSROOT_REV)
 ## Linux image parameters
 LINUX_HEADER_BUILD_DIR := $(BUILD_DIR)/linux_headers
 LINUX_HEADER_ASSETS_BUILD_DIR := $(LINUX_HEADER_BUILD_DIR)/assets
+# Kernel versions selected to cover major enterprise distros and recent mainline.
+# Popular eBPF projects like cilium have moved to 5.10+ as their minimum
+# supported kernel version, with an exception for RHEL.
+# 4.18.20  - RHEL 8.10
+# 5.10.252 - Debian 11 / Amazon Linux 2
+# 5.14.21  - RHEL 9
+# 6.1.167  - Debian 12 / Amazon Linux 2023
+# 6.6.132  - Ubuntu 24.04 LTS
+# 6.12.80  - latest LTS
+# 6.18.21  - recent mainline
+# 6.19.10  - latest mainline
 LINUX_KERNEL_VERSIONS := 4.18.20 \
         5.10.252 \
-	5.14.21 \
-	6.1.167 \
-	6.6.132 \
-	6.12.80 \
-	6.18.21 \
-	6.19.10
+        5.14.21 \
+        6.1.167 \
+        6.6.132 \
+        6.12.80 \
+        6.18.21 \
+        6.19.10
 
 
 LINUX_HEADER_TEMPLATE := linux-headers-%.tar.gz
@@ -91,7 +102,6 @@ LINUX_HEADER_ARM64_TARGETS = $(addprefix $(LINUX_HEADER_ASSETS_BUILD_DIR)/, \
 
 LINUX_HEADERS_X86_64_MERGED_FILE := $(LINUX_HEADER_BUILD_DIR)/linux-headers-merged-x86_64-$(LINUX_HEADERS_REV).tar.gz
 LINUX_HEADERS_ARM64_MERGED_FILE := $(LINUX_HEADER_BUILD_DIR)/linux-headers-merged-arm64-$(LINUX_HEADERS_REV).tar.gz
-LINUX_HEADERS_GS_PATH := gs://pixie-dev-public/linux-headers/$(LINUX_HEADERS_REV)
 
 ## NATS image parameters.
 NATS_IMAGE_VERSION := 2.9.25
@@ -114,12 +124,13 @@ elasticsearch_image_tag := "gcr.io/pixie-oss/pixie-dev-public/elasticsearch:$(EL
 
 ## Linux kernel for qemu/BPF tests.
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel_build
-KERNEL_BUILD_VERSIONS := 5.10.252 \
-	5.14.21 \
-	6.1.167 \
-	6.6.132 \
-	6.12.80 \
-	6.18.21
+KERNEL_BUILD_VERSIONS := 4.18.20 \
+        5.10.252 \
+        5.14.21 \
+        6.1.167 \
+        6.6.132 \
+        6.12.80 \
+        6.18.21
 
 KERNEL_BUILD_TEMPLATE := linux-build-%.tar.gz
 KERNEL_BUILD_TARGETS = $(addprefix $(KERNEL_BUILD_DIR)/, $(patsubst %,$(KERNEL_BUILD_TEMPLATE), $(KERNEL_BUILD_VERSIONS)))
@@ -228,7 +239,6 @@ $(LINUX_HEADERS_ARM64_MERGED_FILE): $(LINUX_HEADER_ARM64_TARGETS)
 
 .PHONY: upload_linux_headers
 upload_linux_headers:  $(LINUX_HEADERS_X86_64_MERGED_FILE) $(LINUX_HEADERS_ARM64_MERGED_FILE) ## Target to build and upload linux headers image
-	# gsutil cp $^ $(LINUX_HEADERS_GS_PATH)
 	$(GH_RELEASE_UPLOAD) linux-headers $(LINUX_HEADERS_REV) $^
 	sha256sum $^
 

--- a/tools/docker/linux_headers_image/Dockerfile
+++ b/tools/docker/linux_headers_image/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update
 RUN apt-get upgrade -y -q
 RUN apt-get install -y -q build-essential \
   bc \
+  libdw-dev \
   libelf-dev \
   libssl-dev \
   flex \
@@ -40,6 +41,14 @@ RUN apt-get install -y -q build-essential \
   dwarves \
   debhelper \
   python3
+
+# opensslconf.h lives at the multiarch path (e.g. /usr/include/x86_64-linux-gnu/openssl/).
+# During cross-compilation, dpkg-buildpackage alters include paths so host tools
+# (like scripts/sign-file) can no longer find it. Symlink it to the standard path.
+RUN if [ -f /usr/include/x86_64-linux-gnu/openssl/opensslconf.h ] && \
+       [ ! -f /usr/include/openssl/opensslconf.h ]; then \
+      ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h; \
+    fi
 
 WORKDIR /configs
 ADD x86_64_config /configs/x86_64

--- a/tools/docker/linux_headers_image/Dockerfile
+++ b/tools/docker/linux_headers_image/Dockerfile
@@ -27,28 +27,15 @@ RUN apt-get update
 RUN apt-get upgrade -y -q
 RUN apt-get install -y -q build-essential \
   bc \
-  libdw-dev \
   libelf-dev \
   libssl-dev \
   flex \
   bison \
-  kmod \
-  cpio \
   rsync \
   wget \
   binutils-aarch64-linux-gnu \
   gcc-aarch64-linux-gnu \
-  dwarves \
-  debhelper \
   python3
-
-# opensslconf.h lives at the multiarch path (e.g. /usr/include/x86_64-linux-gnu/openssl/).
-# During cross-compilation, dpkg-buildpackage alters include paths so host tools
-# (like scripts/sign-file) can no longer find it. Symlink it to the standard path.
-RUN if [ -f /usr/include/x86_64-linux-gnu/openssl/opensslconf.h ] && \
-       [ ! -f /usr/include/openssl/opensslconf.h ]; then \
-      ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h; \
-    fi
 
 WORKDIR /configs
 ADD x86_64_config /configs/x86_64

--- a/tools/docker/linux_headers_image/build_linux_headers.sh
+++ b/tools/docker/linux_headers_image/build_linux_headers.sh
@@ -73,7 +73,13 @@ if [ "${KERN_MAJ}" -lt 6 ] || { [ "${KERN_MAJ}" -le 6 ] && [ "${KERN_MIN}" -lt 3
 fi
 echo "Building ${TARGET} for ${KERN_VERSION}${LOCALVERSION} (${ARCH})"
 
-make ARCH="${ARCH}" -j "$(nproc)" "${TARGET}" LOCALVERSION="${LOCALVERSION}"
+EXTRA_MAKE_ARGS=""
+if [ "${ARCH}" != "$(uname -m)" ]; then
+    # Skip dpkg dependency checks when cross-compiling, since host packages
+    # (e.g. libssl-dev) won't satisfy target arch requirements.
+    EXTRA_MAKE_ARGS="DPKG_FLAGS=-d"
+fi
+make ARCH="${ARCH}" -j "$(nproc)" "${TARGET}" LOCALVERSION="${LOCALVERSION}" ${EXTRA_MAKE_ARGS}
 
 popd || exit
 popd || exit

--- a/tools/docker/linux_headers_image/build_linux_headers.sh
+++ b/tools/docker/linux_headers_image/build_linux_headers.sh
@@ -49,56 +49,37 @@ mkdir -p "${WORKSPACE}"/src
 pushd "${WORKSPACE}"/src || exit
 
 KERN_MAJ=$(echo "${KERN_VERSION}" | cut -d'.' -f1);
-KERN_MIN=$(echo "${KERN_VERSION}" | cut -d'.' -f2);
 wget -nv http://mirrors.edge.kernel.org/pub/linux/kernel/v"${KERN_MAJ}".x/linux-"${KERN_VERSION}".tar.gz
 
 tar zxf linux-"${KERN_VERSION}".tar.gz
 
 pushd linux-"${KERN_VERSION}" || exit
 
-cp /configs/"${ARCH}" .config
-make ARCH="${ARCH}" olddefconfig
-make ARCH="${ARCH}" clean
-
 LOCALVERSION="-pl"
 
-DEB_ARCH="${ARCH//x86_64/amd64}"
-# binary builds are required for non git trees after linux v6.3 (inclusive).
-# The .deb file suffix is also different.
-TARGET='bindeb-pkg'
-DEB_SUFFIX="-1_${DEB_ARCH}.deb"
-if [ "${KERN_MAJ}" -lt 6 ] || { [ "${KERN_MAJ}" -le 6 ] && [ "${KERN_MIN}" -lt 3 ]; }; then
-    TARGET='deb-pkg'
-    DEB_SUFFIX="${LOCALVERSION}-1_${DEB_ARCH}.deb"
-fi
-echo "Building ${TARGET} for ${KERN_VERSION}${LOCALVERSION} (${ARCH})"
+cp /configs/"${ARCH}" .config
+make ARCH="${ARCH}" olddefconfig
 
-EXTRA_MAKE_ARGS=""
-if [ "${ARCH}" != "$(uname -m)" ]; then
-    # Skip dpkg dependency checks when cross-compiling, since host packages
-    # (e.g. libssl-dev) won't satisfy target arch requirements.
-    EXTRA_MAKE_ARGS="DPKG_FLAGS=-d"
-fi
-make ARCH="${ARCH}" -j "$(nproc)" "${TARGET}" LOCALVERSION="${LOCALVERSION}" ${EXTRA_MAKE_ARGS}
+# Only generate headers — no kernel or module compilation needed.
+# 'make prepare' generates include/generated/ and arch/*/include/generated/
+# which are the only outputs we package.
+echo "Generating headers for ${KERN_VERSION}${LOCALVERSION} (${ARCH})"
+make ARCH="${ARCH}" prepare LOCALVERSION="${LOCALVERSION}"
 
 popd || exit
 popd || exit
 
-# Extract headers into a tarball
-dpkg -x src/linux-headers-"${KERN_VERSION}${LOCALVERSION}_${KERN_VERSION}${DEB_SUFFIX}" .
+# Package headers into the same directory structure the old deb-pkg approach produced
+# (usr/src/linux-headers-<version><localversion>/{include,arch}).
+KERNEL_ARCH="${ARCH//x86_64/x86}"
+HEADERS_DIR="usr/src/linux-headers-${KERN_VERSION}${LOCALVERSION}"
+
+mkdir -p "${HEADERS_DIR}/arch"
+cp -a "src/linux-${KERN_VERSION}/include" "${HEADERS_DIR}/"
+cp -a "src/linux-${KERN_VERSION}/arch/${KERNEL_ARCH}" "${HEADERS_DIR}/arch/"
 
 # Remove broken symlinks
-find usr/src/linux-headers-"${KERN_VERSION}${LOCALVERSION}" -xtype l -exec rm {} +
-
-# Remove uneeded files to reduce size
-# Keep only:
-# - usr/src/linux-headers-x.x.x-pl/include
-# - usr/src/linux-headers-x.x.x-pl/arch/${ARCH}
-# This reduces the size by a little over 2x.
-rm -rf usr/share
-find usr/src/linux-headers-"${KERN_VERSION}${LOCALVERSION}" -maxdepth 1 -mindepth 1 ! -name include ! -name arch -type d \
-    -exec rm -rf {} +
-find usr/src/linux-headers-"${KERN_VERSION}${LOCALVERSION}"/arch -maxdepth 1 -mindepth 1 ! -name "${ARCH//x86_64/x86}" -type d -exec rm -rf {} +
+find "${HEADERS_DIR}" -xtype l -exec rm {} +
 
 tar zcf linux-headers-"${ARCH}"-"${KERN_VERSION}".tar.gz usr
 

--- a/tools/docker/linux_headers_image/build_linux_headers.sh
+++ b/tools/docker/linux_headers_image/build_linux_headers.sh
@@ -49,56 +49,48 @@ mkdir -p "${WORKSPACE}"/src
 pushd "${WORKSPACE}"/src || exit
 
 KERN_MAJ=$(echo "${KERN_VERSION}" | cut -d'.' -f1);
-KERN_MIN=$(echo "${KERN_VERSION}" | cut -d'.' -f2);
 wget -nv http://mirrors.edge.kernel.org/pub/linux/kernel/v"${KERN_MAJ}".x/linux-"${KERN_VERSION}".tar.gz
 
 tar zxf linux-"${KERN_VERSION}".tar.gz
 
 pushd linux-"${KERN_VERSION}" || exit
 
-cp /configs/"${ARCH}" .config
-make ARCH="${ARCH}" olddefconfig
-make ARCH="${ARCH}" clean
-
 LOCALVERSION="-pl"
 
-DEB_ARCH="${ARCH//x86_64/amd64}"
-# binary builds are required for non git trees after linux v6.3 (inclusive).
-# The .deb file suffix is also different.
-TARGET='bindeb-pkg'
-DEB_SUFFIX="-1_${DEB_ARCH}.deb"
-if [ "${KERN_MAJ}" -lt 6 ] || { [ "${KERN_MAJ}" -le 6 ] && [ "${KERN_MIN}" -lt 3 ]; }; then
-    TARGET='deb-pkg'
-    DEB_SUFFIX="${LOCALVERSION}-1_${DEB_ARCH}.deb"
-fi
-echo "Building ${TARGET} for ${KERN_VERSION}${LOCALVERSION} (${ARCH})"
+cp /configs/"${ARCH}" .config
+make ARCH="${ARCH}" olddefconfig
 
-EXTRA_MAKE_ARGS=""
-if [ "${ARCH}" != "$(uname -m)" ]; then
-    # Skip dpkg dependency checks when cross-compiling, since host packages
-    # (e.g. libssl-dev) won't satisfy target arch requirements.
-    EXTRA_MAKE_ARGS="DPKG_FLAGS=-d"
-fi
-make ARCH="${ARCH}" -j "$(nproc)" "${TARGET}" LOCALVERSION="${LOCALVERSION}" ${EXTRA_MAKE_ARGS}
+# Only generate headers — no kernel or module compilation needed.
+# 'make prepare' generates include/generated/ and arch/*/include/generated/
+# which are the only outputs we package.
+echo "Generating headers for ${KERN_VERSION}${LOCALVERSION} (${ARCH})"
+make ARCH="${ARCH}" prepare LOCALVERSION="${LOCALVERSION}"
 
 popd || exit
 popd || exit
 
-# Extract headers into a tarball
-dpkg -x src/linux-headers-"${KERN_VERSION}${LOCALVERSION}_${KERN_VERSION}${DEB_SUFFIX}" .
+# Package headers into the same directory structure the old deb-pkg approach produced
+# (usr/src/linux-headers-<version><localversion>/{include,arch}).
+KERNEL_ARCH="${ARCH//x86_64/x86}"
+HEADERS_DIR="usr/src/linux-headers-${KERN_VERSION}${LOCALVERSION}"
+
+mkdir -p "${HEADERS_DIR}/arch"
+cp -a "src/linux-${KERN_VERSION}/include" "${HEADERS_DIR}/"
+cp -a "src/linux-${KERN_VERSION}/arch/${KERNEL_ARCH}" "${HEADERS_DIR}/arch/"
 
 # Remove broken symlinks
-find usr/src/linux-headers-"${KERN_VERSION}${LOCALVERSION}" -xtype l -exec rm {} +
+find "${HEADERS_DIR}" -xtype l -exec rm {} +
 
-# Remove uneeded files to reduce size
-# Keep only:
-# - usr/src/linux-headers-x.x.x-pl/include
-# - usr/src/linux-headers-x.x.x-pl/arch/${ARCH}
-# This reduces the size by a little over 2x.
-rm -rf usr/share
-find usr/src/linux-headers-"${KERN_VERSION}${LOCALVERSION}" -maxdepth 1 -mindepth 1 ! -name include ! -name arch -type d \
-    -exec rm -rf {} +
-find usr/src/linux-headers-"${KERN_VERSION}${LOCALVERSION}"/arch -maxdepth 1 -mindepth 1 ! -name "${ARCH//x86_64/x86}" -type d -exec rm -rf {} +
+# Remove non-header files from arch/ to reduce size.
+# Only headers (.h), Makefiles, Kconfigs, and Kbuilds are needed.
+find "${HEADERS_DIR}/arch" -type f \
+    ! -name '*.h' \
+    ! -name 'Makefile' \
+    ! -name 'Kconfig*' \
+    ! -name 'Kbuild*' \
+    -delete
+# Clean up empty directories left behind.
+find "${HEADERS_DIR}/arch" -type d -empty -delete
 
 tar zcf linux-headers-"${ARCH}"-"${KERN_VERSION}".tar.gz usr
 


### PR DESCRIPTION
Summary: Trim linux headers to LTS kernel versions for 4.x and 5.x and include new LTS versions for 6.x kernels.

Relevant Issues: #2275, #2344

Type of change: /kind dependency

Test Plan: Deploy a vizier on the following platforms and compared pl7 headers vs the new pl8
- [x] Bottlerocket
- [x] Amazon Linux
- [x] k0s (6.12 kernel)
- [x] Google COS
- Verified that the new build process via `make prepare` creates similarly sized tar files and has roughly the same files present (some files were missing like .config, Makefile, Module.symvers, Kconfig, compile.h, but not of these are used by the PEM)

<details><summary>Bottlerocket /etc/os-release</summary>

```
I20260410 02:06:57.094861  9891 system_info.cc:35] /host/etc/os-release:
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.57.0 (aws-k8s-1.33)"
PRETTY_NAME="Bottlerocket OS 1.57.0 (aws-k8s-1.33)"
VARIANT_ID=aws-k8s-1.33
VERSION_ID=1.57.0
BUILD_ID=beaadc52
VENDOR_NAME=Bottlerocket
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
```

</details>
<details><summary>Google COS /etc/os-release</summary>

```
I20260410 01:17:27.298167 14802 system_info.cc:35] /host/etc/os-release:
NAME="Container-Optimized OS"
ID=cos
PRETTY_NAME="Container-Optimized OS from Google"
HOME_URL="https://cloud.google.com/container-optimized-os/docs"
BUG_REPORT_URL="https://cloud.google.com/container-optimized-os/docs/resources/support-policy#contact_us"
GOOGLE_METRICS_PRODUCT_ID=26
KERNEL_COMMIT_ID=46c2d01887bed5038cc2b8bbd801ae2f7985e7f0
GOOGLE_CRASH_ID=Lakitu
VERSION=125
VERSION_ID=125
BUILD_ID=19216.104.126
```
</details>

<details><summary>header size comparision</summary>

```
  Size Comparison
  ┌──────────┬────────┬───────────┬─────────┬─────────┐
  │ Version  │  Arch  │ pl8 opt  │ pl8 orig  │  pl7  │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 4.18.20  │ x86_64 │ 7.6M      │ 9.9M    │ 7.7M    │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 4.18.20  │ arm64  │ 7.3M      │ 8.1M    │ 7.5M    │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 5.10.252 │ x86_64 │ 8.7M      │ 12M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 5.10.252 │ arm64  │ 8.4M      │ 9.9M    │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 5.14.21  │ x86_64 │ 8.9M      │ 12M     │ 8.8M    │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 5.14.21  │ arm64  │ 8.6M      │ 11M     │ 8.8M    │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.1.167  │ x86_64 │ 9.7M      │ 13M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.1.167  │ arm64  │ 9.4M      │ 12M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.6.132  │ x86_64 │ 11M       │ 13M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.6.132  │ arm64  │ 9.8M      │ 13M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.12.80  │ x86_64 │ 11M       │ 14M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.12.80  │ arm64  │ 11M       │ 14M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.18.21  │ x86_64 │ 12M       │ 14M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.18.21  │ arm64  │ 11M       │ 16M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.19.10  │ x86_64 │ 12M       │ 14M     │ N/A     │
  ├──────────┼────────┼───────────┼─────────┼─────────┤
  │ 6.19.10  │ arm64  │ 12M       │ 16M     │ N/A     │
  └──────────┴────────┴───────────┴─────────┴─────────┘
```

</details>

Changelog Message: Update the vizier-pem's prepackaged linux headers to work with newer AMI / cloud images. This fixes an issue where some platforms which don't have linux header packages (like Google COS) wouldn't show protocol tracing data (#2344)