### PR TITLE
Use github.repository for codecov upload target

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -85,7 +85,7 @@ jobs:
       run: |
         # Github actions container runner creates a docker network without IPv6 support. We enable it manually.
         sysctl -w net.ipv6.conf.lo.disable_ipv6=0
-        ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r pixie-io/pixie
+        ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r ${{ github.repository }}
   generate-matrix:
     needs: [authorize, env-protect-setup, get-dev-image]
     runs-on: oracle-vm-16cpu-64gb-x86-64


### PR DESCRIPTION
Summary: Use github.repository for codecov upload target

This complements the changes in #2363 to make the GitHub actions easily parameterized for any forks.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Reviewed this syntax against GH's documentation