### PR TITLE
[cloud] Replace service-tls-certs usage with cert-manager compatible secret

### DIFF
--- a/k8s/cloud/base/api_deployment.yaml
+++ b/k8s/cloud/base/api_deployment.yaml
@@ -158,8 +158,24 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: vizier-image-secret
         secret:
           secretName: vizier-image-secret

--- a/k8s/cloud/base/artifact_tracker_deployment.yaml
+++ b/k8s/cloud/base/artifact_tracker_deployment.yaml
@@ -86,8 +86,24 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: artifact-access-sa
         secret:
           secretName: artifact-access-sa

--- a/k8s/cloud/base/auth_deployment.yaml
+++ b/k8s/cloud/base/auth_deployment.yaml
@@ -118,5 +118,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/config_manager_deployment.yaml
+++ b/k8s/cloud/base/config_manager_deployment.yaml
@@ -93,5 +93,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/cron_script_deployment.yaml
+++ b/k8s/cloud/base/cron_script_deployment.yaml
@@ -85,5 +85,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/indexer_deployment.yaml
+++ b/k8s/cloud/base/indexer_deployment.yaml
@@ -89,8 +89,24 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: es-certs
         secret:
           secretName: pl-elastic-es-http-certs-internal

--- a/k8s/cloud/base/metrics_deployment.yaml
+++ b/k8s/cloud/base/metrics_deployment.yaml
@@ -71,8 +71,24 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: bq-access-sa
         secret:
           secretName: bq-access-sa

--- a/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/hydra/hydra_deployment.yaml
@@ -209,5 +209,21 @@ spec:
           - key: hydra.yml
             path: hydra.yml
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
+++ b/k8s/cloud/base/ory_auth/kratos/kratos_deployment.yaml
@@ -212,5 +212,21 @@ spec:
           - key: identity.schema.json
             path: identity.schema.json
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/plugin_deployment.yaml
+++ b/k8s/cloud/base/plugin_deployment.yaml
@@ -90,5 +90,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/profile_deployment.yaml
+++ b/k8s/cloud/base/profile_deployment.yaml
@@ -90,5 +90,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/project_manager_deployment.yaml
+++ b/k8s/cloud/base/project_manager_deployment.yaml
@@ -75,5 +75,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/proxy_deployment.yaml
+++ b/k8s/cloud/base/proxy_deployment.yaml
@@ -140,8 +140,15 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: service-certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: envoy-yaml
         configMap:
           name: proxy-envoy-config

--- a/k8s/cloud/base/scriptmgr_deployment.yaml
+++ b/k8s/cloud/base/scriptmgr_deployment.yaml
@@ -63,5 +63,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/base/vzconn_deployment.yaml
+++ b/k8s/cloud/base/vzconn_deployment.yaml
@@ -94,8 +94,24 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: proxycerts
         secret:
           secretName: cloud-proxy-tls-certs

--- a/k8s/cloud/base/vzmgr_deployment.yaml
+++ b/k8s/cloud/base/vzmgr_deployment.yaml
@@ -100,5 +100,21 @@ spec:
           type: RuntimeDefault
       volumes:
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key

--- a/k8s/cloud/dev/plugin_db_updater_job.yaml
+++ b/k8s/cloud/dev/plugin_db_updater_job.yaml
@@ -75,8 +75,24 @@ spec:
         secret:
           secretName: pl-db-secrets
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
   backoffLimit: 1
   parallelism: 1
   completions: 1

--- a/k8s/cloud/overlays/plugin_job/plugin_job.yaml
+++ b/k8s/cloud/overlays/plugin_job/plugin_job.yaml
@@ -91,8 +91,24 @@ spec:
         secret:
           secretName: pl-db-secrets
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
       - name: tmp-pod
         emptyDir: {}
   backoffLimit: 1

--- a/k8s/cloud/public/base/plugin_db_updater_job.yaml
+++ b/k8s/cloud/public/base/plugin_db_updater_job.yaml
@@ -69,8 +69,24 @@ spec:
         secret:
           secretName: pl-db-secrets
       - name: certs
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
+          - secret:
+              name: service-tls-client-certs
+              items:
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
   backoffLimit: 1
   parallelism: 1
   completions: 1

--- a/k8s/cloud_deps/base/nats/statefulset.yaml
+++ b/k8s/cloud_deps/base/nats/statefulset.yaml
@@ -137,8 +137,17 @@ spec:
       # Common volumes for the containers
       volumes:
       - name: nats-server-tls-volume
-        secret:
-          secretName: service-tls-certs
+        projected:
+          sources:
+          - secret:
+              name: service-tls-server-certs
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: ca.crt
       - name: config-volume
         configMap:
           name: nats-config


### PR DESCRIPTION
Summary: [cloud] Replace service-tls-certs usage with cert-manager compatible secret

This is dependent on #2391. This updates all of cloud manifests to use the newer, cert-manager compatible style secret.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Used these changes in https://github.com/k8sstormcenter/pixie to deploy a Pixie Cloud that uses cert-manager service tls certs

Changelog Message: Update Pixie cloud's service tls certs to use cert-manager compatible secrets