### PR TITLE
lint: silence deprecated flake8-mypy noise and bump mypy.ini to py3.1…

### DIFF
--- a/.flake8rc
+++ b/.flake8rc
@@ -3,4 +3,9 @@ max-line-length = 120
 
 # N802: Function names have to be lower case. This is for GRPC service.
 # E999: Mistaken error see https://github.com/PyCQA/pycodestyle/issues/584
-ignore = N802,E999,W503
+# T499: Output from `flake8-mypy`, which has been deprecated since 2020 and is
+# stuck on an older interpreter under Ubuntu noble. The dedicated `mypy` linter
+# entry in `.arclint` already runs `mypy --config-file=mypy.ini` against the
+# proper interpreter, so flake8-mypy is redundant here. Silencing T499 avoids
+# the broken-plugin output without touching the linter image. See issue #1955.
+ignore = N802,E999,W503,T499

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.12
 show_column_numbers = True
 show_error_context = False
 


### PR DESCRIPTION
Fixes #1955.

Two surgical config fixes for the mypy / flake8 linting setup under the Ubuntu noble linter image.

### Root cause

The `T499` errors are emitted by `flake8-mypy`, a flake8 plugin that wraps mypy with its own outdated args. The plugin has been deprecated since 2020 and is stuck on a Python 3.6 interpreter under noble. The plugin gets auto-loaded by flake8 because it's installed in the linter docker image.

`.arclint` already declares a separate, dedicated `mypy` linter that runs `mypy --config-file=mypy.ini` against the proper interpreter, so real mypy linting is happening regardless of `flake8-mypy`.

### Changes

- `.flake8rc`: add `T499` to the `ignore` list with an explanatory comment matching the style of the existing `N802` / `E999` notes. Silences the broken plugin without touching the linter image.
- - `mypy.ini`: bump `python_version` from `3.8` to `3.12` to match the project's actual Python target (`WORKSPACE` declares `python_version = "3.12"`).
This intentionally does not block on or imply the broader linter-replacement work tracked in #1896.

### Tested

Walked through the diff against the issue body's repro. Have not run `arc lint` locally - Pixie's Bazel + linter docker setup isn't in my dev env. Happy for a maintainer to confirm the noise stops on a real run.