### PR TITLE
Support GitHub Enterprise server in plugin/load_db service

### DIFF
--- a/src/cloud/plugin/load_db/main.go
+++ b/src/cloud/plugin/load_db/main.go
@@ -50,7 +50,7 @@ import (
 	"px.dev/pixie/src/utils"
 )
 
-const githubArchiveTmpl = "https://api.github.com/repos/%s/tarball"
+const githubArchiveTmpl = "https://%s/repos/%s/tarball"
 
 // NOTE: After changing this file, remember to push a generated image by running
 // bazel run //src/cloud/plugin/load_db:push_plugin_db_updater_image
@@ -58,6 +58,7 @@ func init() {
 	pflag.String("plugin_repo", "pixie-io/pixie-plugin", "The name of the plugin repo.")
 	pflag.String("plugin_service", "plugin-service.plc.svc.cluster.local:50600", "The plugin service url (load balancer/list is ok)")
 	pflag.String("domain_name", "dev.withpixie.dev", "The domain name of Pixie Cloud")
+	pflag.String("gh_api_host", "api.github.com", "The GitHub API host (e.g. api.github.com for github.com, or ghe.example.com/api/v3 for GitHub Enterprise Server)")
 }
 
 func initDB() *sqlx.DB {
@@ -98,7 +99,7 @@ func loadPlugins(db *sqlx.DB) {
 	}
 
 	client := http.Client{}
-	req, err := http.NewRequest("GET", fmt.Sprintf(githubArchiveTmpl, pluginRepo), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf(githubArchiveTmpl, viper.GetString("gh_api_host"), pluginRepo), nil)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to create req")
 	}

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
@@ -21,29 +21,29 @@ package(default_visibility = ["//src/stirling:__subpackages__"])
 
 # Generate all Go container library permutations for supported Go versions.
 go_container_libraries(
+    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
     container_type = "grpc_server",
-    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
     prebuilt_container_versions = pl_go_test_versions,
 )
 
 # Stirling test cases usually test server side tracing. Therefore
 # we only need to provide the bazel SDK versions for the client containers.
 go_container_libraries(
+    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
     container_type = "grpc_client",
-    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
 )
 
 go_container_libraries(
-    container_type = "tls_server",
     bazel_sdk_versions = pl_all_supported_go_sdk_versions,
+    container_type = "tls_server",
     prebuilt_container_versions = pl_go_test_versions,
 )
 
 # Stirling test cases usually test server side tracing. Therefore
 # we only need to provide the bazel SDK versions for the client containers.
 go_container_libraries(
-    container_type = "tls_client",
     bazel_sdk_versions = pl_all_supported_go_sdk_versions,
+    container_type = "tls_client",
 )
 
 pl_cc_test_library(


### PR DESCRIPTION
Summary: Support GitHub Enterprise server in plugin/load_db service

The airgapped install does not support the Pixie plugin system. For environments that have access to a self-hosted GitHub Enterprise server, the load_db service can use the same API as long as an appropriate hostname is provided. This unblocks an end user from using the pixie plugin system.

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: End user tested out an image and verified their plugin system is now functional

Changelog Message: Pixie plugin system now supported for airgapped installs that have access to GitHub Enterprise server