### PR TITLE
Add clickhouse_cpp bazel repository

### DIFF
--- a/bazel/external/clickhouse_cpp.BUILD
+++ b/bazel/external/clickhouse_cpp.BUILD
@@ -1,0 +1,64 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+)
+
+cmake(
+    name = "clickhouse_cpp",
+    build_args = [
+        "--",  # <- Pass remaining options to the native tool.
+        "-j`nproc`",
+        "-l`nproc`",
+    ],
+    cache_entries = {
+        "BUILD_BENCHMARK": "OFF",
+        "BUILD_TESTS": "OFF",
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "WITH_OPENSSL": "OFF",         # Disable OpenSSL for now
+        "WITH_SYSTEM_ABSEIL": "OFF",   # Use bundled abseil
+        "WITH_SYSTEM_LZ4": "OFF",      # Use bundled for now
+        "WITH_SYSTEM_CITYHASH": "OFF", # Use bundled for now  
+        "WITH_SYSTEM_ZSTD": "OFF",     # Use bundled for now
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+    },
+    lib_source = ":all",
+    out_static_libs = [
+        "libclickhouse-cpp-lib.a",
+        "liblz4.a",
+        "libcityhash.a",
+        "libzstdstatic.a",
+        "libabsl_int128.a",
+    ],
+    targets = [
+        "clickhouse-cpp-lib",
+        "lz4",
+        "cityhash",
+        "zstdstatic",
+        "absl_int128",
+    ],
+    visibility = ["//visibility:public"],
+    working_directory = "",
+)

--- a/bazel/external/clickhouse_cpp.BUILD
+++ b/bazel/external/clickhouse_cpp.BUILD
@@ -37,11 +37,11 @@ cmake(
         "BUILD_TESTS": "OFF",
         "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_BUILD_TYPE": "Release",
-        "WITH_OPENSSL": "OFF",         # Disable OpenSSL for now
-        "WITH_SYSTEM_ABSEIL": "OFF",   # Use bundled abseil
-        "WITH_SYSTEM_LZ4": "OFF",      # Use bundled for now
-        "WITH_SYSTEM_CITYHASH": "OFF", # Use bundled for now  
-        "WITH_SYSTEM_ZSTD": "OFF",     # Use bundled for now
+        "WITH_OPENSSL": "ON",
+        "WITH_SYSTEM_ABSEIL": "ON",
+        "WITH_SYSTEM_LZ4": "OFF",
+        "WITH_SYSTEM_CITYHASH": "OFF",
+        "WITH_SYSTEM_ZSTD": "OFF",
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
     },
     lib_source = ":all",
@@ -50,15 +50,18 @@ cmake(
         "liblz4.a",
         "libcityhash.a",
         "libzstdstatic.a",
-        "libabsl_int128.a",
     ],
     targets = [
         "clickhouse-cpp-lib",
         "lz4",
         "cityhash",
         "zstdstatic",
-        "absl_int128",
     ],
     visibility = ["//visibility:public"],
     working_directory = "",
+    deps = [
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+        "@com_google_absl//absl/numeric:int128",
+    ],
 )

--- a/bazel/external/clickhouse_cpp_boringssl.patch
+++ b/bazel/external/clickhouse_cpp_boringssl.patch
@@ -1,0 +1,16 @@
+diff --git a/cmake/openssl.cmake b/cmake/openssl.cmake
+--- a/cmake/openssl.cmake
++++ b/cmake/openssl.cmake
+@@ -3,4 +3,10 @@
+     IF (WITH_OPENSSL)
+-        FIND_PACKAGE (OpenSSL REQUIRED)
+-        ADD_COMPILE_DEFINITIONS (WITH_OPENSSL=1)
++        ADD_LIBRARY (OpenSSL::Crypto INTERFACE IMPORTED GLOBAL)
++        SET_TARGET_PROPERTIES (OpenSSL::Crypto PROPERTIES
++            INTERFACE_INCLUDE_DIRECTORIES "$ENV{EXT_BUILD_ROOT}/external/boringssl/src/include")
++        ADD_LIBRARY (OpenSSL::SSL INTERFACE IMPORTED GLOBAL)
++        SET_TARGET_PROPERTIES (OpenSSL::SSL PROPERTIES
++            INTERFACE_INCLUDE_DIRECTORIES "$ENV{EXT_BUILD_ROOT}/external/boringssl/src/include"
++            INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
++        ADD_COMPILE_DEFINITIONS (WITH_OPENSSL=1 USE_BORINGSSL)
+     ENDIF ()

--- a/bazel/external/clickhouse_cpp_system_abseil.patch
+++ b/bazel/external/clickhouse_cpp_system_abseil.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -81,6 +81,9 @@
+ IF (WITH_SYSTEM_ABSEIL)
+-    FIND_PACKAGE(absl REQUIRED)
++    ADD_LIBRARY (absl::int128 STATIC IMPORTED)
++    SET_TARGET_PROPERTIES (absl::int128 PROPERTIES
++        IMPORTED_LOCATION "$ENV{EXT_BUILD_DEPS}/lib/libint128.a"
++        INTERFACE_INCLUDE_DIRECTORIES "$ENV{EXT_BUILD_ROOT}/external/com_google_absl")
+ ELSE ()
+     INCLUDE_DIRECTORIES (contrib/absl)
+     SUBDIRS (contrib/absl/absl)
+ ENDIF ()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -153,7 +153,7 @@ def _cc_deps():
     _bazel_repo("com_github_ariafallah_csv_parser", build_file = "//bazel/external:csv_parser.BUILD")
     _bazel_repo("com_github_arun11299_cpp_jwt", build_file = "//bazel/external:cpp_jwt.BUILD")
     _bazel_repo("com_github_cameron314_concurrentqueue", build_file = "//bazel/external:concurrentqueue.BUILD")
-    _bazel_repo("com_github_clickhouse_clickhouse_cpp", build_file = "//bazel/external:clickhouse_cpp.BUILD")
+    _bazel_repo("com_github_clickhouse_clickhouse_cpp", build_file = "//bazel/external:clickhouse_cpp.BUILD", patches = ["//bazel/external:clickhouse_cpp_system_abseil.patch", "//bazel/external:clickhouse_cpp_boringssl.patch"], patch_args = ["-p1"])
     _bazel_repo("com_github_cyan4973_xxhash", build_file = "//bazel/external:xxhash.BUILD")
     _bazel_repo("com_github_nlohmann_json", build_file = "//bazel/external:nlohmann_json.BUILD")
     _bazel_repo("com_github_packetzero_dnsparser", build_file = "//bazel/external:dnsparser.BUILD")

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -153,6 +153,7 @@ def _cc_deps():
     _bazel_repo("com_github_ariafallah_csv_parser", build_file = "//bazel/external:csv_parser.BUILD")
     _bazel_repo("com_github_arun11299_cpp_jwt", build_file = "//bazel/external:cpp_jwt.BUILD")
     _bazel_repo("com_github_cameron314_concurrentqueue", build_file = "//bazel/external:concurrentqueue.BUILD")
+    _bazel_repo("com_github_clickhouse_clickhouse_cpp", build_file = "//bazel/external:clickhouse_cpp.BUILD")
     _bazel_repo("com_github_cyan4973_xxhash", build_file = "//bazel/external:xxhash.BUILD")
     _bazel_repo("com_github_nlohmann_json", build_file = "//bazel/external:nlohmann_json.BUILD")
     _bazel_repo("com_github_packetzero_dnsparser", build_file = "//bazel/external:dnsparser.BUILD")

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -76,6 +76,11 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "concurrentqueue-1.0.3",
         urls = ["https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz"],
     ),
+    com_github_clickhouse_clickhouse_cpp = dict(
+        sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        strip_prefix = "clickhouse-cpp-001025cd72d904104c15657e85e0fb6b0ec58e14",
+        urls = ["https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.6.2.tar.gz"],
+    ),
     com_github_cyan4973_xxhash = dict(
         sha256 = "952ebbf5b11fbf59ae5d760a562d1e9112278f244340ad7714e8556cbe54f7f7",
         strip_prefix = "xxHash-0.7.3",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -77,8 +77,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz"],
     ),
     com_github_clickhouse_clickhouse_cpp = dict(
-        sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        strip_prefix = "clickhouse-cpp-001025cd72d904104c15657e85e0fb6b0ec58e14",
+        sha256 = "bac497857759e991fa4e1638bccf936cb36d10ad79273695a570272cc4891428",
+        strip_prefix = "clickhouse-cpp-2.6.2",
         urls = ["https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.6.2.tar.gz"],
     ),
     com_github_cyan4973_xxhash = dict(


### PR DESCRIPTION
Summary: Add clickhouse_cpp bazel repository

The [k8sstormcenter project](https://github.com/k8sstormcenter/) uses Pixie as a telemetry source  (protocol tracing + dynamic tracing w/ bpftrace) for its security operations control,  which complements the project’s existing detection and threat intelligence capabilities.

k8sstormcenter uses ClickHouse as its central forensic database, where telemetry from multiple security tools is aggregated and correlated. To better integrate Pixie into this architecture, the project extends Pixie with native ClickHouse support, allowing Pixie to:
* Read existing security and forensic data stored in ClickHouse.
* Correlate Pixie’s runtime telemetry with telemetry from other security data sources.
* Persist Pixie-generated telemetry and analysis results directly back into ClickHouse.

This is the first PR of a series that implements the functionality explained above.

Relevant Issues: N/A

Type of change: /kind dep

Test Plan: New bazel repository targets build
