### PR TITLE
Add Pixie cloud traefik Ingress overlay

### DIFF
--- a/k8s/cloud/overlays/exposed_services_traefik/api_service.yaml
+++ b/k8s/cloud/overlays/exposed_services_traefik/api_service.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: plc-cloud-backend-transport@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serversscheme: https

--- a/k8s/cloud/overlays/exposed_services_traefik/cloud_ingress.yaml
+++ b/k8s/cloud/overlays/exposed_services_traefik/cloud_ingress.yaml
@@ -1,0 +1,76 @@
+## Replace all occurrences of pixie.example.com with the custom domain name you wish to use
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cloud-ingress
+spec:
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - pixie.example.com
+    - work.pixie.example.com
+    secretName: cloud-proxy-tls-certs
+  rules:
+  - host: pixie.example.com
+    http:
+      paths:
+      - path: /px.services
+        pathType: Prefix
+        backend:
+          service:
+            name: vzconn-service
+            port:
+              number: 51600
+      - path: /px.cloudapi
+        pathType: Prefix
+        backend:
+          service:
+            name: api-service
+            port:
+              number: 51200
+      - path: /px.api
+        pathType: Prefix
+        backend:
+          service:
+            name: cloud-proxy-service
+            port:
+              number: 4444
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: cloud-proxy-service
+            port:
+              number: 443
+  - host: work.pixie.example.com
+    http:
+      paths:
+      - path: /px.services
+        pathType: Prefix
+        backend:
+          service:
+            name: vzconn-service
+            port:
+              number: 51600
+      - path: /px.cloudapi
+        pathType: Prefix
+        backend:
+          service:
+            name: api-service
+            port:
+              number: 51200
+      - path: /px.api
+        pathType: Prefix
+        backend:
+          service:
+            name: cloud-proxy-service
+            port:
+              number: 4444
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: cloud-proxy-service
+            port:
+              number: 443

--- a/k8s/cloud/overlays/exposed_services_traefik/kustomization.yaml
+++ b/k8s/cloud/overlays/exposed_services_traefik/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+- proxy_service.yaml
+- vzconn_service.yaml
+- cloud_ingress.yaml
+- servers_transport.yaml
+patches:
+- path: api_service.yaml
+  target:
+    kind: Service
+    name: api-service

--- a/k8s/cloud/overlays/exposed_services_traefik/proxy_service.yaml
+++ b/k8s/cloud/overlays/exposed_services_traefik/proxy_service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud-proxy-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: plc-cloud-backend-transport@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serversscheme: https
+spec:
+  type: ClusterIP
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 56000
+    name: tcp-https
+  - port: 4444
+    protocol: TCP
+    targetPort: 56004
+    name: tcp-grcp-web
+  - port: 5555
+    protocol: TCP
+    targetPort: 56000
+    name: tcp-http2
+  selector:
+    name: cloud-proxy-server

--- a/k8s/cloud/overlays/exposed_services_traefik/servers_transport.yaml
+++ b/k8s/cloud/overlays/exposed_services_traefik/servers_transport.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: cloud-backend-transport
+spec:
+  serverName: pixie.example.com
+  insecureSkipVerify: true

--- a/k8s/cloud/overlays/exposed_services_traefik/vzconn_service.yaml
+++ b/k8s/cloud/overlays/exposed_services_traefik/vzconn_service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vzconn-service
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: plc-cloud-backend-transport@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serversscheme: https
+spec:
+  type: ClusterIP
+  ports:
+  - port: 51600
+    protocol: TCP
+    targetPort: 51600
+    name: tcp-http2
+  selector:
+    name: vzconn-server


### PR DESCRIPTION
Summary: Add Pixie cloud traefik Ingress overlay

Pixie Cloud's current Ingress options are nginx (now deprecated) and GCP based load balancers. This means there isn't a maintenance bare metal Ingress option today. This adds support for traefik so open source users have a reference implementation of another Ingress type.

Relevant Issues: N/A

Type of change: /kind infra

Test Plan: Deployed a Pixie cloud on bare metal and verified it works end to end

Changelog Message: Add Pixie cloud manifests for deploying with a Traefik based Ingress