### PR TITLE
Use correct platform for `container_push` pusher binary

### DIFF
--- a/bazel/external/rules_docker_pusher_cfg.patch
+++ b/bazel/external/rules_docker_pusher_cfg.patch
@@ -1,0 +1,26 @@
+diff --git a/container/push.bzl b/container/push.bzl
+index baef9c2..942741d 100644
+--- a/container/push.bzl
++++ b/container/push.bzl
+@@ -205,7 +205,7 @@ container_push_ = rule(
+         ),
+         "_pusher": attr.label(
+             default = "//container/go/cmd/pusher",
+-            cfg = "target",
++            cfg = "exec",
+             executable = True,
+             allow_files = True,
+         ),
+diff --git a/contrib/push-all.bzl b/contrib/push-all.bzl
+index c7e7f72..fd6518b 100644
+--- a/contrib/push-all.bzl
++++ b/contrib/push-all.bzl
+@@ -126,7 +126,7 @@ container_push = rule(
+         ),
+         "_pusher": attr.label(
+             default = Label("//container/go/cmd/pusher"),
+-            cfg = "target",
++            cfg = "exec",
+             executable = True,
+             allow_files = True,
+         ),

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -253,7 +253,7 @@ def _pl_deps():
     _bazel_repo("rules_foreign_cc")
     _bazel_repo("io_bazel_rules_k8s")
     _bazel_repo("io_bazel_rules_closure")
-    _bazel_repo("io_bazel_rules_docker", patches = ["//bazel/external:rules_docker.patch", "//bazel/external:rules_docker_arch.patch"], patch_args = ["-p1"])
+    _bazel_repo("io_bazel_rules_docker", patches = ["//bazel/external:rules_docker.patch", "//bazel/external:rules_docker_arch.patch", "//bazel/external:rules_docker_pusher_cfg.patch"], patch_args = ["-p1"])
     _bazel_repo("rules_python")
     _bazel_repo("rules_pkg")
     _bazel_repo("com_github_bazelbuild_buildtools")


### PR DESCRIPTION
Summary: Use correct platform for `container_push` pusher binary

I'm not sure why upstream switched this to [target](https://github.com/bazelbuild/rules_docker/commit/e48c7cc71773ab69abd0ee08ae47bafff4b5845a), but this fails on our current GitHub runners ([build link](https://github.com/pixie-io/pixie/actions/runs/25715727034/job/75507683014)):
```
Target //k8s/vizier:vizier_images_push up-to-date:
  bazel-bin/k8s/vizier/vizier_images_push
INFO: Elapsed time: 817.792s, Critical Path: 223.45s
INFO: 5492 processes: 430 remote cache hit, 48 internal, 5014 processwrapper-sandbox.
INFO: Build completed successfully, 5492 total actions
INFO: 
INFO: Running command line: bazel-bin/k8s/vizier/vizier_images_push
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/27eff3a9-fc64-4408-8ca4-1c57014fb23d
/github/home/.cache/bazel/_bazel_root/56ec069a32c4abebc78228236a835895/execroot/px/bazel-out/k8-opt/bin/k8s/vizier/vizier_images_push.runfiles/px/k8s/vizier/vizier_images_push.0.push: line 31: /github/home/.cache/bazel/_bazel_root/56ec069a32c4abebc78228236a835895/execroot/px/bazel-out/k8-opt/bin/k8s/vizier/vizier_images_push.runfiles/px/../io_bazel_rules_docker/container/go/cmd/pusher/pusher_/pusher: cannot execute binary file: Exec format error
```

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: vizier-release job tested with a similar change. I ccidentally used `cfg = "host"` on the latest build but should have same effect.