### PR TITLE
chore: typo sweep (occured -> occurred, recieved -> received, nonexistant -> nonexistent)

### DIFF
--- a/src/carnot/exec/grpc_router.h
+++ b/src/carnot/exec/grpc_router.h
@@ -81,7 +81,7 @@ class GRPCRouter final : public carnotpb::ResultSinkService::Service {
   Status DeleteGRPCSourceNode(sole::uuid query_id, int64_t source_id);
 
   /**
-   * @brief Get any errors that may have occured in the incoming worker nodes.
+   * @brief Get any errors that may have occurred in the incoming worker nodes.
    *
    * @param query_id
    * @return StatusOr<std::vector<statuspb::Status>>

--- a/src/carnot/funcs/builtins/sql_parsing/normalization.h
+++ b/src/carnot/funcs/builtins/sql_parsing/normalization.h
@@ -141,7 +141,7 @@ std::ostream& operator<<(std::ostream& os, const NormalizeResult& result);
 
 struct NormalizationState {
   // Number of characters to shift character indices into the query by, to account for replacements
-  // that have already occured.
+  // that have already occurred.
   int n_shift_query = 0;
   std::vector<int> line_start_offsets;
   std::string next_placeholder;

--- a/src/carnot/funcs/metadata/metadata_ops_test.cc
+++ b/src/carnot/funcs/metadata/metadata_ops_test.cc
@@ -542,7 +542,7 @@ TEST_F(MetadataOpsTest, pod_name_to_stop_time) {
   auto function_ctx = std::make_unique<FunctionContext>(metadata_state_, nullptr);
   // pl/terminating_pod is the Pod name for a terminating pod.
   EXPECT_EQ(udf.Exec(function_ctx.get(), "pl/terminating_pod").val, 15);
-  // pl/blah is a nonexistant Pod, should return 0.
+  // pl/blah is a nonexistent Pod, should return 0.
   EXPECT_EQ(udf.Exec(function_ctx.get(), "pl/blah").val, 0);
 }
 

--- a/src/carnot/planner/distributed/grpc_source_conversion.cc
+++ b/src/carnot/planner/distributed/grpc_source_conversion.cc
@@ -114,7 +114,7 @@ StatusOr<bool> MergeSameNodeGRPCBridgeRule::Apply(IRNode* ir_node) {
   int64_t dest_id = grpc_sink->agent_id_to_destination_id().at(current_agent_id_);
   auto node = grpc_sink->graph()->Get(dest_id);
   if (!Match(node, GRPCSource())) {
-    return node->CreateIRNodeError("Expected node to be a 'GRPCSource', but recieved a '$0'",
+    return node->CreateIRNodeError("Expected node to be a 'GRPCSource', but received a '$0'",
                                    node->DebugString());
   }
   auto grpc_sink_parent = grpc_sink->parents()[0];

--- a/src/carnot/planner/objects/qlobject.h
+++ b/src/carnot/planner/objects/qlobject.h
@@ -189,7 +189,7 @@ class QLObject {
 
   /**
    * @brief Creates an error for this objects. Packages checks to make sure you have an ir node for
-   * line,col error resporting. Defaults to standard error in case an ir node is nonexistant..
+   * line,col error resporting. Defaults to standard error in case an ir node is nonexistent.
    *
    * @return Status
    */

--- a/src/carnot/planner/probes/probes.h
+++ b/src/carnot/planner/probes/probes.h
@@ -78,7 +78,7 @@ class TracepointIR {
    * @brief Serializes this probe definition as a protobuf.
    *
    * @param pb
-   * @return Any error that occured during serialization.
+   * @return Any error that occurred during serialization.
    */
   Status ToProto(carnot::planner::dynamic_tracing::ir::logical::TracepointSpec* pb,
                  const std::string& name);

--- a/src/shared/metadata/metadata_state.h
+++ b/src/shared/metadata/metadata_state.h
@@ -157,7 +157,7 @@ class K8sMetadataState : NotCopyable {
   /**
    * PodIDByIPAtTime returns the PodID for the pod with the given IP at the given timestamp.
    * @param pod_ip string of the pod IP.
-   * @param timestamp_ns time at which this request occured.
+   * @param timestamp_ns time at which this request occurred.
    * @return the pod_id or empty string if the pod does not exist.
    */
   UID PodIDByIPAtTime(std::string_view pod_ip, int64_t timestamp_ns) const;

--- a/src/stirling/source_connectors/socket_tracer/data_stream_test.cc
+++ b/src/stirling/source_connectors/socket_tracer/data_stream_test.cc
@@ -495,7 +495,7 @@ TEST_F(DataStreamTest, SpikeCapacityWithLargeDataChunkAndSSLEnabled) {
 }
 
 TEST_F(DataStreamTest, ResyncCausesDuplicateEventBug) {
-  // Test to catch regression on a bug. The bug occured when a resync occurs in ParseFrames, leading
+  // Test to catch regression on a bug. The bug occurred when a resync occurs in ParseFrames, leading
   // to an invalid state where the data stream buffer still had data that had already been
   // processed.
   std::unique_ptr<SocketDataEvent> req0a =

--- a/src/table_store/table/table_store.h
+++ b/src/table_store/table/table_store.h
@@ -180,7 +180,7 @@ class TableStore {
    *
    * @param table_id: table_id within which to create a tablet.
    * @param tablet_id: the tablet to create for the tablet.
-   * @return StatusOr<Table*>: the table object or an error if the table is nonexistant.
+   * @return StatusOr<Table*>: the table object or an error if the table is nonexistent.
    */
   StatusOr<Table*> CreateNewTablet(uint64_t table_id, const types::TabletID& tablet_id);
 

--- a/src/vizier/services/agent/shared/manager/chan_cache.h
+++ b/src/vizier/services/agent/shared/manager/chan_cache.h
@@ -72,7 +72,7 @@ class ChanCache {
    * The period where a connection goes from READY to IDLE can be adjusted with the channel
    * argument: GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS. See the test for an example.
    *
-   * @return Status: whether an error occured while cleaning up Idle/Dead Channels.
+   * @return Status: whether an error occurred while cleaning up Idle/Dead Channels.
    */
   Status CleanupChans();
 


### PR DESCRIPTION
10 single-character typo fixes across `carnot/`, `stirling/`, `shared/`, `table_store/` and `vizier/` — 9 in doc comments and 1 in a user-visible `CreateIRNodeError` error string. No functional change:

- `src/table_store/table/table_store.h:183` — nonexistant -> nonexistent
- `src/shared/metadata/metadata_state.h:160` — occured -> occurred
- `src/vizier/services/agent/shared/manager/chan_cache.h:75` — occured -> occurred
- `src/carnot/exec/grpc_router.h:84` — occured -> occurred
- `src/carnot/funcs/metadata/metadata_ops_test.cc:545` — nonexistant -> nonexistent
- `src/carnot/planner/objects/qlobject.h:192` — nonexistant -> nonexistent (also cleans up the accidental "..")
- `src/carnot/funcs/builtins/sql_parsing/normalization.h:144` — occured -> occurred
- `src/stirling/source_connectors/socket_tracer/data_stream_test.cc:498` — occured -> occurred
- `src/carnot/planner/probes/probes.h:81` — occured -> occurred
- `src/carnot/planner/distributed/grpc_source_conversion.cc:117` — error string `but recieved a /bin/zsh` -> `but received a /bin/zsh`